### PR TITLE
FIM System tests: Agents/Manager configuration file update

### DIFF
--- a/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -135,13 +135,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -180,6 +181,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/201_default_configuration_frequency/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/201_default_configuration_frequency/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -97,14 +97,14 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>10</frequency>
+    <frequency>1000000</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <directories tags="test_tag">/opt/fim_testing</directories>
+    <directories realtime="yes" check_all="yes" recursion_level="4">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -135,13 +135,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -180,6 +181,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_linux_ossec_rpm.conf
+++ b/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_linux_ossec_rpm.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration for ubuntu 19.04
+  Wazuh - Agent - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
+    <config-profile>centos, centos7, centos7.6</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 
@@ -50,6 +50,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -97,15 +102,15 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>43200</frequency>
+    <frequency>1000000</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <!-- Whodata options -->
-    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
+    <directories>/opt/fim_testing</directories>
+    <directories realtime="yes" check_all="yes" recursion_level="4">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -194,22 +199,17 @@
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/202_realtime_monitoring/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/202_realtime_monitoring/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/203_whodata_frequency/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/203_whodata_frequency/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -135,13 +135,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -180,6 +181,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/205_restrict_option/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -106,6 +106,7 @@
     <directories>/bin,/sbin,/boot</directories>
     <directories recursion_level="320" check_all="yes" restrict="fimtest">/opt/fim_testing</directories>
 
+
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
     <ignore>/etc/hosts.deny</ignore>
@@ -135,13 +136,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -180,6 +182,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/205_restrict_option/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/206_tag_option/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/206_tag_option/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -97,14 +97,14 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>1000000</frequency>
+    <frequency>10</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <directories realtime="yes" check_all="yes" recursion_level="4">/opt/fim_testing</directories>
+    <directories tags="test_tag">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -135,13 +135,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -180,6 +181,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/206_tag_option/config/agent_linux_ossec_rpm.conf
+++ b/tests/system/fim/scenarios/206_tag_option/config/agent_linux_ossec_rpm.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>centos, centos7, centos7.6</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 
@@ -50,6 +50,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -102,9 +107,10 @@
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
-    <directories recursion_level="320" check_all="yes" realtime="yes" report_changes="yes">/opt/fim_testing</directories>
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
+    <directories tags="test_tag">/opt/fim_testing</directories>
+
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -135,13 +141,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -181,28 +188,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/206_tag_option/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/206_tag_option/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -102,10 +102,10 @@
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
+    <directories recursion_level="320" check_all="yes" realtime="yes" report_changes="yes">/opt/fim_testing</directories>
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
 
-    <directories>/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -122,7 +122,6 @@
     <ignore>/etc/svc/volatile</ignore>
 
     <!-- File types to ignore -->
-    <ignore type="sregex">.mp3$|.avi$|.mpg$</ignore>
     <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
@@ -137,13 +136,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -182,6 +182,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_linux_ossec_rpm.conf
+++ b/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_linux_ossec_rpm.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration for ubuntu 19.04
+  Wazuh - Agent - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
+    <config-profile>centos, centos7, centos7.6</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 
@@ -50,6 +50,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -97,15 +102,14 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>43200</frequency>
+    <frequency>10</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
+    <directories recursion_level="320" check_all="yes" realtime="yes" report_changes="yes">/opt/fim_testing</directories>
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <!-- Whodata options -->
-    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -194,22 +198,17 @@
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/207_report_changes_frequency/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/207_report_changes_frequency/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/208_ignore_files/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/208_ignore_files/config/agent_linux_ossec_deb.conf
@@ -97,15 +97,15 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>43200</frequency>
+    <frequency>10</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <!-- Whodata options -->
-    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
+
+    <directories>/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -122,6 +122,7 @@
     <ignore>/etc/svc/volatile</ignore>
 
     <!-- File types to ignore -->
+    <ignore type="sregex">.mp3$|.avi$|.mpg$</ignore>
     <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->

