### PR TITLE
Use full package versions on testinfra tests

### DIFF
--- a/ansible/wazuh-ansible/molecule/_utils/test_utils.py
+++ b/ansible/wazuh-ansible/molecule/_utils/test_utils.py
@@ -1,0 +1,12 @@
+import os
+
+API_USER = 'molecule_user'
+API_PASSWORD = 'MoleculePassword'
+MOL_PLATFORM = os.getenv('MOL_PLATFORM', 'centos7')
+
+
+def get_full_version(package):
+    """ Build full package version by joining version and release """
+    if hasattr(package, 'release'):
+        return "{}-{}".format(package.version, package.release)
+    return package.version

--- a/ansible/wazuh-ansible/molecule/default/tests/test_agents.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_agents.py
@@ -14,7 +14,7 @@ def AgentRoleDefaults(host):
     return host.ansible(
         "include_vars",
         (
-            "../../../wazuh-ansible/roles/wazuh/"
+            "../../roles/wazuh/"
             "ansible-wazuh-agent/defaults/main.yml"
         ),
     )["ansible_facts"]

--- a/ansible/wazuh-ansible/molecule/default/tests/test_agents.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_agents.py
@@ -1,8 +1,11 @@
 import os
-import pytest
-import testinfra.utils.ansible_runner
+import sys
 
-MOL_PLATFORM = os.getenv('MOL_PLATFORM', 'centos7')
+import testinfra.utils.ansible_runner
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+from test_utils import get_full_version, MOL_PLATFORM
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
@@ -25,7 +28,8 @@ def test_wazuh_agent_is_installed(host, AgentRoleDefaults):
     agent = host.package("wazuh-agent")
     agent_version = AgentRoleDefaults["wazuh_agent_version"]
     assert agent.is_installed
