### PR TITLE
Add FIM integration tests for prefilter cmd

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -112,12 +112,13 @@ def validate_event(event, checks=None):
     # Check attributes
     attributes = event['data']['attributes'].keys() - {'type', 'checksum'}
     required_attributes = get_required_attributes(checks)
-    assert (attributes ^ required_attributes == set())
+    assert (attributes ^ required_attributes == set()), f'attributes and required_attributes are not the same'
 
     # Check audit
     if event['data']['mode'] == 'whodata':
-        assert ('audit' in event['data'])
-        assert (event['data']['audit'].keys() ^ _REQUIRED_AUDIT == set())
+        assert ('audit' in event['data']), f'audit no detected in event'
+        assert (event['data']['audit'].keys() ^ _REQUIRED_AUDIT == set()), \
+            f'audit keys and required_audit are no the same'
 
 
 def is_fim_scan_ended():
@@ -245,6 +246,7 @@ def modify_file(path, name, is_binary=False, options=None):
     :type options: Dict
     :return: None
     """
+
     def modify_file_content():
         content = "1234567890qwertyuiopasdfghjklzxcvbnm"
         with open(regular_path, 'ab' if is_binary else 'a') as f:
@@ -315,7 +317,7 @@ def modify_file(path, name, is_binary=False, options=None):
                     modify_file_permission()
 
                 elif check == REQUIRED_ATTRIBUTES[CHECK_INODE] or check == CHECK_INODE:
-                    modify_file_inode() 
+                    modify_file_inode()
 
 
 def change_internal_options(opt_path, pattern, value):
@@ -433,7 +435,7 @@ def callback_configuration_error(line):
 
 
 def regular_file_cud(folder, log_monitor, file_list=['testfile0'], time_travel=False, min_timeout=1, options=None,
-                     triggers_event=True, validators_after_create=None, validators_after_update=None, 
+                     triggers_event=True, validators_after_create=None, validators_after_update=None,
                      validators_after_delete=None, validators_after_cud=None):
     """ Checks if creation, update and delete events are detected by syscheck
 
