### PR TITLE
Add FIM disabled option tests

### DIFF
--- a/test_wazuh/test_fim/test_basic_usage/data/wazuh_conf_disabled.yaml
+++ b/test_wazuh/test_fim/test_basic_usage/data/wazuh_conf_disabled.yaml
@@ -1,0 +1,14 @@
+---
+# conf 1
+- tags:
+  - disabled_conf
+  apply_to_modules:
+  - test_basic_disabled
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'yes'
+  - directories:
+      value: TEST_DIRECTORIES
+      attributes:
+      - FIM_MODE

--- a/test_wazuh/test_fim/test_basic_usage/test_basic_disabled.py
+++ b/test_wazuh/test_fim/test_basic_usage/test_basic_disabled.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2015-2019, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing.fim import (LOG_FILE_PATH, generate_params, regular_file_cud, DEFAULT_TIMEOUT,
+                               callback_detect_end_scan)
+from wazuh_testing.tools import FileMonitor, load_wazuh_configurations, PREFIX
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+
+test_directories = [os.path.join(PREFIX, 'testdir'), os.path.join(PREFIX, 'not_exists')]
+
+directory_str = test_directories[0]
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_disabled.yaml')
+testdir, testdir_not_exists = test_directories
+
+# configurations
+
+conf_params = {'TEST_DIRECTORIES': directory_str}
+p, m = generate_params(extra_params=conf_params)
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('folder', [testdir, testdir_not_exists])
+def test_disabled(folder, get_configuration, configure_environment, restart_syscheckd):
+    """Check if syscheckd sends events when disabled="yes".
+
+    * This test is intended to be used with valid configurations files. Each execution of this test will configure
+      the environment properly, restart the service and wait for the initial scan.
+
+    Parameters
+    ----------
+    folder : str
+        Path where files will be created.
+    """
+    # Expect a timeout when checking for syscheckd initial scan
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=20, callback=callback_detect_end_scan)
+
+    # Use `regular_file_cud` and don't expect any event
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+    regular_file_cud(folder, wazuh_log_monitor, time_travel=scheduled, min_timeout=DEFAULT_TIMEOUT,
+                     triggers_event=False)


### PR DESCRIPTION
Hi team, this solves #396 .

This PR adds new basic tests with `<disabled>yes</disabled>`.

## Tests performed

### Linux
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 6 items                                                                                       

test_fim/test_basic_usage/test_basic_disabled.py ......                                           [100%]

=============================== 6 passed in 281019.28s (3 days, 6:03:39) ================================
```

### Windows
```
================================================= test session starts ================================================== 
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 6 items

test_fim\test_basic_usage\test_basic_disabled.py ......                                                           [100%]

======================================= 6 passed in 281115.49s (3 days, 6:05:15) =======================================
```

### MacOS
```
================================== test session starts ==================================
platform darwin -- Python 3.7.5, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
rootdir: /Users/vagrant/Desktop/Shared/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 2 items                                                                       

test_fim/test_basic_usage/test_basic_disabled.py ..                               [100%]

======================= 2 passed in 280774.22s (3 days, 5:59:34) ========================
```