### PR TITLE
Add FIM integration tests for Hard Links with 'check_inode' option

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -246,13 +246,24 @@ def _create_regular(path, name, content):
 
 
 def delete_file(path, name):
-    """ Deletes regular file """
+    """ Deletes regular file 
+    
+    :param path String Path to the file to be deleted
+    :param name String Name of the file to be deleted
+    """
     regular_path = os.path.join(path, name)
     if os.path.exists(regular_path):
         os.remove(regular_path)
 
 
 def modify_file_content(path, name, new_content=None, is_binary=False):
+    """Modifies the content of a file 
+    
+    :param path String Path to the file to be modified
+    :param name String Name of the file to be modified
+    :param new_content String New content to append to the file. Previous content will remain
+    :param is_binary boolean True if the file's content is in binary format, False otherwise
+    """
     path_to_file = os.path.join(path, name)
     content = "1234567890qwertyu" if new_content is None else new_content
     with open(path_to_file, 'ab' if is_binary else 'a') as f:
@@ -260,6 +271,11 @@ def modify_file_content(path, name, new_content=None, is_binary=False):
 
 
 def modify_file_mtime(path, name):
+    """Change the modification time of a file
+    
+    :param path String Path to the file to be modified
+    :param name String Name of the file to be modified
+    """
     path_to_file = os.path.join(path, name)
     stat = os.stat(path_to_file)
     access_time = stat[ST_ATIME]
@@ -269,21 +285,41 @@ def modify_file_mtime(path, name):
 
 
 def modify_file_owner(path, name):
+    """Change the owner of a file. The new owner will be '1'
+    
+    :param path String Path to the file to be modified
+    :param name String Name of the file to be modified
+    """
     path_to_file = os.path.join(path, name)
     os.chown(path_to_file, 1, -1)
 
 
 def modify_file_group(path, name):
+    """Change the group of a file. The new group will be '1'
+    
+    :param path String Path to the file to be modified
+    :param name String Name of the file to be modified
+    """
     path_to_file = os.path.join(path, name)
     os.chown(path_to_file, -1, 1)
 
 
 def modify_file_permission(path, name):
+    """Change the permision of a file. The new one will be '666'
+    
+    :param path String Path to the file to be modified
+    :param name String Name of the file to be modified
+    """
     path_to_file = os.path.join(path, name)
     os.chmod(path_to_file, 0o666)
 
 
 def modify_file_inode(path, name):
+    """Change the inode of a file.
+    
+    :param path String Path to the file to be modified
+    :param name String Name of the file to be modified
+    """
     path_to_file = os.path.join(path, name)
     shutil.copy2(path_to_file, os.path.join(path, "inodetmp"))
     os.replace(os.path.join(path, "inodetmp"), path_to_file)
@@ -298,8 +334,6 @@ def modify_file(path, name, new_content=None, is_binary=False):
     :type name: String
     :param is_binary: True if the file is binary. False otherwise.
     :type is_binary: boolean
-    :param options: Dict with all the checkers 
-    :type options: Dict
     :return: None
     """
     modify_file_content(path, name, new_content, is_binary)
@@ -437,6 +471,10 @@ def callback_configuration_error(line):
 
 
 def check_time_travel(time_travel):
+    """ Changes date and time of the system
+
+    :param time_travel boolean True if we need to update time, False otherwise
+    """
     if time_travel:
         TimeMachine.travel_to_future(timedelta(hours=13))
 
@@ -449,6 +487,8 @@ def callback_configuration_warning(line):
 
 
 class EventChecker:
+    """ Utility to allow fetch events and validate them
+    """
     def __init__(self, log_monitor, folder, file_list=['testfile0'], options=None, custom_validator=None):
         self.log_monitor = log_monitor
         self.folder = folder
@@ -459,11 +499,22 @@ class EventChecker:
         
 
     def fetch_and_check(self, event_type, min_timeout=1, triggers_event=True):
+        """Calls both 'fetch_events' and 'check_events'
+
+        :param event_type String Expected type of the raised event. It can be 'added', 'modified' or 'deleted'.
+        :param min_timeout int Seconds to wait until an event is raised when trying to fetch.
+        :param triggers_event boolean True if the event should be raised, False otherwise.
+        """
         self.fetch_events(min_timeout, triggers_event)
         self.check_events(event_type)
 
 
     def fetch_events(self, min_timeout=1, triggers_event=True):
+        """Try to fetch events on a given log monitor. Will return a list with the events detected.
+
+        :param min_timeout int Seconds to wait until an event is raised when trying to fetch.
+        :param triggers_event boolean True if the event should be raised, False otherwise.
+        """
         try:
             result = self.log_monitor.start(timeout=max(len(self.file_list) * 0.01, min_timeout),
                                        callback=callback_detect_event,
@@ -476,8 +527,16 @@ class EventChecker:
 
 
     def check_events(self, event_type):
+        """Check and validate all events in the 'events' list
 
