### PR TITLE
Add new case sregex matching a folder

### DIFF
--- a/test_wazuh/test_fim/test_ignore/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_ignore/data/wazuh_conf.yaml
@@ -170,7 +170,7 @@
       attributes:
       - check_all: 'yes'
       - FIM_MODE
-# conf 11
+# conf 10
 - tags:
   - negation_regex
   apply_to_modules:
@@ -185,6 +185,24 @@
       - type: sregex
   - directories:
       value: "/testdir1,/testdir2"
+      attributes:
+      - check_all: 'yes'
+      - FIM_MODE
+# conf 11
+- tags:
+  - incomplete_regex
+  apply_to_modules:
+  - test_ignore_valid
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - ignore:
+      value: "^/testdir1/f"
+      attributes:
+      - type: sregex
+  - directories:
+      value: "/testdir1"
       attributes:
       - check_all: 'yes'
       - FIM_MODE

--- a/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
+++ b/test_wazuh/test_fim/test_ignore/test_ignore_valid.py
@@ -27,10 +27,11 @@ configurations_path = os.path.join(test_data_path,
 test_directories = [os.path.join(PREFIX, 'testdir1'),
                     os.path.join(PREFIX, 'testdir1', 'subdir'),
                     os.path.join(PREFIX, 'testdir1', 'ignore_this'),
+                    os.path.join(PREFIX, 'testdir1', 'folder'),
                     os.path.join(PREFIX, 'testdir2'),
                     os.path.join(PREFIX, 'testdir2', 'subdir')
                     ]
-testdir1, testdir1_sub, testdir1_ignore, testdir2, testdir2_sub = test_directories
+testdir1, testdir1_sub, testdir1_ignore, testdir1_ignore_folder, testdir2, testdir2_sub = test_directories
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
@@ -74,7 +75,9 @@ def get_configuration(request):
     (testdir1, 'whatever.txt', "test", False, {'valid_empty'}),
     (testdir2, 'whatever2.txt', "test", False, {'valid_empty'}),
     (testdir1, 'mytest', "test", True, {'negation_regex'}),
-    (testdir1, 'othername', "test", False, {'negation_regex'})
+    (testdir1, 'othername', "test", False, {'negation_regex'}),
+    (testdir1, 'file1', "test", False, {'incomplete_regex'}),
+    (testdir1_ignore_folder, 'file2', "test", False, {'incomplete_regex'})
 ])
 def test_ignore_subdirectory(folder, filename, content, triggers_event,
                              tags_to_apply, get_configuration,

--- a/test_wazuh/test_fim/test_restrict/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_restrict/data/wazuh_conf.yaml
@@ -33,6 +33,7 @@
 # conf 3
 - tags:
   - valid_regex
+  - valid_regex2
   apply_to_modules:
   - test_restrict_valid
   section: syscheck
@@ -48,7 +49,7 @@
 # conf 4
 - tags:
   - valid_regex
-  - valid_regex2
+  - valid_regex3
   apply_to_modules:
   - test_restrict_valid
   section: syscheck

--- a/test_wazuh/test_fim/test_restrict/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_restrict/data/wazuh_conf.yaml
@@ -75,4 +75,4 @@
       attributes:
       - check_all: 'yes'
       - FIM_MODE
-      - restrict: "^/testdir1/f"
+      - restrict: "^/testdir1/f|^/testdir1/subdir/f|^/testdir2/f|^/testdir2/subdir/f"

--- a/test_wazuh/test_fim/test_restrict/data/wazuh_conf.yaml
+++ b/test_wazuh/test_fim/test_restrict/data/wazuh_conf.yaml
@@ -63,3 +63,19 @@
       - check_all: 'yes'
       - FIM_MODE
       - restrict: "filerestricted|other_restricted$"
+# conf 5
+- tags:
+  - valid_regex
+  - valid_regex2
+  apply_to_modules:
+  - test_restrict_valid
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: TEST_DIRECTORIES
+      attributes:
+      - check_all: 'yes'
+      - FIM_MODE
+      - restrict: "^/testdir1/f"

--- a/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
+++ b/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
@@ -62,9 +62,9 @@ def get_configuration(request):
     ("restricted", "w", "Test", False, {'valid_regex'}),
     ("myfilerestricted", "w", "", True, {'valid_regex_3'}),
     ("myother_restricted", "wb", b"", True, {'valid_regex_3'}),
-    ('folder' + os.sep + '.restricted', 'w', "Sample content", True, {'valid_regex_incomplete'}),
-    ('fake' + os.sep + 'binary.restricted', 'wb', b"Sample content", True, {'valid_regex_incomplete'}),
-    ('folder' + os.sep + 'testfile2', 'w', "", True, {'valid_regex_incomplete'}),
+    ('fileinfolder', 'w', "Sample content", True, {'valid_regex_incomplete'}),
+    ('fileinfolder1', 'wb', b"Sample content", True, {'valid_regex_incomplete'}),
+    ('testing_regex', 'w', "", False, {'valid_regex_incomplete'}),
 ])
 def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply,
                   get_configuration, configure_environment, restart_syscheckd,
