### PR TITLE
Remove Windows xfails from test_basic_usage_move_dir

### DIFF
--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -98,9 +98,6 @@ def test_move_dir(source_folder, target_folder, subdir, tags_to_apply,
     if mode == 'whodata' and subdir[-1] == os.path.sep and sys.platform == 'linux':
         pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/4720')
 
-    if mode == 'whodata' and sys.platform == 'win32' and triggers_add_event:
-        pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/4596')
-
     # Move folder to target directory
     os.rename(os.path.join(source_folder, subdir), os.path.join(target_folder, subdir))
     check_time_travel(scheduled, monitor=wazuh_log_monitor)


### PR DESCRIPTION
Hello team,


When merging the PR number [4762](https://github.com/wazuh/wazuh/pull/4762), the Windows expected fails in `test_basic_usage_move_dir.py` will be solved.

![imagen](https://user-images.githubusercontent.com/17710550/77434813-b5991880-6de1-11ea-8f35-a4e0b94cf93c.png)

Best regards,
Eva