### PR TITLE
Create a single master cluster

### DIFF
--- a/ansible/wazuh-ansible/molecule/elasticsearch-xpack/playbook.yml
+++ b/ansible/wazuh-ansible/molecule/elasticsearch-xpack/playbook.yml
@@ -11,7 +11,6 @@
       elasticsearch_bootstrap_node: true
       elasticsearch_cluster_nodes:
         - node-1
-        - node-2
       elasticsearch_discovery_nodes:
         - node-1
         - node-2
@@ -43,9 +42,6 @@
       elasticsearch_node_name: node-2
       single_node: false
       elasticsearch_master_candidate: true
-      elasticsearch_cluster_nodes:
-        - node-1
-        - node-2
       elasticsearch_discovery_nodes:
         - node-1
         - node-2

--- a/ansible/wazuh-ansible/molecule/elasticsearch-xpack/playbook.yml.template
+++ b/ansible/wazuh-ansible/molecule/elasticsearch-xpack/playbook.yml.template
@@ -11,7 +11,6 @@
       elasticsearch_bootstrap_node: true
       elasticsearch_cluster_nodes:
         - elasticsearch_%PLATFORM%-1
-        - elasticsearch_%PLATFORM%-2
       elasticsearch_discovery_nodes:
         - elasticsearch_%PLATFORM%-1
         - elasticsearch_%PLATFORM%-2
@@ -43,9 +42,6 @@
       elasticsearch_node_name: elasticsearch_%PLATFORM%-2
       single_node: false
       elasticsearch_master_candidate: true
-      elasticsearch_cluster_nodes:
-        - elasticsearch_%PLATFORM%-1
-        - elasticsearch_%PLATFORM%-2
       elasticsearch_discovery_nodes:
         - elasticsearch_%PLATFORM%-1
         - elasticsearch_%PLATFORM%-2


### PR DESCRIPTION
This PR tweaks molecule's `elastic-xpack` playbook in order to fix #199 

This will create a cluster of 2 nodes and a single master.