### PR TITLE
Change audit-keys list file owner and permissions

### DIFF
--- a/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
@@ -112,7 +112,7 @@ def test_wazuh_api_version(host, ManagerRoleDefaults):
         ("/var/ossec/etc/sslmanager.cert", "root", "root", 0o640),
         ("/var/ossec/etc/sslmanager.key", "root", "root", 0o640),
         ("/var/ossec/etc/rules/local_rules.xml", "root", "ossec", 0o640),
-        ("/var/ossec/etc/lists/audit-keys", "root", "ossec", 0o640),
+        ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o640),
     ],
 )
 def test_wazuh_files(host, wazuh_file, wazuh_owner, wazuh_group, wazuh_mode):

--- a/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
+++ b/ansible/wazuh-ansible/molecule/default/tests/test_manager.py
@@ -112,7 +112,7 @@ def test_wazuh_api_version(host, ManagerRoleDefaults):
         ("/var/ossec/etc/sslmanager.cert", "root", "root", 0o640),
         ("/var/ossec/etc/sslmanager.key", "root", "root", 0o640),
         ("/var/ossec/etc/rules/local_rules.xml", "root", "ossec", 0o640),
-        ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o640),
+        ("/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660),
     ],
 )
 def test_wazuh_files(host, wazuh_file, wazuh_owner, wazuh_group, wazuh_mode):


### PR DESCRIPTION
Hi all!

This PR contains the changes to:
- Change the owner user of `"/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660`
- Change the permissions of `"/var/ossec/etc/lists/audit-keys", "ossec", "ossec", 0o660`

Kr,

Rshad