### PR TITLE
Add markers, tier and ossec.log in report.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ yum groupinstall "Development Tools"
 yum install python36 python36-pip python36-devel -y
 
 # Install Python libraries
-pip3 install pytest freezegun jq jsonschema pyyaml psutil paramiko distro
+pip3 install pytest freezegun jq jsonschema pyyaml psutil paramiko distro pandas pytest-html==2.0.1 numpydoc==0.9.2
 ```
 
 - Add some internal options and restart
@@ -75,7 +75,7 @@ choco install jq
 - Install Python dependencies
 
 ```shell script
-pip install pytest freezegun jsonschema pyyaml psutil paramiko distro pywin32 pypiwin32 wmi
+pip install pytest freezegun jsonschema pyyaml psutil paramiko distro pywin32 pypiwin32 wmi pandas pytest-html==2.0.1 numpydoc==0.9.2
 ```
 
 - Change `time-reconnect` from `C:\Program Files (x86)\ossec-agent\ossec.conf`
@@ -110,7 +110,7 @@ brew install python3
 brew install autoconf automake libtool
 
 # Install Python libraries
-pip3 install pytest freezegun jq jsonschema pyyaml psutil paramiko distro
+pip3 install pytest freezegun jq jsonschema pyyaml psutil paramiko distro pandas pytest-html==2.0.1 numpydoc==0.9.2
 ```
 
 - Add some internal options and restart
@@ -258,7 +258,7 @@ This will be our python module with all the needed code to test everything.
 To run them, we need to install all these Python dependencies:
 
 ```shell script
-pip3 install distro freezegun jq jsonschema paramiko psutil pydevd-pycharm pytest pyyaml
+pip3 install distro freezegun jq jsonschema paramiko psutil pydevd-pycharm pytest pyyaml pandas pytest-html==2.0.1 numpydoc==0.9.2
 ```
 
 _**NOTE:** `jq` library can only be installed with `pip` on **Linux**_
@@ -356,6 +356,7 @@ python3 -m pytest [options] [file_or_dir] [file_or_dir] [...]
 - `x`: instantly exit after the first error. Very helpful when using a log truncate since it will keep the last failed result
 - `m`: only run tests matching given expression (-m MARKEXPR)
 - `--tier`: only run tests with given tier (ex. --tier 2)
+- `--html`: generates a HTML report for the test results. (ex. --html=report.html)
 - `--default-timeout`: overwrites the default timeout (in seconds). This value is used to make a test fail if a condition 
 is not met before the given time lapse. Some tests make use of this value and other has other fixed timeout that cannot be 
 modified.

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -10,6 +10,7 @@ if sys.platform == 'win32':
     WAZUH_PATH = os.path.join("C:", os.sep, "Program Files (x86)", "ossec-agent")
     WAZUH_CONF = os.path.join(WAZUH_PATH, 'ossec.conf')
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'ossec.log')
     PREFIX = os.path.join('c:', os.sep)
     GEN_OSSEC = None
 
@@ -17,6 +18,7 @@ elif sys.platform == 'darwin':
     WAZUH_PATH = os.path.join('/', 'Library', 'Ossec')
     WAZUH_CONF = os.path.join(WAZUH_PATH, 'etc', 'ossec.conf')
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     PREFIX = os.sep
     GEN_OSSEC = None
 
@@ -24,6 +26,7 @@ else:
     WAZUH_PATH = os.path.join('/', 'var', 'ossec')
     WAZUH_CONF = os.path.join(WAZUH_PATH, 'etc', 'ossec.conf')
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     GEN_OSSEC = os.path.join(WAZUH_SOURCES, 'gen_ossec.sh')
     PREFIX = os.sep
 
@@ -38,5 +41,4 @@ else:
         WAZUH_SERVICE = 'wazuh-manager' if type_ == 'server' else 'wazuh-agent'
 
 _data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
 WAZUH_LOGS_PATH = os.path.join(WAZUH_PATH, 'logs')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -103,14 +103,14 @@ def pytest_configure(config):
 
 
 def pytest_html_results_table_header(cells):
-    cells.insert(4, html.th('Tier'))
+    cells.insert(4, html.th('Tier', class_='sortable tier', col='tier'))
     cells.insert(3, html.th('Markers'))
     cells.insert(2, html.th('Description'))
     cells.insert(1, html.th('Time', class_='sortable time', col='time'))
 
 
 def pytest_html_results_table_row(report, cells):
-    cells.insert(4, html.td(report.tier))
+    cells.insert(4, html.td(report.tier, class_='col-tier'))
     cells.insert(3, html.td(report.markers))
     cells.insert(2, html.td(report.description))
     cells.insert(1, html.td(datetime.utcnow(), class_='col-time'))
