### PR TITLE
Add extra parameters variable

### DIFF
--- a/tests/system/fim/common_tasks/create_files.yml
+++ b/tests/system/fim/common_tasks/create_files.yml
@@ -1,7 +1,7 @@
 ---
 - block:
   - name: Run script generate_files.py on agents | Linux
-    script: "generate_files.py -c {{ files_config_linux_destination_path }} -o {{ files_generated_output_path }}"
+    script: "generate_files.py -c {{ files_config_linux_destination_path }} -o {{ files_generated_output_path }} {{ create_script_extra_params }}"
     args:
       executable: "python3"
       chdir: "{{ agents_linux_output_path }}"
@@ -19,7 +19,7 @@
 
 - block:
   - name: Run script generate_files.py on agents | Windows
-    script: "generate_files.py -c {{ files_config_windows_destination_path }} -o {{ files_generated_output_path }}"
+    script: "generate_files.py -c {{ files_config_windows_destination_path }} -o {{ files_generated_output_path }} {{ create_script_extra_params }}"
     args:
       executable: "python"
       chdir: "{{ agents_windows_output_path }}"

--- a/tests/system/fim/common_tasks/delete_files.yml
+++ b/tests/system/fim/common_tasks/delete_files.yml
@@ -1,7 +1,7 @@
 ---
 - block:
   - name: "Delete FIM test files at Wazuh Agents | Linux"
-    script: "delete_files.py -i {{ files_generated_output_path }} -o {{ files_deleted_output_path }}"
+    script: "delete_files.py -i {{ files_generated_output_path }} -o {{ files_deleted_output_path }} {{ delete_script_extra_params }}"
     args:
       executable: "python3"
       chdir: "{{ agents_linux_output_path }}"
@@ -19,7 +19,7 @@
 
 - block:
   - name: "Delete FIM test files at Wazuh Agents | Windows"
-    script: "delete_files.py -i {{ files_generated_output_path }} -o {{ files_deleted_output_path }}"
+    script: "delete_files.py -i {{ files_generated_output_path }} -o {{ files_deleted_output_path }} {{ delete_script_extra_params }}"
     args:
       executable: "python"
       chdir: "{{ agents_windows_output_path }}"

--- a/tests/system/fim/common_tasks/modify_files.yml
+++ b/tests/system/fim/common_tasks/modify_files.yml
@@ -1,7 +1,7 @@
 ---
 - block:
   - name: "Modify FIM test files at Wazuh Managers | Linux"
-    script: "modify_files.py -i {{ files_generated_output_path }} -o {{ files_modified_output_path }}"
+    script: "modify_files.py -i {{ files_generated_output_path }} -o {{ files_modified_output_path }} {{ modify_script_extra_params }}"
     args:
       executable: "python3"
       chdir: "{{ agents_linux_output_path }}"
@@ -19,7 +19,7 @@
 
 - block:
   - name: "Modify FIM test files at Wazuh Managers | Windows"
-    script: "modify_files.py -i {{ files_generated_output_path }} -o {{ files_modified_output_path }}"
+    script: "modify_files.py -i {{ files_generated_output_path }} -o {{ files_modified_output_path }} {{ modify_script_extra_params }}"
     args:
       executable: "python"
       chdir: "{{ agents_windows_output_path }}"

--- a/tests/system/fim/vars/main.yml
+++ b/tests/system/fim/vars/main.yml
@@ -32,3 +32,7 @@ agents_results_manager_path: "/opt/agents_files_output"
 agents_results_elastic_path: "/opt/agents_files_output"   # Path on Manager of the imported results from Agents
 missing_alerts_json_path: "missing_alerts_json.txt"
 missing_alerts_elasticsearch_path: "missing_alerts_elasticsearch.txt"
+
+create_script_extra_params: ""
+modify_script_extra_params: ""
+delete_script_extra_params: ""


### PR DESCRIPTION
Hi all!

We added a new variable `script_extra_params` as an empty string by default, which will be used to include the extra parameters or optional ones in Ansible tasks responsible for running the action scripts for FIM testing.

https://github.com/wazuh/wazuh-qa/blob/18032fdc12fa93bf285487aac331216433276ca1/tests/system/fim/vars/main.yml#L36

https://github.com/wazuh/wazuh-qa/blob/18032fdc12fa93bf285487aac331216433276ca1/tests/system/fim/common_tasks/modify_files.yml#L4

https://github.com/wazuh/wazuh-qa/blob/18032fdc12fa93bf285487aac331216433276ca1/tests/system/fim/common_tasks/create_files.yml#L4

_Same changes for Windows related tasks._

Kr,

Rshad