### PR TITLE
Add new arg option --fim-database-memory to tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -15,6 +15,7 @@ class Parameters:
         timeouts['linux'] = 5
         timeouts['darwin'] = 5
         self._default_timeout = timeouts[sys.platform]
+        self._fim_database_memory = False
 
     @property
     def default_timeout(self):
@@ -36,6 +37,29 @@ class Parameters:
         ----------
         value : int
             New value for the default timeout. Must be in seconds.
+        """
+        self._default_timeout = value
+
+    @property
+    def fim_database_memory(self):
+        """
+        Getter method for the fim_database_memory property
+
+        Returns
+        -------
+        boolean representing if fim_database_memory is activated
+        """
+        return self._default_timeout
+
+    @fim_database_memory.setter
+    def fim_database_memory(self, value):
+        """
+        Setter method for the fim_database_memory property
+
+        Parameters
+        ----------
+        value : bool
+            New value for the fim_database_memory.
         """
         self._default_timeout = value
 

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -49,7 +49,7 @@ class Parameters:
         -------
         boolean representing if fim_database_memory is activated
         """
-        return self._default_timeout
+        return self._fim_database_memory
 
     @fim_database_memory.setter
     def fim_database_memory(self, value):
@@ -61,7 +61,7 @@ class Parameters:
         value : bool
             New value for the fim_database_memory.
         """
-        self._default_timeout = value
+        self._fim_database_memory = value
 
     @property
     def current_configuration(self):

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -43,7 +43,7 @@ class Parameters:
     @property
     def fim_database_memory(self):
         """
-        Getter method for the fim_database_memory property
+        Getter method for the `fim_database_memory` property
 
         Returns
         -------

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -54,7 +54,7 @@ class Parameters:
     @fim_database_memory.setter
     def fim_database_memory(self, value):
         """
-        Setter method for the fim_database_memory property
+        Setter method for the `fim_database_memory` property
 
         Parameters
         ----------

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -47,7 +47,7 @@ class Parameters:
 
         Returns
         -------
-        boolean representing if fim_database_memory is activated
+        boolean representing if `fim_database_memory` is activated
         """
         return self._fim_database_memory
 

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -59,7 +59,7 @@ class Parameters:
         Parameters
         ----------
         value : bool
-            New value for the fim_database_memory.
+            New value for the `fim_database_memory`.
         """
         self._fim_database_memory = value
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,7 +108,7 @@ def pytest_configure(config):
     if default_timeout:
         global_parameters.default_timeout = default_timeout
 
-    # Set default timeout only if it is passed through command line args
+    # Set fim_database_memory only if it is passed through command line args
     fim_database_memory = config.getoption("--fim-database-memory")
     if fim_database_memory:
         global_parameters.fim_database_memory = True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -90,6 +90,11 @@ def pytest_addoption(parser):
              "those with a hardcoded timeout not depending on global_parameters.default_timeout "
              "variable from wazuh_testing package"
     )
+    parser.addoption(
+        "--fim-database-memory",
+        action="store_true",
+        help="run tests activating database memory in the syscheck configuration"
+    )
 
 
 def pytest_configure(config):
@@ -102,6 +107,11 @@ def pytest_configure(config):
     default_timeout = config.getoption("--default-timeout")
     if default_timeout:
         global_parameters.default_timeout = default_timeout
+
+    # Set default timeout only if it is passed through command line args
+    fim_database_memory = config.getoption("--fim-database-memory")
+    if fim_database_memory:
+        global_parameters.fim_database_memory = True
 
 
 def pytest_html_results_table_header(cells):

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -43,8 +43,11 @@ def configure_environment(get_configuration, request):
     backup_config = get_wazuh_conf()
 
     # configuration for testing
+    elements = get_configuration.get('elements')
+    if global_parameters.fim_database_memory:
+        elements.append({'database': {'value': 'memory'}})
     test_config = set_section_wazuh_conf(get_configuration.get('section'),
-                                         get_configuration.get('elements'))
+                                         new_elements=elements)
 
     # create test directories
     if hasattr(request.module, 'test_directories'):

--- a/tests/integration/test_fim/test_report_changes/test_report_deleted_diff.py
+++ b/tests/integration/test_fim/test_report_changes/test_report_deleted_diff.py
@@ -124,7 +124,10 @@ def create_and_check_diff(name, path, fim_mode):
 def disable_report_changes():
     """Change the `report_changes` value in the `ossec.conf` file and then restart `Syscheck` to apply the changes."""
     new_conf = change_conf(report_value='no')
-    new_ossec_conf = set_section_wazuh_conf(new_conf[0].get('section'), new_conf[0].get('elements'))
+    elements = new_conf[0].get('elements')
+    if global_parameters.fim_database_memory:
+        elements.append({'database': {'value': 'memory'}})
+    new_ossec_conf = set_section_wazuh_conf(new_conf[0].get('section'), new_elements=elements)
     restart_wazuh_with_new_conf(new_ossec_conf)
     # Wait for FIM scan to finish
     detect_fim_scan(wazuh_log_monitor)

--- a/tests/integration/test_fim/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_skip/test_skip.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import distro
 import pytest
 
+from wazuh_testing import global_parameters
 from wazuh_testing.fim import (LOG_FILE_PATH, regular_file_cud, detect_initial_scan, callback_detect_event,
                                generate_params, callback_detect_integrity_state, check_time_travel)
 from wazuh_testing.tools import PREFIX
@@ -104,8 +105,10 @@ def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, 
         # Get new skip_proc configuration
         for conf in new_conf:
             if conf['metadata']['skip'] == 'no' and conf['tags'] == ['skip_proc']:
-                new_ossec_conf = set_section_wazuh_conf(conf.get('section'),
-                                                        conf.get('elements'))
+                elements = get_configuration.get('elements')
+                if global_parameters.fim_database_memory:
+                    elements.append({'database': {'value': 'memory'}})
+                new_ossec_conf = set_section_wazuh_conf(conf.get('section'), new_elements=elements)
         restart_wazuh_with_new_conf(new_ossec_conf)
         proc_monitor = FileMonitor(LOG_FILE_PATH)
         detect_initial_scan(proc_monitor)


### PR DESCRIPTION
Hello team,

This PR adds a new argument `--fim-database-memory` to fim tests to allow for sqlite memory testing.

Best regards,

David J. Iglesias

We check the option is only added to config when the parameter is set:
```
[root@wazuh-master integration]# python3 -m pytest test_fim/test_basic_usage/test_basic_usage_changes.py --fim-database-memory
[root@wazuh-master wazuh_testing]# cat /var/ossec/etc/ossec.conf | grep syscheck
  <syscheck><disabled>no</disabled><directories check_all="yes">/testdir1,/testdir2,/noexists</directories><database>memory</database></syscheck><global>
    <group>syscheck</group>

[root@wazuh-master integration]# python3 -m pytest test_fim/test_basic_usage/test_basic_usage_changes.py
[root@wazuh-master wazuh_testing]# cat /var/ossec/etc/ossec.conf | grep syscheck
  <syscheck><disabled>no</disabled><directories check_all="yes">/testdir1,/testdir2,/noexists</directories></syscheck><global>
    <group>syscheck</group>
```

