### PR TITLE
Remove nfs configuration fixture for default skip tests

### DIFF
--- a/tests/integration/test_fim/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_skip/test_skip.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import uuid
 import os
 import shutil
 import subprocess
@@ -192,19 +193,20 @@ def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration
     (os.path.join('/', 'nfs-mount-point'), {'skip_nfs'})
 ])
 @patch('wazuh_testing.fim.modify_file_inode')
-def test_skip_nfs(modify_inode_mock, directory, tags_to_apply, get_configuration, configure_environment, configure_nfs, restart_syscheckd,
-                  wait_for_initial_scan):
+def test_skip_nfs(modify_inode_mock, directory, tags_to_apply, get_configuration, configure_environment,
+                  restart_syscheckd, wait_for_initial_scan):
     """Check if syscheckd skips nfs directories when setting 'skip_nfs="yes"'.
 
-    /proc, /sys, /dev and nfs directories are special directories. Unless it is specified with skip_*='no', syscheck
-    will skip these directories. If not, they will be monitored like a normal directory.
+    This test assumes you have a nfs directory mounted on '/nfs-mount-point'. If you do not have one, use the fixture
+    `configure_nfs`.
 
     Parameters
     ----------
     directory : str
         Directory that will be monitored.
     """
+    file = str(uuid.uuid1())
     check_apply_test(tags_to_apply, get_configuration['tags'])
     trigger = get_configuration['metadata']['skip'] == 'no'
 
-    regular_file_cud(directory, wazuh_log_monitor, time_travel=True, min_timeout=3, triggers_event=trigger)
+    regular_file_cud(directory, wazuh_log_monitor, file_list=[file], time_travel=True, min_timeout=3, triggers_event=trigger)


### PR DESCRIPTION
Hi team.

This PR removes the `configure_nfs` fixture used in `test_skip` because we do not need it anymore unless we are running these tests on local machines.

It also uses `UUID` now to generate random file names in order to avoid possible conflicts with the monitored directory when running these tests simultaneously on multiple machines.

## Tests performed
```
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.9', 'Platform': 'Linux-4.15.0-1060-aws-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1'}}
rootdir: /tmp/973_INTEGRATION_FIM_TESTS_B440_20200303161702/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collecting ... collected 32 items

test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration0] PASSED [  3%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration0] SKIPPED [  6%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration0-/dev-tags_to_apply0] SKIPPED [  9%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration0-/nfs-mount-point-tags_to_apply0] SKIPPED [ 12%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration1] SKIPPED [ 15%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration1] PASSED [ 18%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration1-/dev-tags_to_apply0] SKIPPED [ 21%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration1-/nfs-mount-point-tags_to_apply0] SKIPPED [ 25%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration2] SKIPPED [ 28%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration2] SKIPPED [ 31%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration2-/dev-tags_to_apply0] PASSED [ 34%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration2-/nfs-mount-point-tags_to_apply0] SKIPPED [ 37%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration3] SKIPPED [ 40%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration3] SKIPPED [ 43%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration3-/dev-tags_to_apply0] SKIPPED [ 46%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration3-/nfs-mount-point-tags_to_apply0] PASSED [ 50%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration4] PASSED [ 53%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration4] SKIPPED [ 56%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration4-/dev-tags_to_apply0] SKIPPED [ 59%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration4-/nfs-mount-point-tags_to_apply0] SKIPPED [ 62%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration5] SKIPPED [ 65%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration5] PASSED [ 68%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration5-/dev-tags_to_apply0] SKIPPED [ 71%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration5-/nfs-mount-point-tags_to_apply0] SKIPPED [ 75%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration6] SKIPPED [ 78%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration6] SKIPPED [ 81%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration6-/dev-tags_to_apply0] PASSED [ 84%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration6-/nfs-mount-point-tags_to_apply0] SKIPPED [ 87%]
test_fim/test_skip/test_skip.py::test_skip_proc[get_configuration7] SKIPPED [ 90%]
test_fim/test_skip/test_skip.py::test_skip_sys[get_configuration7] SKIPPED [ 93%]
test_fim/test_skip/test_skip.py::test_skip_dev[get_configuration7-/dev-tags_to_apply0] SKIPPED [ 96%]
test_fim/test_skip/test_skip.py::test_skip_nfs[get_configuration7-/nfs-mount-point-tags_to_apply0] PASSED [100%]
=================== 8 passed, 24 skipped in 72.55s (0:01:12) ===================
```

Regards.