### PR TITLE
Wait until connection in max_eps_synchronization

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -797,6 +797,12 @@ def callback_integrity_message(line):
             return datetime.strptime(match.group(1), '%Y/%m/%d %H:%M:%S'), json.dumps(match.group(2))
 
 
+def callback_connection_message(line):
+    match = re.match(r'.* Connected to the server .*', line)
+    if match:
+        return True
+
+
 def callback_event_message(line):
     if callback_detect_event(line):
         match = re.match(r"(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}).*({.*?})$", line)

--- a/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
@@ -8,7 +8,8 @@ from collections import Counter
 
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, create_file, generate_params, callback_integrity_message
+from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, create_file, generate_params, callback_integrity_message, \
+    callback_connection_message
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -70,8 +71,13 @@ def test_max_eps_on_start(get_configuration, create_files, configure_environment
     check_apply_test({'max_eps_synchronization'}, get_configuration['tags'])
     max_eps = int(get_configuration['metadata']['max_eps'])
 
+    # Wait until the agent connects to the manager.
+    wazuh_log_monitor.start(timeout=90,
+                            callback=callback_connection_message,
+                            error_message="Agent couldn't connect to server.").result()
+
     #  Find integrity start before attempting to read max_eps
-    wazuh_log_monitor.start(timeout=15,
+    wazuh_log_monitor.start(timeout=30,
                             callback=callback_integrity_message,
                             error_message="Didn't receive integrity_check_global").result()
 


### PR DESCRIPTION
Hello team,

## Description
In previous versions of the test_max_eps_synchronization.py there were multiple failures because the agent was disconnected from the manager, being essential in this case that their communication. It was fixed by restarting all Wazuh instead of only syscheck, as seen here:
https://github.com/wazuh/wazuh-qa/blob/8dbf6e1cdf91d1fbf19e957eb05447494c0b01e7/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py#L63

The problem is that it is taking more than 15s to connect, which leads to TimeoutErrors. 

## Fix
Before starting to receive integrity messages, the following message must always have been received:

> Connected to the server

So now it is verified that this log is obtained before performing the integrity test. The timeout to receive the first integrity message is also extended. The tests pass correctly with these changes.

## Tests performed
### Centos
```
 /usr/bin/python3.6 -m pytest test_fim/test_max_eps/test_max_eps_synchronization.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /tmp/973_FIM_INTEGRATION_TESTS_STABLE_B239_20200311103504/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 4 items                                                                                                                                                                                                 

test_fim/test_max_eps/test_max_eps_synchronization.py ....                                                                                                                                                  [100%]

========================================================================================== 4 passed in 108.63s (0:01:48) ==========================================================================================
```

Kind regards,
Jose Luis.
