### PR TITLE
FIM: clean_results function improved

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -887,29 +887,32 @@ class EventChecker:
             Message to explain a possible timeout error
         """
         def clean_results(event_list):
+            """Iterate the event_list provided and check if the 'modified' events contained should be merged to fix
+            whodata's bug that raise more than one modification event when a file is modified. If some 'modified' event
+            shares 'path' and 'timestamp' we assume that belongs to the same modification.
+            """
             if not isinstance(event_list, list):
                 return event_list
-            result_list = []
-            previous_event = None
+            result_list = list()
+            previous = None
             while(len(event_list) > 0):
-                current_event = event_list.pop(0)
-                if current_event['data']['type'] == "modified":
-                    if not previous_event:
-                        previous_event = current_event
-                    elif (previous_event['data']['path'] == current_event['data']['path']
-                          and current_event['data']['timestamp'] in [previous_event['data']['timestamp'],
-                                                                     previous_event['data']['timestamp'] + 1]
-                          and set(current_event['data']['changed_attributes']).intersection(
-                              set(previous_event['data']['changed_attributes'])) == set()):
-                        previous_event['data']['changed_attributes'] += current_event['data']['changed_attributes']
-                        previous_event['data']['attributes'] = current_event['data']['attributes']
+                current = event_list.pop(0)
+                if current['data']['type'] == "modified":
+                    if not previous:
+                        previous = current
+                    elif (previous['data']['path'] == current['data']['path'] and
+                          current['data']['timestamp'] in [previous['data']['timestamp'],
+                                                           previous['data']['timestamp'] + 1]):
+                        previous['data']['changed_attributes'] = list(set(previous['data']['changed_attributes']
+                                                                          + current['data']['changed_attributes']))
+                        previous['data']['attributes'] = current['data']['attributes']
                     else:
-                        result_list.append(previous_event)
-                        previous_event = current_event
+                        result_list.append(previous)
+                        previous = current
                 else:
-                    result_list.append(current_event)
-            if previous_event:
-                result_list.append(previous_event)
+                    result_list.append(current)
+            if previous:
+                result_list.append(previous)
             return result_list
 
         try:


### PR DESCRIPTION
This PR upgrades `clean_results` function on `fim.py` to ensure duplicate events generated by `Whodata` will be correctly merged if applicable by removing one of the condition it had, fixing an unwanted behavior.

## Test results
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 171 items                                                                                                                                                                                                                          

test_fim/test_checks/test_check_all.py ..........sssssssssssssssssss........sssssssssssssssssss...........sssssssssssssssssss........sssssssssssssssssss...........sssssssssssssssssss........sssssssssssssssssss.                     [100%]

================================================================================================ 57 passed, 114 skipped in 345.43s (0:05:45) =================================================================================================
```