### PR TITLE
Fix minor bugs

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -684,7 +684,7 @@ def callback_audit_removed_rule(line):
 
 
 def callback_audit_deleting_rule(line):
-    match = re.match(r'.*Deleting Audit rules...', line)
+    match = re.match(r'.*Deleting Audit rules.', line)
     if match:
         return True
     return None

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -684,7 +684,7 @@ def callback_audit_removed_rule(line):
 
 
 def callback_audit_deleting_rule(line):
-    match = re.match(r'.*Deleting Audit rules.', line)
+    match = re.match(r'.*Deleting Audit rules\.', line)
     if match:
         return True
     return None

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
@@ -88,7 +88,7 @@ def test_delete_folder(folder, file_list, filetype, tags_to_apply,
     # Expect deleted events
     event_list = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
                                     accum_results=len(file_list)).result()
-    path_list = [event['data']['path'] for event in event_list]
+    path_list = set([event['data']['path'] for event in event_list])
     counter_type = Counter([event['data']['type'] for event in event_list])
 
     assert counter_type['deleted'] == len(file_list), f'Number of "deleted" events should be {len(file_list)}'


### PR DESCRIPTION
Hello team,

This PR fixes some small errors that caused failures in certain tests.

## Test_basic_usage_delete_folder

### Description

When the `Test_basic_usage_delete_folder` test was run, despite working well in CentOS, it showed an error like the following in Ubuntu.

```
E           AssertionError: assert ('deleted' in 'deleted' and '/testdir2/subdir/regular0' in '/testdir2/subdir/regular2')
E            +  where '/testdir2/subdir/regular0' = <function join at 0x7ff208bebd08>('/testdir2/subdir', 'regular0')
E            +    where <function join at 0x7ff208bebd08> = <module 'posixpath' from '/usr/lib/python3.7/posixpath.py'>.join
E            +      where <module 'posixpath' from '/usr/lib/python3.7/posixpath.py'> = os.path
```

The problem is that, due to the multi-threaded structure, sometimes the events were not generated in the expected order, which resulted in incorrect asserts.

### Fix

It has been corrected by adding all events to a list and checking that the expected field is within one of the events in the list.

### Test performed

```
python3 -m pytest test_fim/test_basic_usage/test_basic_usage_delete_folder.py   
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 6 items                                                                                                                                            

test_fim/test_basic_usage/test_basic_usage_delete_folder.py ......                                                                                     [100%]

================================================================ 6 passed in 61.44s (0:01:01) ================================================================
```


## Test_remove_rule_five_times

### Description

The test generated a timeout error when waiting for an event like the following:

`2020/06/30 08:00:58 ossec-syscheckd[516] syscheck_audit.c:1357 at clean_rules(): DEBUG: (6250): Deleting Audit rules.`

### Fix

It has been fixed by replacing
`match = re.match(r'.*Deleting Audit rules...', line)`
with
`match = re.match(r'.*Deleting Audit rules.', line)`

### Test performed

```
python3 -m pytest test_fim/test_audit/test_remove_rule_five_times.py   
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 1 item                                                                                                                                             

test_fim/test_audit/test_remove_rule_five_times.py .                                                                                                   [100%]

===================================================================== 1 passed in 25.32s =====================================================================

```

Kind regards,
Jose Luis.