### PR TITLE
Disable MD5 check

### DIFF
--- a/tests/system/provisioning/vars/wazuh_agent.yml
+++ b/tests/system/provisioning/vars/wazuh_agent.yml
@@ -15,4 +15,4 @@ wazuh_winagent_config_url: https://s3-us-west-1.amazonaws.com/packages-dev.wazuh
 wazuh_winagent_package_name: wazuh-agent-3.12.0-0.3319fimreworksqlite.msi
 
 wazuh_winagent_config:
-  md5: 598ae7999f9dfec77f960e994c218d52
+  check_md5: False

--- a/tests/system/provisioning/vars/wazuh_agent.yml
+++ b/tests/system/provisioning/vars/wazuh_agent.yml
@@ -15,4 +15,5 @@ wazuh_winagent_config_url: https://s3-us-west-1.amazonaws.com/packages-dev.wazuh
 wazuh_winagent_package_name: wazuh-agent-3.12.0-0.3319fimreworksqlite.msi
 
 wazuh_winagent_config:
+  md5: 598ae7999f9dfec77f960e994c218d52
   check_md5: False


### PR DESCRIPTION
This PR disables MD5 checks on the provision scenario taking advantage of the latest flag `check_md5` commited to wazuh-ansible's devel branch.