### PR TITLE
Fim integration tests tools

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -102,6 +102,11 @@ def is_fim_scan_ended():
 
 
 def create_file(type, path):
+    """ Creates a file in a given path.
+
+    :param type: Defined constant that specifies the type. It can be: FIFO, SYSLINK, SOCKET or REGULAR
+    :param path: Path where the file will be created
+    """
     getattr(sys.modules[__name__], f'_create_{type}')(path)
 
 
@@ -136,3 +141,16 @@ def _create_regular(path):
     regular_path = os.path.join(path, 'regular_file')
     with open(regular_path, 'w') as f:
         f.write('')
+
+def change_internal_options(int_opt_path, pattern, value):
+    """ Changes the value of a given parameter
+
+    :param int_opt_path: internal_options.conf path
+    :param pattern: Parameter to change
+    :param value: New value
+    """
+    with open(int_opt_path, "r") as sources:
+        lines = sources.readlines()
+    with open(int_opt_path, "w") as sources:
+        for line in lines:
+            sources.write(re.sub(f'{pattern}\=[0-9]*', f'{pattern}={value}', line))


### PR DESCRIPTION
This PR adds the following functions to **packages/wazuh_testing/wazuh_testing/fim.py**:

- `create_file(type, path)` : it creates a specific type of file in a given path.

- `change_internal_options(int_opt_path, pattern, value)` : it changes the value of a parameter inside `internal_options.conf`.

These are useful for testing with **FIM** using temporal files.