### PR TITLE
Add FIM integration tests for  'recursion_level' and 'check_inode' options on the same directory

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -18,6 +18,7 @@ from jsonschema import validate
 
 from wazuh_testing.tools import TimeMachine
 
+
 _data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 WAZUH_PATH = os.path.join('/', 'var', 'ossec')
@@ -413,7 +414,7 @@ def callback_audit_loaded_rule(line):
 
 
 def callback_audit_event_too_long(line):
-    if '.*Caching Audit message: event too long' in line:
+    if 'Caching Audit message: event too long' in line:
         return True
     return None
 

--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -292,12 +292,13 @@ class FileMonitor:
         self._result = None
         self.timer = None
 
-    def _monitor(self, callback=_callback_default, accum_results=1):
+    def _monitor(self, callback=_callback_default, accum_results=1, update_position=True):
         """Wait for new lines to be appended to the file.
 
         A callback function will be called every time a new line is detected. This function must receive two
         positional parameters: a references to the FileMonitor object and the line detected.
         """
+        previous_position = self._position
         self._result = [] if accum_results > 1 else None
         with open(self.file_path) as f:
             f.seek(self._position)
@@ -322,9 +323,9 @@ class FileMonitor:
                             if self._result:
                                 self.stop()
 
-            self._position = f.tell()
+            self._position = f.tell() if update_position else previous_position
 
-    def start(self, timeout=-1, callback=_callback_default, accum_results=1):
+    def start(self, timeout=-1, callback=_callback_default, accum_results=1, update_position=True):
         """Start the file monitoring until the stop method is called"""
         if not self._continue:
             self._continue = True
@@ -332,7 +333,7 @@ class FileMonitor:
             if timeout > 0:
                 self.timer = Timer(timeout, self.abort)
                 self.timer.start()
-            self._monitor(callback=callback, accum_results=accum_results)
+            self._monitor(callback=callback, accum_results=accum_results, update_position=update_position)
 
         return self
 

--- a/test_wazuh/test_fim/test_recursion_level/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_recursion_level/data/wazuh_conf.yaml
@@ -8,48 +8,48 @@
   - directories:
       value: "/test_no_recursion"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "0"
       - FIM_MODE
   - directories:
       value: "/test no recursion"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "0"
       - FIM_MODE
   - directories:
       value: "/test_recursion_1"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "1"
       - FIM_MODE
   - directories:
       value: "/test recursion 1"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "1"
       - FIM_MODE
   - directories:
       value: "/test_recursion_5"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "5"
       - FIM_MODE
   - directories:
       value: "/test recursion 5"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "5"
       - FIM_MODE
   - directories:
       value: "/test_recursion_320"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "320"
       - FIM_MODE
   - directories:
       value: "/test recursion 320"
       attributes:
-      - check_all: 'yes'
+      - CHECK
       - recursion_level: "320"
       - FIM_MODE


### PR DESCRIPTION
This closes #212.

This PR modifies the currently existing tests for the `recursion_level` option to add configurations where  `recursion_level` is used along with `check_inode="no"` option.

`Test_recursion_level.py` and `tools.py` has been also modified to fix a bug related to `event too long` message raised by whodata when using a too long directory name.

## Test performed

This is the current status of `test_recursion_level.py` after the modification:
```
================================== test session starts ==================================
platform linux -- Python 3.6.8, pytest-5.2.2, py-1.8.0, pluggy-0.13.0
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 48 items

test_recursion_level.py ................................................           [100%]

===================== 48 passed in 8425024.97s (97 days, 12:17:04) ======================
```