### PR TITLE
invalid alerts.json characters handling

### DIFF
--- a/tests/system/fim/common_tasks/verify_alerts_json.py
+++ b/tests/system/fim/common_tasks/verify_alerts_json.py
@@ -10,6 +10,7 @@
 
 import sys
 import json
+import traceback
 
 if sys.version_info.major < 3:
     print('ERROR: Python 2 is not supported.')
@@ -37,7 +38,7 @@ def alerts_prune(path, target_event):
         :return: Returns a set containing the alerts files path
     """
     alerts_list = []
-    with open(path) as json_file:
+    with open(path,errors='replace') as json_file:
         for line in json_file:
             try:
                 data = json.loads(line)
@@ -118,7 +119,7 @@ def main():
             print("Elapsed time: ~ %s seconds \n" % int(elapsed))
 
     except Exception:
-        print("An error has ocurred. Exiting")
+        traceback.print_exc()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi team,


Alerts as the following one, containing invalid characters, caused the `verify_alerts_json.py` script to fail:

```json
.................... Feb 19 08:31:29 WinEvtLog: x�0\u0001��0\u0001o5�w8: ERROR(10016): ......................{"dstuser":"Administrator","id":"10016","status":"ERROR","extra_data":"DCOM","system_name":"serv-test-windows-1","type":"x�0\u0001��0\u0001o5�w8"},"location":"WinEvtLog"}
```

`verify_alerts_json.py` error:
```python
Traceback (most recent call last):
  File "verify_alerts_json.py", line 85, in <module>
    main()
  File "verify_alerts_json.py", line 69, in main
    pruned_alerts_set = alerts_prune(args.log_json_path, args.event)
  File "verify_alerts_json.py", line 41, in alerts_prune
    for line in json_file:
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xda in position 4317: invalid continuation byte
```

Two solutions have been considered:
- open(filenames_list_path,errors='replace') solves the encoding issue mantaining the invalid bytes.

- open(filenames_list_path,errors='ignore') solves the encoding issue dropping the invalid bytes. We discarded this solution as it truncates the log


Greetings, 

JP Sáez