### PR TITLE
Add tier levels to FIM tests.

### DIFF
--- a/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
@@ -13,6 +13,10 @@ from wazuh_testing.fim import (LOG_FILE_PATH, regular_file_cud, create_file, WAZ
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine, PREFIX)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/test_wazuh/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
@@ -15,6 +15,10 @@ from wazuh_testing.fim import (DEFAULT_TIMEOUT, LOG_FILE_PATH, regular_file_cud,
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, PREFIX)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_ambiguous_confs/test_duplicate_entries.py
+++ b/test_wazuh/test_fim/test_ambiguous_confs/test_duplicate_entries.py
@@ -10,7 +10,9 @@ from wazuh_testing.fim import (LOG_FILE_PATH, check_time_travel, callback_detect
                                create_file, REGULAR, generate_params, DEFAULT_TIMEOUT)
 from wazuh_testing.tools import (FileMonitor, load_wazuh_configurations, PREFIX, check_apply_test)
 
-pytestmark = [pytest.mark.linux, pytest.mark.win32]
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=2)]
 
 # variables
 test_directories = [os.path.join(PREFIX, 'testdir1')]*2

--- a/test_wazuh/test_fim/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/test_wazuh/test_fim/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_ignore, callback_detect_ev
     generate_params, check_time_travel, DEFAULT_TIMEOUT
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
 # Variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_audit/test_audit.py
+++ b/test_wazuh/test_fim/test_audit/test_audit.py
@@ -23,8 +23,9 @@ from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  control_service,
                                  truncate_file)
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_audit/test_audit_after_initial_scan.py
+++ b/test_wazuh/test_fim/test_audit/test_audit_after_initial_scan.py
@@ -19,9 +19,9 @@ from wazuh_testing.tools import (FileMonitor, load_wazuh_configurations,
                                  check_apply_test, truncate_file)
 
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Variables
 

--- a/test_wazuh/test_fim/test_audit/test_remove_audit.py
+++ b/test_wazuh/test_fim/test_audit/test_remove_audit.py
@@ -13,9 +13,9 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_audit_cannot_start
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations, check_apply_test
 
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Variables
 

--- a/test_wazuh/test_fim/test_audit/test_remove_rule_five_times.py
+++ b/test_wazuh/test_fim/test_audit/test_remove_rule_five_times.py
@@ -15,9 +15,9 @@ from wazuh_testing.tools import (FileMonitor,
                                  check_apply_test)
 
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Variables
 

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_baseline_generation.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_baseline_generation.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, callback_detect_event, ca
                                generate_params)
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_changes.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_changes.py
@@ -8,6 +8,10 @@ import pytest
 from wazuh_testing.fim import CHECK_ALL, LOG_FILE_PATH, regular_file_cud, generate_params, DEFAULT_TIMEOUT
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import (CHECK_ALL, DEFAULT_TIMEOUT, FIFO, LOG_FILE_PATH, 
                                callback_detect_event, create_file, validate_event, generate_params)
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import CHECK_ALL, DEFAULT_TIMEOUT, FIFO, LOG_FILE_PATH, R
     create_file, validate_event, generate_params
 from wazuh_testing.tools import FileMonitor, TimeMachine, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]
 

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGUL
     callback_detect_event, check_time_travel, DEFAULT_TIMEOUT
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -10,9 +10,9 @@ from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGUL
     DEFAULT_TIMEOUT, callback_entries_path_count, check_time_travel
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
-# marks
+# Marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5]
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_move_file.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_move_file.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGUL
     callback_detect_event, check_time_travel, DEFAULT_TIMEOUT, delete_file
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_rename.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_rename.py
@@ -12,6 +12,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGUL
     callback_detect_event, check_time_travel, DEFAULT_TIMEOUT
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX, TimeMachine
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import DEFAULT_TIMEOUT, LOG_FILE_PATH, REGULAR, callback_
     create_file, generate_params, modify_file_content, check_time_travel, delete_file
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
 # Variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]

--- a/test_wazuh/test_fim/test_benchmark/test_benchmark.py
+++ b/test_wazuh/test_fim/test_benchmark/test_benchmark.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud, generate_params
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, PREFIX)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=3)
+
 # variables
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]

