### PR TITLE
Add FIM integration tests for skip_*

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -359,6 +359,14 @@ def callback_detect_event(line):
     return None
 
 
+def callback_detect_integrity_event(line):
+    match = re.match(r'.*Sending integrity control message: (.+)$', line)
+    if match:
+        if json.loads(match.group(1))['type'] == 'state':
+            return json.loads(match.group(1))
+    return None
+
+
 def callback_ignore(line):
     match = re.match(r".*Ignoring '.*?' '(.*?)' due to sregex '.*?'", line)
     if match:

--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -496,7 +496,7 @@ def restart_wazuh_with_new_conf(new_conf):
     :return: None
     """
     write_wazuh_conf(new_conf)
-    restart_wazuh_service()
+    restart_wazuh_daemon('ossec-syscheckd')
 
 
 def restart_wazuh_service():

--- a/test_wazuh/test_fim/test_skip/data/configure_nfs.sh
+++ b/test_wazuh/test_fim/test_skip/data/configure_nfs.sh
@@ -5,3 +5,4 @@ mkdir /media/nfs-folder
 mkdir /nfs-mount-point
 echo "/media/nfs-folder     172.19.0.100*(rw,sync,no_root_squash)" > /etc/exports
 exportfs -a
+mount -o hard,nolock 172.19.0.100:/media/nfs-folder /nfs-mount-point/

--- a/test_wazuh/test_fim/test_skip/data/configure_nfs.sh
+++ b/test_wazuh/test_fim/test_skip/data/configure_nfs.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
-rpm -qa | grep -E "nfs-utils.*" || yum -y install nfs-utils
+# Check if ip package is installed and get the manager IP
+$1 | grep -E "iproute.*" || $2 iproute
+ip=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+# Check if nfs-utils is installed
+$1 | grep -E "nfs-utils.*" || $2 nfs-utils
 service nfs restart
 mkdir /media/nfs-folder
 mkdir /nfs-mount-point
-echo "/media/nfs-folder     172.19.0.100*(rw,sync,no_root_squash)" > /etc/exports
-exportfs -a
-mount -o hard,nolock 172.19.0.100:/media/nfs-folder /nfs-mount-point/
+# If we are on a FreeBSD distribution, configure NFS differently
+if [ "$3" = "true" ]
+then
+  echo 'nfs_client_enable="YES"' >> /etc/rc.conf
+  echo 'nfs_client_flags="-n 4"' >> /etc/rc.conf
+  nfsiod -n 4
+  mount -v "$ip":/media/nfs-folder /nfs-mount-point/
+else
+  echo "/media/nfs-folder     $ip*(rw,sync,no_root_squash)" > /etc/exports
+  exportfs -a
+  mount -o hard,nolock "$ip":/media/nfs-folder /nfs-mount-point/
+fi

--- a/test_wazuh/test_fim/test_skip/data/create_nfs.sh
+++ b/test_wazuh/test_fim/test_skip/data/create_nfs.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-mount -o hard,nolock 172.19.0.100:/media/nfs-folder /nfs-mount-point/
-

--- a/test_wazuh/test_fim/test_skip/data/proc.py
+++ b/test_wazuh/test_fim/test_skip/data/proc.py
@@ -1,0 +1,2 @@
+while True:
+    pass

--- a/test_wazuh/test_fim/test_skip/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_skip/data/wazuh_conf.yaml
@@ -9,9 +9,8 @@
   - disabled:
       value: 'no'
   - directories:
-      value: "/proc"
+      value: DIRECTORY
       attributes:
-      - FIM_MODE
   - skip_proc:
       value: SKIP
 # conf 2
@@ -24,9 +23,8 @@
   - disabled:
       value: 'no'
   - directories:
-      value: "/sys"
+      value: "/sys/module/video"
       attributes:
-      - FIM_MODE
   - skip_sys:
       value: SKIP
 # conf 3
@@ -41,7 +39,6 @@
   - directories:
       value: "/dev"
       attributes:
-        - FIM_MODE
   - skip_dev:
       value: SKIP
 # conf 4
@@ -56,6 +53,5 @@
   - directories:
       value: "/nfs-mount-point"
       attributes:
-        - FIM_MODE
   - skip_nfs:
       value: SKIP

--- a/test_wazuh/test_fim/test_skip/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_skip/data/wazuh_conf.yaml
@@ -1,0 +1,62 @@
+---
+## conf 1
+#- tags:
+#  - skip_nfs
+#  apply_to_modules:
+#  - test_skip
+#  section: syscheck
+#  elements:
+#  - disabled:
+#      value: 'no'
+#  - directories:
+#      value: "/testdir1"
+#      attributes:
+#      - FIM_MODE
+#  - skip_nfs:
+#      SKIP
+# conf 2
+- tags:
+  - skip_dev
+  apply_to_modules:
+  - test_skip
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/dev"
+      attributes:
+      - FIM_MODE
+  - skip_dev:
+      value: SKIP
+# conf 3
+- tags:
+  - skip_proc
+  apply_to_modules:
+  - test_skip
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/proc"
+      attributes:
+      - FIM_MODE
+  - skip_proc:
+      value: SKIP
+# conf 4
+- tags:
+  - skip_sys
+  apply_to_modules:
+  - test_skip
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/sys"
+      attributes:
+      - FIM_MODE
+  - skip_sys:
+      value: SKIP
+

--- a/test_wazuh/test_fim/test_skip/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_skip/data/wazuh_conf.yaml
@@ -1,7 +1,7 @@
 ---
 # conf 1
 - tags:
-  - skip_nfs
+  - skip_proc
   apply_to_modules:
   - test_skip
   section: syscheck
@@ -9,16 +9,31 @@
   - disabled:
       value: 'no'
   - directories:
-      value: "/nfs-mount-point"
+      value: "/proc"
       attributes:
       - FIM_MODE
-  - skip_nfs:
+  - skip_proc:
       value: SKIP
 # conf 2
 - tags:
-  - skip_dev
+  - skip_sys
   apply_to_modules:
   - test_skip
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/sys"
+      attributes:
+      - FIM_MODE
+  - skip_sys:
+      value: SKIP
+# conf 3
+- tags:
+    - skip_dev
+  apply_to_modules:
+    - test_skip
   section: syscheck
   elements:
   - disabled:
@@ -26,37 +41,21 @@
   - directories:
       value: "/dev"
       attributes:
-      - FIM_MODE
+        - FIM_MODE
   - skip_dev:
       value: SKIP
-## conf 3
-#- tags:
-#  - skip_proc
-#  apply_to_modules:
-#  - test_skip
-#  section: syscheck
-#  elements:
-#  - disabled:
-#      value: 'no'
-#  - directories:
-#      value: "/proc"
-#      attributes:
-#      - FIM_MODE
-#  - skip_proc:
-#      value: SKIP
-## conf 4
-#- tags:
-#  - skip_sys
-#  apply_to_modules:
-#  - test_skip
-#  section: syscheck
-#  elements:
-#  - disabled:
-#      value: 'no'
-#  - directories:
-#      value: "/sys"
-#      attributes:
-#      - FIM_MODE
-#  - skip_sys:
-#      value: SKIP
-
+# conf 4
+- tags:
+    - skip_nfs
+  apply_to_modules:
+    - test_skip
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/nfs-mount-point"
+      attributes:
+        - FIM_MODE
+  - skip_nfs:
+      value: SKIP

--- a/test_wazuh/test_fim/test_skip/test_skip.py
+++ b/test_wazuh/test_fim/test_skip/test_skip.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing.fim import (LOG_FILE_PATH,
+                               callback_detect_integrity_event, regular_file_cud)
+from wazuh_testing.tools import (FileMonitor, check_apply_test,
+                                 load_wazuh_configurations)
+
+# variables
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+test_directories = [os.path.join('/', 'testdir1')]
+testdir1 = test_directories
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# configurations
+
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=[{'FIM_MODE': '', 'SKIP': 'yes'},
+                                                   {'FIM_MODE': '', 'SKIP': 'no'},
+                                                   {'FIM_MODE': {'realtime': 'yes'}, 'SKIP': 'yes'},
+                                                   {'FIM_MODE': {'realtime': 'yes'}, 'SKIP': 'no'},
+                                                   {'FIM_MODE': {'whodata': 'yes'}, 'SKIP': 'yes'},
+                                                   {'FIM_MODE': {'whodata': 'yes'}, 'SKIP': 'no'}
+                                                   ],
+                                           metadata=[{'fim_mode': 'scheduled', 'skip': 'yes'},
+                                                     {'fim_mode': 'scheduled', 'skip': 'no'},
+                                                     {'fim_mode': 'realtime', 'skip': 'yes'},
+                                                     {'fim_mode': 'realtime', 'skip': 'no'},
+                                                     {'fim_mode': 'whodata', 'skip': 'yes'},
+                                                     {'fim_mode': 'whodata', 'skip': 'no'}
+                                                     ]
+                                           )
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('directory,  tags_to_apply', [
+    # (os.path.join('/', 'nfs'), {'skip_nfs'}),
+    (os.path.join('/', 'dev'), {'skip_dev'})
+    # (os.path.join('/', 'proc'), {'skip_proc'}),
+    # (os.path.join('/', 'sys'), {'skip_sys'})
+])
+def test_regular_file_changes(directory, tags_to_apply,
+                              get_configuration, configure_environment,
+                              restart_syscheckd, wait_for_initial_scan):
+    """ Checks if syscheckd detects regular file changes (add, modify, delete)
+
+    :param folder: Directory where the files will be created
+    :param checkers: Dict of syscheck checkers (check_all)
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    if get_configuration['metadata']['skip'] == 'yes':
+        trigger = False
+    else:
+        trigger = True
+    regular_file_cud(directory, wazuh_log_monitor,
+                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                     min_timeout=3, triggers_event=trigger)