@@ -90,10 +90,6 @@ def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply
         Run test if match with a configuration identifier, skip otherwise
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-
-    if os.sep in filename:
-        filename = filename.split(os.sep)
-        folder, filename = os.path.join(folder, *filename[:-1]), filename[-1]
 
     # Create text files
     create_file(REGULAR, folder, filename, content=content)

--- a/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
+++ b/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
@@ -10,9 +10,9 @@ import pytest
 from wazuh_testing.fim import LOG_FILE_PATH, DEFAULT_TIMEOUT, callback_detect_event, callback_restricted, create_file, \
     REGULAR, generate_params
 from wazuh_testing.tools import PREFIX
-from wazuh_testing.tools.time import TimeMachine
-from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.time import TimeMachine
 
 # Marks
 
@@ -24,13 +24,12 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 test_directories = [os.path.join(PREFIX, 'testdir1'),
                     os.path.join(PREFIX, 'testdir1', 'subdir'),
-                    os.path.join(PREFIX, 'testdir1', 'folder'),
                     os.path.join(PREFIX, 'testdir2'),
                     os.path.join(PREFIX, 'testdir2', 'subdir')
                     ]
-testdir1, testdir1_sub, testdir1_restrict_folder, testdir2, testdir2_sub = test_directories
+testdir1, testdir1_sub, testdir2, testdir2_sub = test_directories
 
