### PR TITLE
FIM Scenarios config unification

### DIFF
--- a/tests/system/fim/scenarios/203_whodata_frequency/config/agent_linux_ossec.conf
+++ b/tests/system/fim/scenarios/203_whodata_frequency/config/agent_linux_ossec.conf
@@ -105,7 +105,7 @@
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
     <!-- Whodata options -->
-    <directories check_all="yes" whodata="yes">/opt/fim_testing</directories>
+    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/tests/system/fim/scenarios/203_whodata_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/203_whodata_frequency/config/agent_windows_ossec.conf
@@ -72,9 +72,9 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>43200</frequency>
+    <directories recursion_level="320" check_all="yes" whodata="yes">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
-    <directories recursion_level="320" check_all="yes" whodata="yes">C:\fim_testing</directories>
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -204,4 +204,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_linux_ossec.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_linux_ossec.conf
@@ -97,14 +97,14 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>10</frequency>
+    <frequency>43200</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <directories whodata="yes" check_all="yes" recursion_level="4">/opt/fim_testing</directories>
+    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
@@ -71,7 +71,7 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>10</frequency>
+    <frequency>43200</frequency>
     <directories recursion_level="320">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
@@ -72,9 +72,9 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
+    <directories recursion_level="320">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
-    <directories recursion_level="320">C:\fim_testing</directories>
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -204,4 +204,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/205_restrict_option/config/agent_linux_ossec.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/agent_linux_ossec.conf
@@ -104,7 +104,7 @@
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <directories restrict="fimtest">/opt/fim_testing</directories>
+    <directories recursion_level="320" check_all="yes" restrict="fimtest">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/tests/system/fim/scenarios/205_restrict_option/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/agent_windows_ossec.conf
@@ -72,9 +72,9 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
+    <directories recursion_level="320" check_all="yes" restrict="fimtest">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
-    <directories restrict="fimtest" recursion_level="320">C:\fim_testing</directories>
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -204,4 +204,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-


### PR DESCRIPTION
Hi team, 

This PR unifies the current scenarios configurations files for windows and linux agents. We now use `recursion_level=320` and `check_all="yes"` as default. 

Greetings, JP Sáez