### PR TITLE
Removed clean_directories from test_not_following_symbolic_link

### DIFF
--- a/tests/integration/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -46,19 +46,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope='function')
-def clean_directories(request):
-    directories = getattr(request.module, 'test_directories')
-    for folder in directories:
-        for the_file in os.listdir(folder):
-            file_path = os.path.join(folder, the_file)
-            try:
-                if os.path.isfile(file_path):
-                    os.unlink(file_path)
-            except Exception as e:
-                print(e)
-
-
 # tests
 
 @pytest.mark.parametrize('monitored_dir, non_monitored_dir1, non_monitored_dir2, sym_target, tags_to_apply', [
@@ -67,7 +54,7 @@ def clean_directories(request):
 ])
 def test_symbolic_monitor_directory_with_symlink(monitored_dir, non_monitored_dir1, non_monitored_dir2,
                                                  sym_target, tags_to_apply, get_configuration, configure_environment,
-                                                 clean_directories, restart_syscheckd, wait_for_initial_scan):
+                                                 restart_syscheckd, wait_for_initial_scan):
     """
     Check what happens with a symlink and its target when syscheck monitors a directory with a symlink
     and not the symlink itself.
@@ -85,9 +72,9 @@ def test_symbolic_monitor_directory_with_symlink(monitored_dir, non_monitored_di
         Non-monitored directory.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    name1 = 'regular1'
-    name2 = 'regular2'
-    sl_name = 'symlink'
+    name1 = f'{sym_target}regular1'
+    name2 = f'{sym_target}regular2'
+    sl_name = f'{sym_target}symlink'
     a_path = os.path.join(non_monitored_dir1, name1)
     b_path = os.path.join(non_monitored_dir1, name2) if sym_target == 'file' else non_monitored_dir2
     sl_path = os.path.join(monitored_dir, sl_name)


### PR DESCRIPTION
This PR updates `test_not_following_symbolic_link` to remove `clean_directories` fixture function. With this version created files will have different names during test cases execution to prevent them from affecting each other. Those files will be deleted when the tests ends by `configure_environment` fixture instead. This will prevent random failures.

## Test results

```
================================ test session starts ================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 6 items                                                                   

test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py ...... [100%]

=========================== 6 passed in 97.02s (0:01:37) ============================
```