### PR TITLE
Add FIM check_all set to no tests

### DIFF
--- a/test_wazuh/test_fim/test_checks/data/wazuh_check_all.yaml
+++ b/test_wazuh/test_fim/test_checks/data/wazuh_check_all.yaml
@@ -128,3 +128,17 @@
       attributes:
       - FIM_MODE
       - check_all: "yes"
+
+- tags:
+  - test_check_all_no
+  apply_to_modules:
+  - test_check_all
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "/testdir1"
+      attributes:
+      - FIM_MODE
+      - check_all: "no"

--- a/test_wazuh/test_fim/test_checks/data/wazuh_check_all_windows.yaml
+++ b/test_wazuh/test_fim/test_checks/data/wazuh_check_all_windows.yaml
@@ -116,3 +116,17 @@
       attributes:
       - FIM_MODE
       - check_all: "yes"
+
+- tags:
+  - test_check_all_no
+  apply_to_modules:
+  - test_check_all
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: "c:\\testdir1"
+      attributes:
+      - FIM_MODE
+      - check_all: "no"

--- a/test_wazuh/test_fim/test_checks/test_check_all.py
+++ b/test_wazuh/test_fim/test_checks/test_check_all.py
@@ -9,7 +9,8 @@ import pytest
 
 from wazuh_testing.fim import (CHECK_ALL, CHECK_ATTRS, CHECK_GROUP, CHECK_INODE, CHECK_MD5SUM, CHECK_MTIME, CHECK_OWNER,
                                CHECK_PERM, CHECK_SHA1SUM, CHECK_SHA256SUM, CHECK_SIZE, CHECK_SUM, LOG_FILE_PATH,
-                               REQUIRED_ATTRIBUTES, regular_file_cud, generate_params)
+                               REQUIRED_ATTRIBUTES, regular_file_cud, generate_params, create_file, REGULAR,
+                               check_time_travel, callback_detect_event, delete_file, modify_file)
 from wazuh_testing.tools import FileMonitor, check_apply_test, load_wazuh_configurations, PREFIX
 
 # Marks
@@ -130,3 +131,44 @@ def test_check_all(path, checkers, get_configuration, configure_environment, res
 
     regular_file_cud(path, wazuh_log_monitor, min_timeout=15, options=checkers,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')
+
+
+@pytest.mark.parametrize('path, checkers', [(testdir1, {})])
+def test_check_all_no(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """Test the functionality of `check_all` option when set to no.
+
+    When setting `check_all` to no, only 'type' and 'checksum' attributes should appear in every event. This will
+    avoid any modification event.
+
+    This test is intended to be used with valid configurations files. Each execution of this test will configure the
+    environment properly, restart the service and wait for the initial scan.
+
+    Parameters
+    ----------
+    path : str
+        Directory where the file is being created and monitored
+    checkers : dict
+        Dict with all the check options to be used
+    """
+    check_apply_test({'test_check_all_no'}, get_configuration['tags'])
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+
+    # Create regular file and dont expect any check
+    file = 'regular'
+    create_file(REGULAR, path, file)
+    check_time_travel(scheduled)
+    create_event = wazuh_log_monitor.start(callback=callback_detect_event, timeout=15).result()
+    assert create_event['data']['type'] == 'added'
+    assert list(create_event['data']['attributes'].keys()) == ['type', 'checksum']
+
+    # Delete regular file and dont expect any check. Since it is not using any check, modification events will not
+    # be triggered
+    modify_file(path, file, 'Sample modification')
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(callback=callback_detect_event, timeout=5)
+
+    delete_file(path, file)
+    check_time_travel(scheduled)
+    delete_event = wazuh_log_monitor.start(callback=callback_detect_event, timeout=15).result()
+    assert delete_event['data']['type'] == 'deleted'
+    assert list(delete_event['data']['attributes'].keys()) == ['type', 'checksum']


### PR DESCRIPTION
Hi team, this solves #401  .

This PR adds new check tests with 
```xml
<directories check_all="no">...</directories>
```

## Tests performed

### Linux
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 9 items                                                                                       

test_fim/test_checks/test_check_all.py ss.ss.ssF                                                  [100%]

=============================================== FAILURES ================================================
```

Tests on Linux fail on benchmark monitoring due to a reported bug:
```
self = <encodings.utf_8.IncrementalDecoder object at 0x7ff106dfc208>
input = b'2020/02/02 08:24:47 ossec-syscheckd[6546] syscheck_audit.c:1376 at filterkey_audit_events(): DEBUG: (6251): Match au...0002\xdc.\x7f","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","ppid":31152}}}\n'
final = False

    def decode(self, input, final=False):
        # decode input (taking the buffer into account)
        data = self.buffer + input
>       (result, consumed) = self._buffer_decode(data, self.errors, final)
E       UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 in position 292: invalid start byte

```

### Windows
```
================================================= test session starts ==================================================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\test_wazuh, inifile: pytest.ini
collected 9 items

test_fim\test_checks\test_check_all.py ss.ss.ss.                                                                  [100%]

================================== 3 passed, 6 skipped in 93794.77s (1 day, 2:03:14) ===================================
```

### MacOS
```
================================== test session starts ==================================
platform darwin -- Python 3.7.5, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
rootdir: /Users/vagrant/Desktop/Shared/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 3 items                                                                       

test_fim/test_checks/test_check_all.py ss.                                        [100%]

=================== 1 passed, 2 skipped in 93634.03s (1 day, 2:00:34) ===================

```