@@ -490,12 +492,12 @@ def regular_file_cud(folder, log_monitor, file_list=['testfile0'], time_travel=F
 
     def check_events_type(ev_type):
         event_types = Counter(jq(".[].data.type").transform(events, multiple_output=True))
-        assert (event_types[ev_type] == len(file_list))
+        assert (event_types[ev_type] == len(file_list)), f'Non expected number of events'
 
     def check_files_in_event():
         file_paths = jq(".[].data.path").transform(events, multiple_output=True)
         for file_name in file_list:
-            assert (os.path.join(folder, file_name) in file_paths)
+            assert (os.path.join(folder, file_name) in file_paths), f'{file_name} does not exist in {file_paths}'
 
     def check_events(event_type, validate_after):
         if events is not None:

--- a/test_wazuh/test_fim/test_audit/test_audit.py
+++ b/test_wazuh/test_fim/test_audit/test_audit.py
@@ -66,9 +66,9 @@ def test_added_rules(tags_to_apply, get_configuration,
                                      callback=callback_audit_added_rule,
                                      accum_results=3).result()
 
-    assert (testdir1 in events)
-    assert (testdir2 in events)
-    assert (testdir3 in events)
+    assert (testdir1 in events), f'{testdir1} not detected in scan'
+    assert (testdir2 in events), f'{testdir2} not detected in scan'
+    assert (testdir3 in events), f'{testdir3} not detected in scan'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -89,7 +89,7 @@ def test_readded_rules(tags_to_apply, get_configuration,
         events = wazuh_log_monitor.start(timeout=10,
                                          callback=callback_audit_reloaded_rule).result()
 
-        assert (dir in events)
+        assert (dir in events), f'{dir} not in {events}'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -111,9 +111,9 @@ def test_readded_rules_on_restart(tags_to_apply, get_configuration,
                                      callback=callback_audit_loaded_rule,
                                      accum_results=3).result()
 
-    assert (testdir1 in events)
-    assert (testdir2 in events)
-    assert (testdir3 in events)
+    assert (testdir1 in events), f'{testdir1} not in {events}'
+    assert (testdir2 in events), f'{testdir2} not in {events}'
+    assert (testdir3 in events), f'{testdir3} not in {events}'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -132,9 +132,9 @@ def test_move_rules_realtime(tags_to_apply, get_configuration,
                                      callback=callback_realtime_added_directory,
                                      accum_results=3).result()
 
-    assert (testdir1 in events)
-    assert (testdir2 in events)
-    assert (testdir3 in events)
+    assert (testdir1 in events), f'{testdir1} not detected in scan'
+    assert (testdir2 in events), f'{testdir2} not detected in scan'
+    assert (testdir3 in events), f'{testdir3} not detected in scan'
 
     # Start Audit
     p = subprocess.Popen(["service", "auditd", "start"])

--- a/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
@@ -98,8 +98,8 @@ def test_ignore_subdirectory(folder, filename, content, triggers_event,
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=3,
                                         callback=callback_detect_event).result()
-        assert (event['data']['type'] == 'added')
-        assert (event['data']['path'] == os.path.join(folder, filename))
+        assert (event['data']['type'] == 'added'), f'Event type not equal'
+        assert (event['data']['path'] == os.path.join(folder, filename)), f'Event path not equal'
     else:
         while True:
             ignored_file = wazuh_log_monitor.start(timeout=3,

--- a/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
+++ b/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
@@ -93,15 +93,17 @@ def test_no_diff_subdirectory(folder, filename, content, hidden_content,
         for file in files:
             diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local',
                                      folder.strip('/'), file)
-            assert (os.path.exists(diff_file))
-            assert (event['data'].get('content_changes') is not None)
+            assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
+            assert (event['data'].get('content_changes') is not None), f'content_changes is empty'
 
     def no_diff_validator(event):
         """ Validate content_changes value is truncated if the file is set to no_diff """
         if hidden_content:
-            assert ('<Diff truncated because nodiff option>' in event['data'].get('content_changes'))
+            assert ('<Diff truncated because nodiff option>' in event['data'].get('content_changes')), \
+                    f'content_changes is not truncated'
         else:
-            assert ('<Diff truncated because nodiff option>' not in event['data'].get('content_changes'))
+            assert ('<Diff truncated because nodiff option>' not in event['data'].get('content_changes')), \
+                    f'content_changes is truncated'
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=files,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',

--- a/test_wazuh/test_fim/test_prefilter_cmd/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_prefilter_cmd/data/wazuh_conf.yaml
@@ -1,0 +1,16 @@
+---
+# conf 1
+- tags:
+  - prefilter_cmd
+  apply_to_modules:
+  - test_prefilter_cmd
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/testdir1"
+      attributes:
+      - FIM_MODE
+  - prefilter_cmd:
+      value: PREFILTER_CMD

--- a/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan
+from wazuh_testing.tools import (FileMonitor, check_apply_test,
+                                 load_wazuh_configurations, restart_wazuh_daemon, truncate_file)
+
+# variables
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+test_directories = [os.path.join('/', 'testdir1')
+                    ]
+force_restart_after_restoring = True
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# configurations
+
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=[{'FIM_MODE': '', 'PREFILTER_CMD': '/usr/sbin/prelink -y'},
+                                                   {'FIM_MODE': {'realtime': 'yes'},
+                                                    'PREFILTER_CMD': '/usr/sbin/prelink -y'},
+                                                   {'FIM_MODE': {'whodata': 'yes'},
+                                                    'PREFILTER_CMD': '/usr/sbin/prelink -y'}
+                                                   ],
+                                           metadata=[{'fim_mode': 'scheduled', 'prefilter_cmd': '/usr/sbin/prelink -y'},
+                                                     {'fim_mode': 'realtime', 'prefilter_cmd': '/usr/sbin/prelink -y'},
+                                                     {'fim_mode': 'whodata', 'prefilter_cmd': '/usr/sbin/prelink -y'}
+                                                     ]
+                                           )
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('tags_to_apply', [
+    ({'prefilter_cmd'})
+])
+def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment):
+    """Checks if prelink is installed and syscheck works."""
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    if get_configuration['metadata']['prefilter_cmd'] == '/usr/sbin/prelink -y':
+        prelink = get_configuration['metadata']['prefilter_cmd'].split(' ')[0]
+        assert os.path.exists(prelink), 'Prelink is not installed'
+        truncate_file(LOG_FILE_PATH)
+        restart_wazuh_daemon('ossec-syscheckd')
+        detect_initial_scan(wazuh_log_monitor)

--- a/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -55,7 +55,7 @@ def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment):
 
     if get_configuration['metadata']['prefilter_cmd'] == '/usr/sbin/prelink -y':
         prelink = get_configuration['metadata']['prefilter_cmd'].split(' ')[0]
