### PR TITLE
Add test to check the registry ignore in Windows

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -300,7 +300,7 @@ def delete_file(path, name):
         os.remove(regular_path)
 
 
-def delete_registry(key, subkey):
+def delete_registry(key, subkey, arch):
     """ Deletes a registry
 
     :param key: The key of the registry
@@ -309,9 +309,7 @@ def delete_registry(key, subkey):
     :type subkey: String
     :return: None
     """
-    if sys.platform != 'win32':
-        return
-    key = winreg.CreatDeleteKeyEx(key, subkey)
+    sys.platform == 'win32' and winreg.DeleteKeyEx(key, subkey, access=arch)
 
 
 def modify_registry(key, subkey, value):
@@ -325,9 +323,7 @@ def modify_registry(key, subkey, value):
     :type value: String
     :return: None
     """
-    if sys.platform != 'win32':
-        return
-    key = winreg.SetValue(key, subkey, value)
+    sys.platform == 'win32' and winreg.SetValue(key, subkey, winreg.REG_SZ, value)
 
 
 def modify_file_content(path, name, new_content=None, is_binary=False):

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -24,6 +24,7 @@ from wazuh_testing.tools import TimeMachine
 if sys.platform == 'win32':
     import win32con
     import win32api
+    import winreg
 else:
     from jq import jq
 
@@ -175,6 +176,21 @@ def create_file(type_, path, name, **kwargs):
     getattr(sys.modules[__name__], f'_create_{type_}')(path, name, **kwargs)
 
 
+def create_registry(key, subkey, arch)
+    """ Creates a registry given the key and the subkey. The registry is opened if it already exists
+
+    :param key: The key of the registry
+    :type key: HKEY_* constants
+    :param subkey: The subkey (name) of the registry
+    :type subkey: String
+    :return: None
+    """
+    if sys.platform != 'win32':
+        return
+    access_ = arch | winreg.KEY_WRITE
+    key = winreg.CreateKeyEx(key, subkey, access=access_)
+
+
 def _create_fifo(path, name):
     """Creates a FIFO file.
 
@@ -274,6 +290,36 @@ def delete_file(path, name):
     regular_path = os.path.join(path, name)
     if os.path.exists(regular_path):
         os.remove(regular_path)
+
+
+def delete_registry(key, subkey)
+    """ Deletes a registry
+
+    :param key: The key of the registry
+    :type key: HKEY_* constants
+    :param subkey: The subkey (name) of the registry
+    :type subkey: String
+    :return: None
+    """
+    if sys.platform != 'win32':
+        return
+    key = winreg.CreatDeleteKeyEx(key, subkey)
+
+
+def modify_registry(key, subkey, value)
+    """ Modifies the content of REG_SZ in a registry
+
+    :param key: The key of the registry
+    :type key: HKEY_* constants
+    :param subkey: The subkey (name) of the registry
+    :type subkey: String
+    :param value: The value to be set
+    :type value: String
+    :return: None
+    """
+    if sys.platform != 'win32':
+        return
+    key = winreg.SetValue(key, subkey, value)
 
 
 def modify_file_content(path, name, new_content=None, is_binary=False):

--- a/packages/wazuh_testing/wazuh_testing/fim.py
+++ b/packages/wazuh_testing/wazuh_testing/fim.py
@@ -185,13 +185,15 @@ def create_file(type_, path, name, **kwargs):
 
 
 def create_registry(key, subkey, arch):
-    """ Creates a registry given the key and the subkey. The registry is opened if it already exists
+    """
+    Creates a registry given the key and the subkey. The registry is opened if it already exists
 
-    :param key: The key of the registry
-    :type key: HKEY_* constants
-    :param subkey: The subkey (name) of the registry
-    :type subkey: String
-    :return: None
+    Parameters
+    ----------
+    key : str
+        The key of the registry (HKEY_* constants).
+    subkey : str
+        The subkey (name) of the registry.
     """
     if sys.platform != 'win32':
         return
@@ -301,27 +303,31 @@ def delete_file(path, name):
 
 
 def delete_registry(key, subkey, arch):
-    """ Deletes a registry
+    """
+    Deletes a registry
 
-    :param key: The key of the registry
-    :type key: HKEY_* constants
-    :param subkey: The subkey (name) of the registry
-    :type subkey: String
-    :return: None
+    Parameters
+    ----------
+    key : str
+        The key of the registry (HKEY_* constants).
+    subkey : str
+        The subkey (name) of the registry.
     """
     sys.platform == 'win32' and winreg.DeleteKeyEx(key, subkey, access=arch)
 
 
 def modify_registry(key, subkey, value):
