### PR TITLE
Make tests host type specific

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ from wazuh_testing.tools.monitoring import FileMonitor, SocketController, Socket
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_sockets
 
 PLATFORMS = set("darwin linux win32 sunos5".split())
-TYPES = set("server agent".split())
+HOST_TYPES = set("server agent".split())
 
 catalog = list()
 
@@ -36,7 +36,8 @@ def pytest_runtest_setup(item):
     with open(os.path.join(WAZUH_PATH, 'etc', 'ossec-init.conf')) as f:
         reg = r'TYPE=\"(.*)\"$'
         host_type = re.findall(reg, f.read())[0]
-        if host_type not in TYPES.intersection(mark.name for mark in item.iter_markers()):
+        supported_types = HOST_TYPES.intersection(mark.name for mark in item.iter_markers())
+        if supported_types and host_type not in supported_types:
             pytest.skip("Cannot run on wazuh {}".format(host_type))
 
     # Consider only first mark

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -6,3 +6,5 @@ markers =
     linux
     sunos5
     win32
+    server
+    agent

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.py
@@ -11,7 +11,7 @@ from wazuh_testing.analysis import callback_analysisd_message, callback_wazuh_db
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, WAZUH_LOGS_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_socket_responses.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_socket_responses.py
@@ -11,7 +11,7 @@ from wazuh_testing.analysis import callback_analysisd_message, callback_wazuh_db
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, WAZUH_LOGS_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_linux_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_linux_analysisd_alerts.py
@@ -10,7 +10,7 @@ from wazuh_testing.analysis import validate_analysis_alert_complex
 from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH, LOG_FILE_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_rare_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_rare_analysisd_alerts.py
@@ -10,7 +10,7 @@ from wazuh_testing.analysis import validate_analysis_alert_complex
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, WAZUH_LOGS_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.py
@@ -10,7 +10,7 @@ from wazuh_testing.analysis import validate_analysis_alert_complex
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, WAZUH_LOGS_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_error_messages/test_error_messages.py
+++ b/tests/integration/test_analysisd/test_error_messages/test_error_messages.py
@@ -13,7 +13,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 # marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_event_messages/test_event_messages.py
+++ b/tests/integration/test_analysisd/test_event_messages/test_event_messages.py
@@ -14,7 +14,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 # marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_integrity_messages/test_integrity_messages.py
+++ b/tests/integration/test_analysisd/test_integrity_messages/test_integrity_messages.py
@@ -14,7 +14,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 # marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_analysisd/test_scan_messages/test_scan_messages.py
+++ b/tests/integration/test_analysisd/test_scan_messages/test_scan_messages.py
@@ -13,7 +13,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 # marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
@@ -16,7 +16,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
 
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = [pytest.mark.tier(level=1), pytest.mark.agent]
 
 # Variables
 test_directories_no_delete = [os.path.join(PREFIX, 'testdir1')]

--- a/tests/integration/test_fim/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_stats_integrity_sync/test_FIM_performance.py
@@ -22,7 +22,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service, check_daemon_status
 
 # Marks
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=3)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=3), pytest.mark.server]
 
 root_dir = '/test'
 tested_daemon = 'ossec-syscheckd'

--- a/tests/integration/test_fim/test_stats_integrity_sync/test_stats_integrity_sync.py
+++ b/tests/integration/test_fim/test_stats_integrity_sync/test_stats_integrity_sync.py
@@ -24,7 +24,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=3)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=3), pytest.mark.server]
 
 # variables
 

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -13,7 +13,7 @@ from wazuh_testing.wazuh_db import callback_wazuhdb_response
 
 # marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 # variables
 


### PR DESCRIPTION
Hi team,

This PR closes https://github.com/wazuh/wazuh-qa/issues/600. 

It adds the necessary tools to mark tests to only run on Wazuh agent or Wazuh server whenever needed. `pytest.mark.agent` and `pytest.mark.server` can be used for this purpose.

Best regards,

David J. Iglesias

### **Test_results:**

We have marked `test_max_eps_synchronization.py` as `pytest.mark.agent`. When we run the test in a wazuh manager we can check this test is skipped. 
```[root@wazuh-master integration]# python3 -m pytest test_fim/test_max_eps/
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1
collected 12 items                                                                                                                                                             

test_fim/test_max_eps/test_max_eps.py ..x..x                                                                                                                             [ 50%]
test_fim/test_max_eps/test_max_eps_synchronization.py ssssss                                                                                                             [100%]

============================================================== 4 passed, 6 skipped, 2 xfailed in 88.11s (0:01:28) ==============================================================
```