### PR TITLE
Fix wazuh worker API assert in test_default.py

### DIFF
--- a/ansible/wazuh-ansible/molecule/worker/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/worker/tests/test_default.py
@@ -45,8 +45,8 @@ def test_wazuh_services_are_running(host):
     if distribution == 'centos':
         # assert manager.is_running
         assert manager.is_enabled
-        # assert not api.is_running
-        assert not api.is_enabled
+        # assert api.is_running
+        assert api.is_enabled
     elif distribution == 'ubuntu':
         # assert manager.is_running
         assert manager.is_enabled


### PR DESCRIPTION
Hi team,

This PR fixes the API assert in the worker tests

Best regards

Jose