### PR TITLE
Add multiple_directories tests for FIM

### DIFF
--- a/tests/integration/test_fim/test_multiple_dirs/common.py
+++ b/tests/integration/test_fim/test_multiple_dirs/common.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+import time
 
 from wazuh_testing.fim import REGULAR, check_time_travel, validate_event, create_file, modify_file, delete_file, \
     callback_detect_event
@@ -31,6 +32,7 @@ def multiple_dirs_test(dir_list=None, file=None, scheduled=None, log_monitor=Non
         for directory in dir_list:
             args = [REGULAR, directory, file] if func.__name__ == 'create_file' else [directory, file]
             func(*args, **kwargs)
+            time.sleep(0.01)
 
         check_time_travel(time_travel=scheduled)
         events = log_monitor.start(timeout=timeout,
@@ -38,6 +40,7 @@ def multiple_dirs_test(dir_list=None, file=None, scheduled=None, log_monitor=Non
                                    accum_results=len(dir_list),
                                    error_message='Did not receive expected "Sending FIM event: ..." '
                                                  'event').result()
+        time.sleep(1)
 
         for ev in events:
             validate_event(ev)

--- a/tests/integration/test_fim/test_multiple_dirs/common.py
+++ b/tests/integration/test_fim/test_multiple_dirs/common.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+
+from wazuh_testing.fim import REGULAR, check_time_travel, validate_event, create_file, modify_file, delete_file, \
+    callback_detect_event
+from wazuh_testing.tools import PREFIX
+
+n_dirs = 100
+test_directories = [os.path.join(PREFIX, f'testdir{i}') for i in range(n_dirs)]
+
+
+def multiple_dirs_test(dir_list=None, file=None, scheduled=None, log_monitor=None, timeout=1):
+    """Perform a given action for every directory and validate all the events.
+
+    Parameters
+    ----------
+    dir_list : list, optional
+        List of created/monitored directories. Default `None`
+    file : str, optional
+        Name of the file to be created. Default `None`
+    scheduled : str, optional
+        Monitoring mode. Default `None`
+    log_monitor : FileMonitor, optional
+        File monitor. Default `None`
+    timeout : int, optional
+        Maximum timeout to raise a TimeoutError. Default `1`
+    """
+    def perform_and_validate_events(func, kwargs):
+        for directory in dir_list:
+            args = [REGULAR, directory, file] if func.__name__ == 'create_file' else [directory, file]
+            func(*args, **kwargs)
+
+        check_time_travel(time_travel=scheduled)
+        events = log_monitor.start(timeout=timeout,
+                                   callback=callback_detect_event,
+                                   accum_results=len(dir_list),
+                                   error_message='Did not receive expected "Sending FIM event: ..." '
+                                                 'event').result()
+
+        for ev in events:
+            validate_event(ev)
+
+    try:
+        perform_and_validate_events(create_file, {'content': ''})
+        perform_and_validate_events(modify_file, {'new_content': 'New content'})
+        perform_and_validate_events(delete_file, {})
+
+    finally:
+        for directory in dir_list:
+            delete_file(directory, file)

--- a/tests/integration/test_fim/test_multiple_dirs/data/multiple_dirs.yaml
+++ b/tests/integration/test_fim/test_multiple_dirs/data/multiple_dirs.yaml
@@ -1,0 +1,14 @@
+---
+# conf 1
+- tags:
+  - multiple_dirs
+  apply_to_modules:
+  - test_multiple_dirs
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: TEST_DIRECTORIES
+      attributes:
+        - FIM_MODE

--- a/tests/integration/test_fim/test_multiple_dirs/data/multiple_entries.yaml
+++ b/tests/integration/test_fim/test_multiple_dirs/data/multiple_entries.yaml
@@ -1,0 +1,408 @@
+- tags:
+  - multiple_dir_entries
+  apply_to_modules:
+  - test_multiple_entries
+  section: syscheck
+  elements:
+  - disabled:
+      value: 'no'
+  - directories:
+      value: DIR0
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR1
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR2
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR3
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR4
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR5
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR6
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR7
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR8
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR9
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR10
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR11
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR12
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR13
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR14
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR15
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR16
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR17
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR18
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR19
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR20
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR21
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR22
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR23
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR24
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR25
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR26
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR27
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR28
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR29
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR30
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR31
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR32
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR33
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR34
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR35
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR36
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR37
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR38
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR39
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR40
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR41
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR42
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR43
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR44
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR45
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR46
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR47
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR48
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR49
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR50
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR51
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR52
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR53
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR54
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR55
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR56
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR57
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR58
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR59
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR60
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR61
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR62
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR63
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR64
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR65
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR66
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR67
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR68
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR69
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR70
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR71
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR72
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR73
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR74
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR75
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR76
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR77
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR78
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR79
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR80
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR81
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR82
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR83
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR84
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR85
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR86
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR87
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR88
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR89
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR90
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR91
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR92
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR93
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR94
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR95
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR96
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR97
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR98
+      attributes:
+      - FIM_MODE
+  - directories:
+      value: DIR99
+      attributes:
+      - FIM_MODE

--- a/tests/integration/test_fim/test_multiple_dirs/test_multiple_dirs.py
+++ b/tests/integration/test_fim/test_multiple_dirs/test_multiple_dirs.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+from wazuh_testing import global_parameters
+
+from test_fim.test_multiple_dirs.common import multiple_dirs_test, test_directories
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
+# variables
+
+directory_str = ','.join(test_directories)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'multiple_dirs.yaml')
+
+# configurations
+
+conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('dir_list, tags_to_apply', [
+    (test_directories, {'multiple_dirs'})
+])
+def test_multiple_dirs(dir_list, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
+                       wait_for_initial_scan):
+    """
+    Check if syscheck can detect every event when adding, modifying and deleting a file within multiple monitored
+    directories.
+
+    These directories will be added in one single entry like so:
+        <directories>testdir0, testdir1, ..., testdirn</directories>
+
+    Parameters
+    ----------
+    dir_list : list
+        List with all the directories to be monitored.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    file = 'regular'
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+
+    multiple_dirs_test(dir_list=dir_list, file=file, scheduled=scheduled, log_monitor=wazuh_log_monitor,
+                       timeout=2 * global_parameters.default_timeout)

--- a/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
+++ b/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+import yaml
+from wazuh_testing import global_parameters
+
+from test_fim.test_multiple_dirs.common import multiple_dirs_test, test_directories
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
+# variables
+
+directory_str = ','.join(test_directories)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'multiple_entries.yaml')
+
+
+def create_yaml(n_dirs=0):
+    """Create a new YAML with the required WILDCARDS for every directory in `test_directories`.
+
+    Parameters
+    ----------
+    n_dirs : int, optional
+        Number of created/monitored directories. Default `0`
+    """
+    with open(os.path.join(test_data_path, 'multiple_entries.yaml'), 'w') as f:
+        dikt = [
+            {
+                'tags': ['multiple_dir_entries'],
+                'apply_to_modules': ['test_multiple_entries'],
+                'section': 'syscheck',
+                'elements':
+                    [
+                        {'disabled': {'value': 'no'}},
+                    ]
+            }
+        ]
+
+        for new_dir in ({'directories': {'value': f'DIR{i}', 'attributes': ['FIM_MODE']}} for i in range(n_dirs)):
+            dikt[0]['elements'].append(new_dir)
+        f.write(yaml.safe_dump(dikt, sort_keys=False))
+
+
+# configurations
+
+create_yaml(n_dirs=len(test_directories))
+conf_params = {f'DIR{i}': testdir for i, testdir in enumerate(test_directories)}
+conf_params['MODULE_NAME'] = __name__
+p, m = generate_params(extra_params=conf_params)
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('dir_list, tags_to_apply', [
+    (test_directories, {'multiple_dir_entries'})
+])
+def test_cud_multiple_dir_entries(dir_list, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
+                                  wait_for_initial_scan):
+    """
+    Check if syscheck can detect every event when adding, modifying and deleting a file within multiple monitored
+    directories.
+
+    These directories will be added using a new entry for every one of them:
+        <directories>testdir0</directories>
+        ...
+        <directories>testdirn</directories>
+
+    Parameters
+    ----------
+    dir_list : list
+        List with all the directories to be monitored.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    file = 'regular'
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+
+    multiple_dirs_test(dir_list=dir_list, file=file, scheduled=scheduled, log_monitor=wazuh_log_monitor,
+                       timeout=2 * global_parameters.default_timeout)

--- a/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
+++ b/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
@@ -60,7 +60,6 @@ p, m = generate_params(extra_params=conf_params)
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
-
 # fixtures
 
 @pytest.fixture(scope='module', params=configurations)


### PR DESCRIPTION
Hi team, this closes #577 .

What these tests are testing can be found in the related issue. 

## Tests performed
### Linux
```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 6 items                                                                                       

test_fim/test_multiple_dirs/test_multiple_dirs.py FFF                                             [ 50%]
test_fim/test_multiple_dirs/test_multiple_entries.py ..F                                          [100%]

=============================================== FAILURES ================================================
```

#### Multiple dirs
 They fail due to syscheck not being able to monitor all the directories. It consistenly catches these number of events:
- Scheduled: 63
- Realtime: 63
- Whodata: 51

#### Multiple entries
They fail on **whodata** monitoring because syscheck does not detect events at some point. If we increase the delay between actions (create, modify and delete) to at least 0.1s, it works. I let it to **0.01s** to prevent `rt_delay`. It still fails even with 0.05s.

### Windows
```
================================================= test session starts =================================================
platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 6 items
test_multiple_dirs\test_multiple_dirs.py FFF                                                                     [ 50%]
test_multiple_dirs\test_multiple_entries.py ...                                                                  [100%]
====================================================== FAILURES =======================================================
```

Same reasons as Linux.

Regards.