### PR TITLE
Add Datetime format for Windows and Linux

### DIFF
--- a/packages/wazuh_testing/wazuh_testing/tools.py
+++ b/packages/wazuh_testing/wazuh_testing/tools.py
@@ -146,7 +146,7 @@ class TimeMachine:
         """
         import shlex
         subprocess.call(shlex.split("timedatectl set-ntp false"))
-        subprocess.call(shlex.split("sudo date -s '%s'" % datetime_))
+        subprocess.call(shlex.split("sudo date -s " + str(datetime_) + "+%Y-%m-%dT%H:%M:%S.%s"))
         subprocess.call(shlex.split("sudo hwclock -w"))
 
     @staticmethod

--- a/test_wazuh/test_fim/conftest.py
+++ b/test_wazuh/test_fim/conftest.py
@@ -4,6 +4,7 @@
 
 import os
 import shutil
+import subprocess
 import sys
 
 import pytest
@@ -50,7 +51,7 @@ def configure_environment(get_configuration, request):
 
     # Change Windows Date format to ensure TimeMachine will work properly
     if sys.platform == 'win32':
-        os.system('reg add "HKCU\\Control Panel\\International" /f /v sShortDate /t REG_SZ /d "dd/MM/yyyy" >nul')
+        subprocess.call('reg add "HKCU\\Control Panel\\International" /f /v sShortDate /t REG_SZ /d "dd/MM/yyyy" >nul', shell=True)
 
     # Call extra functions before yield
     if hasattr(request.module, 'extra_configuration_before_yield'):

--- a/test_wazuh/test_fim/conftest.py
+++ b/test_wazuh/test_fim/conftest.py
@@ -48,6 +48,10 @@ def configure_environment(get_configuration, request):
     # set new configuration
     write_wazuh_conf(test_config)
 
+    # Change Windows Date format to ensure TimeMachine will work properly
+    if sys.platform == 'win32':
+        os.system('reg add "HKCU\\Control Panel\\International" /f /v sShortDate /t REG_SZ /d "dd/MM/yyyy" >nul')
+
     # Call extra functions before yield
     if hasattr(request.module, 'extra_configuration_before_yield'):
         func = getattr(request.module, 'extra_configuration_before_yield')


### PR DESCRIPTION
Hi Team,

This PR upgrades our Wazuh Tools to ensure the time format used when trying to travel to the future during our tests is the proper one.

`conftest.py` has been modified to change the short date format when configuring environment under windows. In addition to that, `_linux_set_time` in `tools.py` has been improved to specify the format of the date command used.

No changes where needed for MacOS and Solaris because those already uses a very strict and specified date format when changing the datetime.

## Test results

**Linux**
```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 90 items                                                             

test_fim/test_basic_usage/test_basic_usage_baseline_generation.py ..     [  2%]
test_fim/test_basic_usage/test_basic_usage_changes.py ......             [  8%]
test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py ............. [ 23%]
...........                                                              [ 35%]
test_fim/test_basic_usage/test_basic_usage_create_scheduled.py ......... [ 45%]
...                                                                      [ 48%]
test_fim/test_basic_usage/test_basic_usage_delete_folder.py ......       [ 55%]
test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py . [ 56%]
                                                                         [ 56%]
test_fim/test_basic_usage/test_basic_usage_move_dir.py ....FF.FF         [ 66%]
test_fim/test_basic_usage/test_basic_usage_move_file.py ...............  [ 83%]
test_fim/test_basic_usage/test_basic_usage_rename.py ...F.F              [ 90%]
test_fim/test_basic_usage/test_basic_usage_starting_agent.py .........   [100%]

=================================== FAILURES ===================================
```
**Windows**
```
=================================== test session starts ===================================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 90 items

test_fim\test_basic_usage\test_basic_usage_baseline_generation.py ..                [  2%]
test_fim\test_basic_usage\test_basic_usage_changes.py ......                        [  8%]
test_fim\test_basic_usage\test_basic_usage_create_rt_wd.py ........................ [ 35%]
test_fim\test_basic_usage\test_basic_usage_create_scheduled.py ............         [ 48%]
test_fim\test_basic_usage\test_basic_usage_delete_folder.py ......                  [ 55%]
test_fim\test_basic_usage\test_basic_usage_entries_match_path_count.py s            [ 56%]
test_fim\test_basic_usage\test_basic_usage_move_dir.py ....FFFFF                    [ 66%]
test_fim\test_basic_usage\test_basic_usage_move_file.py .............FF             [ 83%]
test_fim\test_basic_usage\test_basic_usage_rename.py ...F.F                         [ 90%]
test_fim\test_basic_usage\test_basic_usage_starting_agent.py .........              [100%]

======================================== FAILURES =========================================
```
