### PR TITLE
Added capability to detect host operating system

### DIFF
--- a/test_wazuh/pytest.ini
+++ b/test_wazuh/pytest.ini
@@ -2,3 +2,7 @@
 addopts = --strict-markers
 markers =
     benchmark
+    darwin
+    linux
+    sunos5
+    win32

--- a/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
@@ -13,12 +13,11 @@ from wazuh_testing.fim import (LOG_FILE_PATH, regular_file_cud, create_file, WAZ
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine, PREFIX)
 
-
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path,
-                                   'wazuh_conf_complex_win32.yaml' if sys.platform == 'win32' else 'wazuh_conf_complex.yaml')
+configurations_path = os.path.join(
+    test_data_path, 'wazuh_conf_complex_win32.yaml' if sys.platform == 'win32' else 'wazuh_conf_complex.yaml')
 testdir = os.path.join(PREFIX, 'testdir')
 subdir = 'subdir'
 test_directories = [testdir]
@@ -29,7 +28,6 @@ for n in range(5):
 tag = 'Sample_tag'
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # configurations
 
@@ -118,8 +116,8 @@ def check_report_changes(directory, trigger, check_list, file_list, timeout, sch
                 diff_file = os.path.join(diff_file, directory.strip('C:\\'), file)
             else:
                 diff_file = os.path.join(diff_file, directory.strip('/'), file)
-            assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
-            assert (event['data'].get('content_changes') is not None), f'content_changes is empty'
+            assert os.path.exists(diff_file), f'{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
 
     regular_file_cud(directory, wazuh_log_monitor, file_list=file_list,
                      time_travel=scheduled,

--- a/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
@@ -18,8 +18,8 @@ from wazuh_testing.tools import (FileMonitor, check_apply_test,
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path,
-                                   'wazuh_conf_simple_win32.yaml' if sys.platform == 'win32' else 'wazuh_conf_simple.yaml')
+configurations_path = os.path.join(
+    test_data_path, 'wazuh_conf_simple_win32.yaml' if sys.platform == 'win32' else 'wazuh_conf_simple.yaml')
 checkdir_default = os.path.join(PREFIX, 'checkdir_default')
 checkdir_checkall = os.path.join(checkdir_default, 'checkdir_checkall')
 checkdir_no_inode = os.path.join(checkdir_checkall, 'checkdir_no_inode')
@@ -122,8 +122,8 @@ def test_ambiguous_report(folders, tags_to_apply,
                 diff_file = os.path.join(diff_file, folder.strip('C:\\'), file)
             else:
                 diff_file = os.path.join(diff_file, folder.strip('/'), file)
-            assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
-            assert (event['data'].get('content_changes') is not None), f'content_changes is empty'
+            assert os.path.exists(diff_file), f'{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
 
     def no_report_changes_validator(event):
         """ Validate content_changes event property does not exist in the event
@@ -136,8 +136,8 @@ def test_ambiguous_report(folders, tags_to_apply,
                 diff_file = os.path.join(diff_file, folder.strip('C:\\'), file)
             else:
                 diff_file = os.path.join(diff_file, folder.strip('/'), file)
-            assert (not os.path.exists(diff_file)), f'{diff_file} exists'
-            assert ('content_changes' not in event['data'].keys()), f"'content_changes' in event"
+            assert not os.path.exists(diff_file), f'{diff_file} exists'
+            assert 'content_changes' not in event['data'].keys(), f"'content_changes' in event"
 
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 

--- a/test_wazuh/test_fim/test_audit/test_audit.py
+++ b/test_wazuh/test_fim/test_audit/test_audit.py
@@ -8,7 +8,6 @@ import time
 import psutil
 import pytest
 
-
 from wazuh_testing.fim import (LOG_FILE_PATH, callback_audit_added_rule,
                                callback_audit_connection,
                                callback_audit_health_check,
@@ -16,7 +15,7 @@ from wazuh_testing.fim import (LOG_FILE_PATH, callback_audit_added_rule,
                                callback_audit_reloaded_rule,
                                callback_audit_rules_manipulation,
                                callback_realtime_added_directory,
-                               callback_audit_key, 
+                               callback_audit_key,
                                create_file, REGULAR,
                                detect_initial_scan)
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
@@ -24,6 +23,8 @@ from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  control_service,
                                  truncate_file)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
 
 # variables
 
@@ -33,7 +34,6 @@ test_directories = [os.path.join('/', 'testdir1'), os.path.join('/', 'testdir2')
 testdir1, testdir2, testdir3 = test_directories
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # configurations
 
@@ -73,9 +73,9 @@ def test_added_rules(tags_to_apply, get_configuration,
                                      callback=callback_audit_added_rule,
                                      accum_results=3).result()
 
-    assert (testdir1 in events), f'{testdir1} not detected in scan'
-    assert (testdir2 in events), f'{testdir2} not detected in scan'
-    assert (testdir3 in events), f'{testdir3} not detected in scan'
+    assert testdir1 in events, f'{testdir1} not detected in scan'
+    assert testdir2 in events, f'{testdir2} not detected in scan'
+    assert testdir3 in events, f'{testdir3} not detected in scan'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -96,7 +96,7 @@ def test_readded_rules(tags_to_apply, get_configuration,
         events = wazuh_log_monitor.start(timeout=10,
                                          callback=callback_audit_reloaded_rule).result()
 
-        assert (dir in events), f'{dir} not in {events}'
+        assert dir in events, f'{dir} not in {events}'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -118,9 +118,9 @@ def test_readded_rules_on_restart(tags_to_apply, get_configuration,
                                      callback=callback_audit_loaded_rule,
                                      accum_results=3).result()
 
-    assert (testdir1 in events), f'{testdir1} not in {events}'
-    assert (testdir2 in events), f'{testdir2} not in {events}'
-    assert (testdir3 in events), f'{testdir3} not in {events}'
+    assert testdir1 in events, f'{testdir1} not in {events}'
+    assert testdir2 in events, f'{testdir2} not in {events}'
+    assert testdir3 in events, f'{testdir3} not in {events}'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -139,9 +139,9 @@ def test_move_rules_realtime(tags_to_apply, get_configuration,
                                      callback=callback_realtime_added_directory,
                                      accum_results=3).result()
 
-    assert (testdir1 in events), f'{testdir1} not detected in scan'
-    assert (testdir2 in events), f'{testdir2} not detected in scan'
-    assert (testdir3 in events), f'{testdir3} not detected in scan'
+    assert testdir1 in events, f'{testdir1} not detected in scan'
+    assert testdir2 in events, f'{testdir2} not detected in scan'
+    assert testdir3 in events, f'{testdir3} not detected in scan'
 
     # Start Audit
     p = subprocess.Popen(["service", "auditd", "start"])
@@ -176,7 +176,7 @@ def test_audit_key(audit_key, path, get_configuration, configure_environment, re
     events = wazuh_log_monitor.start(timeout=30,
                                      callback=callback_audit_key,
                                      accum_results=1).result()
-    assert (audit_key in events)
+    assert audit_key in events
 
     # Remove watch rule
     os.system("auditctl -W " + path + " -p wa -k " + audit_key)
@@ -195,12 +195,13 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
     :param tags_to_apply set Run test if matches with a configuration identifier, skip otherwise
     :param should_restart boolean True if Auditd should restart, False otherwise
     """
+
     def get_audit_creation_time():
         for proc in psutil.process_iter(attrs=['name']):
             if proc.name() == "auditd":
                 return proc.create_time()
         pytest.fail("Auditd is not running")
-    
+
     plugin_path = "/etc/audisp/plugins.d/af_wazuh.conf"
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
@@ -210,12 +211,12 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
     time_before_restart = get_audit_creation_time()
     control_service('restart')
     time.sleep(5)
-    
+
     time_after_restart = get_audit_creation_time()
 
     if should_restart:
-        assert(time_before_restart != time_after_restart)
+        assert time_before_restart != time_after_restart
     else:
-        assert(time_before_restart == time_after_restart)
+        assert time_before_restart == time_after_restart
 
-    assert(os.path.isfile(plugin_path))
+    assert os.path.isfile(plugin_path)

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_changes.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_changes.py
@@ -18,7 +18,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 testdir1, testdir2 = test_directories
 
-
 # configurations
 
 conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
@@ -21,7 +21,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 testdir1, testdir2 = test_directories
 
-
 # configurations
 
 monitoring_modes = ['realtime', 'whodata']

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
@@ -21,7 +21,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 testdir1, testdir2 = test_directories
 
-
 # configurations
 
 monitoring_modes = ['scheduled']

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_rename.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_rename.py
@@ -17,7 +17,7 @@ from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_config
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]
 
-directory_str = ','.join(test_directories )
+directory_str = ','.join(test_directories)
 for direc in list(test_directories):
     test_directories.append(os.path.join(direc, 'subdir'))
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -73,6 +73,7 @@ def test_rename(folder, tags_to_apply,
         * This test is intended to be used with valid configurations files. Each execution of this test will configure
           the environment properly, restart the service and wait for the initial scan.
     """
+
     def expect_events(path):
         event = wazuh_log_monitor.start(timeout=timeout, callback=callback_detect_event).result()
         try:

--- a/test_wazuh/test_fim/test_checks/test_check_others.py
+++ b/test_wazuh/test_fim/test_checks/test_check_others.py
@@ -6,36 +6,26 @@ import os
 import sys
 
 import pytest
-from wazuh_testing.fim import (CHECK_ALL, CHECK_ATTRS, CHECK_GROUP, CHECK_INODE, CHECK_MD5SUM, CHECK_MTIME, CHECK_OWNER,
+
+from wazuh_testing.fim import (CHECK_ATTRS, CHECK_GROUP, CHECK_INODE, CHECK_MD5SUM, CHECK_MTIME, CHECK_OWNER,
                                CHECK_PERM, CHECK_SHA1SUM, CHECK_SHA256SUM, CHECK_SIZE, CHECK_SUM,
                                LOG_FILE_PATH, REQUIRED_ATTRIBUTES, regular_file_cud)
-from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations
-
+from wazuh_testing.tools import FileMonitor, PREFIX, check_apply_test, load_wazuh_configurations
 
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
-if sys.platform == 'win32':
-    test_directories = [os.path.join('C:', os.sep, 'testdir1'), os.path.join('C:', os.sep, 'testdir2')]
-    test_directories = [os.path.join('C:', os.sep, 'testdir1'), os.path.join('C:', os.sep, 'testdir2'),
-                        os.path.join('C:', os.sep, 'testdir3'), os.path.join('C:', os.sep, 'testdir4'),
-                        os.path.join('C:', os.sep, 'testdir5'), os.path.join('C:', os.sep, 'testdir6'),
-                        os.path.join('C:', os.sep, 'testdir7'), os.path.join('C:', os.sep, 'testdir8'),
-                        os.path.join('C:', os.sep, 'testdir9'), os.path.join('C:', os.sep, 'testdir0')]
-    configurations_path = os.path.join(test_data_path, 'wazuh_check_others_windows.yaml')
-
-else:
-    test_directories = [os.path.join('/', 'testdir1'), os.path.join('/', 'testdir2'),
-                        os.path.join('/', 'testdir3'), os.path.join('/', 'testdir4'),
-                        os.path.join('/', 'testdir5'), os.path.join('/', 'testdir6'),
-                        os.path.join('/', 'testdir7'), os.path.join('/', 'testdir8'),
-                        os.path.join('/', 'testdir9'), os.path.join('/', 'testdir0')]
-    configurations_path = os.path.join(test_data_path, 'wazuh_check_others.yaml')
+test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2'),
+                    os.path.join(PREFIX, 'testdir3'), os.path.join(PREFIX, 'testdir4'),
+                    os.path.join(PREFIX, 'testdir5'), os.path.join(PREFIX, 'testdir6'),
+                    os.path.join(PREFIX, 'testdir7'), os.path.join(PREFIX, 'testdir8'),
+                    os.path.join(PREFIX, 'testdir9'), os.path.join(PREFIX, 'testdir0')]
+configurations_path = os.path.join(
+    test_data_path, 'wazuh_check_others_windows.yaml' if sys.platform == 'win32' else 'wazuh_check_others.yaml')
 
 testdir1, testdir2, testdir3, testdir4, testdir5, testdir6, testdir7, testdir8, testdir9, testdir0 = test_directories
-
 
 # configurations
 configurations = load_wazuh_configurations(configurations_path, __name__,
@@ -60,29 +50,24 @@ def get_configuration(request):
 
 # tests
 
+parametrize_list = [(testdir1, REQUIRED_ATTRIBUTES[CHECK_SUM]),
+                    (testdir2, {CHECK_MD5SUM}),
+                    (testdir3, {CHECK_SHA1SUM}),
+                    (testdir4, {CHECK_SHA256SUM}),
+                    (testdir5, {CHECK_SIZE}),
+                    (testdir6, {CHECK_OWNER}),
+                    (testdir8, {CHECK_PERM})]
 if sys.platform == 'win32':
-    parametrize_list = [(testdir1, REQUIRED_ATTRIBUTES[CHECK_SUM]),
-                        (testdir2, {CHECK_MD5SUM}),
-                        (testdir3, {CHECK_SHA1SUM}),
-                        (testdir4, {CHECK_SHA256SUM}),
-                        (testdir5, {CHECK_SIZE}),
-                        (testdir6, {CHECK_OWNER}),
-                        (testdir7, {CHECK_ATTRS}),
-                        (testdir8, {CHECK_PERM}),
-                        (testdir9, {CHECK_MTIME})
-                        ]
+    parametrize_list.extend([
+        (testdir7, {CHECK_ATTRS}),
+        (testdir9, {CHECK_MTIME})
+    ])
 else:
-    parametrize_list = [(testdir1, REQUIRED_ATTRIBUTES[CHECK_SUM]),
-                        (testdir2, {CHECK_MD5SUM}),
-                        (testdir3, {CHECK_SHA1SUM}),
-                        (testdir4, {CHECK_SHA256SUM}),
-                        (testdir5, {CHECK_SIZE}),
-                        (testdir6, {CHECK_OWNER}),
-                        (testdir7, {CHECK_GROUP}),
-                        (testdir8, {CHECK_PERM}),
-                        (testdir9, {CHECK_MTIME}),
-                        (testdir0, {CHECK_INODE})
-                        ]
+    parametrize_list.extend([
+        (testdir7, {CHECK_GROUP}),
+        (testdir9, {CHECK_MTIME}),
+        (testdir0, {CHECK_INODE})
+    ])
 
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
@@ -99,8 +84,8 @@ def test_check_others_individually(path, checkers, get_configuration, configure_
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param path string Directory where the file is being created and monitored
-    :param checkers dict Dict with all the check options to be used
+    :param path: Directory where the file is being created and monitored
+    :param checkers: Dict with all the check options to be used
     """
     check_apply_test({'test_check_others_individually'}, get_configuration['tags'])
 
@@ -108,30 +93,30 @@ def test_check_others_individually(path, checkers, get_configuration, configure_
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')
 
 
+parametrize_list = [(testdir1, REQUIRED_ATTRIBUTES[CHECK_SUM] | {CHECK_SIZE}),
+                    (testdir3, {CHECK_SHA1SUM} | {CHECK_SHA256SUM}),
+                    (testdir6, {CHECK_PERM} | {CHECK_MTIME}),
+                    (testdir8, {CHECK_SHA256SUM})]
+
 if sys.platform == 'win32':
-    parametrize_list = [(testdir1, REQUIRED_ATTRIBUTES[CHECK_SUM] | {CHECK_SIZE}),
-                        (testdir2, {CHECK_MD5SUM} | {CHECK_OWNER} | {CHECK_MTIME}),
-                        (testdir3, {CHECK_SHA1SUM} | {CHECK_SHA256SUM}),
-                        (testdir4, {CHECK_SIZE} | {CHECK_PERM} | {CHECK_ATTRS}),
-                        (testdir5, {CHECK_OWNER} | {CHECK_ATTRS}),
-                        (testdir6, {CHECK_PERM} | {CHECK_MTIME}),
-                        (testdir7, {CHECK_ATTRS} | {CHECK_MTIME}),
-                        (testdir8, {CHECK_SHA256SUM})
-                        ]
+    parametrize_list.extend([
+        (testdir2, {CHECK_MD5SUM} | {CHECK_OWNER} | {CHECK_MTIME}),
+        (testdir4, {CHECK_SIZE} | {CHECK_PERM} | {CHECK_ATTRS}),
+        (testdir5, {CHECK_OWNER} | {CHECK_ATTRS}),
+        (testdir7, {CHECK_ATTRS} | {CHECK_MTIME})
+    ])
 else:
-    parametrize_list = [(testdir1, REQUIRED_ATTRIBUTES[CHECK_SUM] | {CHECK_SIZE}),
-                        (testdir2, {CHECK_MD5SUM} | {CHECK_GROUP} | {CHECK_MTIME}),
-                        (testdir3, {CHECK_SHA1SUM} | {CHECK_SHA256SUM}),
-                        (testdir4, {CHECK_SIZE} | {CHECK_PERM} | {CHECK_INODE}),
-                        (testdir5, {CHECK_OWNER} | {CHECK_GROUP}),
-                        (testdir6, {CHECK_PERM} | {CHECK_MTIME}),
-                        (testdir7, {CHECK_GROUP} | {CHECK_MTIME}),
-                        (testdir8, {CHECK_SHA256SUM})
-                        ]
+    parametrize_list.extend([
+        (testdir2, {CHECK_MD5SUM} | {CHECK_GROUP} | {CHECK_MTIME}),
+        (testdir4, {CHECK_SIZE} | {CHECK_PERM} | {CHECK_INODE}),
+        (testdir5, {CHECK_OWNER} | {CHECK_GROUP}),
+        (testdir7, {CHECK_GROUP} | {CHECK_MTIME})
+    ])
 
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
-def test_check_others(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_check_others(path, checkers, get_configuration, configure_environment,
+                      restart_syscheckd, wait_for_initial_scan):
     """Test the behaviour of several combinations of Check options over the same directory with Check_all disabled to
     avoid using the default check_all configuration. The order of the checks (including check_all="no") will be
     different on each case to test the behaviour of check_all="no".
@@ -145,8 +130,8 @@ def test_check_others(path, checkers, get_configuration, configure_environment, 
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param path string Directory where the file is being created and monitored
-    :param checkers dict Dict with all the check options to be used
+    :param path: Directory where the file is being created and monitored
+    :param checkers: Dict with all the check options to be used
     """
     check_apply_test({'test_check_others'}, get_configuration['tags'])
 

--- a/test_wazuh/test_fim/test_checks/test_checksums.py
+++ b/test_wazuh/test_fim/test_checks/test_checksums.py
@@ -6,35 +6,25 @@ import os
 import sys
 
 import pytest
+
 from wazuh_testing.fim import (CHECK_ALL, CHECK_MD5SUM, CHECK_SHA1SUM, CHECK_SHA256SUM, CHECK_SUM, DEFAULT_TIMEOUT,
                                LOG_FILE_PATH, REQUIRED_ATTRIBUTES, regular_file_cud)
-from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations
-
+from wazuh_testing.tools import FileMonitor, PREFIX, check_apply_test, load_wazuh_configurations
 
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
-if sys.platform == 'win32':
-    test_directories = [os.path.join('C:', os.sep, 'testdir1'), os.path.join('C:', os.sep, 'testdir2')]
-    test_directories = [os.path.join('C:', os.sep, 'testdir1'), os.path.join('C:', os.sep, 'testdir2'),
-                        os.path.join('C:', os.sep, 'testdir3'), os.path.join('C:', os.sep, 'testdir4'),
-                        os.path.join('C:', os.sep, 'testdir5'), os.path.join('C:', os.sep, 'testdir6'),
-                        os.path.join('C:', os.sep, 'testdir7'), os.path.join('C:', os.sep, 'testdir8'),
-                        os.path.join('C:', os.sep, 'testdir9'), os.path.join('C:', os.sep, 'testdir0')]
-    configurations_path = os.path.join(test_data_path, 'wazuh_checksums_windows.yaml')
-
-else:
-    test_directories = [os.path.join('/', 'testdir1'), os.path.join('/', 'testdir2'),
-                        os.path.join('/', 'testdir3'), os.path.join('/', 'testdir4'),
-                        os.path.join('/', 'testdir5'), os.path.join('/', 'testdir6'),
-                        os.path.join('/', 'testdir7'), os.path.join('/', 'testdir8'),
-                        os.path.join('/', 'testdir9'), os.path.join('/', 'testdir0')]
-    configurations_path = os.path.join(test_data_path, 'wazuh_checksums.yaml')
+test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2'),
+                    os.path.join(PREFIX, 'testdir3'), os.path.join(PREFIX, 'testdir4'),
+                    os.path.join(PREFIX, 'testdir5'), os.path.join(PREFIX, 'testdir6'),
+                    os.path.join(PREFIX, 'testdir7'), os.path.join(PREFIX, 'testdir8'),
+                    os.path.join(PREFIX, 'testdir9'), os.path.join(PREFIX, 'testdir0')]
+configurations_path = os.path.join(
+    test_data_path, 'wazuh_checksums_windows.yaml' if sys.platform == 'win32' else 'wazuh_checksums.yaml')
 
 testdir1, testdir2, testdir3, testdir4, testdir5, testdir6, testdir7, testdir8, testdir9, testdir0 = test_directories
-
 
 # configurations
 
@@ -69,8 +59,10 @@ def get_configuration(request):
     (testdir5, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_MD5SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
     (testdir6, REQUIRED_ATTRIBUTES[CHECK_ALL] - REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA1SUM}),
     (testdir6, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_MD5SUM} - {CHECK_SHA1SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
-    (testdir7, REQUIRED_ATTRIBUTES[CHECK_ALL] - REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA1SUM} - {CHECK_SHA256SUM}),
-    (testdir7, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_MD5SUM} - {CHECK_SHA1SUM} - {CHECK_SHA256SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
+    (testdir7, REQUIRED_ATTRIBUTES[CHECK_ALL] -
+     REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA1SUM} - {CHECK_SHA256SUM}),
+    (testdir7, REQUIRED_ATTRIBUTES[CHECK_ALL] -
+     {CHECK_MD5SUM} - {CHECK_SHA1SUM} - {CHECK_SHA256SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_SHA1SUM} - {CHECK_SHA256SUM}),
     (testdir9, REQUIRED_ATTRIBUTES[CHECK_ALL] - REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA256SUM}),
     (testdir9, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_MD5SUM} - {CHECK_SHA256SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
@@ -88,8 +80,8 @@ def test_checksums_checkall(path, checkers, get_configuration, configure_environ
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param path string Directory where the file is being created and monitored
-    :param checkers dict Dict with all the check options to be used
+    :param path: Directory where the file is being created and monitored
+    :param checkers: Dict with all the check options to be used
     """
     check_apply_test({'test_checksums_checkall'}, get_configuration['tags'])
 
@@ -111,9 +103,9 @@ def test_checksums_checkall(path, checkers, get_configuration, configure_environ
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA256SUM}),
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_SHA256SUM} - {CHECK_MD5SUM})
 ])
-def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                   wait_for_initial_scan):
-    """Test the checksum options (checksum, sha1sum, sha256sum and md5sum) behaviour when is used alone or in conjuntion.
+def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """Test the checksum options (checksum, sha1sum, sha256sum and md5sum)
+    behaviour when is used alone or in conjunction.
     Check_all option will be set to "no" in order to avoid using the default check_all configuration.
 
     Example:
@@ -124,9 +116,8 @@ def test_checksums(path, checkers, get_configuration, configure_environment, res
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param path string Directory where the file is being created
-    :param checkers dict Dict with all the check options to be used
-    :param triggers_event bool Boolean to determinate if the event should be raised or not.
+    :param path: Directory where the file is being created
+    :param checkers: Dict with all the check options to be used
     """
     check_apply_test({'test_checksums'}, get_configuration['tags'])
 

--- a/test_wazuh/test_fim/test_checks/test_hard_link.py
+++ b/test_wazuh/test_fim/test_checks/test_hard_link.py
@@ -10,14 +10,12 @@ from wazuh_testing.fim import (DEFAULT_TIMEOUT, HARDLINK, LOG_FILE_PATH, REGULAR
                                check_time_travel, create_file, delete_file, modify_file_content)
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations, truncate_file
 
-
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_hard_link.yaml')
 testdir1 = os.path.join('/', 'testdir1')
 test_directories = [testdir1]
-
 
 # configurations
 
@@ -62,10 +60,10 @@ def test_hard_link(path_file, path_link, num_links, get_configuration,
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param path_file string The path to the regular file to be created
-    :param path_link string The path to the Hard links to be created
-    :param num_links int Number of hard links to create. All of them will be pointing to the same regular file.
-    :param checkers dict Dict with all the check options to be used
+    :param path_file: The path to the regular file to be created
+    :param path_link: The path to the Hard links to be created
+    :param num_links: Number of hard links to create. All of them will be pointing to the same regular file.
+    :param checkers: Dict with all the check options to be used
     """
     truncate_file(LOG_FILE_PATH)
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -84,8 +82,8 @@ def test_hard_link(path_file, path_link, num_links, get_configuration,
 
         # Create as many links pointing to the regular file as num_links
         for link in range(0, num_links):
-            hardlinks_list.append("HardLink"+str(link))
-            create_file(HARDLINK, path_link, "HardLink"+str(link), target=os.path.join(path_file, regular_file_name))
+            hardlinks_list.append("HardLink" + str(link))
+            create_file(HARDLINK, path_link, "HardLink" + str(link), target=os.path.join(path_file, regular_file_name))
 
         # Try to detect the creation events for all the created links
         if path_file == path_link:

--- a/test_wazuh/test_fim/test_follow_symbolic_link/common.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/common.py
@@ -19,6 +19,7 @@ symlink_interval = 20
 
 def debug_sym_check(func):
     """ Decorator to see how long it's taking wazuh log monitor to detect the sym_check event """
+
     def wrapper(*args, **kwargs):
         now1 = datetime.datetime.now()
         func(*args, **kwargs)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target.py
@@ -13,6 +13,9 @@ from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_d
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
@@ -34,7 +37,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder, aux_folder', [
     ({'monitored_file'}, testdir1, testdir_not_target),
     ({'monitored_dir'}, testdir_target, testdir_not_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target.py
@@ -34,6 +34,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder, aux_folder', [
     ({'monitored_file'}, testdir1, testdir_not_target),
     ({'monitored_dir'}, testdir_target, testdir_not_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
@@ -13,6 +13,9 @@ from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_d
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 # configurations
 
 conf_params, conf_metadata = generate_params()
@@ -34,7 +37,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, previous_target, new_target', [
     ({'monitored_file'}, testdir1, os.path.join(testdir2, 'regular1')),
     ({'monitored_dir'}, testdir_target, testdir2)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
@@ -34,6 +34,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, previous_target, new_target', [
     ({'monitored_file'}, testdir1, os.path.join(testdir2, 'regular1')),
     ({'monitored_dir'}, testdir_target, testdir2)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_symlink.py
@@ -13,6 +13,9 @@ from wazuh_testing.fim import (generate_params, create_file, REGULAR, SYMLINK, c
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 # configurations
 
 conf_params, conf_metadata = generate_params()
@@ -34,7 +37,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder, aux_folder', [
     ({'monitored_file'}, testdir1, testdir_not_target),
     ({'monitored_dir'}, testdir_target, testdir_not_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_symlink.py
@@ -34,6 +34,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder, aux_folder', [
     ({'monitored_file'}, testdir1, testdir_not_target),
     ({'monitored_dir'}, testdir_target, testdir_not_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_target.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_target.py
@@ -33,6 +33,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder, aux_folder', [
     ({'monitored_file'}, testdir1, testdir_not_target),
     ({'monitored_dir'}, testdir_target, testdir_not_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_target.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_target.py
@@ -12,6 +12,9 @@ from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_d
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 # configurations
 
 conf_params, conf_metadata = generate_params()
@@ -33,7 +36,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder, aux_folder', [
     ({'monitored_file'}, testdir1, testdir_not_target),
     ({'monitored_dir'}, testdir_target, testdir_not_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
@@ -32,6 +32,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder', [
     ({'monitored_file'}, testdir1),
     ({'monitored_dir'}, testdir_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
@@ -11,6 +11,9 @@ from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_d
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 # configurations
 
 conf_params, conf_metadata = generate_params()
@@ -32,7 +35,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply, main_folder', [
     ({'monitored_file'}, testdir1),
     ({'monitored_dir'}, testdir_target)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -13,6 +13,9 @@ from wazuh_testing.fim import (LOG_FILE_PATH,
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, PREFIX)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -61,7 +64,6 @@ def modify_symlink(target, path):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('monitored_dir, non_monitored_dir1, non_monitored_dir2, sym_target, tags_to_apply', [
     (testdir_link, testdir1, testdir2, 'file', {'non_monitored_dir'}),
     (testdir_link, testdir1, testdir2, 'folder', {'non_monitored_dir'})

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -21,7 +21,6 @@ test_directories = [os.path.join(PREFIX, 'testdir_link'), os.path.join(PREFIX, '
                     os.path.join(PREFIX, 'testdir2')]
 testdir_link, testdir1, testdir2 = test_directories
 
-
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
@@ -62,6 +61,7 @@ def modify_symlink(target, path):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('monitored_dir, non_monitored_dir1, non_monitored_dir2, sym_target, tags_to_apply', [
     (testdir_link, testdir1, testdir2, 'file', {'non_monitored_dir'}),
     (testdir_link, testdir1, testdir2, 'folder', {'non_monitored_dir'})

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_revert_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_revert_symlink.py
@@ -34,6 +34,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply', [
     {'monitored_file'}
 ])
@@ -48,6 +49,7 @@ def test_symbolic_revert_symlink(tags_to_apply, get_configuration, configure_env
     * This test is intended to be used with valid configurations files. Each execution of this test will configure
     the environment properly, restart the service and wait for the initial scan.
     """
+
     def modify_and_assert(file):
         modify_file_content(testdir1, file, new_content='Sample modification')
         check_time_travel(scheduled)

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_revert_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_revert_symlink.py
@@ -13,6 +13,9 @@ from wazuh_testing.fim import (generate_params, callback_detect_event,
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
@@ -34,7 +37,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply', [
     {'monitored_file'}
 ])

--- a/test_wazuh/test_fim/test_frequency/test_frequency.py
+++ b/test_wazuh/test_fim/test_frequency/test_frequency.py
@@ -80,6 +80,8 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.linux
+@pytest.mark.win32
 @pytest.mark.parametrize('folder, tags_to_apply', [
     (directory_str, {'ossec_conf'})
 ])

--- a/test_wazuh/test_fim/test_frequency/test_frequency.py
+++ b/test_wazuh/test_fim/test_frequency/test_frequency.py
@@ -12,6 +12,9 @@ import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, DEFAULT_TIMEOUT, regular_file_cud, generate_params
 from wazuh_testing.tools import FileMonitor, TimeMachine, check_apply_test, load_wazuh_configurations, PREFIX
 
+# All tests in this module apply to linux and windows only
+pytestmark = [pytest.mark.linux, pytest.mark.win32]
+
 # variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1')]
@@ -20,7 +23,6 @@ directory_str = os.path.join(PREFIX, 'frequencydir')
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
-testdir1 = test_directories
 
 # Configuration with frequency values
 
@@ -68,8 +70,6 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.linux
-@pytest.mark.win32
 @pytest.mark.parametrize('folder, tags_to_apply', [
     (directory_str, {'ossec_conf'})
 ])

--- a/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
@@ -7,7 +7,8 @@ from datetime import timedelta
 
 import pytest
 import sys
-from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, callback_ignore, create_file, REGULAR, generate_params
+from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, callback_ignore, create_file, REGULAR, \
+    generate_params
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, TimeMachine, PREFIX
 
 # variables
@@ -26,12 +27,12 @@ testdir1, testdir1_sub, testdir1_ignore, testdir2, testdir2_sub = test_directori
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-
 # configurations
 
 conf_params, conf_metadata = generate_params()
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
+
 
 # fixtures
 
@@ -60,7 +61,8 @@ def get_configuration(request):
     (testdir2_sub, "another.ignored", b"other content", True, {'valid_regex'}),
     (testdir2, "another.ignored2", "", True, {'valid_regex', 'valid_no_regex'}),
     (testdir2, "another.ignore2", "", False, {'valid_regex2', 'valid_regex3'}),
-    (testdir1, 'ignore_prefix_test.txt', "test", True, {'valid_regex1', 'valid_regex2', 'valid_regex3', 'valid_regex4'}),
+    (testdir1, 'ignore_prefix_test.txt', "test", True,
+     {'valid_regex1', 'valid_regex2', 'valid_regex3', 'valid_regex4'}),
     (testdir1, 'ignore_prefix_test.txt', "test", False, {'valid_regex5'}),
     (testdir1, 'whatever.txt', "test", False, {'valid_empty'}),
     (testdir2, 'whatever2.txt', "test", False, {'valid_empty'}),
@@ -77,11 +79,11 @@ def test_ignore_subdirectory(folder, filename, content, triggers_event,
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param folder string Directory where the file is being created
-    :param filename string Name of the file to be created
-    :param content string, bytes Content to fill the new file
-    :param triggers_event bool True if an event must be generated, False otherwise
-    :param tags_to_apply set Run test if matches with a configuration identifier, skip otherwise
+    :param folder: Directory where the file is being created
+    :param filename: Name of the file to be created
+    :param content: Content to fill the new file
+    :param triggers_event: True if an event must be generated, False otherwise
+    :param tags_to_apply: Run test if matches with a configuration identifier, skip otherwise
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
@@ -95,8 +97,8 @@ def test_ignore_subdirectory(folder, filename, content, triggers_event,
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=10,
                                         callback=callback_detect_event).result()
-        assert (event['data']['type'] == 'added'), f'Event type not equal'
-        assert (event['data']['path'] == os.path.join(folder, filename)), f'Event path not equal'
+        assert event['data']['type'] == 'added', f'Event type not equal'
+        assert event['data']['path'] == os.path.join(folder, filename), f'Event path not equal'
     else:
         while True:
             ignored_file = wazuh_log_monitor.start(timeout=10,

--- a/test_wazuh/test_fim/test_invalid/test_invalid.py
+++ b/test_wazuh/test_fim/test_invalid/test_invalid.py
@@ -10,7 +10,6 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_configuration_error
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, PREFIX)
 
-
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -21,7 +20,6 @@ directory_str = ','.join(test_directories)
 force_restart_after_restoring = True
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # configurations
 

--- a/test_wazuh/test_fim/test_moving_files/test_moving_files.py
+++ b/test_wazuh/test_fim/test_moving_files/test_moving_files.py
@@ -3,11 +3,14 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import shutil
+
 import pytest
 
 from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, DEFAULT_TIMEOUT, callback_detect_event, create_file)
 from wazuh_testing.tools import FileMonitor, PREFIX, load_wazuh_configurations
+
+# All tests in this module apply to linux and windows only
+pytestmark = [pytest.mark.linux, pytest.mark.win32]
 
 # Variables
 
@@ -73,8 +76,6 @@ def get_configuration(request):
 
 # Test
 
-@pytest.mark.linux
-@pytest.mark.win32
 @pytest.mark.parametrize('dirsrc, dirdst, filename, mod_del_event, mod_add_event', [
     (testdir1, testdir2, testfile1, whodata, realtime),
     (testdir2, testdir1, testfile2, realtime, whodata)

--- a/test_wazuh/test_fim/test_moving_files/test_moving_files.py
+++ b/test_wazuh/test_fim/test_moving_files/test_moving_files.py
@@ -9,7 +9,6 @@ import pytest
 from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, DEFAULT_TIMEOUT, callback_detect_event, create_file)
 from wazuh_testing.tools import FileMonitor, PREFIX, load_wazuh_configurations
 
-
 # Variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]
@@ -25,7 +24,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # Configurations
 
@@ -46,16 +44,16 @@ def extra_configuration_before_yield():
 def check_event(dirsrc, dirdst, filename, mod_del_event, mod_add_event):
     """
     Check the event has been generated
-    :param dirsrc: source directory
-    :param dirdst: target directory
-    :param filename: file name
-    :param mod_del_event: mode of deleted event
-    :param mod_add_event: mode of added event
+    :param dirsrc: Source directory
+    :param dirdst: Target directory
+    :param filename: File name
+    :param mod_del_event: Mode of deleted event
+    :param mod_add_event: Mode of added event
     """
     event = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT, callback=callback_detect_event).result()
 
     try:
-        assert (event['data']['mode'] == mod_del_event and  event['data']['type'] == deleted and
+        assert (event['data']['mode'] == mod_del_event and event['data']['type'] == deleted and
                 os.path.join(dirsrc, filename) in event['data']['path'])
     except AssertionError:
         if (event['data']['mode'] != mod_add_event and event['data']['type'] != added and
@@ -75,6 +73,8 @@ def get_configuration(request):
 
 # Test
 
+@pytest.mark.linux
+@pytest.mark.win32
 @pytest.mark.parametrize('dirsrc, dirdst, filename, mod_del_event, mod_add_event', [
     (testdir1, testdir2, testfile1, whodata, realtime),
     (testdir2, testdir1, testfile2, realtime, whodata)
@@ -85,11 +85,11 @@ def test_moving_file_to_whodata(dirsrc, dirdst, filename, mod_del_event, mod_add
     Test Syscheck's behaviors when moving files from a directory monitored by whodata to another
     monitored by realtime and vice versa.
 
-    :param dirsrc Source directory
-    :param dirdst Target directory
-    :param filename File name
-    :param mod_del_event Added event mode
-    :param mod_add_event Deleted event mode
+    :param dirsrc: Source directory
+    :param dirdst: Target directory
+    :param filename: File name
+    :param mod_del_event: Added event mode
+    :param mod_add_event: Deleted event mode
     """
 
     os.rename(os.path.join(dirsrc, filename), os.path.join(dirdst, filename))

--- a/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
+++ b/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
@@ -71,14 +71,14 @@ def test_no_diff_subdirectory(folder, filename, content, hidden_content,
                               wait_for_initial_scan):
     """ Checks files are ignored in the subdirectory according to configuration
 
-    When using the nodiff option for a file in syscheck configuration, everytime we get an event from this file,
+    When using the nodiff option for a file in syscheck configuration, every time we get an event from this file,
     we won't be able to see its content. We'll see 'Diff truncated because nodiff option' instead.
 
-    :param folder: string Directory where the file is being created
-    :param filename: string Name of the file to be created
-    :param content: string, bytes Content to fill the new file
-    :param hidden_content: bool True if content must be truncated,, False otherwise
-    :param tags_to_apply: set Run test if matches with a configuration identifier, skip otherwise
+    :param folder: Directory where the file is being created
+    :param filename: Name of the file to be created
+    :param content: Content to fill the new file
+    :param hidden_content: True if content must be truncated,, False otherwise
+    :param tags_to_apply: Run test if matches with a configuration identifier, skip otherwise
 
     * This test is intended to be used with valid nodiff configurations. Each execution of this test will configure
     the environment properly, restart the service and wait for the initial scan.
@@ -92,17 +92,17 @@ def test_no_diff_subdirectory(folder, filename, content, hidden_content,
         for file in files:
             diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local',
                                      folder.strip(PREFIX), file)
-            assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
-            assert (event['data'].get('content_changes') is not None), f'content_changes is empty'
+            assert os.path.exists(diff_file), f'{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
 
     def no_diff_validator(event):
         """ Validate content_changes value is truncated if the file is set to no_diff """
         if hidden_content:
-            assert ('<Diff truncated because nodiff option>' in event['data'].get('content_changes')), \
-                    f'content_changes is not truncated'
+            assert '<Diff truncated because nodiff option>' in event['data'].get('content_changes'), \
+                f'content_changes is not truncated'
         else:
-            assert ('<Diff truncated because nodiff option>' not in event['data'].get('content_changes')), \
-                    f'content_changes is truncated'
+            assert '<Diff truncated because nodiff option>' not in event['data'].get('content_changes'), \
+                f'content_changes is truncated'
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=files,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',

--- a/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -12,6 +12,9 @@ from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan, generate_param
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, restart_wazuh_daemon, truncate_file)
 
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -58,7 +61,6 @@ def check_prelink():
 # tests
 
 
-@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply', [
     ({'prefilter_cmd'})
 ])

--- a/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -2,10 +2,10 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import distro
 import os
 import subprocess
 
+import distro
 import pytest
 
 from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan, generate_params
@@ -54,8 +54,11 @@ def check_prelink():
         installer = 'apt-get install'
     subprocess.call([f'{path}/data/install_prelink.sh', dist, installer])
 
+
 # tests
 
+
+@pytest.mark.linux
 @pytest.mark.parametrize('tags_to_apply', [
     ({'prefilter_cmd'})
 ])
@@ -73,7 +76,7 @@ def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, 
 
     if get_configuration['metadata']['prefilter_cmd'] == '/usr/sbin/prelink -y':
         prelink = get_configuration['metadata']['prefilter_cmd'].split(' ')[0]
-        # assert os.path.exists(prelink), f'Prelink is not installed'
+        assert os.path.exists(prelink), f'Prelink is not installed'
         truncate_file(LOG_FILE_PATH)
         restart_wazuh_daemon('ossec-syscheckd')
         detect_initial_scan(wazuh_log_monitor)

--- a/test_wazuh/test_fim/test_recursion_level/test_recursion_level.py
+++ b/test_wazuh/test_fim/test_recursion_level/test_recursion_level.py
@@ -2,12 +2,12 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
-import pytest
 import sys
+
+import pytest
 
 from wazuh_testing.fim import (DEFAULT_TIMEOUT, LOG_FILE_PATH, callback_audit_event_too_long, regular_file_cud)
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations
-
 
 # Variables
 
@@ -32,7 +32,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 conf_name = "wazuh_recursion_windows.yaml" if sys.platform == "win32" else "wazuh_recursion.yaml"
 configurations_path = os.path.join(test_data_path, conf_name)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # configurations
 
@@ -91,16 +90,19 @@ def recursion_test(dirname, subdirname, recursion_level, timeout=1, edge_limit=2
         /testdir/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/subdir8/subdir9/subdir10/subdir11/subdir12
 
     This function also takes into account that a very long path will raise a FileNotFound Exception on Windows because
-    of its path lenght limitations. In a similar way, on Linux environments a `Event Too Long` will be raised if the
+    of its path length limitations. In a similar way, on Linux environments a `Event Too Long` will be raised if the
     path name is too long.
 
     :param dirname string The path being monitored by syscheck (indicated in the .conf file)
-    :param subdirname string The name of the subdirectories that will be created during the execution for testing purpouses.
-    :param recursion_level int Recursion level. Also used as the number of subdirectories to be created and checked for the current test.
+    :param subdirname string The name of the subdirectories that will be created during the execution for testing
+    purposes.
+    :param recursion_level int Recursion level. Also used as the number of subdirectories to be created and checked for
+    the current test.
     :param timeout int Max time to wait until an event is raised.
     :param edge_limit Number of directories where the test will monitor events
-    :param ignored_levels Number of directories exceding the specified recursion_level to verify events are not raised
-    :param is_scheduled bool If True the internal date will be modified to trigger scheduled checks by syschecks. False if realtime or Whodata.
+    :param ignored_levels Number of directories exceeding the specified recursion_level to verify events are not raised
+    :param is_scheduled bool If True the internal date will be modified to trigger scheduled checks by syschecks.
+    False if realtime or Whodata.
     """
     path = dirname
     try:
@@ -108,14 +110,15 @@ def recursion_test(dirname, subdirname, recursion_level, timeout=1, edge_limit=2
         for n in range(recursion_level):
             path = os.path.join(path, subdirname + str(n + 1))
             if ((recursion_level < edge_limit * 2) or
-                (recursion_level >= edge_limit * 2 and n < edge_limit) or
-                (recursion_level >= edge_limit * 2 and n > recursion_level - edge_limit)):
+                    (recursion_level >= edge_limit * 2 and n < edge_limit) or
+                    (recursion_level >= edge_limit * 2 and n > recursion_level - edge_limit)):
                 regular_file_cud(path, wazuh_log_monitor, time_travel=is_scheduled, min_timeout=timeout)
 
-        # Check False (exceding the specified recursion_level)
+        # Check False (exceeding the specified recursion_level)
         for n in range(recursion_level, recursion_level + ignored_levels):
             path = os.path.join(path, subdirname + str(n + 1))
-            regular_file_cud(path, wazuh_log_monitor, time_travel=is_scheduled, min_timeout=timeout, triggers_event=False)
+            regular_file_cud(path, wazuh_log_monitor, time_travel=is_scheduled, min_timeout=timeout,
+                             triggers_event=False)
 
     except TimeoutError:
         if wazuh_log_monitor.start(timeout=5, callback=callback_audit_event_too_long, update_position=False).result():
@@ -157,8 +160,10 @@ def test_recursion_level(dirname, subdirname, recursion_level, get_configuration
     environment properly, restart the service and wait for the initial scan.
 
     :param dirname string The path being monitored by syscheck (indicated in the .conf file)
-    :param subdirname string The name of the subdirectories that will be created during the execution for testing purpouses.
-    :param recursion_level int Recursion level. Also used as the number of subdirectories to be created and checked for the current test.
+    :param subdirname string The name of the subdirectories that will be created during the execution for testing
+    purposes.
+    :param recursion_level int Recursion level. Also used as the number of subdirectories to be created and checked for
+    the current test.
     """
     recursion_test(dirname, subdirname, recursion_level, timeout=DEFAULT_TIMEOUT,
                    is_scheduled=get_configuration['metadata']['fim_mode'] == 'scheduled')

--- a/test_wazuh/test_fim/test_report_changes/test_report_changes_and_diff.py
+++ b/test_wazuh/test_fim/test_report_changes/test_report_changes_and_diff.py
@@ -81,16 +81,16 @@ def test_reports_file_and_nodiff(folder, checkers, tags_to_apply,
                 diff_file = os.path.join(diff_file, folder.strip('C:\\'), file)
             else:
                 diff_file = os.path.join(diff_file, folder.strip('/'), file)
-            assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
-            assert (event['data'].get('content_changes') is not None), f'content_changes is empty'
+            assert os.path.exists(diff_file), f'{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
 
     def no_diff_validator(event):
         """ Validate content_changes value is truncated if the file is set to no_diff """
         if is_truncated:
-            assert ('<Diff truncated because nodiff option>' in event['data'].get('content_changes')), \
+            assert '<Diff truncated because nodiff option>' in event['data'].get('content_changes'), \
                 f'content_changes is not truncated'
         else:
-            assert ('<Diff truncated because nodiff option>' not in event['data'].get('content_changes')), \
+            assert '<Diff truncated because nodiff option>' not in event['data'].get('content_changes'), \
                 f'content_changes is truncated'
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=file_list,

--- a/test_wazuh/test_fim/test_report_changes/test_report_deleted_diff.py
+++ b/test_wazuh/test_fim/test_report_changes/test_report_deleted_diff.py
@@ -85,7 +85,7 @@ def create_and_check_diff(name, directory, fim_mode):
         diff_file = os.path.join(diff_file, directory.strip('C:\\'), name)
     else:
         diff_file = os.path.join(diff_file, directory.strip('/'), name)
-    assert (os.path.exists(diff_file)), f'{diff_file} does not exist'
+    assert os.path.exists(diff_file), f'{diff_file} does not exist'
     return diff_file
 
 
@@ -103,7 +103,7 @@ def check_when_no_report_changes(name, directory, fim_mode, new_conf):
     # Wait for FIM scan to finish
     detect_initial_scan(wazuh_log_monitor)
 
-    assert (not os.path.exists(diff_file)), f'{diff_file} exists'
+    assert not os.path.exists(diff_file), f'{diff_file} exists'
 
 
 def check_when_deleted_directories(name, directory, fim_mode):
@@ -123,7 +123,7 @@ def check_when_deleted_directories(name, directory, fim_mode):
     create_and_check_diff(name, directory, fim_mode)
     shutil.rmtree(directory, ignore_errors=True)
     wait_for_event(fim_mode)
-    assert (not os.path.exists(diff_dir)), f'{diff_dir} exists'
+    assert not os.path.exists(diff_dir), f'{diff_dir} exists'
 
 
 # tests

--- a/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
+++ b/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
@@ -7,8 +7,8 @@ from datetime import timedelta
 
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_event, callback_restricted, create_file, REGULAR, \
-    generate_params
+from wazuh_testing.fim import LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_event, callback_restricted, create_file, \
+    REGULAR, generate_params
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine, PREFIX)
 
@@ -71,7 +71,7 @@ def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply
     :param mode string same as mode in open built-in function
     :param content string, bytes Content to fill the new file
     :param triggers_event bool True if an event must be generated, False otherwise
-    :param tags_to_apply set Run test if matchs with a configuration identifier, skip otherwise
+    :param tags_to_apply set Run test if match with a configuration identifier, skip otherwise
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
@@ -85,8 +85,8 @@ def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT,
                                         callback=callback_detect_event).result()
-        assert (event['data']['type'] == 'added'), f'Event type not equal'
-        assert (event['data']['path'] == os.path.join(folder, filename)), f'Event path not equal'
+        assert event['data']['type'] == 'added', f'Event type not equal'
+        assert event['data']['path'] == os.path.join(folder, filename), f'Event path not equal'
     else:
         while True:
             ignored_file = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT,

--- a/test_wazuh/test_fim/test_skip/test_skip.py
+++ b/test_wazuh/test_fim/test_skip/test_skip.py
@@ -5,7 +5,6 @@
 import os
 import shutil
 import subprocess
-import sys
 from copy import deepcopy
 from datetime import timedelta
 
@@ -16,13 +15,16 @@ from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_integrity_event,
                                regular_file_cud, detect_initial_scan, callback_detect_event, generate_params)
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine,
-                                 set_section_wazuh_conf, restart_wazuh_with_new_conf)
+                                 set_section_wazuh_conf, restart_wazuh_with_new_conf, PREFIX)
+
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
 
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
-testdir = os.path.join('/', 'testdir1')
+testdir = os.path.join(PREFIX, 'testdir1')
 test_directories = [testdir]
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_sync/test_invalid_sync_response.py
+++ b/test_wazuh/test_fim/test_sync/test_invalid_sync_response.py
@@ -7,14 +7,12 @@ import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, callback_configuration_warning
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations
 
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 configurations_path = os.path.join(test_data_path, 'wazuh_invalid_conf.yaml')
 test_directories = [os.path.join('/', 'testdir1')]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # configurations
 
@@ -31,6 +29,7 @@ def get_configuration(request):
 
 # Tests
 
+@pytest.mark.linux
 def test_invalid_sync_response(get_configuration, configure_environment, restart_syscheckd):
     """Checks if an invalid ignore configuration is detected by catching the warning message displayed on the log.
 

--- a/test_wazuh/test_fim/test_sync/test_invalid_sync_response.py
+++ b/test_wazuh/test_fim/test_sync/test_invalid_sync_response.py
@@ -2,16 +2,20 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+
 import pytest
 
 from wazuh_testing.fim import LOG_FILE_PATH, callback_configuration_warning
-from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations
+from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
+
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
 
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 configurations_path = os.path.join(test_data_path, 'wazuh_invalid_conf.yaml')
-test_directories = [os.path.join('/', 'testdir1')]
+test_directories = [os.path.join(PREFIX, 'testdir1')]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
@@ -29,7 +33,6 @@ def get_configuration(request):
 
 # Tests
 
-@pytest.mark.linux
 def test_invalid_sync_response(get_configuration, configure_environment, restart_syscheckd):
     """Checks if an invalid ignore configuration is detected by catching the warning message displayed on the log.
 

--- a/test_wazuh/test_fim/test_sync/test_response_timeout.py
+++ b/test_wazuh/test_fim/test_sync/test_response_timeout.py
@@ -8,15 +8,20 @@ from datetime import datetime, timedelta
 import paramiko
 import psutil
 import pytest
+
 from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_end_scan, callback_detect_synchronization
-from wazuh_testing.tools import FileMonitor, TimeMachine, check_apply_test, load_wazuh_configurations, time_to_timedelta
+from wazuh_testing.tools import FileMonitor, TimeMachine, check_apply_test, load_wazuh_configurations, \
+    time_to_timedelta, PREFIX
+
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
 
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 configurations_path = os.path.join(test_data_path, 'wazuh_response_conf.yaml')
-test_directories = [os.path.join('/', 'testdir1')]
+test_directories = [os.path.join(PREFIX, 'testdir1')]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 response_timeouts = ['10', '10m', '10h', '10d', '10w']
 
@@ -40,7 +45,6 @@ def get_configuration(request):
 
 # Tests
 
-@pytest.mark.linux
 @pytest.mark.parametrize('num_files', [1, 100])
 @pytest.mark.parametrize('sync_interval', ['10', '10h'])
 def test_response_timeout(num_files, sync_interval, get_configuration, configure_environment, restart_syscheckd):

--- a/test_wazuh/test_fim/test_sync/test_sync_interval.py
+++ b/test_wazuh/test_fim/test_sync/test_sync_interval.py
@@ -8,7 +8,6 @@ from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_synchronization, d
 from wazuh_testing.tools import (FileMonitor, truncate_file, check_apply_test, load_wazuh_configurations, TimeMachine,
                                  time_to_timedelta)
 
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -16,7 +15,6 @@ configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 test_directories = [os.path.join('/', 'testdir1')]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 sync_intervals = ['10', '10s', '10m', '10h', '10d', '10w']
-
 
 # configurations
 
@@ -38,12 +36,14 @@ def get_configuration(request):
 
 # Tests
 
+@pytest.mark.linux
 def test_sync_interval(get_configuration, configure_environment, restart_syscheckd):
     """Verify that synchronization checks take place at the expected time given SYNC_INTERVAL variable.
 
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly and restart the service.
     """
+
     def truncate_log():
         truncate_file(LOG_FILE_PATH)
         return FileMonitor(LOG_FILE_PATH)
@@ -61,7 +61,7 @@ def test_sync_interval(get_configuration, configure_environment, restart_syschec
 
     # This should fail as we are only advancing half the time needed for synchronization to occur
     wazuh_log_monitor = truncate_log()
-    TimeMachine.travel_to_future(time_to_timedelta(get_configuration['metadata']['sync_interval'])/2)
+    TimeMachine.travel_to_future(time_to_timedelta(get_configuration['metadata']['sync_interval']) / 2)
     try:
         result = wazuh_log_monitor.start(timeout=1,
                                          callback=callback_detect_synchronization,

--- a/test_wazuh/test_fim/test_sync/test_sync_interval.py
+++ b/test_wazuh/test_fim/test_sync/test_sync_interval.py
@@ -2,17 +2,21 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+
 import pytest
 
 from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_synchronization, detect_initial_scan)
 from wazuh_testing.tools import (FileMonitor, truncate_file, check_apply_test, load_wazuh_configurations, TimeMachine,
-                                 time_to_timedelta)
+                                 time_to_timedelta, PREFIX)
+
+# All tests in this module apply to linux only
+pytestmark = pytest.mark.linux
 
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
-test_directories = [os.path.join('/', 'testdir1')]
+test_directories = [os.path.join(PREFIX, 'testdir1')]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 sync_intervals = ['10', '10s', '10m', '10h', '10d', '10w']
 
@@ -36,7 +40,6 @@ def get_configuration(request):
 
 # Tests
 
-@pytest.mark.linux
 def test_sync_interval(get_configuration, configure_environment, restart_syscheckd):
     """Verify that synchronization checks take place at the expected time given SYNC_INTERVAL variable.
 

--- a/test_wazuh/test_fim/test_tags/test_tags.py
+++ b/test_wazuh/test_fim/test_tags/test_tags.py
@@ -1,9 +1,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-import itertools
 import os
-import sys
 from copy import deepcopy
 
 import pytest

--- a/test_wazuh/test_fim/test_tags/test_tags.py
+++ b/test_wazuh/test_fim/test_tags/test_tags.py
@@ -20,12 +20,11 @@ test_directories = [os.path.join(PREFIX, 'testdir_tags'),
 directory_str = ','.join([test_directories[0], test_directories[2]])
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-
 # configurations
 
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 tags = ['tag1', 'tág', '0tag', '000', 'a' * 1000]
-# Create an incresing tag set. I.e.: ['tag1', 'tag1,tag2', 'tag1,tag2,tag3']
+# Create an increasing tag set. I.e.: ['tag1', 'tag1,tag2', 'tag1,tag2,tag3']
 test_tags = [tags[0], ','.join(tags)]
 fim_modes = ['', {'realtime': 'yes'}, {'whodata': 'yes'}]
 fim_modes_metadata = ['scheduled', 'realtime', 'whodata']
@@ -71,7 +70,7 @@ def test_tags(folder, name, content,
     defined_tags = get_configuration['metadata']['fim_tags']
 
     def tag_validator(event):
-        assert(defined_tags == event['data']['tags']), f'defined_tags are not equal'
+        assert defined_tags == event['data']['tags'], f'defined_tags are not equal'
 
     files = {name: content}
 


### PR DESCRIPTION
Hi team,

This PR closes #292. In this PR we have included the capability to detect the host operating system on which we run the tests. In this way only the tests corresponding to the host operating system will be executed.

This is an example of the new functionality. We have forced to run the test test_change_target to run only in Windows (only for testing):

## Test results
```bash
[root@centos7 test_wazuh]# python3 -m pytest -xrs -vv test_fim/test_follow_symbolic_link/test_change_target.py 
============================================================================================================================== test session starts ===============================================================================================================================
platform linux -- Python 3.6.8, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 12 items                                                                                                                                                                                                                                                               

test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration0-tags_to_apply0-/testdir1-/testdir_not_target] SKIPPED                                                                                                             [  8%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration0-tags_to_apply1-/testdir_target-/testdir_not_target] SKIPPED                                                                                                       [ 16%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration1-tags_to_apply0-/testdir1-/testdir_not_target] SKIPPED                                                                                                             [ 25%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration1-tags_to_apply1-/testdir_target-/testdir_not_target] SKIPPED                                                                                                       [ 33%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration2-tags_to_apply0-/testdir1-/testdir_not_target] SKIPPED                                                                                                             [ 41%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration2-tags_to_apply1-/testdir_target-/testdir_not_target] SKIPPED                                                                                                       [ 50%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration3-tags_to_apply0-/testdir1-/testdir_not_target] SKIPPED                                                                                                             [ 58%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration3-tags_to_apply1-/testdir_target-/testdir_not_target] SKIPPED                                                                                                       [ 66%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration4-tags_to_apply0-/testdir1-/testdir_not_target] SKIPPED                                                                                                             [ 75%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration4-tags_to_apply1-/testdir_target-/testdir_not_target] SKIPPED                                                                                                       [ 83%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration5-tags_to_apply0-/testdir1-/testdir_not_target] SKIPPED                                                                                                             [ 91%]
test_fim/test_follow_symbolic_link/test_change_target.py::test_symbolic_change_target[get_configuration5-tags_to_apply1-/testdir_target-/testdir_not_target] SKIPPED                                                                                                       [100%]

============================================================================================================================ short test summary info =============================================================================================================================
SKIPPED [12] /vagrant/wazuh-qa/test_wazuh/conftest.py:20: Cannot run on platform linux
============================================================================================================================== 12 skipped in 0.09s ===============================================================================================================================
```

Regards