### PR TITLE
Fix test_invalid in linux (and windows) platforms

### DIFF
--- a/tests/integration/test_fim/test_invalid/test_invalid.py
+++ b/tests/integration/test_fim/test_invalid/test_invalid.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
@@ -56,7 +57,12 @@ def test_invalid(tags_to_apply, get_configuration, configure_environment):
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
     # Configuration error -> ValueError raised
-    control_service('restart')
+    try:
+        control_service('restart')
+    except ValueError:
+        assert sys.platform != 'win32', 'Restarting ossec with invalid configuration should ' \
+                                        'not raise an exception in win32'
+
     wazuh_log_monitor.start(timeout=3, callback=callback_configuration_error,
                             error_message='Did not receive expected '
                                           '"CRITICAL: ...: Configuration error at" event')


### PR DESCRIPTION
Hello team,

## Description

`test_invalid.py` did not work in Windows platform because performing the following command returned no error:
```
/var/ossec/bin/ossec-control stop
/var/ossec/bin/ossec-control start
```
It was fixed for Windows in the commit https://github.com/wazuh/wazuh-qa/commit/44adeea158a92010eec12aa785a657531e35872d in order to stop expecting a `ValueError` exception. However, in the rest of the platforms that exception **is still** generated, which leads to failures.

It has been solved with a try except that verifies, if an exception is obtained, that the platform is not Windows.

```Python
    try:
        control_service('restart')
    except ValueError:
        assert sys.platform != 'win32'
```

## Tests performed
### Linux
```
python3 -m pytest test_fim/test_invalid/test_invalid.py 
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 4 items                                                                                                                                

test_fim/test_invalid/test_invalid.py ....                                                                                                 [100%]

=============================================================== 4 passed in 55.68s ===============================================================

```

### Windows
```
================================================= test session starts =================================================
platform win32 -- Python 3.7.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 4 items

test_fim\test_invalid\test_invalid.py ....                                                                       [100%]

============================================ 4 passed in 666.62s (0:11:06) ============================================
```

Kind regards,
José Luis.