### PR TITLE
Add FIM integration tests for max_eps option

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -547,11 +547,12 @@ def callback_symlink_scan_ended(line):
         return None
 
 
-def callback_sending_anything(line):
-    match = re.match(r'(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) .*DEBUG: .*Sending .*({.*?})$', line)
-    if match:
-        return datetime.strptime(match.group(1), '%Y/%m/%d %H:%M:%S'), json.dumps(match.group(2))
-    return None
+def callback_syscheck_message(line):
+    if callback_detect_event(line) or callback_detect_integrity_event(line):
+        match = re.match(r"(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}).*'({.*?})'$", line)
+        if match:
+            return datetime.strptime(match.group(1), '%Y/%m/%d %H:%M:%S'), json.dumps(match.group(2))
+        return None
 
 
 def check_time_travel(time_travel):

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -435,7 +435,7 @@ def callback_detect_end_scan(line):
 
 
 def callback_detect_event(line):
-    msg = r'.*Sending message to server: (.+)' if sys.platform == 'win32' else r'.*Sending event: (.+)$'
+    msg = r'.*Sending FIM event: (.+)$'
     match = re.match(msg, line)
 
     try:
@@ -450,8 +450,15 @@ def callback_detect_event(line):
 def callback_detect_integrity_event(line):
     match = re.match(r'.*Sending integrity control message: (.+)$', line)
     if match:
-        if json.loads(match.group(1))['type'] == 'state':
-            return json.loads(match.group(1))
+        return json.loads(match.group(1))
+    return None
+
+
+def callback_detect_integrity_state(line):
+    event = callback_detect_integrity_event(line)
+    if event:
+        if event['type'] == 'state':
+            return json.loads(event)
     return None
 
 
@@ -548,8 +555,8 @@ def callback_symlink_scan_ended(line):
 
 
 def callback_syscheck_message(line):
-    if callback_detect_event(line) or callback_detect_integrity_event(line):
-        match = re.match(r"(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}).*'({.*?})'$", line)
+    if callback_detect_integrity_event(line) or callback_detect_event(line):
+        match = re.match(r"(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}).*({.*?})$", line)
         if match:
             return datetime.strptime(match.group(1), '%Y/%m/%d %H:%M:%S'), json.dumps(match.group(2))
         return None

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -10,6 +10,7 @@ import shutil
 import socket
 import sys
 import time
+from datetime import datetime
 import subprocess
 from collections import Counter
 from copy import deepcopy
@@ -544,6 +545,13 @@ def callback_symlink_scan_ended(line):
         return True
     else:
         return None
+
+
+def callback_sending_anything(line):
+    match = re.match(r'(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) .*DEBUG: .*Sending .*({.*?})$', line)
+    if match:
+        return datetime.strptime(match.group(1), '%Y/%m/%d %H:%M:%S'), json.dumps(match.group(2))
+    return None
 
 
 def check_time_travel(time_travel):

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -501,7 +501,7 @@ def callback_detect_integrity_state(line):
     event = callback_detect_integrity_event(line)
     if event:
         if event['type'] == 'state':
-            return json.loads(event)
+            return event
     return None
 
 

