### PR TITLE
Remove Carriage Return character

### DIFF
--- a/kitchen/wazuh-puppet/kitchen/test/conftest.py
+++ b/kitchen/wazuh-puppet/kitchen/test/conftest.py
@@ -17,4 +17,4 @@ def get_wazuh_version():
     wazuh_version = wazuh_version.replace('"', '') # Remove double quote.
     wazuh_version = wazuh_version.split("v",1)[1] # Get string after 'v' : X.XX.X 
     
-    return wazuh_version
+    return wazuh_version.rstrip()


### PR DESCRIPTION
Hi all!

Recently when testing the changes of https://github.com/wazuh/wazuh-puppet/pull/234 we got an error when running `kitchen verify` and especially when checking the version of Wazuh.

```
>           assert manager.version.startswith(get_wazuh_version)
E           AssertionError: assert False
E            +  where False = <built-in method startswith of str object at 0x7fa8d65c9870>('3.11.4\r')
E            +    where <built-in method startswith of str object at 0x7fa8d65c9870> = '3.11.4-1'.startswith
E            +      where '3.11.4-1' = <package wazuh-manager>.version
```

This error could not be found with other branches' testing, but after deep debugging, we found nothing wrong with the changes applied to the branch.

So In order to solve this issue, we needed to remove the `Carriage Return` character using the function `rstrip()`.

```python
@pytest.fixture
def get_wazuh_version():
    version_file_content = str(test_host.file('/tmp/kitchen/modules/wazuh/VERSION').content_string)
    wazuh_version = version_file_content.split("\n")[0] # WAZUH-PUPPET_VERSION="vX.XX.X"
    wazuh_version = wazuh_version.replace('"', '') # Remove double quote.
    wazuh_version = wazuh_version.split("v",1)[1] # Get string after 'v' : X.XX.X
    return wazuh_version.rstrip()
```

Kr,

Rshad