@@ -149,8 +149,9 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
     documentation = FunctionDoc(item.function)
     report.description = '. '.join(documentation["Summary"])
-    report.tier = ', '.join(str(mark.kwargs['level']) for mark in item.iter_markers(name='tier'))
-    report.markers = ', '.join(mark.name for mark in item.iter_markers() if mark.name != 'tier')
+    report.tier = ', '.join(str(mark.kwargs['level']) for mark in item.iter_markers(name="tier"))
+    report.markers = ', '.join(mark.name for mark in item.iter_markers() if
+                               mark.name != 'tier' and mark.name != 'parametrize')
 
     extra = getattr(report, 'extra', [])
     if report.when == 'call':

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,13 +8,14 @@ import re
 import sys
 from datetime import datetime
 from time import time
+import uuid
 
 import pytest
 from numpydoc.docscrape import FunctionDoc
 from py.xml import html
 
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_LOGS_PATH
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_LOGS_PATH, WAZUH_CONF
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor, SocketController, SocketMonitor
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_sockets
@@ -110,7 +111,7 @@ def pytest_html_results_table_header(cells):
 
 
 def pytest_html_results_table_row(report, cells):
-    cells.insert(4, html.td(report.tier, class_='col-tier'))
+    cells.insert(4, html.td(report.tier))
     cells.insert(3, html.td(report.markers))
     cells.insert(2, html.td(report.description))
     cells.insert(1, html.td(datetime.utcnow(), class_='col-time'))
@@ -121,9 +122,8 @@ def pytest_html_results_table_row(report, cells):
 def create_asset(
         self, content, extra_index, test_index, file_extension, mode="w"
 ):
-    asset_file_name = "{}_{}.{}".format(
-        re.sub(r"[^\w\.\:]", "_", self.test_id).split('::')[0],
-        str(time()),
+    asset_file_name = "{}.{}".format(
+        str(uuid.uuid4()),
         file_extension
     )
     asset_path = os.path.join(
@@ -148,6 +148,8 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
     documentation = FunctionDoc(item.function)
+
+    # Add description, markers and tier to the report
     report.description = '. '.join(documentation["Summary"])
     report.tier = ', '.join(str(mark.kwargs['level']) for mark in item.iter_markers(name="tier"))
     report.markers = ', '.join(mark.name for mark in item.iter_markers() if
@@ -157,12 +159,16 @@ def pytest_runtest_makereport(item, call):
     if report.when == 'call':
         # Apply hack to fix length filename problem
         pytest_html.HTMLReport.TestResult.create_asset = create_asset
+
+        # Add extended information from docstring inside 'Result' section
         extra.append(pytest_html.extras.html('<div><h2>Test function details</h2></div>'))
         for section in ('Extended Summary', 'Parameters'):
             extra.append(pytest_html.extras.html(f'<div><h3>{section}</h3></div>'))
             for line in documentation[section]:
                 extra.append(pytest_html.extras.html(f'<div>{line}</div>'))
         arguments = dict()
+
+        # Add arguments of each text as a json file
         for key, value in item.funcargs.items():
             if isinstance(value, set):
                 arguments[key] = list(value)
@@ -172,9 +178,13 @@ def pytest_runtest_makereport(item, call):
             except (TypeError, OverflowError):
                 arguments[key] = str(value)
         extra.append(pytest_html.extras.json(arguments, name="Test arguments"))
-        with open(LOG_FILE_PATH, 'r') as f:
-            ossec_log = f.read()
-            extra.append(pytest_html.extras.text(ossec_log, name='Ossec.log'))
+
+        # Extra files to be added in 'Links' section
+        for filepath in (LOG_FILE_PATH, WAZUH_CONF):
+            with open(filepath, 'r') as f:
+                content = f.read()
+                extra.append(pytest_html.extras.text(content, name=os.path.split(filepath)[-1]))
+
         report.extra = extra
 
 


### PR DESCRIPTION
This PR is related to issue #383 

## Description

This PR adds some fields to the html report that is produced when using pytest-html. To generate the report, it is necessary to indicate an existing route:

```
python3 -m pytest test_fim/test_basic_usage/test_basic_usage_move_dir.py --html=/vagrant/report/report.html
```

The added fields are:
- **Markers**: It contains all the markers of each test within the pytestmark variable, except tier.
- **Tier**: It contains the marker tier of each test. It can be ordered.
- **Link to ossec.log**: Open a copy of the ossec.log file as it was after the test run.
- **Link to ossec.conf**: Open a copy of the ossec.conf file.


Kind regards,
José Luis.