--- a/test_wazuh/test_fim/test_skip/test_skip.py
+++ b/test_wazuh/test_fim/test_skip/test_skip.py
@@ -5,40 +5,40 @@
 import os
 import shutil
 import subprocess
+from datetime import timedelta
 
 import pytest
 
 from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_integrity_event,
-                               regular_file_cud)
+                               regular_file_cud, detect_initial_scan, callback_detect_event)
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
-                                 load_wazuh_configurations)
+                                 load_wazuh_configurations, TimeMachine,
+                                 set_section_wazuh_conf, restart_wazuh_with_new_conf)
 
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
-test_directories = [os.path.join('/', 'testdir1')]
+testdir = os.path.join('/', 'testdir1')
+test_directories = [testdir]
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
+
 # configurations
 
-configurations = load_wazuh_configurations(configurations_path, __name__,
-                                           params=[{'FIM_MODE': '', 'SKIP': 'yes'},
-                                                   {'FIM_MODE': '', 'SKIP': 'no'},
-                                                   {'FIM_MODE': {'realtime': 'yes'}, 'SKIP': 'yes'},
-                                                   {'FIM_MODE': {'realtime': 'yes'}, 'SKIP': 'no'},
-                                                   {'FIM_MODE': {'whodata': 'yes'}, 'SKIP': 'yes'},
-                                                   {'FIM_MODE': {'whodata': 'yes'}, 'SKIP': 'no'}
-                                                   ],
-                                           metadata=[{'fim_mode': 'scheduled', 'skip': 'yes'},
-                                                     {'fim_mode': 'scheduled', 'skip': 'no'},
-                                                     {'fim_mode': 'realtime', 'skip': 'yes'},
-                                                     {'fim_mode': 'realtime', 'skip': 'no'},
-                                                     {'fim_mode': 'whodata', 'skip': 'yes'},
-                                                     {'fim_mode': 'whodata', 'skip': 'no'}
-                                                     ]
-                                           )
+def change_conf(directory):
+    return load_wazuh_configurations(configurations_path, __name__,
+                                     params=[{'SKIP': 'yes', 'DIRECTORY': directory},
+                                             {'SKIP': 'no', 'DIRECTORY': directory},
+                                             ],
+                                     metadata=[{'skip': 'yes', 'directory': directory},
+                                               {'skip': 'no', 'directory': directory},
+                                               ]
+                                     )
+
+
+configurations = change_conf(testdir)
 
 
 # fixtures
