### PR TITLE
Fix Elasticsaerch unit tests for linting

### DIFF
--- a/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
@@ -30,7 +30,7 @@ def test_elasticsearch_is_installed(host, ElasticRoleDefaults):
     es_version = ElasticRoleDefaults["elastic_stack_version"]
     es_full_version = get_full_version(elasticsearch)
     assert elasticsearch.is_installed
-    assert elasticsearch.version.startswith(es_version)
+    assert es_full_version.startswith(es_version)
 
 
 def test_elasticsearch_is_running(host):


### PR DESCRIPTION
Hi all,

This PR updates the `test_default.py` to use `es_full_version` in order to avoid linting errors

Best regards

Jose