--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -221,13 +221,13 @@ def set_section_wazuh_conf(section: str = 'syscheck',
                 if new_elements:
                     create_elements(tag, new_elements)
                 else:
-                    tag.text = properties.get('value')
+                    tag.text = str(properties.get('value'))
                     attributes = properties.get('attributes')
                     if attributes:
                         for attribute in attributes:
                             if attribute is not None and isinstance(attribute, dict):  # noqa: E501
                                 for attr_name, attr_value in attribute.items():
-                                    tag.attrib[attr_name] = attr_value
+                                    tag.attrib[attr_name] = str(attr_value)
     # get Wazuh configuration
     wazuh_conf = get_wazuh_conf()
     section_conf = wazuh_conf.find(section)

--- a/test_wazuh/test_fim/test_max_eps/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_max_eps/data/wazuh_conf.yaml
@@ -1,0 +1,16 @@
+---
+# conf 1
+- tags:
+  - max_eps
+  apply_to_modules:
+  - MODULE_NAME
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: TEST_DIRECTORIES
+      attributes:
+      - FIM_MODE
+  - max_eps:
+      value: MAX_EPS

--- a/test_wazuh/test_fim/test_max_eps/test_max_eps.py
+++ b/test_wazuh/test_fim/test_max_eps/test_max_eps.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+from collections import Counter
+from copy import deepcopy
+
+import pytest
+
+from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, create_file, generate_params, callback_sending_anything
+from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
+
+# variables
+test_directories = [os.path.join(PREFIX, 'testdir1')]
+
+directory_str = ','.join(test_directories)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+testdir1 = test_directories[0]
+
+
+# configurations
+conf_params = {'TEST_DIRECTORIES': directory_str,
+               'MODULE_NAME': __name__
+               }
+conf_metadata = {'test_directories': directory_str,
+                 'module_name': __name__
+                 }
+p, m = generate_params(extra_params=conf_params, extra_metadata=conf_metadata)
+params, metadata = list(), list()
+for max_eps in ['10', '50', '100', '200', '500']:
+    for p_dict, m_dict in zip(p, m):
+        p_dict['MAX_EPS'] = max_eps
+        m_dict['max_eps'] = max_eps
+        params.append(deepcopy(p_dict))
+        metadata.append(deepcopy(m_dict))
+configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+def extra_configuration_before_yield():
+    # Create 1000 files before starting syscheck
+    for i in range(1000):
+        create_file(REGULAR, testdir1, f'test{i}', content='')
+
+
+def test_max_eps_on_start(get_configuration, configure_environment, restart_syscheckd):
+    """Checks that max_eps is respected when a big quatity of events are generated
+
+    Before starting the service, a great number of files is created thanks to function `extra_configuration_before_yield`.
+    After that, syscheck is launched and starts generating as much events as files created.
+
+    * This test is intended to be used with valid configurations files. Each execution of this test will configure
+          the environment properly and restart the service.
+    """
+    check_apply_test({'max_eps'}, get_configuration['tags'])
+
+    result = wazuh_log_monitor.start(timeout=120,
+                                     accum_results=1000,
+                                     callback=callback_sending_anything,
+                                     update_position=False).result()
+
+    max_eps = get_configuration['metadata']['max_eps']
+    counter = Counter([date_time for date_time, _ in result])
+    for date_time, n_occurrences in counter.items():
+        assert n_occurrences <= int(max_eps), f'Sent {n_occurrences} but a maximum of {max_eps} was set'

--- a/test_wazuh/test_fim/test_skip/test_skip.py
+++ b/test_wazuh/test_fim/test_skip/test_skip.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import distro
 import pytest
 
-from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_integrity_event,
+from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_integrity_state,
                                regular_file_cud, detect_initial_scan, callback_detect_event)
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine,
@@ -134,7 +134,7 @@ def test_skip(directory, tags_to_apply,
 
         else:
             with pytest.raises(TimeoutError):
-                wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_event)
+                wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_state)
 
     elif tags_to_apply == {'skip_sys'}:
         if trigger:
