### PR TITLE
Restore the system internal date after running FIM tests with TimeTravel

### DIFF
--- a/test_wazuh/test_fim/conftest.py
+++ b/test_wazuh/test_fim/conftest.py
@@ -9,7 +9,7 @@ import sys
 
 import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan
-from wazuh_testing.tools import (FileMonitor, get_wazuh_conf, set_section_wazuh_conf,
+from wazuh_testing.tools import (FileMonitor, TimeMachine, get_wazuh_conf, set_section_wazuh_conf,
                                  truncate_file, write_wazuh_conf, control_service)
 
 
@@ -59,6 +59,8 @@ def configure_environment(get_configuration, request):
         func()
 
     yield
+
+    TimeMachine.time_rollback()
 
     # remove created folders (parents)
     if sys.platform == 'win32':


### PR DESCRIPTION
This closes #389 

Added the functionality to restore the system date after the tests execution if TimeMachine was used. This will avoid possible problems with the environment and also allows pytest to show the real duration of the tests.