### PR TITLE
Fix process_priority in SunOS

### DIFF
--- a/tests/integration/test_fim/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_process_priority/test_process_priority.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
@@ -20,6 +21,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 force_restart_after_restoring = True
 test_directories = []
+priority_delta = -20 if sys.platform == 'sunos5' else 0  # Psutil library returns incorrect priority in SunOS
 
 # configurations
 
@@ -50,4 +52,5 @@ def test_process_priority(get_configuration, configure_environment, restart_sysc
     syscheckd_process = get_process(process_name)
 
     assert syscheckd_process is not None, f'Process {process_name} not found'
-    assert syscheckd_process.nice() == priority, f'Process {process_name} has not updated its priority.'
+    assert (syscheckd_process.nice() + priority_delta) == priority, \
+        f'Process {process_name} has not updated its priority.'

--- a/tests/integration/test_fim/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_process_priority/test_process_priority.py
@@ -3,7 +3,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
 
 import pytest
 
@@ -21,7 +20,6 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 force_restart_after_restoring = True
 test_directories = []
-priority_delta = -20 if sys.platform == 'sunos5' else 0  # Psutil library returns incorrect priority in SunOS
 
 # configurations
 
@@ -52,5 +50,5 @@ def test_process_priority(get_configuration, configure_environment, restart_sysc
     syscheckd_process = get_process(process_name)
 
     assert syscheckd_process is not None, f'Process {process_name} not found'
-    assert (syscheckd_process.nice() + priority_delta) == priority, \
+    assert (os.getpriority(os.PRIO_PROCESS, syscheckd_process.pid)) == priority, \
         f'Process {process_name} has not updated its priority.'


### PR DESCRIPTION
Hello team,

## Description
The `test_process_priority.py` was failing only in `SunOS` platforms. The error is that, although both the renice command and the` <process_priority>` tag of ossec.conf correctly apply the priority, the test fails because the nice value it gets is incorrect. It always has 20 points above the real one.

After doing some research, I found an issue in the psutil repository (which is used to obtain the niceness in the test) that reports this behavior. It is supposed to be fixed in previous versions but currently it does not work. The issue can be found here: https://github.com/giampaolo/psutil/issues/1082

## Fix
We have fixed it by using this method of OS library. Psutil is still used in order to get the PID of the syscheckd process. The fix has been tested in CentOS and SunOS and it works correctly.
```Python
os.getpriority(os.PRIO_PROCESS, pid)
```

## Tests performed
### SunOS

```
/opt/python3/bin/python3.7 -m pytest test_fim/test_process_priority/
==================================================================== test session starts =====================================================================
platform sunos5 -- Python 3.7.6, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /tmp/973_FIM_INTEGRATION_TESTS_STABLE_B219_20200309150235/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 3 items                                                                                                                                            

test_fim/test_process_priority/test_process_priority.py ...                                                                                            [100%]

===================================================================== 3 passed in 40.06s =====================================================================
```

### CentOS
```
python3 -m pytest test_fim/test_process_priority/test_process_priority.py 
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 9 items                                                                                                                                                           

test_fim/test_process_priority/test_process_priority.py .........                                                                                                     [100%]

======================================================================= 9 passed in 129.11s (0:02:09) =======================================================================
```

Regards!
José Luis.
