### PR TITLE
Add event validation to FIM tests

### DIFF
--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_baseline_generation.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_baseline_generation.py
@@ -8,7 +8,7 @@ from time import time
 import pytest
 
 from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, callback_detect_event, callback_detect_end_scan, create_file,
-                               generate_params)
+                               generate_params, validate_event)
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -72,9 +72,11 @@ def test_wait_until_baseline(get_configuration, configure_environment, restart_s
     if this event has generated.
     """
     check_apply_test({'ossec_conf'}, get_configuration['tags'])
+    mode = get_configuration['metadata']['fim_mode']
 
     # Create a file during initial scan to check if the event is logged after the 'scan ended' message
     create_file(REGULAR, testdir1, f'test_{int(round(time() * 10 ** 6))}', content='')
 
-    wazuh_log_monitor.start(timeout=120, callback=callback_detect_event_before_end_scan,
-                            error_message='Did not receive expected event before end the scan')
+    ev = wazuh_log_monitor.start(timeout=120, callback=callback_detect_event_before_end_scan,
+                                 error_message='Did not receive expected event before end the scan').result()
+    validate_event(ev, mode=mode)

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -9,7 +9,7 @@ import pytest
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, \
-    callback_detect_event, check_time_travel
+    callback_detect_event, check_time_travel, validate_event
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -90,6 +90,7 @@ def test_move_file(source_folder, target_folder, subdir, tags_to_apply,
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+    mode = get_configuration['metadata']['fim_mode']
 
     # Move folder to target directory
     os.rename(os.path.join(source_folder, subdir), os.path.join(target_folder, subdir))
@@ -119,3 +120,7 @@ def test_move_file(source_folder, target_folder, subdir, tags_to_apply,
         if triggers_add_event:
             assert 'added' in events['data']['type'] and os.path.join(target_folder, subdir) \
                    in os.path.dirname(events['data']['path'])
+
+    events = [events] if not isinstance(events, list) else events
+    for ev in events:
+        validate_event(ev, mode=mode)

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
@@ -8,7 +8,7 @@ import pytest
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_detect_event, \
-    create_file, generate_params, modify_file_content, check_time_travel, delete_file
+    create_file, generate_params, modify_file_content, check_time_travel, delete_file, validate_event
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -69,6 +69,7 @@ def test_events_from_existing_files(filename, tags_to_apply, get_configuration,
     """Check if syscheck generates modified alerts for files that exists when starting the agent"""
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+    mode = get_configuration['metadata']['fim_mode']
 
     # Modify file
     modify_file_content(testdir1, filename, new_content='Sample content')
@@ -80,6 +81,7 @@ def test_events_from_existing_files(filename, tags_to_apply, get_configuration,
                                                            '"Sending FIM event: ..." event').result()
     assert 'modified' in modified_event['data']['type'] and \
            os.path.join(testdir1, filename) in modified_event['data']['path']
+    validate_event(modified_event, mode=mode)
 
     # Delete file
     delete_file(testdir1, filename)
@@ -91,3 +93,4 @@ def test_events_from_existing_files(filename, tags_to_apply, get_configuration,
                                                           '"Sending FIM event: ..." event').result()
     assert 'deleted' in deleted_event['data']['type'] and \
            os.path.join(testdir1, filename) in deleted_event['data']['path']
+    validate_event(deleted_event, mode=mode)


### PR DESCRIPTION
Hi team.

This PR adds the `validate_event` function to every test that did not use `regular_file_cud` ir order to properly check every event. These are the modules that got this changed (basic usage):

- Baseline generation
- Delete folder
- Move dir
- Move file
- Rename
- Starting agent

## Tests performed
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 172 items                                                                                     

test_fim/test_basic_usage/test_basic_disabled.py ......                                           [  3%]
test_fim/test_basic_usage/test_basic_usage_baseline_generation.py ..                              [  4%]
test_fim/test_basic_usage/test_basic_usage_changes.py ..........ss..........ss..........ss        [ 25%]
test_fim/test_basic_usage/test_basic_usage_create_after_delete_dir.py ss                          [ 26%]
test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py ......................ss.............. [ 48%]
........ss                                                                                        [ 54%]
test_fim/test_basic_usage/test_basic_usage_create_scheduled.py ......................ss           [ 68%]
test_fim/test_basic_usage/test_basic_usage_delete_folder.py ......                                [ 72%]
test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py .                          [ 72%]
test_fim/test_basic_usage/test_basic_usage_move_dir.py ....FF.FF                                  [ 77%]
test_fim/test_basic_usage/test_basic_usage_move_file.py ...............                           [ 86%]
test_fim/test_basic_usage/test_basic_usage_new_dirs.py .F                                         [ 87%]
test_fim/test_basic_usage/test_basic_usage_no_dir.py ......                                       [ 91%]
test_fim/test_basic_usage/test_basic_usage_rename.py ......                                       [ 94%]
test_fim/test_basic_usage/test_basic_usage_starting_agent.py .........                            [100%]

=============================================== FAILURES ================================================

```