### PR TITLE
Bugfix testinfra flake8 linting

### DIFF
--- a/ansible/wazuh-ansible/molecule/default/tests/test_agents.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_agents.py
@@ -4,7 +4,9 @@ import sys
 import testinfra.utils.ansible_runner
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+sys.path.append(
+                os.path.join(os.path.dirname(__file__), '../../_utils/')
+                )  # noqa: E402
 from test_utils import get_full_version, MOL_PLATFORM
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
@@ -4,7 +4,9 @@ import sys
 import testinfra.utils.ansible_runner
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+sys.path.append(
+                os.path.join(os.path.dirname(__file__), '../../_utils/')
+                )  # noqa: E402
 from test_utils import get_full_version, MOL_PLATFORM
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/ansible/wazuh-ansible/molecule/elasticsearch-xpack/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch-xpack/tests/test_default.py
@@ -5,7 +5,9 @@ import json
 import testinfra.utils.ansible_runner
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+sys.path.append(
+                os.path.join(os.path.dirname(__file__), '../../_utils/')
+                )  # noqa: E402
 from test_utils import get_full_version, API_USER, API_PASSWORD
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/elasticsearch/tests/test_default.py
@@ -4,7 +4,9 @@ import sys
 import testinfra.utils.ansible_runner
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
+sys.path.append(
+                os.path.join(os.path.dirname(__file__), '../../_utils/')
+                )  # noqa: E402
 from test_utils import get_full_version
 
 

--- a/ansible/wazuh-ansible/molecule/kibana/tests/test_default.py
+++ b/ansible/wazuh-ansible/molecule/kibana/tests/test_default.py
@@ -1,12 +1,9 @@
 import os
-import sys
 import json
 
 import testinfra.utils.ansible_runner
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../_utils/'))
-from test_utils import get_full_version
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')


### PR DESCRIPTION
This PR fixes a linting error introduced on #264 

Changes:

- flake8 was set to ignore E402 to allow a statement before an import