### PR TITLE
FIM: validate audit path in whodata events

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -968,20 +968,28 @@ class EventChecker:
             event_types = Counter(filter_events(events, ".[].data.type"))
             assert (event_types[ev_type] == len(file_list)), f'Non expected number of events. {event_types[ev_type]} != {len(file_list)}'
 
-        def check_files_in_event(events, folder, file_list=['testfile0']):
-            file_paths = filter_events(events, ".[].data.path")
+        def check_events_path(events, folder, file_list=['testfile0'], mode=None):
+            mode = global_parameters.current_configuration['metadata']['fim_mode'] if mode is None else mode
+            audit_path = filter_events(events, ".[].data.audit.path") if mode == "whodata" else None
+            data_path = filter_events(events, ".[].data.path")
             for file_name in file_list:
-                expected_file_path = os.path.join(folder, file_name)
-                expected_file_path = expected_file_path[:1].lower() + expected_file_path[1:]
+                expected_path = os.path.join(folder, file_name)
+                expected_path = expected_path[:1].lower() + expected_path[1:]
                 if self.encoding is not None:
-                    for index, item in enumerate(file_paths):
-                        file_paths[index] = item.encode(encoding=self.encoding)
+                    for index, item in enumerate(data_path):
+                        data_path[index] = item.encode(encoding=self.encoding)
+                    if audit_path:
+                        for index, item in enumerate(audit_path):
+                            audit_path[index] = item.encode(encoding=self.encoding)
                 if sys.platform == 'darwin' and self.encoding and self.encoding != 'utf-8':
-                    logger.info(f'Not asserting {expected_file_path} in event.data.path. '
+                    logger.info(f'Not asserting {expected_path} in event.data.path. '
                                  f'Reason: using non-utf-8 encoding in darwin.')
                 else:
-                    error_msg = f"Expected path was '{expected_file_path}' but event path is '{file_paths}'"
-                    assert (expected_file_path in file_paths), error_msg
+                    error_msg = f"Expected data path was '{expected_path}' but event data path is '{data_path}'"
+                    assert (expected_path in data_path), error_msg
+                    if audit_path:
+                        error_msg = f"Expected audit path was '{expected_path}' but event audit path is '{audit_path}'"
+                        assert (expected_path in audit_path), error_msg
 
         def filter_events(events, mask):
             """Returns a list of elements matching a specified mask in the events list using jq module."""
@@ -994,7 +1002,7 @@ class EventChecker:
         if self.events is not None:
             validate_checkers_per_event(self.events, self.options, mode)
             check_events_type(self.events, event_type, self.file_list)
-            check_files_in_event(self.events, self.folder, self.file_list)
+            check_events_path(self.events, self.folder, self.file_list, mode)
 
             if self.custom_validator is not None:
                 self.custom_validator.validate_after_cud(self.events)

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1002,7 +1002,7 @@ class EventChecker:
         if self.events is not None:
             validate_checkers_per_event(self.events, self.options, mode)
             check_events_type(self.events, event_type, self.file_list)
-            check_events_path(self.events, self.folder, self.file_list, mode)
+            check_events_path(self.events, self.folder, file_list=self.file_list, mode=mode)
 
             if self.custom_validator is not None:
                 self.custom_validator.validate_after_cud(self.events)


### PR DESCRIPTION
This PR updates `check_events` function in `fim.py` to check the audit path of whodata events. This must match with the data path. 

Here is an example of a whodata event:

```
Sending FIM event: {
    "type": "event",
    "data": {
        "path": "/testdir1/regular",
        "mode": "whodata",
        "type": "added",
        "timestamp": 1582817146,
        "attributes": {
            "type": "file",
            "size": 0,
            "perm": "rw-r--r--",
            "uid": "0",
            "gid": "0",
            "user_name": "root",
            "group_name": "root",
            "inode": 25165955,
            "mtime": 1582817145,
            "hash_md5": "d41d8cd98f00b204e9800998ecf8427e",
            "hash_sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
            "hash_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "checksum": "562bb50962f3e185ad7d08ae13031eba33e91345"
        },
        "audit": {
            "path": "/testdir1/regular",
            "user_id": "0",
            "user_name": "root",
            "process_name": "/usr/bin/python3.6",
            "process_id": 3279,
            "group_id": "0",
            "group_name": "root",
            "audit_uid": "1000",
            "audit_name": "centos",
            "effective_uid": "0",
            "effective_name": "root",
            "ppid": 29886
        }
    }
}
```

## Test results

```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 441 items                                                            

test_fim/test_checks/test_check_all.py ..........sssssssssssssssssss.... [  7%]
....sssssssssssssssssss...........sssssssssssssssssss........sssssssssss [ 23%]
ssssssss...........sssssssssssssssssss........sssssssssssssssssss.       [ 38%]
test_fim/test_checks/test_check_others.py ..........ssssssssssssssssss.. [ 45%]
................ssssssssssssssssss..................ssssssssssssssssss.. [ 61%]
......                                                                   [ 63%]
test_fim/test_checks/test_checksums.py .............ssssssssssssssssssss [ 70%]
sssss.........................sssssssssssssssssssssssss................. [ 87%]
........sssssssssssssssssssssssss............                            [ 97%]
test_fim/test_checks/test_hard_link.py ............                      [100%]

================ 198 passed, 243 skipped in 1212.37s (0:20:12) =================
```