### PR TITLE
Adapt molecules tests to last wazuh-agent role changes

### DIFF
--- a/ansible/wazuh-ansible/molecule/default/playbook.yml
+++ b/ansible/wazuh-ansible/molecule/default/playbook.yml
@@ -22,15 +22,15 @@
   roles:
     - role: wazuh/ansible-wazuh-agent
   vars:
-    wazuh_manager:
-      address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
-      port: 1514
-      protocol: udp
-      api_port: 55000
-      api_proto: 'http'
-      api_user: ansible
+    wazuh_managers:
+      - address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
+        port: 1514
+        protocol: udp
+        api_port: 55000
+        api_proto: 'http'
+        api_user: ansible
     wazuh_agent_authd:
-      authd_address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
+      registration_address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
       enable: true
       port: 1515
       ssl_agent_ca: null

--- a/ansible/wazuh-ansible/molecule/wazuh-agent/molecule.yml
+++ b/ansible/wazuh-ansible/molecule/wazuh-agent/molecule.yml
@@ -73,15 +73,15 @@ provisioner:
     group_vars:
       agent:
         api_pass: password
-        wazuh_manager:
-          address: "{{ wazuh_manager_ip }}"
-          port: 1514
-          protocol: udp
-          api_port: 55000
-          api_proto: 'http'
-          api_user: null
+        wazuh_managers:
+          - address: "{{ wazuh_manager_ip }}"
+            port: 1514
+            protocol: udp
+            api_port: 55000
+            api_proto: 'http'
+            api_user: null
         wazuh_agent_authd:
-          authd_address: "{{ wazuh_manager_ip }}"
+          registration_address: "{{ wazuh_manager_ip }}"
           enable: true
           port: 1515
           ssl_agent_ca: null

--- a/ansible/wazuh-ansible/molecule/wazuh-agent/playbook.yml
+++ b/ansible/wazuh-ansible/molecule/wazuh-agent/playbook.yml
@@ -4,15 +4,15 @@
   roles:
     - role: wazuh/ansible-wazuh-agent
   vars:
-    wazuh_manager:
-      address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
-      port: 1514
-      protocol: udp
-      api_port: 55000
-      api_proto: 'http'
-      api_user: ansible
+    wazuh_managers:
+      - address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
+        port: 1514
+        protocol: udp
+        api_port: 55000
+        api_proto: 'http'
+        api_user: ansible
     wazuh_agent_authd:
-      authd_address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
+      registration_address: "manager-{{ lookup('env', 'MOL_PLATFORM') or 'centos7' }}"
       enable: true
       port: 1515
       ssl_agent_ca: null


### PR DESCRIPTION
Hi team,

This PR introduces minor updates in ansible variables used by molecule tests regarding wazuh-agent role. This update is necessary to adapt the tests to changes [here](https://github.com/wazuh/wazuh-ansible/pull/389) regarding wazuh-agent role variables.

It overwrites the recent update to this tests related to https://github.com/wazuh/wazuh-ansible/pull/388 . It has been decided to continue supporting the [failover](https://documentation.wazuh.com/3.11/user-manual/configuring-cluster/advanced-settings.html#pointing-agents-to-the-cluster-failover-mode) configuration scheme.

Greetings, JP Sáez