### PR TITLE
Fix various scan ended

### DIFF
--- a/ansible/wazuh-ansible/Pipfile
+++ b/ansible/wazuh-ansible/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 docker-py = "*"
-ansible = "==2.7.13"
+ansible = "==2.7.16"
 molecule = "==2.22"
 
 [dev-packages]

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -80,6 +80,7 @@ REQUIRED_ATTRIBUTES = {
 }
 
 _last_log_line = 0
+_os_excluded_from_rt_wd = ['darwin', 'sunos5']
 
 
 def validate_event(event, checks=None, mode=None):
@@ -1313,9 +1314,9 @@ def get_fim_mode_param(mode, key='FIM_MODE'):
     metadata = {key.lower(): mode}
     if mode == 'scheduled':
         return {key: ''}, metadata
-    elif mode == 'realtime' and sys.platform != 'darwin' and sys.platform != 'sunos5':
+    elif mode == 'realtime' and sys.platform not in _os_excluded_from_rt_wd:
         return {key: {'realtime': 'yes'}}, metadata
-    elif mode == 'whodata' and sys.platform != 'darwin' and sys.platform != 'sunos5':
+    elif mode == 'whodata' and sys.platform not in _os_excluded_from_rt_wd:
         return {key: {'whodata': 'yes'}}, metadata
     else:
         return None, None

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1313,9 +1313,9 @@ def get_fim_mode_param(mode, key='FIM_MODE'):
     metadata = {key.lower(): mode}
     if mode == 'scheduled':
         return {key: ''}, metadata
-    elif mode == 'realtime' and sys.platform != 'darwin':
+    elif mode == 'realtime' and sys.platform != 'darwin' and sys.platform != 'sunos5':
         return {key: {'realtime': 'yes'}}, metadata
-    elif mode == 'whodata' and sys.platform != 'darwin':
+    elif mode == 'whodata' and sys.platform != 'darwin' and sys.platform != 'sunos5':
         return {key: {'whodata': 'yes'}}, metadata
     else:
         return None, None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,13 +43,16 @@ def pytest_runtest_setup(item):
 
 @pytest.fixture(scope='module')
 def restart_wazuh(get_configuration, request):
+    # Stop Wazuh
+    control_service('stop')
+
     # Reset ossec.log and start a new monitor
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
 
-    # Restart Wazuh and wait for the command to end
-    control_service('restart')
+    # Start Wazuh
+    control_service('start')
 
 
 def pytest_addoption(parser):

--- a/tests/integration/test_fim/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_audit/test_audit.py
@@ -193,8 +193,9 @@ def test_audit_key(audit_key, path, get_configuration, configure_environment, re
     os.system(add_rule_command)
 
     # Restart and for wazuh
+    control_service('stop')
     truncate_file(LOG_FILE_PATH)
-    control_service('restart')
+    control_service('start')
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
     detect_initial_scan(wazuh_log_monitor)
 

--- a/tests/integration/test_fim/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_audit/test_audit.py
@@ -195,8 +195,8 @@ def test_audit_key(audit_key, path, get_configuration, configure_environment, re
     # Restart and for wazuh
     control_service('stop')
     truncate_file(LOG_FILE_PATH)
-    control_service('start')
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+    control_service('start')
     detect_initial_scan(wazuh_log_monitor)
 
     # Look for audit_key word

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -51,6 +51,7 @@ def extra_configuration_before_yield():
     """Create subdirs before restarting Wazuh."""
     create_file(REGULAR, os.path.join(testdir1, 'subdir'), 'regular1', content='')
     create_file(REGULAR, os.path.join(testdir3, 'subdir2'), 'regular2', content='')
+    create_file(REGULAR, os.path.join(testdir3, 'subdir3'), 'regular3', content='')
     create_file(REGULAR, os.path.join(testdir4, 'subdir'), 'regular1', content='')
 
 
@@ -65,6 +66,7 @@ def extra_configuration_after_yield():
     (testdir4, testdir2, 'subdir', {'ossec_conf'}, False, True),
     (testdir1, PREFIX, 'subdir', {'ossec_conf'}, True, False),
     (testdir3, testdir2, 'subdir2', {'ossec_conf'}, True, True),
+    (testdir3, testdir2, f'subdir3{os.path.sep}', {'ossec_conf'}, True, True)
 ])
 def test_move_file(source_folder, target_folder, subdir, tags_to_apply,
                    triggers_delete_event, triggers_add_event,
@@ -112,7 +114,7 @@ def test_move_file(source_folder, target_folder, subdir, tags_to_apply,
                        for event in events]
         assert set([event[0] for event in events_data]) == {'deleted', 'added'}
         for _, path, expected_path in events_data:
-            assert path == expected_path
+            assert path == expected_path.rstrip(os.path.sep)
     else:
         if triggers_delete_event:
             assert 'deleted' in events['data']['type'] and os.path.join(source_folder, subdir) \

--- a/tests/integration/test_fim/test_checks/test_hard_link.py
+++ b/tests/integration/test_fim/test_checks/test_hard_link.py
@@ -9,10 +9,9 @@ import pytest
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import (HARDLINK, LOG_FILE_PATH, REGULAR, EventChecker,
-                               check_time_travel, create_file, delete_file, modify_file_content, generate_params)
+                               check_time_travel, create_file, modify_file_content, generate_params)
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
@@ -26,6 +25,8 @@ configurations_path = os.path.join(test_data_path, 'wazuh_hard_link.yaml')
 testdir1 = os.path.join(PREFIX, 'testdir1')
 unmonitored_dir = os.path.join(PREFIX, 'test_unmonitorized')
 test_directories = [testdir1, unmonitored_dir]
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
 
@@ -45,9 +46,6 @@ def get_configuration(request):
     return request.param
 
 
-from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan
-from wazuh_testing.tools.services import control_service
-
 @pytest.fixture(scope='function')
 def clean_directories(request):
 
@@ -60,6 +58,8 @@ def clean_directories(request):
                     os.unlink(file_path)
             except Exception as e:
                 print(e)
+
+
 # tests
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Hard links.")

--- a/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -8,11 +8,9 @@ import subprocess
 import distro
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan, generate_params
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
-from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.services import restart_wazuh_daemon
 
 # Marks
 
@@ -61,7 +59,8 @@ def check_prelink():
 @pytest.mark.parametrize('tags_to_apply', [
     ({'prefilter_cmd'})
 ])
-def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, check_prelink):
+def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, check_prelink, restart_syscheckd,
+                       wait_for_initial_scan):
     """
     Check if prelink is installed and syscheck works
 
@@ -74,6 +73,3 @@ def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, 
     if get_configuration['metadata']['prefilter_cmd'] == '/usr/sbin/prelink -y':
         prelink = get_configuration['metadata']['prefilter_cmd'].split(' ')[0]
         assert os.path.exists(prelink), f'Prelink is not installed'
-        truncate_file(LOG_FILE_PATH)
-        restart_wazuh_daemon('ossec-syscheckd')
-        detect_initial_scan(wazuh_log_monitor)


### PR DESCRIPTION
Hello team,

This PR adds several fixes to syscheck integration tests related with race conditions when using detect_initial_scan and truncate_file.

Best regards,

David J. Iglesias