### PR TITLE
Add XFAIL mark to basic usage tests on Windows

### DIFF
--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
@@ -59,7 +59,7 @@ def get_configuration(request):
                                                                                 pytest.mark.sunos5)),
     pytest.param('نصبسيط', 'cp720', {CHECK_ALL}, {'ossec_conf'}, marks=(pytest.mark.linux,
                                                                         pytest.mark.darwin, pytest.mark.sunos5)),
-    pytest.param('Ξ³ΞµΞΉΞ±', None, {CHECK_ALL}, {'ossec_conf'}, marks=pytest.mark.win32)
+    pytest.param('Ξ³ΞµΞΉΞ±', None, {CHECK_ALL}, {'ossec_conf'}, marks=(pytest.mark.win32, pytest.mark.xfail))
 
 ])
 def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
@@ -73,7 +73,8 @@ def get_configuration(request):
     pytest.param('نصبسيط', REGULAR, '', {CHECK_ALL}, {'ossec_conf'}, 'cp720', marks=(pytest.mark.linux,
                                                                                      pytest.mark.darwin,
                                                                                      pytest.mark.sunos5)),
-    pytest.param('Ξ³ΞµΞΉΞ±', REGULAR, '', {CHECK_ALL}, {'ossec_conf'}, None, marks=pytest.mark.win32)
+    pytest.param('Ξ³ΞµΞΉΞ±', REGULAR, '', {CHECK_ALL}, {'ossec_conf'}, None, marks=(pytest.mark.win32,
+                                                                                    pytest.mark.xfail))
 ])
 def test_create_file_realtime_whodata(folder, name, filetype, content, checkers, tags_to_apply, encoding,
                                       get_configuration,

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
@@ -74,7 +74,8 @@ def get_configuration(request):
     pytest.param('نصبسيط', REGULAR, '', {CHECK_ALL}, {'ossec_conf'}, 'cp720', marks=(pytest.mark.linux,
                                                                                      pytest.mark.darwin,
                                                                                      pytest.mark.sunos5)),
-    pytest.param('Ξ³ΞµΞΉΞ±', REGULAR, '', {CHECK_ALL}, {'ossec_conf'}, None, marks=pytest.mark.win32)
+    pytest.param('Ξ³ΞµΞΉΞ±', REGULAR, '', {CHECK_ALL}, {'ossec_conf'}, None, marks=(pytest.mark.win32,
+                                                                                    pytest.mark.xfail))
 ])
 def test_create_file_scheduled(folder, name, filetype, content, checkers, tags_to_apply, encoding, get_configuration,
                                configure_environment, restart_syscheckd, wait_for_initial_scan):


### PR DESCRIPTION
Hi team.

## Summary

This PR adds the `xfail` mark to the rare cases on Windows for the basic usage tests:
- test_basic_usage_create_scheduled
- test_basic_usage_create_rt_wd
- test_basic_usage_changes

These tests are expected to fail and we will fix this behaviour later on.

Regards.

## Tests performed

```
======================================== test session starts ========================================= platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 108 items

test_fim\test_basic_usage\test_basic_usage_create_scheduled.py ..............ssssssssxx         [ 22%] test_fim\test_basic_usage\test_basic_usage_create_rt_wd.py ..............ssssssssxx............ [ 55%] ..ssssssssxx                                                                                    [ 66%] test_fim\test_basic_usage\test_basic_usage_changes.py ..ssssssssxx..ssssssssxx..ssssssssxx      [100%]

======================= 48 passed, 48 skipped, 12 xfailed in 331.60s (0:05:31) =======================
```