### PR TITLE
Add FIM basic tests with quick CUD cicles 

### DIFF
--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 import time
 
 import pytest
@@ -16,7 +17,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
 
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0)]
 
 # variables
 
@@ -65,6 +66,9 @@ def test_regular_file_changes(sleep, tags_to_apply, get_configuration, configure
     sleep : float
         Delay in seconds between every action.
     """
+    threshold = 1.5 if sys.platform == 'win32' else 1.25
+    if sleep < threshold and get_configuration['metadata']['fim_mode'] == 'whodata':
+        pytest.xfail('Xfailing due to whodata threshold.')
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     file = 'regular'

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import time
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, \
+    modify_file, delete_file, callback_detect_event, validate_event
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+
+test_directories = [os.path.join(PREFIX, 'testdir1')]
+
+directory_str = ','.join(test_directories)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+testdir1 = test_directories[0]
+
+# configurations
+
+conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params, modes=['realtime', 'whodata'])
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('sleep, tags_to_apply', [
+    (0.25, {'ossec_conf'}),
+    (0.5, {'ossec_conf'}),
+    (0.75, {'ossec_conf'}),
+    (1, {'ossec_conf'}),
+    (1.25, {'ossec_conf'}),
+    (1.50, {'ossec_conf'}),
+    (1.75, {'ossec_conf'}),
+    (2, {'ossec_conf'})
+])
+def test_regular_file_changes(sleep, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
+                              wait_for_initial_scan):
+    """
+    Check if syscheckd detects regular file changes (add, modify, delete) with a very specific delay between every
+    action.
+
+    Parameters
+    ----------
+    sleep : float
+        Delay in seconds between every action.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    file = 'regular'
+    create_file(REGULAR, path=testdir1, name=file, content='')
+    time.sleep(sleep)
+    modify_file(path=testdir1, name=file, new_content='Sample')
+    time.sleep(sleep)
+    delete_file(path=testdir1, name=file)
+
+    events = wazuh_log_monitor.start(timeout=max(sleep * 3, global_parameters.default_timeout), callback=callback_detect_event, accum_results=3,
+                                     error_message='Did not receive expected "Sending FIM event: ..." event').result()
+
+    for ev in events:
+        validate_event(ev)


### PR DESCRIPTION
Hi team.

This PR adds new basic tests that check if `syscheck` detects 'added', 'modified' and 'deleted' events with very specific delays between them.


## Tests performed

## Linux

```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 16 items                                                                                      

test_fim/test_basic_usage/test_basic_usage_quick_changes.py ........xxxx....                      [100%]

==================================== 12 passed, 4 xfailed in 50.38s =====================================
```

On Linux, syscheck cannot detect 'modified' events with **whodata** monitoring with a delay lesser than **1.25s** . 


### Windows

```
======================================== test session starts ========================================= platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 16 items

test_fim\test_basic_usage\test_basic_usage_quick_changes.py ........xxxxx...                    [100%]

=================================== 11 passed, 5 xfailed in 53.88s ===================================
```

On Windows, syscheck cannot detect 'modified' events with **whodata** monitoring with a delay lesser than **1.75s** .

Regards.