@@ -51,20 +51,20 @@ def get_configuration(request):
 
 @pytest.fixture(scope='session')
 def configure_nfs():
-    # create and configure nfs mount point
-    subprocess.call(['./data/configure_nfs.sh'])
+    """ Call NFS scripts to create and configure a NFS mount point """
+    path = os.path.dirname(os.path.abspath(__file__))
+    subprocess.call([f'{path}/data/configure_nfs.sh'])
     yield
     # remove nfs
-    subprocess.call(['./data/remove_nfs.sh'])
+    subprocess.call([f'{path}/data/remove_nfs.sh'])
     shutil.rmtree(os.path.join('/', 'media', 'nfs-folder'), ignore_errors=True)
 
 
 # tests
 
-
 @pytest.mark.parametrize('directory,  tags_to_apply', [
     (os.path.join('/', 'proc'), {'skip_proc'}),
-    (os.path.join('/', 'sys'), {'skip_sys'}),
+    (os.path.join('/', 'sys', 'video'), {'skip_sys'}),
     (os.path.join('/', 'dev'), {'skip_dev'}),
     (os.path.join('/', 'nfs-mount-point'), {'skip_nfs'})
 ])
@@ -73,27 +73,65 @@ def test_skip(directory, tags_to_apply,
               restart_syscheckd, wait_for_initial_scan):
     """ Check if syscheck is skipping the directory based on its skip configuration
 
-    :param directory: Directory that will be monitored
+    :param directory: Directory that will be monitored. We only use it on skip_dev and skip_nfs
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    timeout = 3
-    if tags_to_apply == {'skip_proc'}:
-        timeout = 100
 
     if get_configuration['metadata']['skip'] == 'yes':
         trigger = False
     else:
         trigger = True
 
-    if tags_to_apply == {'skip_proc'} or tags_to_apply == {'skip_sys'}:
+    if tags_to_apply == {'skip_proc'}:
         if trigger:
-            event = wazuh_log_monitor.start(timeout=8, callback=callback_detect_integrity_event).result()
-            assert any(path in event['data'].get('path') for path in ['/proc', '/sys'])
+            proc = subprocess.Popen(["python3", f"{os.path.dirname(os.path.abspath(__file__))}/data/proc.py"])
+            # Change configuration, monitoring the PID path in /proc
+            new_conf = change_conf(f'/proc/{proc.pid}')
+            # new_conf[1] -> 'skip': 'no'
+            new_ossec_conf = set_section_wazuh_conf(new_conf[1].get('section'),
+                                                    new_conf[1].get('elements'))
+            restart_wazuh_with_new_conf(new_ossec_conf)
+            detect_initial_scan(wazuh_log_monitor)
+
+            # Do not expect any 'Sending event'
+            with pytest.raises(TimeoutError):
+                wazuh_log_monitor.start(timeout=5, callback=callback_detect_event)
+
+            TimeMachine.travel_to_future(timedelta(hours=13))
+
+            found_event = False
+            while not found_event:
+                event = wazuh_log_monitor.start(timeout=5, callback=callback_detect_event).result()
+                if f'/proc/{proc.pid}/' in event['data'].get('path'):
+                    found_event = True
+
+            # Kill the process
+            subprocess.Popen(["kill", "-9", str(proc.pid)])
+
         else:
             with pytest.raises(TimeoutError):
-                wazuh_log_monitor.start(timeout=5, callback=callback_detect_integrity_event)
+                wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_event)
 
+    elif tags_to_apply == {'skip_sys'}:
+        if trigger:
+            # If /sys/module/video does not exist, use 'modprobe video'
+            assert os.path.exists('/sys/module/video'), f'/sys/module/video does not exist'
+            # Do not expect any 'Sending event'
+            with pytest.raises(TimeoutError):
+                wazuh_log_monitor.start(timeout=5, callback=callback_detect_event)
+            # Remove module video and travel to future to check alerts
+            subprocess.Popen(["modprobe", "-r", "video"])
+            TimeMachine.travel_to_future(timedelta(hours=13))
+            # Detect at least one 'delete' event in /sys/module/video path
+            event = wazuh_log_monitor.start(timeout=5, callback=callback_detect_event).result()
+            assert event['data'].get('type') == 'deleted' and '/sys/module/video' in event['data'].get('path'), \
+                f'Sys event not detected'
+            # Restore module video
+            subprocess.Popen(["modprobe", "video"])
+        else:
+            with pytest.raises(TimeoutError):
+                wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_event)
     else:
         regular_file_cud(directory, wazuh_log_monitor,
-                         time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                         min_timeout=timeout, triggers_event=trigger)
+                         time_travel=True,
+                         min_timeout=3, triggers_event=trigger)

--- a/test_wazuh/test_fim/test_skip/test_skip.py
+++ b/test_wazuh/test_fim/test_skip/test_skip.py
@@ -11,8 +11,7 @@ import pytest
 from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_integrity_event,
                                regular_file_cud)
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
-                                 load_wazuh_configurations, get_wazuh_conf, set_section_wazuh_conf, write_wazuh_conf,
-                                 restart_wazuh_service)
+                                 load_wazuh_configurations)
 
 # variables
 
@@ -50,52 +49,12 @@ def get_configuration(request):
     return request.param
 
 
-# @pytest.fixture(scope='module', params=configurations)
-# def configure_environment(get_configuration, request):
-#     """Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."""
-#     print(f"Setting a custom environment: {str(get_configuration)}")
-#
-#     # save current configuration
-#     backup_config = get_wazuh_conf()
-#     # configuration for testing
-#     test_config = set_section_wazuh_conf(get_configuration.get('section'),
-#                                          get_configuration.get('elements'))
-#
-#     # create test directories
-#     test_directories = getattr(request.module, 'test_directories')
-#     for test_dir in test_directories:
-#         os.makedirs(test_dir, exist_ok=True)
-#
-#     # create nfs mount point
-#     subprocess.call(['./data/create_nfs.sh'])
-#
-#     # set new configuration
-#     write_wazuh_conf(test_config)
-#
-#     yield
-#
-#     # remove created folders (parents)
-#     for test_dir in test_directories:
-#         shutil.rmtree(test_dir, ignore_errors=True)
-#
-#     # remove nfs created folder
-#     subprocess.call(['./data/remove_nfs.sh'])
-#
-#     # restore previous configuration
-#     write_wazuh_conf(backup_config)
-#
-#     if hasattr(request.module, 'force_restart_after_restoring'):
-#         if getattr(request.module, 'force_restart_after_restoring'):
-#             restart_wazuh_service()
-
-
 @pytest.fixture(scope='session')
 def configure_nfs():
-    # create nfs mount point
+    # create and configure nfs mount point
     subprocess.call(['./data/configure_nfs.sh'])
-    subprocess.call(['./data/create_nfs.sh'])
     yield
-    # remove nfs created folder
+    # remove nfs
     subprocess.call(['./data/remove_nfs.sh'])
     shutil.rmtree(os.path.join('/', 'media', 'nfs-folder'), ignore_errors=True)
 
@@ -112,7 +71,10 @@ def configure_nfs():
 def test_skip(directory, tags_to_apply,
               get_configuration, configure_environment, configure_nfs,
               restart_syscheckd, wait_for_initial_scan):
-    """ Check if syscheck is skipping the directory based on its skip configuration """
+    """ Check if syscheck is skipping the directory based on its skip configuration
+
+    :param directory: Directory that will be monitored
+    """
     check_apply_test(tags_to_apply, get_configuration['tags'])
     timeout = 3
     if tags_to_apply == {'skip_proc'}:
@@ -123,10 +85,10 @@ def test_skip(directory, tags_to_apply,
     else:
         trigger = True
 
-    if tags_to_apply == {'skip_proc'} or {'skip_sys'}:
+    if tags_to_apply == {'skip_proc'} or tags_to_apply == {'skip_sys'}:
         if trigger:
             event = wazuh_log_monitor.start(timeout=8, callback=callback_detect_integrity_event).result()
-            assert '/proc' or '/sys' in event['data'].get('path'), f'Path not found in event'
+            assert any(path in event['data'].get('path') for path in ['/proc', '/sys'])
         else:
             with pytest.raises(TimeoutError):
                 wazuh_log_monitor.start(timeout=5, callback=callback_detect_integrity_event)


### PR DESCRIPTION
This closes #172 .

This PR adds the requested tests for every `skip_*` option under scheduled, realtime and whodata monitoring.

* The `skip_nfs` option specifies if syscheck should scan network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
* The `skip_dev` option specifies if should scan files inside a devnf file system (/dev).
* The `skip_proc` option specifies if should scan files inside a procfs file system (/proc).
* The `skip_sys` option specifies if should scan files inside a sysfs file system (/sys).

These tests needed a new callback, called `callback_detect_integrity_event`. This callback detects when a file integrity event appears in the log. Only `fim.py` was modified.

## Tests example
```
================================ test session starts =================================
platform linux -- Python 3.6.8, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 96 items                                                                   

test_skip.py .ssss.ssss.ssss..ssss.ssss.ssss..ssss.ssss.ssss..ssss.ssss.ssss.. [ 67%]
ssss.ssss.ssss..ssss.ssss.ssss.                                                [100%]

=============== 24 passed, 72 skipped in 562203.07s (6 days, 12:10:03) ===============
```