### PR TITLE
Add stats scripts to get metrics about syscheck integrity process

### DIFF
--- a/tests/integration/test_fim/test_stats_integrity_sync/data/template_agent.conf
+++ b/tests/integration/test_fim/test_stats_integrity_sync/data/template_agent.conf
@@ -1,53 +1,21 @@
 <agent_config>
   <client>
-    <server>
-      <address>10.0.0.15</address>
-      <port>1514</port>
-    </server>
     <notify_time>1</notify_time>
   </client>
 
-  <client_buffer><disabled>yes</disabled></client_buffer>
+  <client_buffer><disabled>CLIENT</disabled></client_buffer>
 
   <syscheck>
-    <directories check_all="yes">/test500k</directories>
+    <directories check_all="yes">TESTING_DIRECTORY</directories>
 
-    <max_eps>1000</max_eps>
+    <max_eps>FIM_EPS</max_eps>
 
     <synchronization>
       <enabled>yes</enabled>
       <interval>20s</interval>
       <max_interval>20s</max_interval>
       <response_timeout>15s</response_timeout>
+      <max_eps>SYNC_EPS</max_eps>
     </synchronization>
   </syscheck>
-
-  <rootcheck>
-    <disabled>yes</disabled>
-  </rootcheck>
-
-  <sca>
-    <enabled>no</enabled>
-  </sca>
-
-  <wodle name="cis-cat">
-    <disabled>yes</disabled>
-  </wodle>
-
-  <wodle name="docker-listener">
-    <disabled>yes</disabled>
-  </wodle>
-
-  <wodle name="open-scap">
-    <disabled>yes</disabled>
-  </wodle>
-
-  <wodle name="osquery">
-    <disabled>yes</disabled>
-  </wodle>
-
-  <wodle name="syscollector">
-    <disabled>yes</disabled>
-  </wodle>
-
 </agent_config>


### PR DESCRIPTION
Hi team,

This PR closes #500. This is the new stats folder structure:

```bash
.
├── case0_info.csv
├── case0_state-ossec-analysisd.csv
├── case0_state-ossec-remoted.csv
├── case0_stats-ossec-analysisd.csv
├── case0_stats-ossec-remoted.csv
├── case0_stats-wazuh-db.csv
├── case1_info.csv
├── case1_state-ossec-analysisd.csv
├── case1_state-ossec-remoted.csv
├── case1_stats-ossec-analysisd.csv
├── case1_stats-ossec-remoted.csv
├── case1_stats-wazuh-db.csv
├── case2_info.csv
├── case2_state-ossec-analysisd.csv
├── case2_state-ossec-remoted.csv
├── case2_stats-ossec-analysisd.csv
├── case2_stats-ossec-remoted.csv
└── case2_stats-wazuh-db.csv
```