-directory_str = ','.join([test_directories[0], test_directories[2]])
+directory_str = ','.join([os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')])
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
@@ -56,13 +55,16 @@ def get_configuration(request):
 @pytest.mark.parametrize('filename, mode, content, triggers_event, tags_to_apply', [
     ('.restricted', 'w', "Sample content", True, {'valid_regex1'}),
     ('binary.restricted', 'wb', b"Sample content", True, {'valid_regex1'}),
-    ('testfile2', 'w', "", False, {'valid_regex', 'valid_regex_incomplete'}),
+    ('testfile2', 'w', "", False, {'valid_regex'}),
     ("btestfile2", "wb", b"", False, {'valid_regex'}),
     ('testfile2', 'w', "", True, {'valid_empty'}),
     ("btestfile2", "wb", b"", True, {'valid_empty'}),
-    ("restricted", "w", "Test", False, {'valid_regex', 'valid_regex_incomplete'}),
-    ("myfilerestricted", "w", "", True, {'valid_regex_2'}),
-    ("myother_restricted", "wb", b"", True, {'valid_regex_2'})
+    ("restricted", "w", "Test", False, {'valid_regex'}),
+    ("myfilerestricted", "w", "", True, {'valid_regex_3'}),
+    ("myother_restricted", "wb", b"", True, {'valid_regex_3'}),
+    ('folder' + os.sep + '.restricted', 'w', "Sample content", True, {'valid_regex_incomplete'}),
+    ('fake' + os.sep + 'binary.restricted', 'wb', b"Sample content", True, {'valid_regex_incomplete'}),
+    ('folder' + os.sep + 'testfile2', 'w', "", True, {'valid_regex_incomplete'}),
 ])
 def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply,
                   get_configuration, configure_environment, restart_syscheckd,
@@ -72,14 +74,26 @@ def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply
     This test is intended to be used with valid configurations files. Each execution of this test will configure the
     environment properly, restart the service and wait for the initial scan.
 
-    :param folder string Directory where the file is being created
-    :param filename string Name of the file to be created
-    :param mode string same as mode in open built-in function
-    :param content string, bytes Content to fill the new file
-    :param triggers_event bool True if an event must be generated, False otherwise
-    :param tags_to_apply set Run test if match with a configuration identifier, skip otherwise
+    Parameters
+    ----------
+    folder : str
+        Directory where the file is being created
+    filename : str
+        Name of the file to be created
+    mode : str
+        Same as mode in open built-in function
+    content : str or bytes
+        Content to fill the new file
+    triggers_event : bool
+        True if an event must be generated, False otherwise
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    if os.sep in filename:
+        filename = filename.split(os.sep)
+        folder, filename = os.path.join(folder, *filename[:-1]), filename[-1]
 
     # Create text files
     create_file(REGULAR, folder, filename, content=content)

--- a/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
+++ b/test_wazuh/test_fim/test_restrict/test_restrict_valid.py
@@ -24,10 +24,11 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 test_directories = [os.path.join(PREFIX, 'testdir1'),
                     os.path.join(PREFIX, 'testdir1', 'subdir'),
+                    os.path.join(PREFIX, 'testdir1', 'folder'),
                     os.path.join(PREFIX, 'testdir2'),
                     os.path.join(PREFIX, 'testdir2', 'subdir')
                     ]
-testdir1, testdir1_sub, testdir2, testdir2_sub = test_directories
+testdir1, testdir1_sub, testdir1_restrict_folder, testdir2, testdir2_sub = test_directories
 
 directory_str = ','.join([test_directories[0], test_directories[2]])
 


### PR DESCRIPTION
Hi team,

This PR closes #395. In this PR we have added more tests for sregex tests.

### Test results
#### Ignore
```bash
[root@wazuh-master test_wazuh]# python3 -m pytest -x test_fim/test_ignore/test_ignore_valid.py 
============================================================================================================= test session starts =============================================================================================================
platform linux -- Python 3.6.8, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 825 items                                                                                                                                                                                                                           

test_fim/test_ignore/test_ignore_valid.py sssssssssssssssssss..ssss....s......ssss.sssssssss....s......ssss.sssssssss....s......ssss.sssssssss................s.sssssss..................sssssss..................sssssss....s......s.s [ 22%]
..s.sssssss....s......s.s..ss.sssssssssssssssssssssssssss..sssssssssssssssssssssssss..sssssssssssssssssss..ssss....s......ssss.sssssssss....s......ssss.sssssssss....s......ssss.sssssssss................s.sssssss..................ss [ 50%]
sssss..................sssssss....s......s.s..s.sssssss....s......s.s..ss.sssssssssssssssssssssssssss..sssssssssssssssssssssssss..sssssssssssssssssss..ssss....s......ssss.sssssssss....s......ssss.sssssssss....s......ssss.sssssssss. [ 78%]
...............s.sssssss..................sssssss..................sssssss....s......s.s..s.sssssss....s......s.s..ss.sssssssssssssssssssssssssss..sssssssssssssssssssssssss..                                                          [100%]

================================================================================================ 360 passed, 465 skipped in 1186.43s (0:19:46) ================================================================================================
```

#### Restrict
```bash
[root@wazuh-master test_wazuh]# python3 -m pytest -x test_fim/test_restrict/test_restrict_valid.py 
============================================================================================================= test session starts =============================================================================================================
platform linux -- Python 3.6.8, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/test_wazuh, inifile: pytest.ini
collected 720 items                                                                                                                                                                                                                           

test_fim/test_restrict/test_restrict_valid.py ssssssssssssssss........ssssssssssssssssssssssss................ssssssss....ssssssssssssssssssssssssssss........ssssssss....ssssssssssssssssssssssssssss........ssssssss....sssssssssssss [ 25%]
sssssssssssssssssssssssssssssssssssssssssss............ssssssssssssssss........ssssssssssssssssssssssss................ssssssss....ssssssssssssssssssssssssssss........ssssssss....ssssssssssssssssssssssssssss........ssssssss....ssss [ 57%]
ssssssssssssssssssssssssssssssssssssssssssssssssssss............ssssssssssssssss........ssssssssssssssssssssssss................ssssssss....ssssssssssssssssssssssssssss........ssssssss....ssssssssssssssssssssssssssss........sssssss [ 89%]
s....ssssssssssssssssssssssssssssssssssssssssssssssssssssssss............                                                                                                                                                               [100%]

================================================================================================ 192 passed, 528 skipped in 663.23s (0:11:03) =================================================================================================
```
