### PR TITLE
FIM's tests - moving files from whodata directory to realtime directory and vice versa

### DIFF
--- a/test_wazuh/test_fim/test_moving_files/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_moving_files/data/wazuh_conf.yaml
@@ -1,0 +1,18 @@
+---
+# conf 1
+- tags:
+  - monitoring_realtime
+  apply_to_modules:
+  - test_moving_files
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/testdir1"
+      attributes:
+      - whodata: 'yes'
+  - directories:
+      value: "/testdir2"
+      attributes:
+      - realtime: 'yes'

--- a/test_wazuh/test_fim/test_moving_files/test_moving_files.py
+++ b/test_wazuh/test_fim/test_moving_files/test_moving_files.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import shutil
+import pytest
+
+from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, DEFAULT_TIMEOUT, callback_detect_event, create_file)
+from wazuh_testing.tools import FileMonitor, PREFIX, load_wazuh_configurations
+
+
+# Variables
+
+test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]
+testdir1, testdir2 = test_directories
+testfile1 = 'file1'
+testfile2 = 'file2'
+whodata = 'whodata'
+realtime = 'realtime'
+added = 'added'
+deleted = 'deleted'
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+
+# Configurations
+
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+
+# Internal functions
+
+def extra_configuration_before_yield():
+    """
+    Create /testdir1/file1 and /testdir2/file2 before execute test
+    """
+
+    create_file(REGULAR, testdir1, testfile1, content='')
+    create_file(REGULAR, testdir2, testfile2, content='')
+
+
+def check_event(dirsrc, dirdst, filename, mod_del_event, mod_add_event):
+    """
+    Check the event has been generated
+    :param dirsrc: source directory
+    :param dirdst: target directory
+    :param filename: file name
+    :param mod_del_event: mode of deleted event
+    :param mod_add_event: mode of added event
+    """
+    event = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT, callback=callback_detect_event).result()
+
+    try:
+        assert (event['data']['mode'] == mod_del_event and  event['data']['type'] == deleted and
+                os.path.join(dirsrc, filename) in event['data']['path'])
+    except AssertionError:
+        if (event['data']['mode'] != mod_add_event and event['data']['type'] != added and
+                os.path.join(dirdst, filename) in event['data']['path']):
+            raise AssertionError(f'Event not found')
+
+
+# Fixture
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """
+    Get configurations from the module.
+    """
+    return request.param
+
+
+# Test
+
+@pytest.mark.parametrize('dirsrc, dirdst, filename, mod_del_event, mod_add_event', [
+    (testdir1, testdir2, testfile1, whodata, realtime),
+    (testdir2, testdir1, testfile2, realtime, whodata)
+])
+def test_moving_file_to_whodata(dirsrc, dirdst, filename, mod_del_event, mod_add_event, get_configuration,
+                                configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """
+    Test Syscheck's behaviors when moving files from a directory monitored by whodata to another
+    monitored by realtime and vice versa.
+
+    :param dirsrc Source directory
+    :param dirdst Target directory
+    :param filename File name
+    :param mod_del_event Added event mode
+    :param mod_add_event Deleted event mode
+    """
+
+    os.rename(os.path.join(dirsrc, filename), os.path.join(dirdst, filename))
+
+    check_event(dirsrc, dirdst, filename, mod_del_event, mod_add_event)
+    check_event(dirsrc, dirdst, filename, mod_del_event, mod_add_event)


### PR DESCRIPTION
| Issue |
| --- |
| [284](https://github.com/wazuh/wazuh-qa/issues/284) |

Hello team,

This PR contains tests to check the behavior of syscheck when files are moved from realtime directory to whodata directory and vice versa.

I attach some logs and pytest's outputs below.

Best regards,
Eva

**Testing on Linux**

The events in `ossec.log`:

1. First test
```
2019/12/10 13:06:30 ossec-syscheckd[7360] run_check.c:77 at send_syscheck_msg(): DEBUG: (6321): Sending event: {"type":"event","data":{"path":"/testdir2/file1","mode":"real-time","type":"added","timestamp":1575983190,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":17844950,"mtime":1575983168,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"90e28ecc9fc9ff931affa99c1392280c08b62743"}}}
2019/12/10 13:06:31 ossec-syscheckd[7360] run_check.c:77 at send_syscheck_msg(): DEBUG: (6321): Sending event: {"type":"event","data":{"path":"/testdir1/file1","mode":"whodata","type":"deleted","timestamp":1575983178,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":17844950,"mtime":1575983168,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"90e28ecc9fc9ff931affa99c1392280c08b62743"},"audit":{"path":"/testdir1/file1","user_id":"0","user_name":"root","process_name":"/usr/local/bin/python3.7","process_id":7359,"group_id":"0","group_name":"root","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","ppid":3409}}}
```

2. Second test
```
2019/12/10 13:06:31 ossec-syscheckd[7360] run_check.c:77 at send_syscheck_msg(): DEBUG: (6321): Sending event: {"type":"event","data":{"path":"/testdir2/file2","mode":"real-time","type":"deleted","timestamp":1575983178,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":34425080,"mtime":1575983168,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"9f8f8a53fbbc3101383239130cbde5dbbe97ed8e"}}}
2019/12/10 13:06:32 ossec-syscheckd[7360] run_check.c:77 at send_syscheck_msg(): DEBUG: (6321): Sending event: {"type":"event","data":{"path":"/testdir1/file2","mode":"whodata","type":"added","timestamp":1575983192,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":34425080,"mtime":1575983168,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"9f8f8a53fbbc3101383239130cbde5dbbe97ed8e"},"audit":{"path":"/testdir1/file2","user_id":"0","user_name":"root","process_name":"/usr/local/bin/python3.7","process_id":7359,"group_id":"0","group_name":"root","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","ppid":3409}}}
```


Pytest's output:
```
[root@agent-master-1 test_wazuh]# python3 -m pytest test_fim/test_moving_files 
========================================== test session starts ===========================================
platform linux -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 2 items                                                                                        

test_fim/test_moving_files/test_moving_files.py ..                                                 [100%]

=========================================== 2 passed in 25.36s ===========================================
[root@agent-master-1 test_wazuh]# 
```


**Testing on Windows:**

The events in `ossec.log`:

1. First test
```
2019/12/10 05:16:48 ossec-agent[3240] win_agent.c:499 at SendMSG(): DEBUG: Sending message to server: {"type":"event","data":{"path":"c:\\testdir2\\file1","mode":"real-time","type":"added","timestamp":1575983806,"attributes":{"type":"file","size":0,"perm":"SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes","uid":"S-1-5-32-544","user_name":"Administrators","inode":0,"mtime":1575983788,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","attributes":"ARCHIVE","checksum":"069ba6d460e321a0b15573125063e84ffb1863c9"}}}
2019/12/10 05:16:48 ossec-agent[3240] win_agent.c:499 at SendMSG(): DEBUG: Sending message to server: {"type":"event","data":{"path":"c:\\testdir1\\file1","mode":"whodata","type":"deleted","timestamp":1575983795,"attributes":{"type":"file","size":0,"perm":"SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes","uid":"S-1-5-32-544","user_name":"Administrators","inode":0,"mtime":1575983788,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","attributes":"ARCHIVE","checksum":"069ba6d460e321a0b15573125063e84ffb1863c9"},"audit":{"path":"c:\\testdir1\\file1","user_id":"S-1-5-21-4221104624-2075587475-3446184934-500","user_name":"Administrator","process_name":"C:\\Users\\Administrator\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe","process_id":2656}}}
```

2. Second test

```
2019/12/10 05:16:49 ossec-agent[3240] win_agent.c:499 at SendMSG(): DEBUG: Sending message to server: {"type":"event","data":{"path":"c:\\testdir2\\file2","mode":"real-time","type":"deleted","timestamp":1575983795,"attributes":{"type":"file","size":0,"perm":"SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes","uid":"S-1-5-32-544","user_name":"Administrators","inode":0,"mtime":1575983788,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","attributes":"ARCHIVE","checksum":"069ba6d460e321a0b15573125063e84ffb1863c9"}}}
2019/12/10 05:16:49 ossec-agent[3240] win_whodata.c:719 at whodata_callback(): DEBUG: (6244): New files have been detected in the 'c:\testdir1' directory and will be scanned.
2019/12/10 05:16:49 ossec-agent[3240] win_agent.c:499 at SendMSG(): DEBUG: Sending message to server: {"type":"event","data":{"path":"c:\\testdir1\\file2","mode":"whodata","type":"added","timestamp":1575983809,"attributes":{"type":"file","size":0,"perm":"SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Users (allowed): read_control|synchronize|read_data|read_ea|execute|read_attributes","uid":"S-1-5-32-544","user_name":"Administrators","inode":0,"mtime":1575983788,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","attributes":"ARCHIVE","checksum":"069ba6d460e321a0b15573125063e84ffb1863c9"},"audit":{"path":"c:\\testdir1","user_id":"S-1-5-21-4221104624-2075587475-3446184934-500","user_name":"Administrator","process_name":"C:\\Users\\Administrator\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe","process_id":2656}}}
2019/12/10 05:16:49 ossec-agent[3240] win_whodata.c:772 at whodata_callback(): DEBUG: (6231): The 'c:\testdir1' directory has been scanned after detecting event of new files.
```

Pytest's output:

``` 
PS C:\Users\Administrator\Documents\test_wazuh> py.exe -m pytest .\test_fim\test_moving_files\
================================================= test session starts =================================================
platform win32 -- Python 3.7.5, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
rootdir: C:\Users\Administrator\Documents\test_wazuh, inifile: pytest.ini
collected 2 items

test_fim\test_moving_files\test_moving_files.py ..                                                               [100%]

================================================= 2 passed in 25.25s ==================================================
PS C:\Users\Administrator\Documents\test_wazuh>
```

