### PR TITLE
Add test to check report_changes with large modifications

### DIFF
--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -95,7 +95,7 @@ def generateString(stringLength=10, character='0'):
 ])
 def test_large_changes(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
                             configure_environment, restart_syscheckd, wait_for_initial_scan):
-    """Check content_changes when it exceeds the maximum size.
+    """Check content_changes shows the tag 'More changes' when it exceeds the maximum size.
 
     Every change in the content of the file shall produce an alert including
     the difference. But, if the difference is greater or equal than 59370 bytes, 'More changes'
@@ -130,13 +130,13 @@ def test_large_changes(filename, folder, original_size, modified_size, tags_to_a
     check_time_travel(fim_mode == 'scheduled')
     event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()
 
-    # Assert old content is shown in content_changes when it is lower than the limit.
+    # Assert old content is shown in content_changes
     assert '0' in event['data']['content_changes']
 
-    # Assert new content is shown when old content is lower than the limit
+    # Assert new content is shown when old content is lower than the limit or platform is Windows
     if original_size < limit or sys.platform == 'win32':
         assert '1' in event['data']['content_changes'], f'Not equal {sys.getsizeof(original_string)}'
 
     # Assert 'More changes' is shown when the sum of old and new content is greater than the limit.
-    if (original_size + modified_size) >= limit and sys.platform != 'win32':
-        assert 'More changes' in event['data']['content_changes']
+    if (original_size + modified_size) >= limit:
+        assert 'More changes' in event['data']['content_changes'], 'More changes not found within content_changes.'

--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, REGULAR, create_file, delete_file, \
+    generate_params, check_time_travel
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import check_apply_test, load_wazuh_configurations
+
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
+
+# variables
+
+test_directories = [os.path.join(PREFIX, 'testdir')]
+nodiff_file = os.path.join(PREFIX, 'testdir_nodiff', 'regular_file')
+directory_str = ','.join(test_directories)
+testdir = test_directories[0]
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+
+
+# configurations
+
+conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': 'yes'},
+                                                           'TEST_DIRECTORIES': directory_str,
+                                                           'NODIFF_FILE': nodiff_file,
+                                                           'MODULE_NAME': __name__})
+configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+@pytest.mark.parametrize('tags_to_apply', [
+    {'ossec_conf_report'}
+])
+@pytest.mark.parametrize('filename, folder, original_size, modified_size', [
+    ('regular_0', testdir, 29660, 29660),
+    ('regular_1', testdir, 30000, 30000),
+    ('regular_2', testdir, 70000, 70000),
+    ('regular_4', testdir, 10, 29660),
+    ('regular_5', testdir, 10, 70000),
+    ('regular_6', testdir, 29660, 10),
+    ('regular_6', testdir, 70000, 10),
+])
+def test_report_changes_big(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
+                            configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """Check content_changes when it exceeds the maximum size.
+
+    Every change in the content of the file shall produce an alert including
+    the difference. But, if the difference is greater or equal than 59370 bytes, 'More changes'
+    appears instead.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to be created.
+    folder : str
+        Directory where the files are being created.
+    original_size : int
+        Size of each file in bytes before being modified.
+    modified_size : int
+        Size of each file in bytes after being modified.
+    tags_to_apply : set
+        Run test if matches with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    fim_mode = get_configuration['metadata']['fim_mode']
+    limit = 59370
+
+    # Create the file and and capture the event.
+    create_file(REGULAR, folder, filename, content=b'0'*original_size)
+    check_time_travel(fim_mode == 'scheduled')
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()
+
+    # Modify the file with new content
+    create_file(REGULAR, folder, filename, content=b'1'*modified_size)
+    check_time_travel(fim_mode == 'scheduled')
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()
+
+    # Assert old content is shown in content_changes when it is lower than the limit.
+    if original_size < limit:
+        assert '0' * original_size in event['data']['content_changes']
+    # Assert new content is shown when it is lower than the limit (and the sum of both is still lower)
+    if modified_size < limit and (original_size + modified_size) < limit:
+        assert '1' * modified_size in event['data']['content_changes'], 'Not equal'
+    # Assert 'More changes' is shown when the sum of old and new content is greater than the limit.
+    if (original_size + modified_size) >= limit:
+        assert 'More changes' in event['data']['content_changes']
+
+    # Delete all created files
+    delete_file(folder, filename)
+    check_time_travel(fim_mode == 'scheduled')
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()

--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -88,9 +88,9 @@ def generateString(stringLength=10, character='0'):
     ('regular_0', testdir, 500, 500),
     ('regular_1', testdir, 30000, 30000),
     ('regular_2', testdir, 70000, 70000),
-    ('regular_4', testdir, 10, 20000),
-    ('regular_5', testdir, 10, 70000),
-    ('regular_6', testdir, 20000, 10),
+    ('regular_3', testdir, 10, 20000),
+    ('regular_4', testdir, 10, 70000),
+    ('regular_5', testdir, 20000, 10),
     ('regular_6', testdir, 70000, 10),
 ])
 def test_large_changes(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
@@ -131,12 +131,13 @@ def test_large_changes(filename, folder, original_size, modified_size, tags_to_a
     event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()
 
     # Assert old content is shown in content_changes
-    assert '0' in event['data']['content_changes']
+    assert '0' in event['data']['content_changes'], '"0" is the old value but it is not found within content_changes'
 
     # Assert new content is shown when old content is lower than the limit or platform is Windows
     if original_size < limit or sys.platform == 'win32':
-        assert '1' in event['data']['content_changes'], f'Not equal {sys.getsizeof(original_string)}'
+        assert '1' in event['data']['content_changes'], '"1" is the new value but it is not found ' \
+                                                        'within content_changes'
 
     # Assert 'More changes' is shown when the sum of old and new content is greater than the limit.
     if (original_size + modified_size) >= limit:
-        assert 'More changes' in event['data']['content_changes'], 'More changes not found within content_changes.'
+        assert 'More changes' in event['data']['content_changes'], '"More changes" not found within content_changes.'

--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -4,15 +4,16 @@
 
 import os
 import sys
-import random
-import string
+import subprocess
+import gzip
+import shutil
 
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, REGULAR, create_file, delete_file, \
+from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, REGULAR, create_file, \
     generate_params, check_time_travel
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools import PREFIX, WAZUH_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.configuration import check_apply_test, load_wazuh_configurations
 
@@ -28,6 +29,7 @@ test_directories = [os.path.join(PREFIX, 'testdir')]
 nodiff_file = os.path.join(PREFIX, 'testdir_nodiff', 'regular_file')
 directory_str = ','.join(test_directories)
 testdir = test_directories[0]
+unzip_diff_dir = os.path.join(PREFIX, 'unzip_diff')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -79,6 +81,15 @@ def generateString(stringLength=10, character='0'):
     return random_str
 
 
+def extra_configuration_before_yield():
+    """Create a folder to store diff files unzipped"""
+    os.makedirs(unzip_diff_dir, exist_ok=True)
+
+
+def extra_configuration_after_yield():
+    """Delete the folder after the test"""
+    shutil.rmtree(unzip_diff_dir, ignore_errors=True)
+
 # Tests
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -94,11 +105,11 @@ def generateString(stringLength=10, character='0'):
     ('regular_6', testdir, 70000, 10),
 ])
 def test_large_changes(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
-                            configure_environment, restart_syscheckd, wait_for_initial_scan):
+                       configure_environment, restart_syscheckd, wait_for_initial_scan):
     """Check content_changes shows the tag 'More changes' when it exceeds the maximum size.
 
     Every change in the content of the file shall produce an alert including
-    the difference. But, if the difference is greater or equal than 59370 bytes, 'More changes'
+    the difference. But, if the difference is greater or equal than 59391 bytes, 'More changes'
     appears instead.
 
     Parameters
@@ -114,9 +125,20 @@ def test_large_changes(filename, folder, original_size, modified_size, tags_to_a
     tags_to_apply : set
         Run test if matches with a configuration identifier, skip otherwise.
     """
+
+    limit = 59391
+    output_size = 0
+    original_file = os.path.join(folder, filename)
+    unzip_diff_file = os.path.join(unzip_diff_dir, filename + '-old')
+    diff_file_path = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local')
+    if sys.platform == 'win32':
+        diff_file_path = os.path.join(diff_file_path, 'c')
+        diff_file_path = os.path.join(diff_file_path, folder.strip('c:\\'), filename, 'last-entry.gz')
+    else:
+        diff_file_path = os.path.join(diff_file_path, folder.strip('/'), filename, 'last-entry.gz')
+
     check_apply_test(tags_to_apply, get_configuration['tags'])
     fim_mode = get_configuration['metadata']['fim_mode']
-    limit = 58000
 
     # Create the file and and capture the event.
     original_string = generateString(original_size, '0')
@@ -124,11 +146,33 @@ def test_large_changes(filename, folder, original_size, modified_size, tags_to_a
     check_time_travel(fim_mode == 'scheduled')
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()
 
+    # Store uncompressed diff file in backup folder
+    with gzip.open(diff_file_path, 'rb') as f_in:
+        with open(unzip_diff_file, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
     # Modify the file with new content
     modified_string = generateString(modified_size, '1')
     create_file(REGULAR, folder, filename, content=modified_string)
     check_time_travel(fim_mode == 'scheduled')
     event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event).result()
+
+    # Run the diff/fc command and get the output length
+    try:
+        if sys.platform == 'win32':
+            subprocess.check_output(['fc', '/n', original_file, unzip_diff_file])
+        else:
+            subprocess.check_output(['diff', original_file, unzip_diff_file])
+    except subprocess.CalledProcessError as e:
+        # Inputs are different
+        if e.returncode == 1:
+            output_size = len(e.output)
+
+    # Assert 'More changes' is shown when the command returns more than 'limit' characters
+    if output_size > limit:
+        assert 'More changes' in event['data']['content_changes'], '"More changes" not found within content_changes.'
+    else:
+        assert 'More changes' not in event['data']['content_changes'], '"More changes" found within content_changes.'
 
     # Assert old content is shown in content_changes
     assert '0' in event['data']['content_changes'], '"0" is the old value but it is not found within content_changes'
@@ -137,7 +181,3 @@ def test_large_changes(filename, folder, original_size, modified_size, tags_to_a
     if original_size < limit or sys.platform == 'win32':
         assert '1' in event['data']['content_changes'], '"1" is the new value but it is not found ' \
                                                         'within content_changes'
-
-    # Assert 'More changes' is shown when the sum of old and new content is greater than the limit.
-    if (original_size + modified_size) >= limit:
-        assert 'More changes' in event['data']['content_changes'], '"More changes" not found within content_changes.'


### PR DESCRIPTION
This PR closes issue #441.

## Description

This PR adds a test to check the behavior when the `report_changes` option is used and modifications are made greater than the maximum allowed size. 

According to the related issue (#441), when the monitored file is changed with a difference greater or equal than 59391 bytes, only these number of bytes should be in the diff member of the alert, followed by "More changes...:. 

## Tests performed

### Linux

```
===================================== test session starts ======================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
collected 21 items                                                                             

test_large_changes.py .....................                                              [100%]

================================ 21 passed in 138.92s (0:02:18) ================================
```

### MacOS

```
================================================ test session starts =================================================
platform darwin -- Python 3.7.6, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/vagrant/Desktop/shared/wazuh-qa/tests/integration, inifile: pytest.ini
collected 7 items                                                                                                    

test_large_changes.py .......                                                                                  [100%]

================================================= 7 passed in -3.65s =================================================
```

### Windows
Windows tests sometimes show timeout failures. Increasing default_timeout tests run correctly.
```
PS C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration> python -m pytest .\test_fim\test_report_changes\test_large_chan
ges.py --default-timeout=40
================================================= test session starts =================================================
platform win32 -- Python 3.7.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 21 items

test_fim\test_report_changes\test_large_changes.py .....................                                         [100%]

=========================================== 21 passed in 238.42s (0:03:58) ============================================
```

Kind regards,
Jose Luis.