### PR TITLE
Fix time travel on MacOS

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/time.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/time.py
@@ -84,8 +84,8 @@ class TimeMachine:
         datetime_ : datetime
             New date and time to set.
         """
-        # {month}{day}{hour}{minute}{year}
-        os.system('date ' + '-u ' + datetime_.strftime("%m%d%H%M%Y"))
+        # {month}{day}{hour}{minute}{year}.{seconds}
+        os.system('date ' + '-u ' + datetime_.strftime("%m%d%H%M%Y.%S"))
 
     @staticmethod
     def travel_to_future(time_delta, back_in_time=False):


### PR DESCRIPTION
Hi team.

This PR fixes the time travel in MacOS. Every time we travelled in time on MacOS, it would set the seconds to **00**.

We did not have the correct format.

Regards.