### PR TITLE
Tools.py improved to handle ossec.conf files with multiple root elements

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -291,7 +291,7 @@ def generate_wazuh_conf(args: List = None) -> ET.ElementTree:
     return ET.ElementTree(ET.fromstring(wazuh_config))
 
 
-def get_wazuh_conf():
+def get_wazuh_conf() -> List[str]:
     """
     Get current `ossec.conf` file content.
 
@@ -300,7 +300,6 @@ def get_wazuh_conf():
     List of str
         A list containing all the lines of the `ossec.conf` file.
     """
-    lines = []
     with open(WAZUH_CONF) as f:
         lines = f.readlines()
     return lines
@@ -367,7 +366,7 @@ def set_section_wazuh_conf(section: str = 'syscheck', new_elements: List = None)
                                 for attr_name, attr_value in attribute.items():
                                     tag.attrib[attr_name] = str(attr_value)
 
-    def purge_multiple_root_elements(str_list, root_delimeter="</ossec_config>"):
+    def purge_multiple_root_elements(str_list: List[str], root_delimeter: str = "</ossec_config>") -> List[str]:
         """
         Remove from the list all the lines located after the root element ends.
 
@@ -395,7 +394,7 @@ def set_section_wazuh_conf(section: str = 'syscheck', new_elements: List = None)
         else:
             return str_list
 
-    def to_elementTree(str_list):
+    def to_elementTree(str_list: List[str]) -> ET.ElementTree:
         """
         Turn a list of str into an ElementTree object.
 
@@ -413,9 +412,9 @@ def set_section_wazuh_conf(section: str = 'syscheck', new_elements: List = None)
             A ElementTree object with the data of the `str_list`
         """
         str_list = purge_multiple_root_elements(str_list)
-        return ET.fromstringlist(str_list)
+        return ET.ElementTree(ET.fromstringlist(str_list))
 
-    def to_str_list(elementTree):
+    def to_str_list(elementTree: ET.ElementTree) -> List[str]:
         """
         Turn an ElementTree object into a list of str.
 
@@ -429,7 +428,7 @@ def set_section_wazuh_conf(section: str = 'syscheck', new_elements: List = None)
         list of str
             A list of str containing all the lines of the ossec.conf.
         """
-        return ET.tostringlist(elementTree, encoding="unicode")
+        return ET.tostringlist(elementTree.getroot(), encoding="unicode")
 
     # get Wazuh configuration as a list of str
     raw_wazuh_conf = get_wazuh_conf()


### PR DESCRIPTION
Hi team,

This PR solves the `ossec.conf parser failure` issue described in #379 by updating `tools.py` to be able to handle `ossec.conf` files with multiple root elements. If an `ossec.conf` file have more than one `<ossec_config>` section as root elements only the first one will be used.

`get_wazuh_conf` method was retrieving the content of the `ossec.conf` file as an `ElementTree` object but when the file is not properly formatted as an XML this would raise and exception. 

As `get_wazuh_conf` and `write_wazuh_conf` methods are used to backup the original file and be able to restore it after the test execution it was very important that the content of the `ossec.conf` was not altered at all by any of those methods. With this in mind the proposed solution is that `get_wazuh_conf` and `write_wazuh_conf` methods now will retrieve and write the content of the `ossec.conf` file as a list of str instead of as a `ElementTree` and the `set_section_wazuh_conf` method will use only the first occurrence of the root section before turning the list of str into a `ElementTree`, ensuring no exception will be raised.

## Test results

Here are the result of the tests executed in CentOS 7 using both `ossec.conf` files from Sources and Packages installations. After the execution of the tests the `ossec.conf` was restored successfully to its previous state, showing that the `write_wazuh_conf` method still works as intended

```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 90 items                                                             

test_fim/test_basic_usage/test_basic_usage_baseline_generation.py ..     [  2%]
test_fim/test_basic_usage/test_basic_usage_changes.py ......             [  8%]
test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py ............. [ 23%]
...........                                                              [ 35%]
test_fim/test_basic_usage/test_basic_usage_create_scheduled.py ......... [ 45%]
...                                                                      [ 48%]
test_fim/test_basic_usage/test_basic_usage_delete_folder.py ......       [ 55%]
test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py . [ 56%]
                                                                         [ 56%]
test_fim/test_basic_usage/test_basic_usage_move_dir.py ....FF.FF         [ 66%]
test_fim/test_basic_usage/test_basic_usage_move_file.py ...............  [ 83%]
test_fim/test_basic_usage/test_basic_usage_rename.py ...F.F              [ 90%]
test_fim/test_basic_usage/test_basic_usage_starting_agent.py .........   [100%]

=================================== FAILURES ===================================
```
__The failing tests are due to well-known issues with FIM and have nothing to do with this change.__