### PR TITLE
Rename windows_attributes to attributes in syscheck_event_windows.json

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/data/syscheck_event_windows.json
+++ b/packages/wazuh_testing/wazuh_testing/data/syscheck_event_windows.json
@@ -202,8 +202,8 @@
               ],
               "pattern": "^[a-f0-9]{64}$"
             },
-            "win_attributes": {
-              "$id": "#/properties/data/properties/attributes/properties/win_attributes",
+            "attributes": {
+              "$id": "#/properties/data/properties/attributes/properties/attributes",
               "type": "string",
               "default": "",
               "examples": [
@@ -241,7 +241,8 @@
               "gid",
               "user_name",
               "group_name",
-              "inode"
+              "inode",
+              "attributes"
               ],
             "examples": [
               "size",
@@ -255,7 +256,8 @@
               "gid",
               "user_name",
               "group_name",
-              "inode"
+              "inode",
+              "attributes"
             ],
             "pattern": "^(.*)$"
           }


### PR DESCRIPTION
Hi Team,

This PR updates `syscheck_event_windows.json` file used by the FIM integration tests to rename the property `windows_attributes` to `attributes`, as from now on this is how will appear on the events generated by `Syscheckd`. It also also adds it to `changed_attributes`.


**This change only affects to windows environments** and solves one of the "Windows Test Failures" described in issue #379.


## Test results

**Test basic usage**
```
=================================== test session starts ===================================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 90 items

test_fim\test_basic_usage\test_basic_usage_baseline_generation.py ..                [  2%]
test_fim\test_basic_usage\test_basic_usage_changes.py ......                        [  8%]
test_fim\test_basic_usage\test_basic_usage_create_rt_wd.py ........................ [ 35%]
test_fim\test_basic_usage\test_basic_usage_create_scheduled.py ............         [ 48%]
test_fim\test_basic_usage\test_basic_usage_delete_folder.py ......                  [ 55%]
test_fim\test_basic_usage\test_basic_usage_entries_match_path_count.py s            [ 56%]
test_fim\test_basic_usage\test_basic_usage_move_dir.py ....FFFFF                    [ 66%]
test_fim\test_basic_usage\test_basic_usage_move_file.py .............FF             [ 83%]
test_fim\test_basic_usage\test_basic_usage_rename.py ...F.F                         [ 90%]
test_fim\test_basic_usage\test_basic_usage_starting_agent.py .........              [100%]

======================================== FAILURES =========================================
```
**Test check_all**
```
============================== test session starts ==============================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 96 items

test_fim\test_checks\test_check_all.py .........ssssssssssssssss.......... [ 36%]
......ssssssssssssssss................ssssssssssssssss.......              [100%]

============ 48 passed, 48 skipped in 2246802.81s (26 days, 0:06:42) ============
```

**Test check_others**
```
============================== test session starts ==============================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 102 items

test_fim\test_checks\test_check_others.py .........sssssssssssssssss...... [ 31%]
...........sssssssssssssssss.................sssssssssssssssss........     [100%]

=========== 51 passed, 51 skipped in 2387222.47s (27 days, 15:07:02) ============
```