### PR TITLE
Consider all the folders/files of the target branch as the puppet wazuh module

### DIFF
--- a/kitchen/wazuh-puppet/kitchen/run.sh
+++ b/kitchen/wazuh-puppet/kitchen/run.sh
@@ -7,6 +7,7 @@ mkdir -p modules/wazuh
 cp -r ../files ./modules/wazuh/
 cp -r ../templates/ ./modules/wazuh/
 cp -r ../manifests/ ./modules/wazuh/
+cp -rf ../VERSION ./modules/wazuh
 
 if [ -z "$1" ]
 then

--- a/kitchen/wazuh-puppet/kitchen/run.sh
+++ b/kitchen/wazuh-puppet/kitchen/run.sh
@@ -4,10 +4,9 @@ set -e
 
 mkdir -p modules/wazuh
 
-cp -r ../files ./modules/wazuh/
-cp -r ../templates/ ./modules/wazuh/
-cp -r ../manifests/ ./modules/wazuh/
-cp -rf ../VERSION ./modules/wazuh
+cd .. && cp -r `ls -A | grep -v "kitchen"` kitchen/modules/wazuh/
+
+cd kitchen # Access kitchen folder
 
 if [ -z "$1" ]
 then


### PR DESCRIPTION
Hi all!

In this PR we consider all the folders/files of the target branch as the wazuh module for kitchen-puppet tests. This comes after we detected that we are not picking the file `VERSION` of the target branch when testing and though the tests failed as we use `VERSION` to auto-load the target branch's wazuh version.

Kr,

Rshad