### PR TITLE
Refactor wazuh-db tests with MITM

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -5,3 +5,9 @@
 
 def callback_fim_query(line):
     return line
+
+
+def callback_wazuhdb_response(item):
+    if isinstance(item, tuple):
+        data, response = item
+        return response.decode()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,9 +13,9 @@ from numpydoc.docscrape import FunctionDoc
 from py.xml import html
 
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_LOGS_PATH, WAZUH_CONF
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_LOGS_PATH, WAZUH_CONF, QUEUE_DB_PATH
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.tools.monitoring import FileMonitor, SocketController, SocketMonitor
+from wazuh_testing.tools.monitoring import FileMonitor, SocketController, SocketMonitor, ManInTheMiddle, QueueMonitor
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_sockets
 
 ALL = set("darwin linux win32 sunos5".split())
@@ -39,6 +39,18 @@ def pytest_runtest_setup(item):
             pytest.skip(f"test requires a minimum tier level {levels[0]}")
         elif item.config.getoption("--tier-maximum") < levels[0]:
             pytest.skip(f"test requires a maximum tier level {levels[0]}")
+
+
+def remove_logs():
+    for root, dirs, files in os.walk(WAZUH_LOGS_PATH):
+        for file in files:
+            os.remove(os.path.join(root, file))
+
+
+def delete_dbs():
+    for root, dirs, files in os.walk(QUEUE_DB_PATH):
+        for file in files:
+            os.remove(os.path.join(root, file))
 
 
 @pytest.fixture(scope='module')
@@ -270,3 +282,38 @@ def create_unix_sockets(request):
             if e.errno == 9:
                 # Do not try to close the socket again if it was reused
                 pass
+
+
+@pytest.fixture(scope='module')
+def configure_mitm_environment_wazuhdb(request):
+    """Use MITM to replace analysisd and wazuh-db sockets."""
+    wdb_path = getattr(request.module, 'wdb_path')
+
+    # Stop wazuh-service and ensure all daemons are stopped
+    control_service('stop')
+    check_daemon_status(running=False)
+    remove_logs()
+
+    control_service('start', daemon='wazuh-db', debug_mode=True)
+    check_daemon_status(running=True, daemon='wazuh-db')
+
+    mitm_wdb = ManInTheMiddle(socket_path=wdb_path)
+    wdb_queue = mitm_wdb.queue
+    mitm_wdb.start()
+
+    wdb_monitor = QueueMonitor(queue_item=wdb_queue)
+
+    setattr(request.module, 'wdb_monitor', wdb_monitor)
+
+    yield
+
+    mitm_wdb.shutdown()
+
+    for daemon in ['wazuh-db']:
+        control_service('stop', daemon=daemon)
+        check_daemon_status(running=False, daemon=daemon)
+
+    # Delete all db
+    delete_dbs()
+
+    control_service('start')


### PR DESCRIPTION
Hi team.

This PR adds the **MITM** functionality to the `wazuh-db` tests. Some fixtures and callbacks were modified to make this possible.

## Tests performed
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 14 items                                                                                      

test_wazuh_db/test_wazuh_db.py ..............                                                     [100%]

========================================== 14 passed in 11.90s ==========================================
```

Regards.