### PR TITLE
Fix report_changes tests on Windows (FIM)

### DIFF
--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import re
 import sys
 import subprocess
 import gzip
@@ -133,7 +134,8 @@ def test_large_changes(filename, folder, original_size, modified_size, tags_to_a
     diff_file_path = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local')
     if sys.platform == 'win32':
         diff_file_path = os.path.join(diff_file_path, 'c')
-        diff_file_path = os.path.join(diff_file_path, folder.strip('c:\\'), filename, 'last-entry.gz')
+        diff_file_path = os.path.join(diff_file_path, re.match(r'^[a-zA-Z]:(\\){1,2}(\w+)(\\){0,2}$', folder).group(2),
+                                      filename, 'last-entry.gz')
     else:
         diff_file_path = os.path.join(diff_file_path, folder.strip('/'), filename, 'last-entry.gz')
 

--- a/tests/integration/test_fim/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_report_changes/test_report_changes_and_diff.py
@@ -2,12 +2,15 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+import re
 import sys
+import time
 
 import pytest
 
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import (CHECK_ALL, LOG_FILE_PATH, regular_file_cud, WAZUH_PATH, generate_params)
+from wazuh_testing.fim import (CHECK_ALL, LOG_FILE_PATH, regular_file_cud, WAZUH_PATH, generate_params,
+                               callback_detect_end_scan)
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -87,7 +90,8 @@ def test_reports_file_and_nodiff(folder, checkers, tags_to_apply,
             diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local')
             if sys.platform == 'win32':
                 diff_file = os.path.join(diff_file, 'c')
-                diff_file = os.path.join(diff_file, folder.strip('C:\\'), file)
+                diff_file = os.path.join(diff_file, re.match(r'^[a-zA-Z]:(\\){1,2}(\w+)(\\){0,2}$', folder).group(2),
+                                         file)
             else:
                 diff_file = os.path.join(diff_file, folder.strip('/'), file)
             assert os.path.exists(diff_file), f'{diff_file} does not exist'


### PR DESCRIPTION
Hi team.

This PR fixes the `report_changes` tests in order to avoid assertion errors. We had some paths hardcoded. Now we use a regex so there is no room for error.

I also added a small delay after `wait_for_initial_scan` to avoid race conditions on `realtime` and `whodata`. We had a sleep of 11 seconds before, so it was not necessary. Now that we got rid of it, we need this delay on Windows.


## Tests performed

### Linux

```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 36 items                                                                                      

test_fim/test_report_changes/test_large_changes.py .....................                          [ 58%]
test_fim/test_report_changes/test_report_changes_and_diff.py ......                               [ 75%]
test_fim/test_report_changes/test_report_deleted_diff.py .........                                [100%]

==================================== 36 passed in 159.71s (0:02:39) =====================================

```

### Windows

```
======================================== test session starts ========================================= platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 36 items

test_fim\test_report_changes\test_large_changes.py .....................                        [ 58%] test_fim\test_report_changes\test_report_changes_and_diff.py ......                             [ 75%] test_fim\test_report_changes\test_report_deleted_diff.py .......FF                              [100%]

============================================== FAILURES ==============================================
```

Windows results are not reliable. There is a reported behaviour which makes Wazuh go idle for a whole minute and then it restarts. This makes our tests fail in the very first check, the `initial scan`:

```
2020/02/25 13:01:48 ossec-agent[984] win_service.c:250 at OssecServiceCtrlHandler(): INFO: Received exit signal.
2020/02/25 13:02:49 ossec-agent: INFO: Using notify time: 10 and max time to reconnect: 999999999
```

