### PR TITLE
Fix diff path on Windows

### DIFF
--- a/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
+++ b/test_wazuh/test_fim/test_nodiff/test_no_diff_valid.py
@@ -94,8 +94,13 @@ def test_no_diff_subdirectory(folder, filename, content, hidden_content,
     def report_changes_validator(event):
         """ Validate content_changes attribute exists in the event """
         for file in files:
-            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local',
-                                     folder.strip(PREFIX), file)
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local')
+
+            if sys.platform == 'win32':
+                diff_file = os.path.join(diff_file, 'c')
+
+            diff_file = os.path.join(diff_file, folder.strip(PREFIX), file)
+
             assert os.path.exists(diff_file), f'{diff_file} does not exist'
             assert event['data'].get('content_changes') is not None, f'content_changes is empty'
 


### PR DESCRIPTION
Added `c` to the path of a monitored file with the `nodiff` option in Windows.