### PR TITLE
Fix missing dependency (lockfile)

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -23,5 +23,8 @@ setup(name='wazuh_testing',
                                       ]
                     },
       include_package_data=True,
+      install_requires=[
+            'lockfile==0.12.2',
+      ],
       zip_safe=False
       )


### PR DESCRIPTION
Hi team,

This PR add one missing dependency (lockfile). Without this dependency the module wazuh_testing cannot be used.

```bash
python3 SETUP.PY_PATH install
```

Regards