### PR TITLE
clean_results updated on fim.py

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -896,8 +896,11 @@ class EventChecker:
                 if current_event['data']['type'] == "modified":
                     if not previous_event:
                         previous_event = current_event
-                    elif (previous_event['data']['path'] == current_event['data']['path'] and
-                          previous_event['data']['timestamp'] == current_event['data']['timestamp']):
+                    elif (previous_event['data']['path'] == current_event['data']['path']
+                          and current_event['data']['timestamp'] in [previous_event['data']['timestamp'],
+                                                                     previous_event['data']['timestamp'] + 1]
+                          and set(current_event['data']['changed_attributes']).intersection(
+                              set(previous_event['data']['changed_attributes'])) == set()):
                         previous_event['data']['changed_attributes'] += current_event['data']['changed_attributes']
                         previous_event['data']['attributes'] = current_event['data']['attributes']
                     else:


### PR DESCRIPTION
This PR upgrades `clean_results` function on `fim.py` to ensure duplicate events generated by `Whodata` will be correctly merged if applicable. With this improvement false error related to this bevavior will be properly managed. 

## Test results
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 171 items                                                                                                                                                                                                                          

test_fim/test_checks/test_check_all.py ..........sssssssssssssssssss........sssssssssssssssssss...........sssssssssssssssssss........sssssssssssssssssss...........sssssssssssssssssss........sssssssssssssssssss.                     [100%]

================================================================================================ 57 passed, 114 skipped in 359.25s (0:05:59) =================================================================================================
```