+        :param event_type String Expected type of the raised event. It can be 'added', 'modified' or 'deleted'.
+        """
         def validate_checkers_per_event(events, options):
+            """ Checks if each event is properly formatted according to some checks
+
+            :param events List The event list to be checked
+            :param options Set A Set of xml CHECK_* options. Default {CHECK_ALL}.
+            """
             if options is not None:
                 for ev in events:
                     validate_event(ev, options)
@@ -543,7 +602,7 @@ class EventChecker:
 
 
 class CustomValidator:
-    """
+    """ Enables using user-defined validators over the events when validating them with EventChecker
     """
 
     def __init__(self, validators_after_create=None, validators_after_update=None, 
@@ -555,18 +614,34 @@ class CustomValidator:
 
 
     def validate_after_create(self, events):
+        """Custom validators to be applied by default when the event_type is 'added'
+
+        :param events List List of event to be validated.
+        """
         for event in events:
             self.validators_after_create(event)
 
     def validate_after_update(self, events):
+        """Custom validators to be applied by default when the event_type is 'modified'
+
+        :param events List List of event to be validated.
+        """
         for event in events:
             self.validators_after_update(event)
 
     def validate_after_delete(self, events):
+        """Custom validators to be applied by default when the event_type is 'deleted'
+
+        :param events List List of event to be validated.
+        """
         for event in events:
             self.validators_after_delete(event)
 
     def validate_after_cud(self, events):
+        """Custom validators to be applied always by default
+
+        :param events List List of event to be validated.
+        """
         for event in events:
             self.validators_after_cud(event)
 

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -27,6 +27,7 @@ LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
 
 FIFO = 'fifo'
 SYSLINK = 'sys_link'
+HARDLINK = 'hard_link'
 SOCKET = 'socket'
 REGULAR = 'regular'
 
@@ -169,7 +170,7 @@ def _create_fifo(path, name, content):
         raise
 
 
-def _create_sys_link(path, name, content):
+def _create_sys_link(path, name, target):
     """ Creates a SysLink file.
 
     :param path: Path where the file will be created
@@ -182,7 +183,25 @@ def _create_sys_link(path, name, content):
     """
     syslink_path = os.path.join(path, name)
     try:
-        os.symlink(syslink_path, syslink_path)
+        os.symlink(syslink_path, target)
+    except OSError:
+        raise
+
+
+def _create_hard_link(path, name, target):
+    """ Creates a SysLink file.
+
+    :param path: Path where the file will be created
+    :type path: String
+    :param name: File name
+    :type name: String
+    :param content: Content of the created file
+    :type content: String or binary
+    :return: None
+    """
+    link_path = os.path.join(path, name)
+    try:
+        os.link(link_path, target)
     except OSError:
         raise
 
@@ -233,7 +252,44 @@ def delete_file(path, name):
         os.remove(regular_path)
 
 
-def modify_file(path, name, is_binary=False):
+def modify_file_content(path, name, new_content=None, is_binary=False):
+    path_to_file = os.path.join(path, name)
+    content = "1234567890qwertyu" if new_content is None else new_content
+    with open(path_to_file, 'ab' if is_binary else 'a') as f:
+        f.write(content.encode() if is_binary else content)
+
+
+def modify_file_mtime(path, name):
+    path_to_file = os.path.join(path, name)
+    stat = os.stat(path_to_file)
+    access_time = stat[ST_ATIME]
+    modification_time = stat[ST_MTIME]
+    modification_time = modification_time + 120
+    os.utime(path_to_file, (access_time, modification_time))
+
+
+def modify_file_owner(path, name):
+    path_to_file = os.path.join(path, name)
+    os.chown(path_to_file, 1, -1)
+
+
+def modify_file_group(path, name):
+    path_to_file = os.path.join(path, name)
+    os.chown(path_to_file, -1, 1)
+
+
+def modify_file_permission(path, name):
+    path_to_file = os.path.join(path, name)
+    os.chmod(path_to_file, 0o666)
+
+
+def modify_file_inode(path, name):
+    path_to_file = os.path.join(path, name)
+    shutil.copy2(path_to_file, os.path.join(path, "inodetmp"))
+    os.replace(os.path.join(path, "inodetmp"), path_to_file)
+
+
+def modify_file(path, name, new_content=None, is_binary=False):
     """ Modify a Regular file.
 
     :param path: Path where the file will be created
@@ -246,39 +302,12 @@ def modify_file(path, name, is_binary=False):
     :type options: Dict
     :return: None
     """
-    def modify_file_content():
-        content = "1234567890qwertyuiopasdfghjklzxcvbnm"
-        with open(path_to_file, 'ab' if is_binary else 'a') as f:
-            f.write(content.encode() if is_binary else content)
-
-    def modify_file_mtime():
-        stat = os.stat(path_to_file)
-        access_time = stat[ST_ATIME]
-        modification_time = stat[ST_MTIME]
-        modification_time = modification_time + 120
-        os.utime(path_to_file, (access_time, modification_time))
-
-    def modify_file_owner():
-        os.chown(path_to_file, 1, -1)
-
-    def modify_file_group():
-        os.chown(path_to_file, -1, 1)
-
-    def modify_file_permission():
-        os.chmod(path_to_file, 0o666)
-
-    def modify_file_inode():
-        shutil.copy2(path_to_file, os.path.join(path, "inodetmp"))
-        os.replace(os.path.join(path, "inodetmp"), path_to_file)
-
-    path_to_file = os.path.join(path, name)
-
-    modify_file_content()
-    modify_file_mtime()
-    modify_file_owner()
-    modify_file_group()
-    modify_file_permission()
-    modify_file_inode()
+    modify_file_content(path, name, new_content, is_binary)
+    modify_file_mtime(path, name)
+    modify_file_owner(path, name)
+    modify_file_group(path, name)
+    modify_file_permission(path, name)
+    modify_file_inode(path, name)
 
 
 def change_internal_options(opt_path, pattern, value):
@@ -401,6 +430,136 @@ def callback_configuration_error(line):
     return None
 
 
+def check_time_travel(time_travel):
+    if time_travel:
+        TimeMachine.travel_to_future(timedelta(hours=13))
+
+
+class EventChecker:
+    def __init__(self, log_monitor, folder, file_list=['testfile0'], options=None, custom_validator=None):
+        self.log_monitor = log_monitor
+        self.folder = folder
+        self.file_list = file_list
+        self.custom_validator = custom_validator
+        self.options = options
+        self.events = None
+        
+
+    def fetch_and_check(self, event_type, min_timeout=1, triggers_event=True):
+        self.fetch_events(min_timeout, triggers_event)
+        self.check_events(event_type)
+
+
+    def fetch_events(self, min_timeout=1, triggers_event=True):
+        try:
+            result = self.log_monitor.start(timeout=max(len(self.file_list) * 0.01, min_timeout),
+                                       callback=callback_detect_event,
+                                       accum_results=len(self.file_list)
+                                       ).result()
+            return result if isinstance(result, list) else [result]
+        except TimeoutError:
+            if triggers_event:
+                raise
+
+
+    def check_events(self, event_type):
+
+        def validate_checkers_per_event(events, options):
+            if options is not None:
+                for ev in events:
+                    validate_event(ev, options)
+
+        def validate_event(event, checks=None):
+            """ Checks if event is properly formatted according to some checks.
+
+            :param event: dict representing an event generated by syscheckd
+            :param checks: set of xml CHECK_* options. Default {CHECK_ALL}.
+
+            :return: None
+            """
+            checks = {CHECK_ALL} if checks is None else checks
+            with open(os.path.join(_data_path, 'syscheck_event.json'), 'r') as f:
+                schema = json.load(f)
+            validate(schema=schema, instance=event)
+
+            # Check attributes
+            attributes = event['data']['attributes'].keys() - {'type', 'checksum'}
+            required_attributes = get_required_attributes(checks)
+            assert (attributes ^ required_attributes == set()), f'attributes and required_attributes are not the same'
+
+            # Check audit
+            if event['data']['mode'] == 'whodata':
+                assert ('audit' in event['data']), f'audit no detected in event'
+                assert (event['data']['audit'].keys() ^ _REQUIRED_AUDIT == set()), \
+                    f'audit keys and required_audit are no the same'
+        
+        def get_required_attributes(check_attributes, result=None):
+            result = set() if result is None else result
+            for check in check_attributes:
+                mapped = REQUIRED_ATTRIBUTES[check]
+                if isinstance(mapped, str):
+                    result |= {mapped}
+                elif isinstance(mapped, list):
+                    result |= set(mapped)
+                elif isinstance(mapped, set):
+                    result |= get_required_attributes(mapped, result=result)
+            return result
+            
+        def check_events_type(events, ev_type, file_list=['testfile0']):
+            event_types = Counter(jq(".[].data.type").transform(events, multiple_output=True))
+            assert (event_types[ev_type] == len(file_list)), f'Non expected number of events'
+
+        def check_files_in_event(events, folder, file_list=['testfile0']):
+            file_paths = jq(".[].data.path").transform(events, multiple_output=True)
+            for file_name in file_list:
+                assert (os.path.join(folder, file_name) in file_paths), f'{file_name} does not exist in {file_paths}'
+
+        if self.events is not None:
+            validate_checkers_per_event(self.events, self.options)
+            check_events_type(self.events, event_type, self.file_list)
+            check_files_in_event(self.events, self.folder, self.file_list)
+
+            if self.custom_validator is not None:
+                self.custom_validator.validate_after_cud(self.events)
+                if event_type == "added":
+                    self.custom_validator.validate_after_create(self.events)
+                elif event_type == "modified":
+                    self.custom_validator.validate_after_update(self.events)
+                elif event_type == "deleted":
+                    self.custom_validator.validate_after_delete(self.events)
+
+
+class CustomValidator:
+    """
+    """
+
+    def __init__(self, validators_after_create=None, validators_after_update=None, 
+                 validators_after_delete=None, validators_after_cud=None):
+        self.validators_after_create = validators_after_create
+        self.validators_after_update = validators_after_update
+        self.validators_after_delete = validators_after_delete
+        self.validators_after_cud = validators_after_cud
+
+
+    def validate_after_create(self, events):
+        for event in events:
+            self.validators_after_create(event)
+
+    def validate_after_update(self, events):
+        for event in events:
+            self.validators_after_update(event)
+
+    def validate_after_delete(self, events):
+        for event in events:
+            self.validators_after_delete(event)
+
+    def validate_after_cud(self, events):
+        for event in events:
+            self.validators_after_cud(event)
+
+
+
+
 def regular_file_cud(folder, log_monitor, file_list=['testfile0'], time_travel=False, min_timeout=1, options=None,
                      triggers_event=True, validators_after_create=None, validators_after_update=None,
                      validators_after_delete=None, validators_after_cud=None):
@@ -436,79 +595,40 @@ def regular_file_cud(folder, log_monitor, file_list=['testfile0'], time_travel=F
     :type validators_after_cud: list
     :return: None
     """
-
-    def check_time_travel():
-        if time_travel:
-            TimeMachine.travel_to_future(timedelta(hours=13))
-
-    def fetch_events():
-        try:
-            result = log_monitor.start(timeout=max(len(file_list) * 0.01, min_timeout),
-                                       callback=callback_detect_event,
-                                       accum_results=len(file_list)
-                                       ).result()
-            return result if isinstance(result, list) else [result]
-        except TimeoutError:
-            if triggers_event:
-                raise
-
-    def validate_checkers_per_event():
-        if options is not None:
-            for ev in events:
-                validate_event(ev, options)
-
-    def check_events_type(ev_type):
-        event_types = Counter(jq(".[].data.type").transform(events, multiple_output=True))
-        assert (event_types[ev_type] == len(file_list)), f'Non expected number of events'
-
-    def check_files_in_event():
-        file_paths = jq(".[].data.path").transform(events, multiple_output=True)
-        for file_name in file_list:
-            assert (os.path.join(folder, file_name) in file_paths), f'{file_name} does not exist in {file_paths}'
-
-    def check_events(event_type, validate_after):
-        if events is not None:
-            validate_checkers_per_event()
-            check_events_type(event_type)
-            check_files_in_event()
-            run_custom_validators(validators_after_cud)
-            run_custom_validators(validate_after)
-
-    def run_custom_validators(validators):
-        if validators is not None:
-            for validator in validators:
-                for event in events:
-                    validator(event)
-
     # Transform file list
     if not isinstance(file_list, list) and not isinstance(file_list, dict):
         raise ValueError('Value error. It can only be list or dict')
     elif isinstance(file_list, list):
         file_list = {i: '' for i in file_list}
 
+
+    custom_validator = CustomValidator(validators_after_create, validators_after_update, 
+                                       validators_after_delete, validators_after_cud)
+    event_checker = EventChecker(log_monitor, folder, file_list, options, custom_validator)
+
+
     # Create text files
     for name, content in file_list.items():
         create_file(REGULAR, folder, name, content)
 
-    check_time_travel()
-    events = fetch_events()
-    check_events('added', validators_after_create)
+    check_time_travel(time_travel)
+    event_checker.fetch_and_check('added', min_timeout, triggers_event)
+    
 
     # Modify previous text files
     for name, content in file_list.items():
         modify_file(folder, name, is_binary=isinstance(content, bytes))
 
-    check_time_travel()
-    events = fetch_events()
-    check_events('modified', validators_after_update)
+    check_time_travel(time_travel)
+    event_checker.fetch_and_check('modified', min_timeout, triggers_event)
+
 
     # Delete previous text files
     for name in file_list:
         delete_file(folder, name)
 
-    check_time_travel()
-    events = fetch_events()
-    check_events('deleted', validators_after_delete)
+    check_time_travel(time_travel)
+    event_checker.fetch_and_check('deleted', min_timeout, triggers_event)
 
 
 def detect_initial_scan(file_monitor):

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -233,7 +233,7 @@ def delete_file(path, name):
         os.remove(regular_path)
 
 
-def modify_file(path, name, is_binary=False, options=None):
+def modify_file(path, name, is_binary=False):
     """ Modify a Regular file.
 
     :param path: Path where the file will be created
@@ -248,75 +248,37 @@ def modify_file(path, name, is_binary=False, options=None):
     """
     def modify_file_content():
         content = "1234567890qwertyuiopasdfghjklzxcvbnm"
-        with open(regular_path, 'ab' if is_binary else 'a') as f:
+        with open(path_to_file, 'ab' if is_binary else 'a') as f:
             f.write(content.encode() if is_binary else content)
 
     def modify_file_mtime():
-        stat = os.stat(regular_path)
+        stat = os.stat(path_to_file)
         access_time = stat[ST_ATIME]
         modification_time = stat[ST_MTIME]
         modification_time = modification_time + 120
-        os.utime(regular_path, (access_time, modification_time))
+        os.utime(path_to_file, (access_time, modification_time))
 
     def modify_file_owner():
-        os.chown(regular_path, 1, -1)
+        os.chown(path_to_file, 1, -1)
 
     def modify_file_group():
-        os.chown(regular_path, -1, 1)
+        os.chown(path_to_file, -1, 1)
 
     def modify_file_permission():
-        os.chmod(regular_path, 0o666)
+        os.chmod(path_to_file, 0o666)
 
     def modify_file_inode():
-        shutil.copyfile(regular_path, os.path.join(path, "inodetmp"))
-        os.replace(os.path.join(path, "inodetmp"), regular_path)
+        shutil.copy2(path_to_file, os.path.join(path, "inodetmp"))
+        os.replace(os.path.join(path, "inodetmp"), path_to_file)
 
-    regular_path = os.path.join(path, name)
+    path_to_file = os.path.join(path, name)
 
-    if options is None:
-        modify_file_content()
-    else:
-        for modification_type in options:
-            check = REQUIRED_ATTRIBUTES[modification_type]
-            if isinstance(check, set):
-                modify_file(path, name, options=check)
-
-            elif isinstance(check, list):
-                if check == REQUIRED_ATTRIBUTES[CHECK_OWNER]:
-                    modify_file_owner()
-                elif check == REQUIRED_ATTRIBUTES[CHECK_GROUP]:
-                    modify_file_group()
-
-            else:
-                if check == REQUIRED_ATTRIBUTES[CHECK_ALL] or check == CHECK_ALL:
-                    modify_file_content()
-                    modify_file_mtime()
-                    modify_file_owner()
-                    modify_file_group()
-                    modify_file_permission()
-                    modify_file_inode()
-
-                elif (check == REQUIRED_ATTRIBUTES[CHECK_SUM] or check == CHECK_SUM or
-                      check == REQUIRED_ATTRIBUTES[CHECK_SHA1SUM] or check == CHECK_SHA1SUM or
-                      check == REQUIRED_ATTRIBUTES[CHECK_MD5SUM] or check == CHECK_MD5SUM or
-                      check == REQUIRED_ATTRIBUTES[CHECK_SHA256SUM] or check == CHECK_SHA256SUM or
-                      check == REQUIRED_ATTRIBUTES[CHECK_SIZE] or check == CHECK_SIZE):
-                    modify_file_content()
-
-                elif check == REQUIRED_ATTRIBUTES[CHECK_MTIME] or check == CHECK_MTIME:
-                    modify_file_mtime()
-
-                elif check == REQUIRED_ATTRIBUTES[CHECK_OWNER] or check == CHECK_OWNER:
-                    modify_file_owner()
-
-                elif check == REQUIRED_ATTRIBUTES[CHECK_GROUP] or check == CHECK_GROUP:
-                    modify_file_group()
-
-                elif check == REQUIRED_ATTRIBUTES[CHECK_PERM] or check == CHECK_PERM:
-                    modify_file_permission()
-
-                elif check == REQUIRED_ATTRIBUTES[CHECK_INODE] or check == CHECK_INODE:
-                    modify_file_inode()
+    modify_file_content()
+    modify_file_mtime()
+    modify_file_owner()
+    modify_file_group()
+    modify_file_permission()
+    modify_file_inode()
 
 
 def change_internal_options(opt_path, pattern, value):
@@ -534,7 +496,7 @@ def regular_file_cud(folder, log_monitor, file_list=['testfile0'], time_travel=F
 
     # Modify previous text files
     for name, content in file_list.items():
-        modify_file(folder, name, is_binary=isinstance(content, bytes), options=options)
+        modify_file(folder, name, is_binary=isinstance(content, bytes))
 
     check_time_travel()
     events = fetch_events()

--- a/test_wazuh/test_fim/test_checks/data/wazuh_hard_link.yaml
+++ b/test_wazuh/test_fim/test_checks/data/wazuh_hard_link.yaml
@@ -1,0 +1,23 @@
+---
+- apply_to_modules:
+  - test_hard_link
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/testdir1"
+      attributes:
+      - FIM_MODE
+      - check_inode: "yes"
+- apply_to_modules:
+  - test_hard_link
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/testdir1"
+      attributes:
+      - FIM_MODE
+      - check_inode: "no"

--- a/test_wazuh/test_fim/test_checks/data/wazuh_hard_link.yaml
+++ b/test_wazuh/test_fim/test_checks/data/wazuh_hard_link.yaml
@@ -9,15 +9,4 @@
       value: "/testdir1"
       attributes:
       - FIM_MODE
-      - check_inode: "yes"
-- apply_to_modules:
-  - test_hard_link
-  section: syscheck
-  elements:
-  - disabled:
-      value: 'no'
-  - directories:
-      value: "/testdir1"
-      attributes:
-      - FIM_MODE
-      - check_inode: "no"
+      - INODE

--- a/test_wazuh/test_fim/test_checks/test_hard_link.py
+++ b/test_wazuh/test_fim/test_checks/test_hard_link.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+
+from wazuh_testing.fim import (LOG_FILE_PATH, EventChecker, check_time_travel, create_file, modify_file_content, delete_file, REGULAR, HARDLINK)
+from wazuh_testing.tools import (FileMonitor, check_apply_test,
+                                 load_wazuh_configurations)
+
+
+# variables
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_hard_link.yaml')
+testdir1 = os.path.join('/', 'testdir1')
+test_directories = [testdir1]
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+
+# configurations
+
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=[{'FIM_MODE': ''},
+                                                   {'FIM_MODE': {'realtime': 'yes'}},
+                                                   {'FIM_MODE': {'whodata': 'yes'}}
+                                                   ],
+                                           metadata=[{'fim_mode': 'scheduled'},
+                                                     {'fim_mode': 'realtime'},
+                                                     {'fim_mode': 'whodata'}
+                                                     ]
+                                           )
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('path_file, path_link, num_links', [
+    (testdir1, "/", 1)
+    #(testdir1, testdir1, 2),
+])
+def test_hard_link(path_file, path_link, num_links, get_configuration, 
+                   configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """ 
+    """
+
+    try:
+        #check_apply_test({'test_hard_link'}, get_configuration['tags'])
+
+        # Create the regular file to which the hard links will point
+        regular_file_name = "testregularfile"
+        create_file(REGULAR, path_file, regular_file_name, content='test content')
+
+        check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
+
+        file_list = [regular_file_name]
+        event_checker = EventChecker(wazuh_log_monitor, path_file, file_list)
+        event_checker.fetch_and_check('added', min_timeout=2)
+
+
+        # Create as many links as num_links in path_link pointing to regular_file_name
+        hardlinks_list = []
+        for link in range(0, num_links):
+            hardlinks_list.append("HardLink"+str(link))
+            create_file(HARDLINK, path_file, regular_file_name, content=os.path.join(path_link, "HardLink"+str(link)))
+            #create_file(HARDLINK, path_link, "HardLink"+str(link), content=os.path.join(path_file, "testregularfile"))
+
+        # Look for the creation events for all the links created
+        if path_file == path_link:
+            check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
+            event_checker.file_list = hardlinks_list
+            event_checker.fetch_and_check('added', min_timeout=3)
+
+        # Modify the original file
+        event_checker.file_list = file_list
+        modify_file_content(path_file, regular_file_name, new_content="modified testregularfile")
+        check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
+        event_checker.fetch_and_check('modified', min_timeout=3)
+
+        # Modify one of the hard links
+        file_list = file_list + hardlinks_list if path_file == path_link else file_list
+        modify_file_content(path_link, "HardLink0", new_content="modified HardLink0")
+        check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
+        event_checker.fetch_and_check('modified', min_timeout=3)
+
+    finally:
+        # Clean up
+        delete_file(path_file, regular_file_name)
+        for link in hardlinks_list:
+            delete_file(path_link, link)

--- a/test_wazuh/test_fim/test_checks/test_hard_link.py
+++ b/test_wazuh/test_fim/test_checks/test_hard_link.py
@@ -5,10 +5,12 @@
 import os
 import pytest
 
-from wazuh_testing.fim import (LOG_FILE_PATH, EventChecker, check_time_travel, create_file, modify_file_content, delete_file, REGULAR, HARDLINK)
+from wazuh_testing.fim import (HARDLINK, LOG_FILE_PATH, REGULAR, EventChecker,
+                               check_time_travel, create_file, delete_file,
+                               detect_initial_scan, modify_file_content)
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
-                                 load_wazuh_configurations)
-
+                                 load_wazuh_configurations,
+                                 restart_wazuh_service, truncate_file)
 
 # variables
 
@@ -17,19 +19,23 @@ configurations_path = os.path.join(test_data_path, 'wazuh_hard_link.yaml')
 testdir1 = os.path.join('/', 'testdir1')
 test_directories = [testdir1]
 
-wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # configurations
 
 configurations = load_wazuh_configurations(configurations_path, __name__,
-                                           params=[{'FIM_MODE': ''},
-                                                   {'FIM_MODE': {'realtime': 'yes'}},
-                                                   {'FIM_MODE': {'whodata': 'yes'}}
+                                           params=[{'FIM_MODE': '', 'INODE': {'check_inode': 'yes'}},
+                                                   {'FIM_MODE': '', 'INODE': {'check_inode': 'no'}},
+                                                   {'FIM_MODE': {'realtime': 'yes'}, 'INODE': {'check_inode': 'yes'}},
+                                                   {'FIM_MODE': {'realtime': 'yes'}, 'INODE': {'check_inode': 'no'}},
+                                                   {'FIM_MODE': {'whodata': 'yes'}, 'INODE': {'check_inode': 'yes'}},
+                                                   {'FIM_MODE': {'whodata': 'yes'}, 'INODE': {'check_inode': 'no'}}
                                                    ],
-                                           metadata=[{'fim_mode': 'scheduled'},
-                                                     {'fim_mode': 'realtime'},
-                                                     {'fim_mode': 'whodata'}
+                                           metadata=[{'fim_mode': 'scheduled', 'inode': 'yes'},
+                                                     {'fim_mode': 'scheduled', 'inode': 'no'},
+                                                     {'fim_mode': 'realtime', 'inode': 'yes'},
+                                                     {'fim_mode': 'realtime', 'inode': 'no'},
+                                                     {'fim_mode': 'whodata', 'inode': 'yes'},
+                                                     {'fim_mode': 'whodata', 'inode': 'no'}
                                                      ]
                                            )
 
@@ -45,49 +51,57 @@ def get_configuration(request):
 # tests
 
 @pytest.mark.parametrize('path_file, path_link, num_links', [
-    (testdir1, "/", 1)
-    #(testdir1, testdir1, 2),
+    (testdir1, "/", 1),
+    (testdir1, testdir1, 2),
 ])
 def test_hard_link(path_file, path_link, num_links, get_configuration, 
                    configure_environment, restart_syscheckd, wait_for_initial_scan):
-    """ 
+    """Test the check_inode option when used with Hard links.
+
+    This test is intended to be used with valid configurations files.
+
+    :param path_file string The path to the regular file to be created
+    :param path_link string The path to the Hard links to be created
+    :param num_links int Number of hard links to create. All of them will be pointing to the same regular file.
+    :param checkers dict Dict with all the check options to be used
     """
-
+    wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+    regular_file_name = "testregularfile"
+    file_list = [regular_file_name]
+    hardlinks_list = []
+    
     try:
-        #check_apply_test({'test_hard_link'}, get_configuration['tags'])
-
-        # Create the regular file to which the hard links will point
-        regular_file_name = "testregularfile"
-        create_file(REGULAR, path_file, regular_file_name, content='test content')
-
-        check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
-
-        file_list = [regular_file_name]
         event_checker = EventChecker(wazuh_log_monitor, path_file, file_list)
-        event_checker.fetch_and_check('added', min_timeout=2)
 
+        # Create the regular file
+        create_file(REGULAR, path_file, regular_file_name, content='test content')
+        check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
+        event_checker.fetch_and_check('added', min_timeout=3)
 
-        # Create as many links as num_links in path_link pointing to regular_file_name
-        hardlinks_list = []
+        # Create as many links pointing to the regular file as num_links
         for link in range(0, num_links):
             hardlinks_list.append("HardLink"+str(link))
             create_file(HARDLINK, path_file, regular_file_name, content=os.path.join(path_link, "HardLink"+str(link)))
-            #create_file(HARDLINK, path_link, "HardLink"+str(link), content=os.path.join(path_file, "testregularfile"))
 
-        # Look for the creation events for all the links created
+        # Try to detect the creation events for all the created links
         if path_file == path_link:
             check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
             event_checker.file_list = hardlinks_list
             event_checker.fetch_and_check('added', min_timeout=3)
 
-        # Modify the original file
-        event_checker.file_list = file_list
+        # Update file_list with the links if these were created in the monitored folder
+        event_checker.file_list = file_list + hardlinks_list if path_file == path_link else file_list
+
+        # Modify the original file and detect the events for the entire file_list
         modify_file_content(path_file, regular_file_name, new_content="modified testregularfile")
         check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
         event_checker.fetch_and_check('modified', min_timeout=3)
 
-        # Modify one of the hard links
-        file_list = file_list + hardlinks_list if path_file == path_link else file_list
+        # Delete log file to avoid false positives
+        truncate_file(LOG_FILE_PATH)
+        wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+        
+        # Modify one of the hard links and check the modification events for the entire file_list
         modify_file_content(path_link, "HardLink0", new_content="modified HardLink0")
         check_time_travel(get_configuration['metadata']['fim_mode'] == 'scheduled')
         event_checker.fetch_and_check('modified', min_timeout=3)


### PR DESCRIPTION
This closes #209 .

This PR modifies the currently existing tests for the `check_*` options to expand them adding two new tests:

* Related to hard links. Having more than one hard link to the same file we need to ensure that `FIM` reports as many alerts as hard links we have when some of them are modified even with `check_inode="no"`.

* A test that modifies the inode of a file by having two copies of the same file and replacing file A with B when using `check_inode="no". This must not trigger an alert as we will not be monitoring the inode.

To implement these tests it was necessary to reuse the functionality that was already implemented inside `regular_file_cud` so we decided to take the code out of that function and refactor creating two classes within `fim.py` for that purpose.