### PR TITLE
Fix non removed directories and initial scan sleep

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1131,8 +1131,6 @@ def detect_initial_scan(file_monitor):
     """
     file_monitor.start(timeout=60, callback=callback_detect_end_scan,
                        error_message='Did not receive expected "File integrity monitoring scan ended" event')
-    # Add additional sleep to avoid changing system clock issues (TO BE REMOVED when syscheck has not sleeps anymore)
-    time.sleep(11)
 
 
 def generate_params(extra_params: dict = None, apply_to_all: Union[Sequence[Any], Generator[dict, None, None]] = None,

--- a/tests/integration/test_fim/test_basic_usage/test_basic_disabled.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_disabled.py
@@ -56,7 +56,7 @@ def test_disabled(folder, get_configuration, configure_environment, restart_sysc
     """
     # Expect a timeout when checking for syscheckd initial scan
     with pytest.raises(TimeoutError):
-        event = wazuh_log_monitor.start(timeout=20, callback=callback_detect_end_scan)
+        event = wazuh_log_monitor.start(timeout=10, callback=callback_detect_end_scan)
         raise AttributeError(f'Unexpected event {event}')
 
     # Use `regular_file_cud` and don't expect any event

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -57,6 +57,7 @@ def extra_configuration_before_yield():
 def extra_configuration_after_yield():
     """Delete subdir directory after finishing the module execution since it's not monitored."""
     shutil.rmtree(os.path.join(PREFIX, 'subdir'), ignore_errors=True)
+    shutil.rmtree(testdir4, ignore_errors=True)
 
 
 @pytest.mark.parametrize('source_folder, target_folder, subdir, tags_to_apply, \


### PR DESCRIPTION
Hi team.

This PR fixes that `test_basic_usage_move_dir` was not removing its used directories and we also removed the `time.sleep(11)` in `wait_for_initial_scan` fixture, so now every test should be faster.

Regards.