### PR TITLE
Add test to check the values of FIM entries and path count

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -605,6 +605,13 @@ def callback_configuration_warning(line):
     return None
 
 
+def callback_entries_path_count(line):
+    match = re.match(r'.*Fim inode entries: (\d+), path count: (\d+)', line)
+
+    if match:
+        return match.group(1), match.group(2)
+
+
 class EventChecker:
     """Utility to allow fetch events and validate them."""
 

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -6,8 +6,8 @@ import os
 
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, DEFAULT_TIMEOUT,\
-    callback_entries_path_count, check_time_travel
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, \
+    DEFAULT_TIMEOUT, callback_entries_path_count, check_time_travel
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
 # marks
@@ -51,6 +51,7 @@ def extra_configuration_before_yield():
 
 def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
     """ Checks if FIM entries match the path count
+
         It creates two regular files, a symlink and a hard link before the scan begins. After events are logged,
         we should have 3 inode entries and a path count of 4.
         * This test is intended to be used with valid configurations files. Each execution of this test will configure

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -5,12 +5,13 @@
 import os
 import re
 import pytest
-from decimal import Decimal
 
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, callback_detect_event, check_time_travel, DEFAULT_TIMEOUT, delete_file
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, \
+                              callback_entries_path_count, check_time_travel, DEFAULT_TIMEOUT, delete_file
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
 # variables
+pytestmark = [pytest.mark.linux, pytest.mark.darwin]
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2'),
@@ -35,10 +36,6 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
-def callback_entries_path_count(line):
-    if 'inode entries: ' in line:
-        return line
-    return None
 
 # tests
 
@@ -49,22 +46,19 @@ def extra_configuration_before_yield():
     create_file(HARDLINK, testdir1, 'hardlink', target=os.path.join(testdir1, 'test_2'))
 
 
-def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd):
+def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
     """ Checks if FIM entries match the path count
-        It creates two regular files, a symlink and a hard link before the scan begins. After events are logged,  we should have
-        3 inode entries and a path count of 4.
+        It creates two regular files, a symlink and a hard link before the scan begins. After events are logged,
+        we should have 3 inode entries and a path count of 4.
         * This test is intended to be used with valid configurations files. Each execution of this test will configure
           the environment properly, restart the service and wait for the initial scan.
     """
     check_apply_test({'ossec_conf'}, get_configuration['tags'])
-    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 
-    fim_data = wazuh_log_monitor.start(timeout=60, callback=callback_entries_path_count).result()
-    check_time_travel(scheduled)
+    entries, path_count = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT, callback=callback_entries_path_count).result()
+    check_time_travel(True)
 
-    entries = re.match(r'.*Fim inode entries: (\d+), path count: (\d+)', fim_data)
-
-    if entries:
-        assert (fim_data and entries.group(1) == '3' and entries.group(2) == '4'), f'Wrong number of inodes and path count'
+    if entries and path_count:
+        assert entries == '3' and path_count == '4', 'Wrong number of inodes and path count'
     else:
-        raise AssertionError(f'Wrong number of inodes and path count')
+        raise AssertionError('Wrong number of inodes and path count')

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -12,7 +12,7 @@ from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_config
 
 # marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.darwin]
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5]
 
 # variables
 
@@ -50,12 +50,12 @@ def extra_configuration_before_yield():
 
 
 def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
-    """ Checks if FIM entries match the path count
+    """Checks if FIM entries match the path count
 
-        It creates two regular files, a symlink and a hard link before the scan begins. After events are logged,
-        we should have 3 inode entries and a path count of 4.
-        * This test is intended to be used with valid configurations files. Each execution of this test will configure
-          the environment properly, restart the service and wait for the initial scan.
+       It creates two regular files, a symlink and a hard link before the scan begins. After events are logged,
+       we should have 3 inode entries and a path count of 4.
+       * This test is intended to be used with valid configurations files. Each execution of this test will configure
+       the environment properly, restart the service and wait for the initial scan.
     """
     check_apply_test({'ossec_conf'}, get_configuration['tags'])
 

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import re
+import pytest
+from decimal import Decimal
+
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, callback_detect_event, check_time_travel, DEFAULT_TIMEOUT, delete_file
+from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
+
+# variables
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2'),
+                    os.path.join(PREFIX, 'testdir1', 'subdir')]
+directory_str = ','.join(test_directories)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+testdir1, testdir2, testdir1_subdir = test_directories
+
+# configurations
+
+conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}
+conf_metadata = {'test_directories': directory_str, 'module_name': __name__}
+p, m = generate_params(conf_params, conf_metadata, modes=['scheduled'])
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m, )
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+def callback_entries_path_count(line):
+    if 'inode entries: ' in line:
+        return line
+    return None
+
+# tests
+
+def extra_configuration_before_yield():
+    create_file(REGULAR, testdir1, 'test_1', content='')
+    create_file(REGULAR, testdir1, 'test_2', content='')
+    create_file(SYMLINK, testdir1, 'symlink', target=os.path.join(testdir1, 'test_1'))
+    create_file(HARDLINK, testdir1, 'hardlink', target=os.path.join(testdir1, 'test_2'))
+
+
+def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd):
+    """ Checks if FIM entries match the path count
+        It creates two regular files, a symlink and a hard link before the scan begins. After events are logged,  we should have
+        3 inode entries and a path count of 4.
+        * This test is intended to be used with valid configurations files. Each execution of this test will configure
+          the environment properly, restart the service and wait for the initial scan.
+    """
+    check_apply_test({'ossec_conf'}, get_configuration['tags'])
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+
+    fim_data = wazuh_log_monitor.start(timeout=60, callback=callback_entries_path_count).result()
+    check_time_travel(scheduled)
+
+    entries = re.match(r'.*Fim inode entries: (\d+), path count: (\d+)', fim_data)
+
+    if entries:
+        assert (fim_data and entries.group(1) == '3' and entries.group(2) == '4'), f'Wrong number of inodes and path count'
+    else:
+        raise AssertionError(f'Wrong number of inodes and path count')

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -3,15 +3,18 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import re
+
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, \
-                              callback_entries_path_count, check_time_travel, DEFAULT_TIMEOUT, delete_file
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, SYMLINK, HARDLINK, DEFAULT_TIMEOUT,\
+    callback_entries_path_count, check_time_travel
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
-# variables
+# marks
+
 pytestmark = [pytest.mark.linux, pytest.mark.darwin]
+
+# variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2'),
@@ -55,7 +58,8 @@ def test_entries_match_path_count(get_configuration, configure_environment, rest
     """
     check_apply_test({'ossec_conf'}, get_configuration['tags'])
 
-    entries, path_count = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT, callback=callback_entries_path_count).result()
+    entries, path_count = wazuh_log_monitor.start(timeout=DEFAULT_TIMEOUT,
+                                                  callback=callback_entries_path_count).result()
     check_time_travel(True)
 
     if entries and path_count:


### PR DESCRIPTION
This PR solves issue https://github.com/wazuh/wazuh-qa/issues/310.

The test consists in adding 4 files, 2 regular, a symbolic link and a hard link. FIM should detect 3 different inodes and 4 paths.

Output:
```
collected 1 item                                                                                        

test_basic_usage_baseline_generation.py .                                                         [100%]

=================================== 1 passed in 46807.51s (13:00:07) ====================================
```

This test only works on Linux systems.