-    """ Modifies the content of REG_SZ in a registry
+    """
+    Modifies the content of REG_SZ in a registry
 
-    :param key: The key of the registry
-    :type key: HKEY_* constants
-    :param subkey: The subkey (name) of the registry
-    :type subkey: String
-    :param value: The value to be set
-    :type value: String
-    :return: None
+    Parameters
+    ----------
+    key : str
+        The key of the registry (HKEY_* constants)
+    subkey : str
+        The subkey (name) of the registry.
+    value : str
+        The value to be set.
     """
     sys.platform == 'win32' and winreg.SetValue(key, subkey, winreg.REG_SZ, value)
 

--- a/test_wazuh/test_fim/conftest.py
+++ b/test_wazuh/test_fim/conftest.py
@@ -40,9 +40,10 @@ def configure_environment(get_configuration, request):
                                          get_configuration.get('elements'))
 
     # create test directories
-    test_directories = getattr(request.module, 'test_directories')
-    for test_dir in test_directories:
-        os.makedirs(test_dir, exist_ok=True, mode=0o777)
+    if hasattr(request.module, 'test_directories'):
+        test_directories = getattr(request.module, 'test_directories')
+        for test_dir in test_directories:
+            os.makedirs(test_dir, exist_ok=True, mode=0o777)
 
     # set new configuration
     write_wazuh_conf(test_config)
@@ -58,8 +59,9 @@ def configure_environment(get_configuration, request):
     if sys.platform == 'win32':
         control_service('stop')
 
-    for test_dir in test_directories:
-        shutil.rmtree(test_dir, ignore_errors=True)
+    if hasattr(request.module, 'test_directories'):
+        for test_dir in test_directories:
+            shutil.rmtree(test_dir, ignore_errors=True)
 
     if sys.platform == 'win32':
         control_service('start')

--- a/test_wazuh/test_fim/test_ignore/data/wazuh_conf_win32.yaml
+++ b/test_wazuh/test_fim/test_ignore/data/wazuh_conf_win32.yaml
@@ -188,3 +188,76 @@
       attributes:
       - check_all: 'yes'
       - FIM_MODE
+# conf 12
+- tags:
+  - ignore_registry
+  apply_to_modules:
+  - test_ignore_registry
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test\\testreg32"
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test\\testreg64"
+      attributes:
+      - arch: '64bit'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test2\\testregboth_32"
+      attributes:
+      - type: 'sregex'
+      - arch: 'both'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test2\\testregboth_64"
+      attributes:
+      - type: 'sregex'
+      - arch: 'both'
+  - windows_registry:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test"
+  - windows_registry:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test"
+      attributes:
+      - arch: '64bit'
+  - windows_registry:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test2"
+      attributes:
+      - arch: 'both'
+# conf 13
+- tags:
+  - ignore_registry
+  apply_to_modules:
+  - test_ignore_registry
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test\\testreg32"
+      attributes:
+      - type: 'sregex'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test\\testreg64"
+      attributes:
+      - type: 'sregex'
+      - arch: '64bit'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test2\\testregboth_32"
+      attributes:
+      - type: 'sregex'
+      - arch: 'both'
+  - registry_ignore:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test2\\testregboth_64"
+      attributes:
+      - type: 'sregex'
+      - arch: 'both'
+  - windows_registry:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test"
+  - windows_registry:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test"
+      attributes:
+      - arch: '64bit'
+  - windows_registry:
+      value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\test2"
+      attributes:
+      - arch: 'both'

--- a/test_wazuh/test_fim/test_ignore/test_ignore_registry.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_registry.py
@@ -80,14 +80,20 @@ def get_configuration(request):
 ])
 def test_ignore_registry(key_string, key_object, tags_to_apply, get_configuration,
                          configure_environment, restart_syscheckd, wait_for_initial_scan):
-    """Checks registries are ignored according to configuration.
+    """
+    Checks registries are ignored according to configuration.
 
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param key_string: String name of the key
-    :param key_object: Object winreg of the key
-    :param tags_to_apply: Run test if matches with a configuration identifier, skip otherwise
+    Parameters
+    ----------
+    key_string : str
+        String name of the key.
+    key_object : object
+        Object winreg of the key.
+    tags_to_apply : set
+        Run test if matches with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
 

--- a/test_wazuh/test_fim/test_ignore/test_ignore_registry.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_registry.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import pytest
+from datetime import timedelta
+from wazuh_testing.fim import LOG_FILE_PATH, callback_ignore, create_registry, delete_registry
+from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, TimeMachine
+
+
+if sys.platform == 'win32':
+    import winreg
+
+# All tests in this module apply to windows only
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# variables
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_win32.yaml')
+
+keys = [(winreg.HKEY_LOCAL_MACHINE, "HKEY_LOCAL_MACHINE")]
+
+keys_objects = list()
+keys_strings = list()
+
+for key in keys:
+    object_, string_ = key
+    keys_objects.append(object_)
+    keys_strings.append(string_)
+
+regs = [os.path.join('SOFTWARE', 'test'),  os.path.join('SOFTWARE', 'test2')]
+sub_keys = [os.path.join(regs[0], 'testreg32'), os.path.join(regs[0], 'testreg64'),
+            os.path.join(regs[1], 'testregboth_32'), os.path.join(regs[1], 'testregboth_64')]
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# configurations
+
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+
+def extra_configuration_before_yield():
+    """ Initialize registries for this test """
+    reg_handlers = list()
+    for reg in regs:
+        create_registry(keys_objects[0], reg, winreg.KEY_WOW64_32KEY)
+        create_registry(keys_objects[0], reg, winreg.KEY_WOW64_64KEY)
+
+    create_registry(keys_objects[0], sub_keys[0], winreg.KEY_WOW64_32KEY)
+    create_registry(keys_objects[0], sub_keys[1], winreg.KEY_WOW64_64KEY)
+    create_registry(keys_objects[0], sub_keys[2], winreg.KEY_WOW64_32KEY)
+    create_registry(keys_objects[0], sub_keys[3], winreg.KEY_WOW64_64KEY)
+
+
+def extra_configuration_after_yield():
+    delete_registry(keys_objects[0], sub_keys[0], winreg.KEY_WOW64_32KEY)
+    delete_registry(keys_objects[0], sub_keys[1], winreg.KEY_WOW64_64KEY)
+    delete_registry(keys_objects[0], sub_keys[2], winreg.KEY_WOW64_32KEY)
+    delete_registry(keys_objects[0], sub_keys[3], winreg.KEY_WOW64_64KEY)
+
+    for reg in regs:
+        delete_registry(keys_objects[0], reg, winreg.KEY_WOW64_32KEY)
+        delete_registry(keys_objects[0], reg, winreg.KEY_WOW64_64KEY)
+
+
+# fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('key_string, key_object, tags_to_apply', [
+    (keys_strings, keys_objects, {'ignore_registry'})
+])
+def test_ignore_registry(key_string, key_object, tags_to_apply, get_configuration,
+                         configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """Checks registries are ignored according to configuration.
+
+    This test is intended to be used with valid configurations files. Each execution of this test will configure the
+    environment properly, restart the service and wait for the initial scan.
+
+    :param key_string: String name of the key
+    :param key_object: Object winreg of the key
+    :param tags_to_apply: Run test if matches with a configuration identifier, skip otherwise
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    TimeMachine.travel_to_future(timedelta(hours=13))
+
+    ignored_registry = wazuh_log_monitor.start(timeout=10, callback=callback_ignore,
+                                               accum_results=len(sub_keys)).result()
+    ignored_registry = set(ignored_registry)
+    for ign_reg in sub_keys:
+        try:
+            ignored_registry.remove(os.path.join(keys_strings[0], ign_reg))
+        except KeyError:
+            print(f'{os.path.join(keys_strings[0],ign_reg)} not in {ignored_registry}')
+            raise
+    assert len(ignored_registry) == 0


### PR DESCRIPTION
This PR solves #286 

### Test result
```
================================================= test session starts =================================================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0 -- C:\Users\jmv74211\AppData\Local\Programs\Python
\Python37-32\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 2 items
test_fim/test_ignore/test_ignore_registry.py::test_ignore_registry[get_configuration0-key_string0-key_object0-0-tags_to_
apply0] PASSED [ 50%]
test_fim/test_ignore/test_ignore_registry.py::test_ignore_registry[get_configuration1-key_string0-key_object0-0-tags_to_
apply0] PASSED [100%]
======================================= 2 passed in 93645.20s (1 day, 2:00:45) ========================================
```