--- a/tests/system/fim/scenarios/208_ignore_files/config/agent_linux_ossec_rpm.conf
+++ b/tests/system/fim/scenarios/208_ignore_files/config/agent_linux_ossec_rpm.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration for ubuntu 19.04
+  Wazuh - Agent - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
+    <config-profile>centos, centos7, centos7.6</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 
@@ -50,6 +50,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -97,15 +102,15 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>43200</frequency>
+    <frequency>10</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <!-- Whodata options -->
-    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
+
+    <directories>/opt/fim_testing</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -122,6 +127,7 @@
     <ignore>/etc/svc/volatile</ignore>
 
     <!-- File types to ignore -->
+    <ignore type="sregex">.mp3$|.avi$|.mpg$</ignore>
     <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
@@ -194,22 +200,17 @@
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/208_ignore_files/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/208_ignore_files/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_linux_ossec_deb.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration
+  Wazuh - Agent - Default configuration for ubuntu 19.04
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>linux_system_tests</config-profile>
+    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -135,13 +135,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -180,6 +181,11 @@
 </ossec_config>
 
 <ossec_config>
+  <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
   <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>

--- a/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_linux_ossec_rpm.conf
+++ b/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_linux_ossec_rpm.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Agent - Default configuration for ubuntu 19.04
+  Wazuh - Agent - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -11,7 +11,7 @@
       <port>1514</port>
       <protocol>udp</protocol>
     </server>
-    <config-profile>ubuntu, ubuntu19, ubuntu19.04</config-profile>
+    <config-profile>centos, centos7, centos7.6</config-profile>
     <notify_time>10</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 
@@ -50,6 +50,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -97,15 +102,15 @@
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
-    <frequency>43200</frequency>
+    <frequency>600</frequency>
 
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
     <directories>/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin,/boot</directories>
-    <!-- Whodata options -->
-    <directories recursion_level="320" check_all="yes" whodata="yes">/opt/fim_testing</directories>
+    <directories realtime="yes" check_all="yes" recursion_level="4">/opt/fim_testing</directories>
+
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
@@ -194,22 +199,17 @@
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>

--- a/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/manager_ossec.conf
+++ b/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/manager_ossec.conf
@@ -1,5 +1,5 @@
 <!--
-  Wazuh - Manager - Default configuration
+  Wazuh - Manager - Default configuration for centos 7.6
   More info at: https://documentation.wazuh.com
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
@@ -60,6 +60,11 @@
     <timeout>1800</timeout>
     <interval>1d</interval>
     <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-centos-7-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
   </wodle>
 
   <wodle name="cis-cat">
@@ -100,7 +105,7 @@
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
   </sca>
-  
+
 
   <vulnerability-detector>
     <enabled>no</enabled>
@@ -188,13 +193,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -202,7 +208,7 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
+    <white_list>10.0.2.3</white_list>
   </global>
 
   <command>
@@ -333,7 +339,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>NODE_IP</node>
+	<node>NODE_IP</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>yes</disabled>
@@ -343,28 +349,28 @@
 
 <ossec_config>
   <localfile>
+    <log_format>audit</log_format>
+    <location>/var/log/audit/audit.log</location>
+  </localfile>
+
+  <localfile>
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/auth.log</location>
+    <location>/var/log/messages</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
+    <location>/var/log/secure</location>
   </localfile>
 
   <localfile>
     <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/kern.log</location>
+    <location>/var/log/maillog</location>
   </localfile>
 
 </ossec_config>


### PR DESCRIPTION
Hi team,

- This PR adds `rpm` and `deb` segregation for agents `ossec.conf` file. It also updates the outdated `deb` agents `ossec.conf` while including the newer `rpm` one: https://github.com/wazuh/wazuh-qa/commit/4c0a242f7a754a38e2bb3b9741bcca64423d9cd9
- This PR also adds the correct and updated `ossec.conf` `rpm` version to provision all scenarios managers: https://github.com/wazuh/wazuh-qa/commit/96b915dc1c2aa2e526058d4d0cb7d290d284e126
- This PR closes #557 

```
├── agent_linux_ossec_deb.conf
├── agent_linux_ossec_rpm.conf
├── agent_windows_ossec.conf
└── manager_ossec.conf
```

Greetings, JP Sáez