### PR TITLE
Fix import AF_UNIX in Windows

### DIFF
--- a/tests/integration/test_fim/test_stats_integrity_sync/test_stats_integrity_sync.py
+++ b/tests/integration/test_fim/test_stats_integrity_sync/test_stats_integrity_sync.py
@@ -5,11 +5,12 @@
 import os
 import re
 import subprocess
+import sys
 import time
 from enum import Enum
 from multiprocessing import Process, Manager
 from random import randrange
-from socket import socket, AF_UNIX, SOCK_STREAM, MSG_WAITALL
+from socket import socket, SOCK_STREAM, MSG_WAITALL
 from struct import pack, unpack
 
 import pytest
@@ -19,6 +20,9 @@ from wazuh_testing import logger
 from wazuh_testing.tools import WAZUH_PATH, WAZUH_CONF, ALERT_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
+
+if sys.platform != 'win32':
+    from socket import AF_UNIX
 
 # Marks
 


### PR DESCRIPTION
Hello team,

When the tests are executed with the --tier option, all are loaded (even if they are skipped later). This causes an error in Windows when importing the AF_UNIX library since it is not available on that platform, causing an error that prevents the execution of all tests. It can be seen below:

```
PS C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration> python -m pytest .\test_fim --tier 0
================================================= test session starts =================================================
platform win32 -- Python 3.7.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 3510 items / 1 error / 3509 selected

======================================================= ERRORS ========================================================
__________________ ERROR collecting test_fim/test_stats_integrity_sync/test_stats_integrity_sync.py ___________________
ImportError while importing test module 'C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration\test_fim\test_stats_integr
ity_sync\test_stats_integrity_sync.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test_fim\test_stats_integrity_sync\test_stats_integrity_sync.py:12: in <module>
    from socket import socket, AF_UNIX, SOCK_STREAM, MSG_WAITALL
E   ImportError: cannot import name 'AF_UNIX' from 'socket' (C:\Users\jmv74211\AppData\Local\Programs\Python\Python37-32
\lib\socket.py)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================== 1 error in 4.28s ===================================================
```

The error is fixed with this:
```Python
if sys.platform != 'win32':
    from socket import AF_UNIX
```

Kind regards,
José Luis.