### PR TITLE
Fix test_recursion_level in MacOS

### DIFF
--- a/tests/integration/test_fim/test_recursion_level/test_recursion_level.py
+++ b/tests/integration/test_fim/test_recursion_level/test_recursion_level.py
@@ -2,13 +2,13 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
-import sys
-
 import pytest
+import sys
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import (LOG_FILE_PATH, callback_audit_event_too_long, regular_file_cud,
                                generate_params)
+from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -18,18 +18,16 @@ pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 
-prefix = os.path.join('C:', os.sep) if sys.platform == 'win32' else os.sep
-
-dir_no_recursion = os.path.join(prefix, 'test_no_recursion')
-dir_recursion_1 = os.path.join(prefix, 'test_recursion_1')
-dir_recursion_5 = os.path.join(prefix, 'test_recursion_5')
-dir_recursion_320 = os.path.join(prefix, 'test_recursion_320')
+dir_no_recursion = os.path.join(PREFIX, 'test_no_recursion')
+dir_recursion_1 = os.path.join(PREFIX, 'test_recursion_1')
+dir_recursion_5 = os.path.join(PREFIX, 'test_recursion_5')
+dir_recursion_320 = os.path.join(PREFIX, 'test_recursion_320')
 subdir = "dir"
 
-dir_no_recursion_space = os.path.join(prefix, 'test no recursion')
-dir_recursion_1_space = os.path.join(prefix, 'test recursion 1')
-dir_recursion_5_space = os.path.join(prefix, 'test recursion 5')
-dir_recursion_320_space = os.path.join(prefix, 'test recursion 320')
+dir_no_recursion_space = os.path.join(PREFIX, 'test no recursion')
+dir_recursion_1_space = os.path.join(PREFIX, 'test recursion 1')
+dir_recursion_5_space = os.path.join(PREFIX, 'test recursion 5')
+dir_recursion_320_space = os.path.join(PREFIX, 'test recursion 320')
 subdir_space = "dir "
 
 test_directories = [dir_no_recursion, dir_recursion_1, dir_recursion_5, dir_recursion_320, dir_no_recursion_space,


### PR DESCRIPTION
Hello team,

## Description
The test_recursion_level.py was failing in MacOS with this error:
```
        try:
>           mkdir(name, mode)
E           OSError: [Errno 30] Read-only file system: '/test_no_recursion'
```

The reason was already reported on the issue #458. MacOS Catalina has a protection system known as System Integrity Protection (**SIP**). It does not allow the creation of any file or directory on the root path, but the test was trying to create the folders in there. 

## Fix
Everything necessary to make it work was already implemented here https://github.com/wazuh/wazuh-qa/pull/470. All that was needed was to replace the local prefix variable 
https://github.com/wazuh/wazuh-qa/blob/706dd68daae97a11b8654854f0ccd1d73d88fa15/tests/integration/test_fim/test_recursion_level/test_recursion_level.py#L21-L33
with the global one, defined as `PREFIX`.

## Tests performed
### MacOS Catalina
```
/usr/bin/python3 -m pytest test_fim/test_recursion_level/test_recursion_level.py 
============================================================================ test session starts ============================================================================
platform darwin -- Python 3.7.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /private/tmp/973_FIM_INTEGRATION_TESTS_STABLE_B231_20200310160011/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0
collected 16 items                                                                                                                                                          

test_fim/test_recursion_level/test_recursion_level.py ......ss......ss                                                                                                [100%]

====================================================================== 12 passed, 4 skipped in -16.47s ======================================================================
```

Kind regards,
José Luis.
