### PR TITLE
Fix windows_audit_interval tests

### DIFF
--- a/tests/integration/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
+++ b/tests/integration/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
@@ -58,7 +58,8 @@ def extra_configuration_before_yield():
     """Get list of SACL before Wazuh applies its own rules based on whodata monitoring."""
     with Privilege('SeSecurityPrivilege'):
         lfss = get_file_security_descriptor(testdir_restore)
-        setattr(sys.modules[__name__], 'previous_rules', get_sacl(lfss))
+        sacl = get_sacl(lfss) if get_sacl(lfss) is not None else set()
+        setattr(sys.modules[__name__], 'previous_rules', sacl)
 
 
 def callback_sacl_changed(line):


### PR DESCRIPTION
Hi team.

These tests were failing in some cases because if the monitored directory had no SACL's, `previous_sacl` was set to `None` instead of an empty `set`.

This PR will fix that.

Regards. 