-        assert os.path.exists(prelink), 'Prelink is not installed'
+        assert os.path.exists(prelink), f'Prelink is not installed'
         truncate_file(LOG_FILE_PATH)
         restart_wazuh_daemon('ossec-syscheckd')
         detect_initial_scan(wazuh_log_monitor)

--- a/test_wazuh/test_fim/test_recursion_level/test_recursion_level.py
+++ b/test_wazuh/test_fim/test_recursion_level/test_recursion_level.py
@@ -9,7 +9,6 @@ import re
 from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud, callback_audit_event_too_long
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations
 
-
 # Variables
 
 dir_no_recursion = "/test_no_recursion"
@@ -38,7 +37,6 @@ test_directories = [
 ]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-
 # Configurations
 
 configurations = load_wazuh_configurations(configurations_path, __name__,
@@ -65,7 +63,7 @@ def check_config_applies(applies_to_config, get_configuration):
         pytest.skip("Does not apply to this config file")
 
 
-def recursion_test(dirname, subdirname, recursion_level, timeout=1, threshold_true=2, threshold_false=2, 
+def recursion_test(dirname, subdirname, recursion_level, timeout=1, threshold_true=2, threshold_false=2,
                    is_scheduled=False):
     """Checks recursion_level functionality over the first and last n-directories of the dirname hierarchy 
     by creating, modifying and deleting some files in them. It will create all directories and 
@@ -83,25 +81,25 @@ def recursion_test(dirname, subdirname, recursion_level, timeout=1, threshold_tr
 
     # Check True (Within the specified recursion level)
     for n in range(recursion_level):
-        path = os.path.join(path, subdirname + str(n+1))
+        path = os.path.join(path, subdirname + str(n + 1))
         if ((recursion_level < threshold_true * 2) or
-            (recursion_level >= threshold_true * 2 and n < threshold_true) or
-            (recursion_level >= threshold_true * 2 and n > recursion_level - threshold_true)):
+                (recursion_level >= threshold_true * 2 and n < threshold_true) or
+                (recursion_level >= threshold_true * 2 and n > recursion_level - threshold_true)):
             regular_file_cud(path, wazuh_log_monitor, time_travel=is_scheduled, min_timeout=timeout)
 
     # Check False (exceding the specified recursion_level)
     for n in range(recursion_level, recursion_level + threshold_false):
-        path = os.path.join(path, subdirname + str(n+1))
+        path = os.path.join(path, subdirname + str(n + 1))
         regular_file_cud(path, wazuh_log_monitor, time_travel=is_scheduled, min_timeout=timeout, triggers_event=False)
 
 
-def check_event_too_long (get_configuration, recursion_level):
+def check_event_too_long(get_configuration, recursion_level):
     """Checks if the `Event to long` message was raised due to Whodata path length limitation."""
     if (get_configuration['metadata']['fim_mode'] == 'whodata' and recursion_level > 250):
         event = wazuh_log_monitor.start(timeout=30,
                                         callback=callback_audit_event_too_long,
                                         accum_results=1).result()
-        assert (event)
+        assert event, f'event not detected'
 
 
 # Fixtures

--- a/test_wazuh/test_fim/test_report_changes/test_report_changes_and_diff.py
+++ b/test_wazuh/test_fim/test_report_changes/test_report_changes_and_diff.py
@@ -79,15 +79,17 @@ def test_reports_file_and_nodiff(folder, checkers, tags_to_apply,
         for file in file_list:
             diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local',
                                      folder.strip('/'), file)
-            assert(os.path.exists(diff_file))
-            assert(event['data'].get('content_changes') is not None)
+            assert(os.path.exists(diff_file)), f'{diff_file} does not exist'
+            assert(event['data'].get('content_changes') is not None), f'content_changes is empty'
 
     def no_diff_validator(event):
         """ Validate content_changes value is truncated if the file is set to no_diff """
         if is_truncated:
-            assert ('<Diff truncated because nodiff option>' in event['data'].get('content_changes'))
+            assert ('<Diff truncated because nodiff option>' in event['data'].get('content_changes')), \
+                    f'content_changes is not truncated'
         else:
-            assert ('<Diff truncated because nodiff option>' not in event['data'].get('content_changes'))
+            assert ('<Diff truncated because nodiff option>' not in event['data'].get('content_changes')), \
+                    f'content_changes is truncated'
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=file_list,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',

--- a/test_wazuh/test_fim/test_report_changes/test_report_deleted_diff.py
+++ b/test_wazuh/test_fim/test_report_changes/test_report_deleted_diff.py
@@ -89,7 +89,7 @@ def create_and_check_diff(name, directory, fim_mode):
     wait_for_event(fim_mode)
     diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local',
                              directory.strip('/'), name)
-    assert (os.path.exists(diff_file))
+    assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
     return diff_file
 
 
@@ -106,7 +106,7 @@ def check_when_no_report_changes(name, directory, fim_mode, new_conf):
     restart_wazuh_with_new_conf(new_conf)
     # Wait for FIM scan to finish
     detect_initial_scan(wazuh_log_monitor)
-    assert (not os.path.exists(diff_file))
+    assert (not os.path.exists(diff_file)), f'{diff_file} exists'
 
 
 def check_when_deleted_directories(name, directory, fim_mode):
@@ -121,7 +121,7 @@ def check_when_deleted_directories(name, directory, fim_mode):
     create_and_check_diff(name, directory, fim_mode)
     shutil.rmtree(directory, ignore_errors=True)
     wait_for_event(fim_mode)
-    assert (not os.path.exists(diff_dir))
+    assert (not os.path.exists(diff_dir)), f'{diff_dir} exists'
 
 
 # tests

--- a/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
+++ b/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
@@ -85,8 +85,8 @@ def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=3,
                                         callback=callback_detect_event).result()
-        assert (event['data']['type'] == 'added')
-        assert (event['data']['path'] == os.path.join(folder, filename))
+        assert (event['data']['type'] == 'added'), f'Event type not equal'
+        assert (event['data']['path'] == os.path.join(folder, filename)), f'Event path not equal'
     else:
         while True:
             ignored_file = wazuh_log_monitor.start(timeout=3,

--- a/test_wazuh/test_fim/test_tags/test_tags.py
+++ b/test_wazuh/test_fim/test_tags/test_tags.py
@@ -58,7 +58,7 @@ def test_tags(folder, name, content,
     defined_tags = get_configuration['metadata']['fim_tags']
 
     def tag_validator(event):
-        assert(defined_tags == event['data']['tags'])
+        assert(defined_tags == event['data']['tags']), f'defined_tags are not equal'
 
     files = {name: content}
 


### PR DESCRIPTION

This closes #171    .

This PR adds the requested tests for `prefilter-cmd`.

This option only works with `/usr/sbin/prelink -y` right now. I designed these tests to be as generic as possible for future cases, but some checks will have to be added manually.

## Tests example
================================ test session starts ================================
platform linux -- Python 3.6.8, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 3 items                                                                   

test_prefilter_cmd.py ...                                                     [100%]

=========================== 3 passed in 78.87s (0:01:18) ============================

_These tests will fail if the machine does not have `prelink` installed. This can be seen in the `assert error` anyway. `wazuh_testing` module was not modified._