### PR TITLE
Add test to check 'process_priority' option.

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -548,7 +548,8 @@ def control_service(action, daemon=None):
             control_service('start')
             result = 0
         else:
-            result = subprocess.run(["net", action, "OssecSvc"]).returncode
+            result = 0 if subprocess.run(["net", action, "OssecSvc"]).returncode in (0, 2) else \
+                subprocess.run(["net", action, "OssecSvc"]).returncode
     else:  # Default Unix
         if daemon is None:
             if sys.platform == 'darwin':

--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -573,6 +573,27 @@ def control_service(action, daemon=None):
         raise ValueError(f"Error when executing {action} in daemon {daemon}. Exit status: {result}")
 
 
+def get_process(search_name):
+    """
+    Search process by its name.
+
+    Parameters
+    ----------
+    search_name : str
+        Name of the process to be fetched
+
+    Returns
+    -------
+    `psutil.Process` or None
+        first occurrence of the process object matching the `search_name` or None if no process has been found
+    """
+    for proc in psutil.process_iter(attrs=['name']):
+        if proc.name() == search_name:
+            return proc
+
+    return None
+
+
 def reformat_time(scan_time):
     """ Transform scan_time to readable time
 

--- a/test_wazuh/test_fim/test_process_priority/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_process_priority/data/wazuh_conf.yaml
@@ -1,0 +1,12 @@
+---
+# conf 1
+- tags:
+  - ossec_conf
+  apply_to_modules:
+  - test_process_priority
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - process_priority:
+      value: PROCESS_PRIORITY

--- a/test_wazuh/test_fim/test_process_priority/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_process_priority/data/wazuh_conf.yaml
@@ -1,7 +1,7 @@
 ---
 # conf 1
 - tags:
-  - ossec_conf
+  - ossec_conf_1
   apply_to_modules:
   - test_process_priority
   section: syscheck
@@ -9,4 +9,26 @@
   - disabled:
       value: 'no'
   - process_priority:
-      value: PROCESS_PRIORITY
+      value: "0"
+# conf 2
+- tags:
+  - ossec_conf_2
+  apply_to_modules:
+  - test_process_priority
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - process_priority:
+      value: "4"
+# conf 3
+- tags:
+  - ossec_conf_3
+  apply_to_modules:
+  - test_process_priority
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - process_priority:
+      value: "-5"

--- a/test_wazuh/test_fim/test_process_priority/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_process_priority/data/wazuh_conf.yaml
@@ -1,7 +1,7 @@
 ---
 # conf 1
 - tags:
-  - ossec_conf_1
+  - ossec_conf
   apply_to_modules:
   - test_process_priority
   section: syscheck
@@ -9,26 +9,4 @@
   - disabled:
       value: 'no'
   - process_priority:
-      value: "0"
-# conf 2
-- tags:
-  - ossec_conf_2
-  apply_to_modules:
-  - test_process_priority
-  section: syscheck
-  elements:
-  - disabled:
-      value: 'no'
-  - process_priority:
-      value: "4"
-# conf 3
-- tags:
-  - ossec_conf_3
-  apply_to_modules:
-  - test_process_priority
-  section: syscheck
-  elements:
-  - disabled:
-      value: 'no'
-  - process_priority:
-      value: "-5"
+      value: PROCESS_PRIORITY

--- a/test_wazuh/test_fim/test_process_priority/test_process_priority.py
+++ b/test_wazuh/test_fim/test_process_priority/test_process_priority.py
@@ -21,8 +21,6 @@ test_directories = []
 
 # configurations
 
-# conf_params, conf_metadata = generate_params({'PROCESS_PRIORITY': str(priority)}, {'process_priority': str(priority)},
-#                                              modes=monitoring_modes)
 conf_params, conf_metadata = generate_params(modes=monitoring_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
 

--- a/test_wazuh/test_fim/test_process_priority/test_process_priority.py
+++ b/test_wazuh/test_fim/test_process_priority/test_process_priority.py
@@ -3,14 +3,15 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import psutil
 from copy import deepcopy
 
 import pytest
 
-from wazuh_testing.fim import (generate_params)
-from wazuh_testing.tools import (check_apply_test, load_wazuh_configurations)
+from wazuh_testing.fim import generate_params
+from wazuh_testing.tools import check_apply_test, load_wazuh_configurations, get_process
 
+# All tests in this module apply to linux only
+pytestmark = [pytest.mark.linux, pytest.mark.darwin]
 
 # variables
 
@@ -27,17 +28,17 @@ priority_list = ['0', '4', '-5']
 p, m = generate_params(modes=monitoring_modes)
 
 params, metadata = list(), list()
-for priority in priority_list:
+for pr in priority_list:
     for p_dict, m_dict in zip(p, m):
-        p_dict['PROCESS_PRIORITY'] = priority
-        m_dict['process_priority'] = priority
+        p_dict['PROCESS_PRIORITY'] = pr
+        m_dict['process_priority'] = pr
         params.append(deepcopy(p_dict))
         metadata.append(deepcopy(m_dict))
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
-# fixtures
 
+# fixtures
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
@@ -46,28 +47,15 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.parametrize('tags_to_apply', [
-    ({'ossec_conf'})
-])
-def test_process_priority(tags_to_apply, get_configuration,
-                          configure_environment, restart_syscheckd,
-                          wait_for_initial_scan):
+def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
     """Check if the ossec-syscheckd service priority is updated correctly using
        <process_priority> tag in ossec.conf.
     """
-    def get_process(search_name):
-        """ Search process by its name """
-        for proc in psutil.process_iter():
-            if proc.name() == search_name:
-                return proc
-
-        return None
-
-    check_apply_test(tags_to_apply, get_configuration['tags'])
+    check_apply_test({'ossec_conf'}, get_configuration['tags'])
 
     priority = int(get_configuration['metadata']['process_priority'])
     process_name = 'ossec-syscheckd'
     syscheckd_process = get_process(process_name)
 
-    assert syscheckd_process != None, f'Process {process_name} not found'
+    assert syscheckd_process is not None, f'Process {process_name} not found'
     assert syscheckd_process.nice() == priority, f'Process {process_name} has not updated its priority.'

--- a/test_wazuh/test_fim/test_process_priority/test_process_priority.py
+++ b/test_wazuh/test_fim/test_process_priority/test_process_priority.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import psutil
+
+import pytest
+
+from wazuh_testing.fim import (LOG_FILE_PATH, generate_params)
+from wazuh_testing.tools import (FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX)
+
+
+# variables
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+force_restart_after_restoring = True
+monitoring_modes = ['realtime']
+test_directories = []
+priority = 0
+
+# configurations
+
+conf_params, conf_metadata = generate_params({'PROCESS_PRIORITY': str(priority)}, {'process_priority': str(priority)},
+                                             modes=monitoring_modes)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# tests
+
+@pytest.mark.parametrize('priority, tags_to_apply', [
+    (priority, {'ossec_conf'})
+])
+def test_process_priority(priority, tags_to_apply, get_configuration,
+                          configure_environment, restart_syscheckd):
+    """ Check if the ossec-syscheckd service priority is updated correctly using
+        the <process_priority> tag in ossec.conf.
+
+        After applying the configuration, the process is searched and checked
+        if the applied priority is equal to the one it has.
+    """
+
+    def get_process(search_name):
+        """ Search process by its name """
+        for proc in psutil.process_iter():
+            if proc.name() == search_name:
+                return proc
+
+        return None
+
+    process_name = 'ossec-syscheckd'
+    syscheckd_process = get_process(process_name)
+
+    assert syscheckd_process != None, f'Process {process_name} not found'
+    assert syscheckd_process.nice() == priority, f'Process {process_name} has not updated its priority.'

--- a/test_wazuh/test_fim/test_process_priority/test_process_priority.py
+++ b/test_wazuh/test_fim/test_process_priority/test_process_priority.py
@@ -4,11 +4,12 @@
 
 import os
 import psutil
+from copy import deepcopy
 
 import pytest
 
-from wazuh_testing.fim import (LOG_FILE_PATH, generate_params)
-from wazuh_testing.tools import (FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX)
+from wazuh_testing.fim import (generate_params)
+from wazuh_testing.tools import (check_apply_test, load_wazuh_configurations)
 
 
 # variables
@@ -21,8 +22,19 @@ test_directories = []
 
 # configurations
 
-conf_params, conf_metadata = generate_params(modes=monitoring_modes)
-configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
+priority_list = ['0', '4', '-5']
+
+p, m = generate_params(modes=monitoring_modes)
+
+params, metadata = list(), list()
+for priority in priority_list:
+    for p_dict, m_dict in zip(p, m):
+        p_dict['PROCESS_PRIORITY'] = priority
+        m_dict['process_priority'] = priority
+        params.append(deepcopy(p_dict))
+        metadata.append(deepcopy(m_dict))
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
 # fixtures
 
@@ -31,21 +43,18 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # tests
 
-@pytest.mark.parametrize('priority, tags_to_apply', [
-    (0, {'ossec_conf_1'}),
-    (4, {'ossec_conf_2'}),
-    (-5, {'ossec_conf_3'})
+@pytest.mark.parametrize('tags_to_apply', [
+    ({'ossec_conf'})
 ])
-def test_process_priority(priority, tags_to_apply, get_configuration,
+def test_process_priority(tags_to_apply, get_configuration,
                           configure_environment, restart_syscheckd,
                           wait_for_initial_scan):
+    """Check if the ossec-syscheckd service priority is updated correctly using
+       <process_priority> tag in ossec.conf.
     """
-    Check if the ossec-syscheckd service priority is updated correctly using
-    <process_priority> tag in ossec.conf.
-    """
-
     def get_process(search_name):
         """ Search process by its name """
         for proc in psutil.process_iter():