-    assert agent.version.startswith(agent_version)
+    full_agent_version = get_full_version(agent)
+    assert full_agent_version.startswith(agent_version)
 
 
 @pytest.mark.parametrize(

--- a/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
@@ -25,7 +25,7 @@ def FilebeatRoleDefaults(host):
     return host.ansible(
         "include_vars",
         (
-            "../../../wazuh-ansible/roles/wazuh/"
+            "../../roles/wazuh/"
             "ansible-filebeat/defaults/main.yml"
         ),
     )["ansible_facts"]

--- a/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
@@ -1,8 +1,11 @@
 import os
-import pytest
-import testinfra.utils.ansible_runner
+import sys
 
-MOL_PLATFORM = os.getenv("MOL_PLATFORM", "centos7")
+import testinfra.utils.ansible_runner
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+from test_utils import get_full_version, MOL_PLATFORM
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
@@ -42,20 +45,13 @@ def test_wazuh_packages_are_installed(host, ManagerRoleDefaults):
     api = host.package("wazuh-api")
 
     manager_version = ManagerRoleDefaults["wazuh_manager_version"]
-    distribution = host.system_info.distribution.lower()
+    full_manager_version = get_full_version(manager)
+    full_api_version = get_full_version(api)
 
-    if distribution == "centos":
-        if host.system_info.release == "7":
-            assert manager.is_installed
-            assert manager.version.startswith(manager_version)
-            assert api.is_installed
-            assert api.version.startswith(manager_version)
-        elif host.system_info.release.startswith("6"):
-            assert manager.is_installed
-            assert manager.version.startswith(manager_version)
-    elif distribution == "ubuntu":
-        assert manager.is_installed
-        assert manager.version.startswith(manager_version)
+    assert manager.is_installed
+    assert full_manager_version.startswith(manager_version)
+    assert api.is_installed
+    assert full_api_version.startswith(manager_version)
 
 
 def test_wazuh_services_are_running(host):
@@ -115,5 +111,6 @@ def test_filebeat_is_installed(host, FilebeatRoleDefaults):
     """Test if the elasticsearch package is installed."""
     filebeat = host.package("filebeat")
     filebeat_version = FilebeatRoleDefaults["filebeat_version"]
+    full_filebeat_version = get_full_version(filebeat)
     assert filebeat.is_installed
-    assert filebeat.version.startswith(filebeat_version)
+    assert full_filebeat_version.startswith(filebeat_version)

--- a/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
@@ -14,7 +14,7 @@ def ManagerRoleDefaults(host):
     return host.ansible(
         "include_vars",
         (
-            "../../../wazuh-ansible/roles/wazuh/"
+            "../../roles/wazuh/"
             "ansible-wazuh-manager/defaults/main.yml"
         ),
     )["ansible_facts"]

--- a/ansible/wazuh-ansible/molecule/elasticsearch-xpack/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch-xpack/tests/test_default.py
@@ -1,14 +1,15 @@
 import os
+import sys
 import json
 
 import testinfra.utils.ansible_runner
 import pytest
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+from test_utils import get_full_version, API_USER, API_PASSWORD
+
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
-
-API_USER = 'molecule_user'
-API_PASSWORD = 'MoleculePassword'
 
 
 @pytest.fixture(scope="module")
@@ -26,8 +27,9 @@ def test_elasticsearch_is_installed(host, ElasticRoleDefaults):
     """Test if the elasticsearch package is installed."""
     elasticsearch = host.package("elasticsearch")
     elasticsearch_version = ElasticRoleDefaults["elastic_stack_version"]
+    full_es_version = get_full_version(elasticsearch)
     assert elasticsearch.is_installed
-    assert elasticsearch.version.startswith(elasticsearch_version)
+    assert full_es_version.startswith(elasticsearch_version)
 
 
 def test_elasticsearch_is_running(host):

--- a/ansible/wazuh-ansible/molecule/elasticsearch-xpack/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch-xpack/tests/test_default.py
@@ -16,7 +16,7 @@ def ElasticRoleDefaults(host):
     return host.ansible(
         "include_vars",
         (
-            "../../../wazuh-ansible/roles/elastic-stack/"
+            "../../roles/elastic-stack/"
             "ansible-elasticsearch/defaults/main.yml"
         ),
     )["ansible_facts"]

--- a/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
@@ -1,7 +1,12 @@
 import os
+import sys
 
 import testinfra.utils.ansible_runner
 import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+from test_utils import get_full_version
+
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
@@ -23,6 +28,7 @@ def test_elasticsearch_is_installed(host, ElasticRoleDefaults):
     """Test if the elasticsearch package is installed."""
     elasticsearch = host.package("elasticsearch")
     es_version = ElasticRoleDefaults["elastic_stack_version"]
+    es_full_version = get_full_version(elasticsearch)
     assert elasticsearch.is_installed
     assert elasticsearch.version.startswith(es_version)
 

--- a/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
@@ -13,7 +13,7 @@ def ElasticRoleDefaults(host):
     return host.ansible(
         "include_vars",
         (
-            "../../../wazuh-ansible/roles/elastic-stack/"
+            "../../roles/elastic-stack/"
             "ansible-elasticsearch/defaults/main.yml"
         ),
     )["ansible_facts"]

--- a/ansible/wazuh-ansible/molecule/kibana/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/kibana/tests/test_default.py
@@ -13,7 +13,7 @@ def KibanaRoleDefaults(host):
     return host.ansible(
         "include_vars",
         (
-            "../../../wazuh-ansible/roles/elastic-stack/"
+            "../../roles/elastic-stack/"
             "ansible-kibana/defaults/main.yml"
         ),
     )["ansible_facts"]

--- a/ansible/wazuh-ansible/molecule/kibana/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/kibana/tests/test_default.py
@@ -1,8 +1,12 @@
 import os
+import sys
 import json
 
 import testinfra.utils.ansible_runner
 import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+from test_utils import get_full_version
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')


### PR DESCRIPTION
Fixes #263

Changes:
- A common module `test_utils` was created
- New function `get_full_version` to calculate package version correctly on every system