@@ -158,7 +158,7 @@ def test_skip(directory, tags_to_apply,
             subprocess.Popen(["modprobe", "video"])
         else:
             with pytest.raises(TimeoutError):
-                wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_event)
+                wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_state)
     else:
         regular_file_cud(directory, wazuh_log_monitor,
                          time_travel=True,


### PR DESCRIPTION
Hi team, this closes #311 .

This PR includes the callback fix (`callback_detect_event` and `callback_detect_integrity_event`) and a refactor in `test_skip` due to a change in FIM events in addition to the `max_eps` tests.

# Tests performed
## max_eps
### Linux

```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.2, py-1.8.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 15 items                                                                                      

test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration0] PASSED           [  6%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration1] PASSED           [ 13%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration2] PASSED           [ 20%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration3] PASSED           [ 26%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration4] PASSED           [ 33%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration5] PASSED           [ 40%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration6] PASSED           [ 46%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration7] PASSED           [ 53%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration8] PASSED           [ 60%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration9] PASSED           [ 66%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration10] PASSED          [ 73%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration11] PASSED          [ 80%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration12] PASSED          [ 86%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration13] PASSED          [ 93%]
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration14] PASSED          [100%]

==================================== 15 passed in 553.96s (0:09:13) =====================================
```
### Windows
```
================================================= test session starts ================================================== 
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0 -- C:\Users\jmv74211\AppData\Local\Programs\Python\Python37-32\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 15 items

test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration0] PASSED                           [  6%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration1] PASSED                           [ 13%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration2] PASSED                           [ 20%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration3] PASSED                           [ 26%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration4] PASSED                           [ 33%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration5] PASSED                           [ 40%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration6] PASSED                           [ 46%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration7] PASSED                           [ 53%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration8] PASSED                           [ 60%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration9] PASSED                           [ 66%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration10] PASSED                          [ 73%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration11] PASSED                          [ 80%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration12] PASSED                          [ 86%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration13] PASSED                          [ 93%] 
test_fim/test_max_eps/test_max_eps.py::test_max_eps_on_start[get_configuration14] PASSED                          [100%]

============================================ 15 passed in 736.19s (0:12:16) ============================================
```
## skip_*
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.2, py-1.8.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 32 items                                                                                      

test_fim/test_skip/test_skip.py::test_skip[get_configuration0-/proc-tags_to_apply0] PASSED        [  3%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration0-/sys/video-tags_to_apply1] SKIPPED  [  6%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration0-/dev-tags_to_apply2] SKIPPED        [  9%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration0-/nfs-mount-point-tags_to_apply3] SKIPPED [ 12%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration1-/proc-tags_to_apply0] SKIPPED       [ 15%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration1-/sys/video-tags_to_apply1] PASSED   [ 18%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration1-/dev-tags_to_apply2] SKIPPED        [ 21%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration1-/nfs-mount-point-tags_to_apply3] SKIPPED [ 25%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration2-/proc-tags_to_apply0] SKIPPED       [ 28%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration2-/sys/video-tags_to_apply1] SKIPPED  [ 31%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration2-/dev-tags_to_apply2] PASSED         [ 34%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration2-/nfs-mount-point-tags_to_apply3] SKIPPED [ 37%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration3-/proc-tags_to_apply0] SKIPPED       [ 40%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration3-/sys/video-tags_to_apply1] SKIPPED  [ 43%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration3-/dev-tags_to_apply2] SKIPPED        [ 46%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration3-/nfs-mount-point-tags_to_apply3] PASSED [ 50%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration4-/proc-tags_to_apply0] PASSED        [ 53%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration4-/sys/video-tags_to_apply1] SKIPPED  [ 56%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration4-/dev-tags_to_apply2] SKIPPED        [ 59%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration4-/nfs-mount-point-tags_to_apply3] SKIPPED [ 62%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration5-/proc-tags_to_apply0] SKIPPED       [ 65%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration5-/sys/video-tags_to_apply1] PASSED   [ 68%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration5-/dev-tags_to_apply2] SKIPPED        [ 71%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration5-/nfs-mount-point-tags_to_apply3] SKIPPED [ 75%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration6-/proc-tags_to_apply0] SKIPPED       [ 78%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration6-/sys/video-tags_to_apply1] SKIPPED  [ 81%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration6-/dev-tags_to_apply2] PASSED         [ 84%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration6-/nfs-mount-point-tags_to_apply3] SKIPPED [ 87%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration7-/proc-tags_to_apply0] SKIPPED       [ 90%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration7-/sys/video-tags_to_apply1] SKIPPED  [ 93%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration7-/dev-tags_to_apply2] SKIPPED        [ 96%]
test_fim/test_skip/test_skip.py::test_skip[get_configuration7-/nfs-mount-point-tags_to_apply3] PASSED [100%]

========================= 8 passed, 24 skipped in 655416.20s (7 days, 14:03:36) =========================
```