### PR TITLE
Modify --tier parameter and fix error in test

### DIFF
--- a/test_wazuh/conftest.py
+++ b/test_wazuh/conftest.py
@@ -23,8 +23,8 @@ def pytest_runtest_setup(item):
     # Consider only first mark
     levels = [mark.kwargs['level'] for mark in item.iter_markers(name="tier")]
     if levels and len(levels) > 0:
-        tier = item.config.getoption("--tier")
-        if tier is not None and tier != levels[0]:
+        tiers = item.config.getoption("--tier")
+        if tiers is not None and levels[0] not in tiers:
             pytest.skip(f"test requires tier level {levels[0]}")
         elif item.config.getoption("--tier-minimum") > levels[0]:
             pytest.skip(f"test requires a minimum tier level {levels[0]}")
@@ -46,7 +46,7 @@ def restart_wazuh(get_configuration, request):
 def pytest_addoption(parser):
     parser.addoption(
         "--tier",
-        action="store",
+        action="append",
         metavar="level",
         default=None,
         type=int,

--- a/test_wazuh/test_fim/test_ignore/test_ignore_registry.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_registry.py
@@ -13,6 +13,9 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations, check_a
 
 if sys.platform == 'win32':
     import winreg
+    keys = [(winreg.HKEY_LOCAL_MACHINE, "HKEY_LOCAL_MACHINE")]
+else:
+    keys = []
 
 # All tests in this module apply to windows only
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
@@ -21,8 +24,6 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_win32.yaml')
-
-keys = [(winreg.HKEY_LOCAL_MACHINE, "HKEY_LOCAL_MACHINE")]
 
 keys_objects = list()
 keys_strings = list()


### PR DESCRIPTION
Hello team,

This PR converts the `--tier` parameter into a list, so that different tiers can now be specified and all tests that include any of those tiers will be executed. Now, when we run the tests with, for example, these parameters, only level 0 tests and level 3 tests will be executed.: 
`python3 -m pytest --tier 0 --tier 3  test_fim/`

A test that was failing when running outside of Windows has also been modified.

Kind regards,
José Luis.