--- a/test_wazuh/test_fim/test_checks/test_check_all.py
+++ b/test_wazuh/test_fim/test_checks/test_check_all.py
@@ -12,6 +12,10 @@ from wazuh_testing.fim import (CHECK_ALL, CHECK_ATTRS, CHECK_GROUP, CHECK_INODE,
                                REQUIRED_ATTRIBUTES, regular_file_cud, generate_params)
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_checks/test_check_others.py
+++ b/test_wazuh/test_fim/test_checks/test_check_others.py
@@ -12,6 +12,10 @@ from wazuh_testing.fim import (CHECK_ATTRS, CHECK_GROUP, CHECK_INODE, CHECK_MD5S
                                LOG_FILE_PATH, REQUIRED_ATTRIBUTES, regular_file_cud, generate_params)
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_checks/test_checksums.py
+++ b/test_wazuh/test_fim/test_checks/test_checksums.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import (CHECK_ALL, CHECK_MD5SUM, CHECK_SHA1SUM, CHECK_SHA
                                LOG_FILE_PATH, REQUIRED_ATTRIBUTES, regular_file_cud, generate_params)
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_checks/test_hard_link.py
+++ b/test_wazuh/test_fim/test_checks/test_hard_link.py
@@ -11,6 +11,9 @@ from wazuh_testing.fim import (DEFAULT_TIMEOUT, HARDLINK, LOG_FILE_PATH, REGULAR
                                check_time_travel, create_file, delete_file, modify_file_content, generate_params)
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations, truncate_file
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
 
 # variables
 

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target.py
@@ -14,7 +14,7 @@ from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
 # All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
@@ -13,8 +13,9 @@ from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_d
 from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # configurations
 

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_symlink.py
@@ -14,9 +14,9 @@ from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # configurations
 

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_target.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_delete_target.py
@@ -13,9 +13,9 @@ from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # configurations
 

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
@@ -12,9 +12,9 @@ from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # configurations
 

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -15,9 +15,9 @@ from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, PREFIX)
 
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+# Marks
 
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_follow_symbolic_link/test_revert_symlink.py
+++ b/test_wazuh/test_fim/test_follow_symbolic_link/test_revert_symlink.py
@@ -14,8 +14,9 @@ from wazuh_testing.tools import (check_apply_test,
                                  load_wazuh_configurations, FileMonitor)
 
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin]
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/test_wazuh/test_fim/test_frequency/test_frequency.py
+++ b/test_wazuh/test_fim/test_frequency/test_frequency.py
@@ -12,8 +12,9 @@ import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, DEFAULT_TIMEOUT, regular_file_cud, generate_params
 from wazuh_testing.tools import FileMonitor, TimeMachine, check_apply_test, load_wazuh_configurations, PREFIX
 
-# All tests in this module apply to linux and windows only
-pytestmark = [pytest.mark.linux, pytest.mark.win32]
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, callback_ign
     generate_params
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, TimeMachine, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_invalid/test_invalid.py
+++ b/test_wazuh/test_fim/test_invalid/test_invalid.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_configuration_error
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, PREFIX, control_service)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_max_eps/test_max_eps.py
+++ b/test_wazuh/test_fim/test_max_eps/test_max_eps.py
@@ -11,6 +11,10 @@ import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, create_file, generate_params, callback_syscheck_message
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 test_directories = [os.path.join(PREFIX, 'testdir1')]
 

--- a/test_wazuh/test_fim/test_moving_files/test_moving_files.py
+++ b/test_wazuh/test_fim/test_moving_files/test_moving_files.py
@@ -9,8 +9,9 @@ import pytest
 from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, DEFAULT_TIMEOUT, callback_detect_event, create_file)
 from wazuh_testing.tools import FileMonitor, PREFIX, load_wazuh_configurations
 
-# All tests in this module apply to linux and windows only
-pytestmark = [pytest.mark.linux, pytest.mark.win32]
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # Variables
 

--- a/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
+++ b/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
@@ -10,6 +10,10 @@ import pytest
 from wazuh_testing.fim import DEFAULT_TIMEOUT, LOG_FILE_PATH, regular_file_cud, WAZUH_PATH, generate_params
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/test_wazuh/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -12,8 +12,9 @@ from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan, generate_param
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, restart_wazuh_daemon, truncate_file)
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_process_priority/test_process_priority.py
+++ b/test_wazuh/test_fim/test_process_priority/test_process_priority.py
@@ -11,8 +11,9 @@ import pytest
 from wazuh_testing.fim import generate_params
 from wazuh_testing.tools import check_apply_test, load_wazuh_configurations, get_process
 
