### PR TITLE
Fix timeout of test_max_eps_synchronization

### DIFF
--- a/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
@@ -76,7 +76,7 @@ def test_max_eps_on_start(get_configuration, create_files, configure_environment
                             error_message="Didn't receive integrity_check_global").result()
 
     n_results = max_eps * 5
-    result = wazuh_log_monitor.start(timeout=(n_results/max_eps)*6,
+    result = wazuh_log_monitor.start(timeout=120,
                                      accum_results=n_results,
                                      callback=callback_integrity_message,
                                      error_message=f'Received less results than expected ({n_results})').result()


### PR DESCRIPTION
Hello team,

The `test_max_eps_synchronization` was failing when executed in some environment. The reason was that, sometimes, the `Sending integrity control message` events were not generated on time (notice that the agent and the manager are not on the same network). 

For example, when max_eps is 10, the timeout is 30s, but the messages were taking more than 40s to be sent. 
https://github.com/wazuh/wazuh-qa/blob/cb4587b96872107b610fd958d7084f73ec240c4d/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py#L78-L79

When the timeout is increased, the fails are no longer appearing (tested in the problematic instance of the environment).

Kind regards,
José Luis.