### PR TITLE
Fix Chef PR Dockerfile

### DIFF
--- a/kitchen/wazuh-chef/Dockerfile
+++ b/kitchen/wazuh-chef/Dockerfile
@@ -20,7 +20,7 @@ RUN cd $HOME && \
 RUN cd $HOME/wazuh-qa/kitchen/wazuh-chef/ && \
     bundle install
 
-RUN rm -rf /usr/local/bundle/gems/kitchen-docker-2.9.0/* && \
+RUN rm -rf /usr/local/bundle/gems/kitchen-docker-*/* || true && \
     cp -rf $HOME/wazuh-qa/kitchen/kitchen-docker/* /usr/local/bundle/gems/kitchen-docker-2.9.0/
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py

--- a/kitchen/wazuh-chef/Dockerfile
+++ b/kitchen/wazuh-chef/Dockerfile
@@ -21,7 +21,7 @@ RUN cd $HOME/wazuh-qa/kitchen/wazuh-chef/ && \
     bundle install
 
 RUN rm -rf /usr/local/bundle/gems/kitchen-docker-*/* || true && \
-    cp -rf $HOME/wazuh-qa/kitchen/kitchen-docker/* /usr/local/bundle/gems/kitchen-docker-2.9.0/
+    cp -rf $HOME/wazuh-qa/kitchen/kitchen-docker/* /usr/local/bundle/gems/kitchen-docker-*/
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py
 


### PR DESCRIPTION
Hi team,

The Kitchen docker version is not fixed in the installation and it caused some incompatibilities with the hardcoded path 2.9.0. Now it uses a glob to designate the path.

Best regards,

Jose