### PR TITLE
Fix prefilter_cmd tests for FIM

### DIFF
--- a/tests/integration/test_fim/test_prefilter_cmd/data/install_prelink.sh
+++ b/tests/integration/test_fim/test_prefilter_cmd/data/install_prelink.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 
-# Check if prelink is installed and if not, install it
-$1 | grep -E "prelink.*" || $2 prelink
+dist=$1
+
+if [ "$dist" == "ubuntu" ]; then
+  if [ ! "$(dpkg -l | grep -E "prelink.*")" ]; then
+    apt-get update
+    apt-get install prelink
+  fi
+else
+  if [ ! "$(rpm -qa | grep -E "prelink.*")" ]; then
+    yum -y install prelink
+  fi
+fi

--- a/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -51,13 +51,8 @@ def check_prelink():
     # Call script to install prelink if it is not installed
     path = os.path.dirname(os.path.abspath(__file__))
     dist_list = ['centos', 'fedora', 'rhel']
-    if distro.id() in dist_list:
-        dist = 'rpm -qa'
-        installer = 'yum -y install'
-    else:
-        dist = 'dpkg -l'
-        installer = 'apt-get install'
-    subprocess.call([f'{path}/data/install_prelink.sh', dist, installer])
+    dist = 'ubuntu' if distro.id() not in dist_list else 'fedora'
+    subprocess.call([f'{path}/data/install_prelink.sh', dist])
 
 
 # tests


### PR DESCRIPTION
Hi team.

This PR fixes `test_prefilter_cmd` script in order to make it work for every Linux distribution.

Regards.

## Tests performed
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 3 items                                                                                       

test_fim/test_prefilter_cmd/test_prefilter_cmd.py ...                                             [100%]

===================================== 3 passed in 81.86s (0:01:21) ======================================

```