-# All tests in this module apply to linux only
-pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5]
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=1)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_recursion_level/test_recursion_level.py
+++ b/test_wazuh/test_fim/test_recursion_level/test_recursion_level.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import (DEFAULT_TIMEOUT, LOG_FILE_PATH, callback_audit_ev
                                generate_params)
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
 # Variables
 
 prefix = os.path.join('C:', os.sep) if sys.platform == 'win32' else os.sep

--- a/test_wazuh/test_fim/test_report_changes/test_report_changes_and_diff.py
+++ b/test_wazuh/test_fim/test_report_changes/test_report_changes_and_diff.py
@@ -9,6 +9,10 @@ import pytest
 from wazuh_testing.fim import (CHECK_ALL, DEFAULT_TIMEOUT, LOG_FILE_PATH, regular_file_cud, WAZUH_PATH, generate_params)
 from wazuh_testing.tools import (PREFIX, FileMonitor, check_apply_test, load_wazuh_configurations)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 

--- a/test_wazuh/test_fim/test_report_changes/test_report_deleted_diff.py
+++ b/test_wazuh/test_fim/test_report_changes/test_report_deleted_diff.py
@@ -14,6 +14,10 @@ from wazuh_testing.tools import (PREFIX, FileMonitor, TimeMachine,
                                  load_wazuh_configurations, restart_wazuh_with_new_conf, set_section_wazuh_conf,
                                  check_apply_test)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
+++ b/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
@@ -12,6 +12,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_ev
 from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine, PREFIX)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_scan/test_scan_day.py
+++ b/test_wazuh/test_fim/test_scan/test_scan_day.py
@@ -9,6 +9,10 @@ import pytest
 from wazuh_testing.fim import (LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_end_scan)
 from wazuh_testing.tools import (FileMonitor, check_apply_test, load_wazuh_configurations, TimeMachine, PREFIX)
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 