@@ -55,6 +64,8 @@ def test_process_priority(priority, tags_to_apply, get_configuration,
         return None
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    priority = int(get_configuration['metadata']['process_priority'])
     process_name = 'ossec-syscheckd'
     syscheckd_process = get_process(process_name)
 


### PR DESCRIPTION
This PR is related to issue [#313](https://github.com/wazuh/wazuh-qa/issues/313)

## Description
Added test to check if `process_priority` tag updates the priority of the syscheckd process according to the indicated number. For example:

    <syscheck>
    <disabled>no</diabled>
    <process_priority>0</process_priority>
    </syscheck>

With this configuration, the priority of syscheck process should be 0 after restarting it.

## Tests performed
### Linux
```
# python3 -m pytest test_process_priority.py 
============================================= test session starts ==============================================
platform linux -- Python 3.6.8, pytest-5.3.2, py-1.8.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 9 items                                                                                              

test_process_priority.py .sss.sss.                                                                       [100%]

=================================== 3 passed, 6 skipped in 73.88s (0:01:13) ====================================
```

### MacOS
```
# python3 -m pytest test_process_priority.py 
============================================= test session starts ==============================================
platform darwin -- Python 3.7.5, pytest-5.3.2, py-1.8.0, pluggy-0.13.1
rootdir: /Users/vagrant/Desktop/shared/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 9 items                                                                                              

test_process_priority.py .sss.sss.                                                                       [100%]

=================================== 3 passed, 6 skipped in 72.55s (0:01:12) ====================================
```

## Platforms supported by the test

- [x]  Linux
- [ ]  Windows
- [x]  macOS

### Problems supporting Windows
Syscheck does not have its own process in windows, but belongs as a thread to the unique process "ossec-agent.exe". Psutil library does not have any method to access the priority of a thread, so it is not possible to check it in this test.

It is possible to list the threads of the process as you can see below. However, it is not known which one corresponds to syscheck and other deeper information.

```
 [pthread(id=3432, user_time=0.0, system_time=0.0), pthread(id=4932, user_time=0.015625, system_time=0.015625), pthread(id=1232, user_time=0.0, system_time=0.0), pthread(id=4976, user_time=0.0, system_time=0.0), pthread(id=4064, user_time=0.0, system_time=0.0), pthread(id=3608, user_time=0.0, system_time=0.046875), pthread(id=2164, user_time=0.015625, system_time=0.0), pthread(id=1544, user_time=0.0, system_time=0.0), pthread(id=584, user_time=0.03125, system_time=0.015625), pthread(id=1488, user_time=0.0, system_time=0.0), pthread(id=3144, user_time=0.0625, system_time=0.0625), pthread(id=4864, user_time=0.03125, system_time=0.0), pthread(id=4600, user_time=0.0, system_time=0.0), pthread(id=360, user_time=3.640625, system_time=0.40625), pthread(id=3476, user_time=0.0, system_time=0.0), pthread(id=3904, user_time=0.0, system_time=0.0), pthread(id=3008, user_time=0.0, system_time=0.0), pthread(id=3336, user_time=0.0, system_time=0.0), pthread(id=1776, user_time=0.015625, system_time=0.0), pthread(id=1084, user_time=0.03125, system_time=0.09375), pthread(id=2360, user_time=0.015625, system_time=0.0), pthread(id=4000, user_time=0.0, system_time=0.0), pthread(id=3376, user_time=0.0, system_time=0.0), pthread(id=1912, user_time=0.0, system_time=0.0)]
```
