### PR TITLE
Fix errors in tests for Darwin

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -940,7 +940,7 @@ class EventChecker:
                 if self.encoding is not None:
                     for index, item in enumerate(file_paths):
                         file_paths[index] = item.encode(encoding=self.encoding)
-                if sys.platform == 'darwin' and self.encoding != 'utf-8':
+                if sys.platform == 'darwin' and self.encoding and self.encoding != 'utf-8':
                     logger.info(f'Not asserting {expected_file_path} in event.data.path. '
                                  f'Reason: using non-utf-8 encoding in darwin.')
                 else:

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -423,8 +423,10 @@ def set_correct_prefix(configurations, new_prefix):
                         # Get restrict, directories, ignore and nodiff fields and split them into paths lists
                         restrict_dict = {}
                         attributes = sub_element.get('attributes', [])
-                        if isinstance(attributes, dict):
-                            restrict_dict = attributes.get('restrict', {})
+                        for attr in attributes:
+                            if isinstance(attr, dict):
+                                if attr.get('restrict'):
+                                    restrict_dict = attr
                         restrict_list = restrict_dict['restrict'].split('|') if restrict_dict != {} else []
                         paths_list = sub_element['value'].split(',')
                         modified_restricts = ''


### PR DESCRIPTION
Hello team,

There were two errors in the FIM tests for Darwin. 

#### First error
The first can be seen in this line:

https://github.com/wazuh/wazuh-qa/blob/c0ab45466bba3af7ebef42e8a922e8c9222b460b/deps/wazuh_testing/wazuh_testing/fim.py#L943

Unless the test had an utf-8 encoding specified, the comparison of the expected and the obtained path is never executed. With the following fix, the paths are also compared when the encoding is `None`.

```Python
if sys.platform == 'darwin' and self.encoding and self.encoding != 'utf-8':
    logger.info(f'Not asserting {expected_file_path} in event.data.path. '
                      f'Reason: using non-utf-8 encoding in darwin.')
else:
    assert (expected_file_path in file_paths), f'{expected_file_path} does not exist in {file_paths}'
```

#### Second error
There was a bug that caused the non-modification of the restrict attribute even though it had paths inside. This caused multiple errors in those tests that use this attribute in Darwin.

Now a restrict like this:
```YAML
  - directories:
      value: "/testdir1,/testdir2"
      attributes:
      - check_all: 'yes'
      - FIM_MODE
      - restrict: "^/testdir1/f|^/testdir1/subdir/f|^/testdir2/f|^/testdir2/subdir/f"
```

Meets the expected behavior and is modified like this:
```YAML
  - directories:
      value: "/var/root/testdir1,/var/root/testdir2"
      attributes:
      - check_all: 'yes'
      - FIM_MODE
      - restrict: "^/var/root/testdir1/f|^/var/root/testdir1/subdir/f|^/var/root/testdir2/f|^/var/root/testdir2/subdir/f"
```

Kind regards,
José Luis.