--- a/test_wazuh/test_fim/test_scan/test_scan_day_and_time.py
+++ b/test_wazuh/test_fim/test_scan/test_scan_day_and_time.py
@@ -11,6 +11,10 @@ from wazuh_testing.fim import (LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_e
 from wazuh_testing.tools import (FileMonitor, check_apply_test, load_wazuh_configurations, TimeMachine, reformat_time,
                                  PREFIX)
 
+# Marks
+
+pytestmark = [pytest.mark.tier(level=1)]
+
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 

--- a/test_wazuh/test_fim/test_scan/test_scan_time.py
+++ b/test_wazuh/test_fim/test_scan/test_scan_time.py
@@ -10,6 +10,10 @@ from wazuh_testing.fim import (LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_e
 from wazuh_testing.tools import (FileMonitor, check_apply_test, load_wazuh_configurations, reformat_time, TimeMachine,
                                  PREFIX)
 
+# Marks
+
+pytestmark = [pytest.mark.tier(level=1)]
+
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 

--- a/test_wazuh/test_fim/test_skip/test_skip.py
+++ b/test_wazuh/test_fim/test_skip/test_skip.py
@@ -18,8 +18,9 @@ from wazuh_testing.tools import (FileMonitor, check_apply_test,
                                  load_wazuh_configurations, TimeMachine,
                                  set_section_wazuh_conf, restart_wazuh_with_new_conf, PREFIX)
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_sync/test_invalid_sync_response.py
+++ b/test_wazuh/test_fim/test_sync/test_invalid_sync_response.py
@@ -8,8 +8,9 @@ import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, callback_configuration_warning
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
 
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_sync/test_response_timeout.py
+++ b/test_wazuh/test_fim/test_sync/test_response_timeout.py
@@ -17,8 +17,9 @@ if sys.platform == "linux":
     import paramiko
 
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
 
 # variables
 

--- a/test_wazuh/test_fim/test_sync/test_sync_interval.py
+++ b/test_wazuh/test_fim/test_sync/test_sync_interval.py
@@ -9,8 +9,9 @@ from wazuh_testing.fim import (LOG_FILE_PATH, callback_detect_synchronization, d
 from wazuh_testing.tools import (FileMonitor, truncate_file, check_apply_test, load_wazuh_configurations, TimeMachine,
                                  time_to_timedelta, PREFIX)
 
-# All tests in this module apply to linux only
-pytestmark = pytest.mark.linux
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
 
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/test_wazuh/test_fim/test_tags/test_tags.py
+++ b/test_wazuh/test_fim/test_tags/test_tags.py
@@ -9,6 +9,12 @@ import pytest
 from wazuh_testing.fim import DEFAULT_TIMEOUT, LOG_FILE_PATH, regular_file_cud, generate_params
 from wazuh_testing.tools import FileMonitor, load_wazuh_configurations, PREFIX
 
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
+# Variables
+
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 test_directories = [os.path.join(PREFIX, 'testdir_tags'),

--- a/test_wazuh/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
+++ b/test_wazuh/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
@@ -15,8 +15,9 @@ if sys.platform == 'win32':
     from test_fim.test_windows_audit_interval.manage_acl import Privilege, get_file_security_descriptor, modify_sacl, \
         get_sacl
 
-# All tests in this module apply to windows only
-pytestmark = pytest.mark.win32
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # variables
 


### PR DESCRIPTION
This PR is related to issue [#297](https://github.com/wazuh/wazuh-qa/issues/297)

## Description
Add tier levels to each module. This way, it is possible to choose a certain level to perform tests, which are classified according to their importance or required execution time. In total there are four levels, from the most important (0) to the least important (3)

The classification is detailed below:

### Tier 0
- **test_basic_usage** Verify if syscheck correctly detects basic behaviors, such as creating/modifying/deleting files in different FIM modes.


### Tier 1
- **test_audit/test_audit.py** Verify the proper working of the most basic and important audit parts.
- **test_audit/test_remove_audit.py** Check folders monitored with Whodata change to Real-time if auditd is not installed.
- **test_audit/test_audit_after_initial_scan.py** Restart auditd and check Wazuh reconnect to auditd.
- **test_windows_audit_interval** 
- **test_scan** Check that scans occur at specific and established times.
- **test_follow_symbolic_link/test_monitor_symlink.py** Check what happens with a symlink and its target when syscheck monitors it.
- **test_follow_symbolic_link (rest of tests)** 
- **test_checks** Verify different combinations of checks. It is already checked less deeply in test_ambiguous.
- **test_moving_files** Verify the behavior of syscheck when moving files from a directory in 'whodata' to another in 'realtime' and vice versa.
- **test_report_changes/test_reports_file_and_nodiff.py** Check if report_changes events and diff truncated files are correct.
- **test_audit/test_remove_rule_five_times.py** Remove auditd rule using auditctl five times and check Wazuh ignores folder.
- **test_frequency** Checks if a non existing directory is monitored in realtime after the frequency time has passed.
- **test_invalid** Checks if an invalid configuration is detected
- **test_report_changes/test_report_deleted_diff.py** Check if duplicated directories in diff are deleted when changing report_changes to 'no' or deleting the monitored directories.
- **test_restrict** Checks the only files detected are those matching the restrict regex.
- **test_prefilter_cmd** Checks if prelink is installed and syscheck works.
-  **test_process_priority** Check if the ossec-syscheckd service priority is updated correctly using 'process_priority' tag.
- **test_skip** Check if syscheck is skipping the directory based on its skip configuration
- **test_tags** Checks the tags functionality by applying some tags an ensuring the events raised for the monitored directory has the expected tags.
- **test_max_eps** Checks that max_eps is respected when a big quatity of events are generated


### Tier 2
- **test_ambiguous_confs/test_ambiguous_complex.py** Verify the correct application of important and different configurations in subdirectories (checks, report_changes).
- **test_ambiguous_confs/test_ambiguous_simple.py** Verify the correct application of important and different configurations such as 'recursion_level', 'report_changes' and different checks.
- **test_ambiguous_confs/test_ignore_works_over_restrict.py** Checks if the ignore tag prevails over the restrict one when using both in the same directory.
- **test_ambiguous_confs/test_duplicate_entries.py.py** Checks if the ignore tag prevails over the restrict one when using both in the same directory.
- **test_ignore** Checks files are ignored in subdirectory according to configuration.
- **test_nodiff** Checks files are ignored in subdirectory according to configuration.
- **test_recursion_level**  It is already checked less deeply in test_ambiguous. Checks that events are generated in the first and last 'edge_limit' directory levels.
- **test_sync** Checks if an invalid ignore configuration is detected by catching the warning message displayed on the log.

### Tier 3
- **test_benchmark** Checks syscheckd detects a certain volume of file changes (add, modify, delete).