### PR TITLE
Wazuh and ELK versions update in Molecule tests

### DIFF
--- a/tests/wazuh-ansible/molecule/default/tests/test_default.py
+++ b/tests/wazuh-ansible/molecule/default/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def get_wazuh_version():
     """This return the version of Wazuh."""
-    return "3.9.5"
+    return "3.10.0"
 
 
 def test_wazuh_packages_are_installed(host):
@@ -86,4 +86,4 @@ def test_filebeat_is_installed(host):
     """Test if the elasticsearch package is installed."""
     filebeat = host.package("filebeat")
     assert filebeat.is_installed
-    assert filebeat.version.startswith('7.2.1')
+    assert filebeat.version.startswith('7.3.2')

--- a/tests/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
+++ b/tests/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
@@ -10,7 +10,7 @@ def test_elasticsearch_is_installed(host):
     """Test if the elasticsearch package is installed."""
     elasticsearch = host.package("elasticsearch")
     assert elasticsearch.is_installed
-    assert elasticsearch.version.startswith('7.2.1')
+    assert elasticsearch.version.startswith('7.3.2')
 
 
 def test_elasticsearch_is_running(host):

--- a/tests/wazuh-ansible/molecule/kibana/tests/test_default.py
+++ b/tests/wazuh-ansible/molecule/kibana/tests/test_default.py
@@ -14,7 +14,7 @@ def test_port_kibana_is_open(host):
 def test_find_correct_elasticsearch_version(host):
     """Test if we find the kibana/elasticsearch version in package.json"""
     kibana = host.file("/usr/share/kibana/plugins/wazuh/package.json")
-    assert kibana.contains("7.2.1")
+    assert kibana.contains("7.3.2")
 
 
 def test_wazuh_plugin_installed(host):

--- a/tests/wazuh-ansible/molecule/wazuh-agent/tests/test_agents.py
+++ b/tests/wazuh-ansible/molecule/wazuh-agent/tests/test_agents.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def get_wazuh_version():
     """This return the version of Wazuh."""
-    return "3.9.5"
+    return "3.10.0"
 
 
 def test_ossec_package_installed(Package):

--- a/tests/wazuh-ansible/molecule/worker/tests/test_default.py
+++ b/tests/wazuh-ansible/molecule/worker/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def get_wazuh_version():
     """This return the version of Wazuh."""
-    return "3.9.5"
+    return "3.10.0"
 
 
 def test_wazuh_packages_are_installed(host):
@@ -82,4 +82,4 @@ def test_filebeat_is_installed(host):
     """Test if the elasticsearch package is installed."""
     filebeat = host.package("filebeat")
     assert filebeat.is_installed
-    assert filebeat.version.startswith('7.2.1')
+    assert filebeat.version.startswith('7.3.2')


### PR DESCRIPTION
Hi all!

As we are releasing wazuh_ansible 3.10.0_7.3.2, we need to update the versions to correspond to the new versions of Wazuh and ELK components.

Kind regards,

Rshad