### PR TITLE
FIM System tests: Winagents ossec.conf update

### DIFF
--- a/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_windows_ossec.conf
@@ -73,8 +73,9 @@
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
 
-    <!-- Default files to be monitored. -->
     <directories recursion_level="320">C:\fim_testing</directories>
+
+    <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -204,4 +206,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/201_default_configuration_frequency/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_windows_ossec.conf
@@ -73,8 +73,9 @@
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>1000000</frequency>
 
-    <!-- Default files to be monitored. -->
     <directories recursion_level="320" check_all="yes" realtime="yes">C:\fim_testing</directories>
+
+    <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -204,4 +206,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/202_realtime_monitoring/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/203_whodata_frequency/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/203_whodata_frequency/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/203_whodata_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/203_whodata_frequency/config/agent_windows_ossec.conf
@@ -72,6 +72,7 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>43200</frequency>
+
     <directories recursion_level="320" check_all="yes" whodata="yes">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/tests/system/fim/scenarios/203_whodata_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/203_whodata_frequency/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/204_whodata_linux_noaudit/config/agent_windows_ossec.conf
@@ -72,7 +72,6 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>43200</frequency>
-    <directories recursion_level="320">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
@@ -145,13 +144,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/tests/system/fim/scenarios/205_restrict_option/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/205_restrict_option/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/agent_windows_ossec.conf
@@ -72,6 +72,7 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
+
     <directories recursion_level="320" check_all="yes" restrict="fimtest">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/tests/system/fim/scenarios/205_restrict_option/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/205_restrict_option/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/206_tag_option/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/206_tag_option/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/206_tag_option/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/206_tag_option/config/agent_windows_ossec.conf
@@ -73,8 +73,9 @@
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
 
-    <!-- Default files to be monitored. -->
     <directories recursion_level="320" tags="test_tag">C:\fim_testing</directories>
+
+    <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -204,4 +206,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/206_tag_option/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/206_tag_option/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/207_report_changes_frequency/config/agent_windows_ossec.conf
@@ -73,8 +73,9 @@
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
 
-    <!-- Default files to be monitored. -->
     <directories recursion_level="320" check_all="yes" realtime="yes" report_changes="yes">C:\fim_testing</directories>
+
+    <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -204,4 +206,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/208_ignore_files/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/208_ignore_files/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/208_ignore_files/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/208_ignore_files/config/agent_windows_ossec.conf
@@ -75,8 +75,10 @@
 
     <directories recursion_level="320">C:\fim_testing</directories>
 
+
     <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
+
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
     <directories recursion_level="0">%WINDIR%\SysNative\drivers\etc</directories>
     <directories recursion_level="0" restrict="WMIC.exe$">%WINDIR%\SysNative\wbem</directories>
@@ -146,13 +148,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -205,4 +208,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-

--- a/tests/system/fim/scenarios/208_ignore_files/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/208_ignore_files/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/209_recursion_level/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/209_recursion_level/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/209_recursion_level/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/209_recursion_level/config/agent_windows_ossec.conf
@@ -72,6 +72,7 @@
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>10</frequency>
+
     <directories recursion_level="4" check_all="yes">C:\fim_testing</directories>
 
     <!-- Default files to be monitored. -->
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 

--- a/tests/system/fim/scenarios/209_recursion_level/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/209_recursion_level/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_linux_ossec_deb.conf
+++ b/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_linux_ossec_deb.conf
@@ -21,7 +21,7 @@
   <client_buffer>
     <!-- Agent buffer options -->
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_windows_ossec.conf
@@ -21,7 +21,7 @@
   <!-- Agent buffer options -->
   <client_buffer>
     <disabled>no</disabled>
-    <queue_size>15000</queue_size>
+    <queue_size>5000</queue_size>
     <events_per_second>500</events_per_second>
   </client_buffer>
 

--- a/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_windows_ossec.conf
+++ b/tests/system/fim/scenarios/212_realtime_scheduled_monitoring/config/agent_windows_ossec.conf
@@ -73,8 +73,9 @@
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>600</frequency>
 
-    <!-- Default files to be monitored. -->
     <directories recursion_level="320" check_all="yes" realtime="yes">C:\fim_testing</directories>
+
+    <!-- Default files to be monitored. -->
     <directories recursion_level="0" restrict="regedit.exe$|system.ini$|win.ini$">%WINDIR%</directories>
 
     <directories recursion_level="0" restrict="at.exe$|attrib.exe$|cacls.exe$|cmd.exe$|eventcreate.exe$|ftp.exe$|lsass.exe$|net.exe$|net1.exe$|netsh.exe$|reg.exe$|regedt32.exe|regsvr32.exe|runas.exe|sc.exe|schtasks.exe|sethc.exe|subst.exe$">%WINDIR%\SysNative</directories>
@@ -145,13 +146,14 @@
     <process_priority>10</process_priority>
 
     <!-- Maximum output throughput -->
-    <max_eps>200</max_eps>
+    <max_eps>100</max_eps>
 
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_interval>1h</max_interval>
+      <max_eps>10</max_eps>
     </synchronization>
   </syscheck>
 
@@ -204,4 +206,3 @@
 </ossec_config>
 
 <!-- END of Default Configuration. -->
-


### PR DESCRIPTION
Hi team,

This PR updates the Winagents `ossec.conf` template to the latest version found on the last  `wazuh-agent-3.12.0-0.3319fimreworksqlite.msi` package. 

Greetings, 
JP Sáez