### PR TITLE
FIM: Follow Symbolic Link test updated

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -644,7 +644,7 @@ def callback_detect_integrity_state(line):
 
 
 def callback_detect_synchronization(line):
-    if 'Initializing FIM Integrity Synchronization check' in line:
+    if 'Performing synchronization check' in line:
         return line
     return None
 
@@ -725,6 +725,13 @@ def callback_audit_loaded_rule(line):
 
 def callback_audit_event_too_long(line):
     if 'Caching Audit message: event too long' in line:
+        return True
+    return None
+
+
+def callback_audit_reloading_rules(line):
+    match = re.match(r'.*Reloading Audit rules', line)
+    if match:
         return True
     return None
 

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -733,7 +733,6 @@ def callback_audit_reloading_rules(line):
     match = re.match(r'.*Reloading Audit rules', line)
     if match:
         return True
-    return None
 
 
 def callback_audit_reloaded_rule(line):

--- a/tests/integration/test_fim/test_follow_symbolic_link/common.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/common.py
@@ -64,7 +64,7 @@ def delete_f(path, file=None):
 def wait_for_symlink_check(monitor):
     """Wait for symlink thread to finish its scan"""
     monitor.start(timeout=(symlink_interval + 2), callback=callback_symlink_scan_ended,
-                  error_message='Did not receive expected "Sending FIM event: ..." event')
+                  error_message='Did not receive expected "Links check finalized" event')
 
 
 def extra_configuration_before_yield():

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_delete_target.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_delete_target.py
@@ -4,15 +4,16 @@
 
 import os
 import pytest
-import time
+
 from test_fim.test_follow_symbolic_link.common import configurations_path, testdir1, \
     wait_for_symlink_check, wait_for_audit, testdir_target, testdir_not_target, delete_f, symlink_interval
 # noinspection PyUnresolvedReferences
 from test_fim.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
     extra_configuration_after_yield
 
-from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_detect_event, callback_audit_removed_rule,
-                               callback_audit_reloaded_rule, callback_audit_reloading_rules, check_time_travel, modify_file_content, LOG_FILE_PATH)
+from wazuh_testing.fim import generate_params, create_file, REGULAR, callback_detect_event, \
+    callback_audit_removed_rule, callback_audit_reloaded_rule, callback_audit_reloading_rules, check_time_travel, \
+    modify_file_content, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -88,11 +89,13 @@ def test_symbolic_delete_target(tags_to_apply, main_folder, aux_folder, get_conf
     if tags_to_apply == {'monitored_dir'} and whodata:
         os.makedirs(main_folder, exist_ok=True, mode=0o777)
         wazuh_log_monitor.start(timeout=3, callback=callback_audit_removed_rule,
-                                error_message='Did not receive expected "Monitored directory \'{main_folder}\' was removed: Audit rule removed')
+                                error_message='Did not receive expected "Monitored directory \'{main_folder}\' was'
+                                'removed: Audit rule removed')
         wazuh_log_monitor.start(timeout=symlink_interval, callback=callback_audit_reloading_rules,
                                 error_message='Did not receive expected "Reloading Audit rules" event')
         wazuh_log_monitor.start(timeout=symlink_interval, callback=callback_audit_reloaded_rule,
-                                error_message='Did not receive expected "Reloaded audit rule for monitoring directory: \'{main_folder}\'" event')
+                                error_message='Did not receive expected "Reloaded audit rule for monitoring directory: '
+                                '\'{main_folder}\'" event')
     else:
         # If syscheck is monitoring with whodata, wait for audit to reload rules
         wait_for_audit(whodata, wazuh_log_monitor)


### PR DESCRIPTION
This closes #502.

This PR updates `test_delete_target.py` to match the new expected behaviour of symbolic link files and targeting directories when those directories are removed. `Fim.py` has a new callback needed for this purpouse.

The test now performs the followings steps:
```
1. Remove the SysLink's target directory and wait for a "deleted" event.
2. Create again the directory.
3. Wait for "Audit rule removed" message.
4. Wait for "Reloading Audit rules" message.
5. Wait for "Reloaded audit rule for monitoring directory: DIRECTORY_NAME" message.
6. Create a file inside the recently-created folder and wait for the "added" event.
7. Wait for "Links check finalized"
8. Wait for "Audit rule loaded: -w ... -p"
9. Modify the new file and wait for the "modify" event.
This change has been suggested and approved by Core team.
```

## Test results

```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 69 items                                                             

test_fim/test_follow_symbolic_link/test_change_target.py .ss..ss..ss.    [ 17%]
test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py . [ 18%]
ss..ss..ss.                                                              [ 34%]
test_fim/test_follow_symbolic_link/test_delete_symlink.py .ss..ss..ss.   [ 52%]
test_fim/test_follow_symbolic_link/test_delete_target.py .ss..ss..ss.    [ 69%]
test_fim/test_follow_symbolic_link/test_monitor_symlink.py .ss..ss..ss.  [ 86%]
test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py . [ 88%]
.....                                                                    [ 95%]
test_fim/test_follow_symbolic_link/test_revert_symlink.py ...            [100%]

=========== 39 passed, 30 skipped, 2 warnings in 1496.92s (0:24:56) ============


```