### PR TITLE
Improve synchronize tests for FIM

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -804,6 +804,11 @@ def callback_empty_directories(line):
         return None
 
 
+def callback_real_time_whodata_started(line):
+    if 'File integrity monitoring real-time Whodata engine started' in line:
+        return True
+
+
 def check_time_travel(time_travel):
     """
     Change date and time of the system.


### PR DESCRIPTION
Hi team.

This PR adds a new callback to `test_synchronize` in order to assure that `whodata` has started before creating a file. 

Although the synchronization check was detected, sometimes whodata was not ready and some events were skipped.

Regards.