### PR TITLE
Fix upgrade template

### DIFF
--- a/.github/ISSUE_TEMPLATE/test--upgrade.md
+++ b/.github/ISSUE_TEMPLATE/test--upgrade.md
@@ -17,14 +17,12 @@ assignees: ''
 
 - [ ] Install new version.
 - [ ] Check_files.
-- [ ] Check that the databases are purged.
 - [ ] Check that the service are restarted.
 
 ## DEB (Linux)
 
 - [ ] Install new version.
 - [ ] Check_files.
-- [ ] Check that the databases are purged.
 - [ ] Check that the service are restarted.
 
 ## macOS
@@ -40,12 +38,6 @@ assignees: ''
 - [ ] Check that the service are restarted.
 
 ## Solaris (SPARC)
-
-- [ ] Install new version.
-- [ ] Check_files.
-- [ ] Check that the service are restarted.
-
-## HP-UX
 
 - [ ] Install new version.
 - [ ] Check_files.


### PR DESCRIPTION
- Databases aren't purged anymore.
- No upgrade in HP-UX: you need to stop service and remove the previous version of Wazuh before installing a new one.