### PR TITLE
Add run on start integration test for vulnerability detector

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -6,7 +6,6 @@ import re
 
 
 def callback_detect_vulnerability_scan_started(line):
-
     msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Starting\s+vulnerability\s+scanning'
     match = re.match(msg, line)
 
@@ -14,7 +13,6 @@ def callback_detect_vulnerability_scan_started(line):
 
 
 def callback_detect_vulnerability_scan_finished(line):
-
     msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Vulnerability\s+scanning\s+finished'
     match = re.match(msg, line)
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -1,0 +1,21 @@
+import re
+
+
+def callback_detect_vulnerability_start_scan(line):
+
+    msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Starting\s+vulnerability\s+scanning'
+    match = re.match(msg, line)
+
+    if match:
+        return True
+    return None
+
+
+def callback_detect_vulnerability_end_scan(line):
+
+    msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Vulnerability\s+scanning\s+finished'
+    match = re.match(msg, line)
+
+    if match:
+        return True
+    return None

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -1,7 +1,7 @@
 import re
 
 
-def callback_detect_vulnerability_start_scan(line):
+def callback_detect_vulnerability_scan_started(line):
 
     msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Starting\s+vulnerability\s+scanning'
     match = re.match(msg, line)
@@ -11,7 +11,7 @@ def callback_detect_vulnerability_start_scan(line):
     return None
 
 
-def callback_detect_vulnerability_end_scan(line):
+def callback_detect_vulnerability_scan_finished(line):
 
     msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Vulnerability\s+scanning\s+finished'
     match = re.match(msg, line)

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 import re
 
 
@@ -6,9 +10,7 @@ def callback_detect_vulnerability_scan_started(line):
     msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Starting\s+vulnerability\s+scanning'
     match = re.match(msg, line)
 
-    if match:
-        return True
-    return None
+    return match is not None
 
 
 def callback_detect_vulnerability_scan_finished(line):
@@ -16,6 +18,4 @@ def callback_detect_vulnerability_scan_finished(line):
     msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+Vulnerability\s+scanning\s+finished'
     match = re.match(msg, line)
 
-    if match:
-        return True
-    return None
+    return match is not None

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+
+
+@pytest.fixture(scope='module')
+def restart_modulesd(get_configuration, request):
+    # Reset ossec.log and start a new monitor
+    control_service('stop', daemon='wazuh-modulesd')
+    truncate_file(LOG_FILE_PATH)
+    file_monitor = FileMonitor(LOG_FILE_PATH)
+    setattr(request.module, 'wazuh_log_monitor', file_monitor)
+    control_service('start', daemon='wazuh-modulesd')

--- a/tests/integration/test_vulnerability_detector/test_run_on_start/data/wazuh_run_on_start.yaml
+++ b/tests/integration/test_vulnerability_detector/test_run_on_start/data/wazuh_run_on_start.yaml
@@ -1,0 +1,14 @@
+---
+# conf 1
+- tags:
+  - run_on_start
+  apply_to_modules:
+  - test_run_on_start
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: RUN_ON_START
+

--- a/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
@@ -39,14 +39,10 @@ def get_configuration(request):
 
 # Tests
 
-@pytest.mark.parametrize('tags_to_apply, custom_callback, custom_error_message ', [
-    ({'run_on_start'}, callback_detect_vulnerability_scan_started,
-        'Could not find vulnerability starting scan log'),
-    ({'run_on_start'}, callback_detect_vulnerability_scan_finished,
-        'Could not find vulnerability scanning finished log'),
+@pytest.mark.parametrize('tags_to_apply', [
+    {'run_on_start'}
 ])
-def test_run_on_start(tags_to_apply, custom_callback, custom_error_message, get_configuration,
-                      configure_environment, restart_modulesd):
+def test_run_on_start(tags_to_apply, get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd detects the vulnerability detector scan after starting.
 
@@ -66,11 +62,15 @@ def test_run_on_start(tags_to_apply, custom_callback, custom_error_message, get_
     if get_configuration['metadata']['run_on_start'] == 'yes':
 
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=custom_callback,
-                                error_message=custom_error_message)
+                                callback=callback_detect_vulnerability_scan_started,
+                                error_message='Could not find vulnerability starting scan log')
+
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_vulnerability_scan_finished,
+                                error_message='Could not find vulnerability scanning finished log')
     else:
         with pytest.raises(TimeoutError):
-            event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=custom_callback,
-                                            error_message=custom_error_message)
-            raise AttributeError(f'Unexpected event {event}')
+            wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                            callback=callback_detect_vulnerability_scan_started,
+                                            error_message='Found starting scan log when run on start is disabled')
+            raise AttributeError(f'Unexpected event')

--- a/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.vuln_detector import callback_detect_vulnerability_start_scan, \
+    callback_detect_vulnerability_end_scan
+
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_run_on_start.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+p = [{'RUN_ON_START': 'yes'}, {'RUN_ON_START': 'no'}]
+m = [{'run_on_start': 'yes'}, {'run_on_start': 'no'}]
+
+# Lista de configuraciones para cada uno de los p
+configurations = load_wazuh_configurations(
+    configurations_path, __name__, params=p, metadata=m)
+
+# fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('tags_to_apply, _callback', [
+    ({'run_on_start'}, callback_detect_vulnerability_start_scan),
+    ({'run_on_start'}, callback_detect_vulnerability_end_scan),
+])
+def test_run_on_start(tags_to_apply, _callback, get_configuration, configure_environment, restart_modulesd):
+
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    if get_configuration['metadata']['run_on_start'] == 'yes':
+
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                         callback=_callback,
+                                         error_message='Could not find start scan log')
+    else:
+        with pytest.raises(TimeoutError):
+            event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                            callback=_callback)
+            raise AttributeError(f'Unexpected event {event}')

--- a/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
@@ -48,13 +48,6 @@ def test_run_on_start(tags_to_apply, get_configuration, configure_environment, r
 
     If we have set the parameter run_on_start to 'yes', modulesd will have to report the
     vulnerability detector scan, and in case of the value 'no', do not report anything
-
-    Parameters
-    ----------
-    custom_callback : function
-        Callback that will be applied to the value of tags to apply.
-    custom_error_message : str
-        Custom error message that will be shown if the test fails.
     """
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
@@ -71,6 +64,5 @@ def test_run_on_start(tags_to_apply, get_configuration, configure_environment, r
     else:
         with pytest.raises(TimeoutError):
             wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=callback_detect_vulnerability_scan_started,
-                                            error_message='Found starting scan log when run on start is disabled')
-            raise AttributeError(f'Unexpected event')
+                                    callback=callback_detect_vulnerability_scan_started)
+            raise AttributeError(f'Found starting scan log when run on start is disabled')

--- a/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 import os
 import pytest
 
@@ -18,12 +22,13 @@ configurations_path = os.path.join(test_data_path, 'wazuh_run_on_start.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-p = [{'RUN_ON_START': 'yes'}, {'RUN_ON_START': 'no'}]
-m = [{'run_on_start': 'yes'}, {'run_on_start': 'no'}]
+config_wildcards_values = [{'RUN_ON_START': 'yes'}, {'RUN_ON_START': 'no'}]
+config_wildcards_metadata = [{'run_on_start': 'yes'}, {'run_on_start': 'no'}]
 
 # Configuration data
-configurations = load_wazuh_configurations(
-    configurations_path, __name__, params=p, metadata=m)
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=config_wildcards_values,
+                                           metadata=config_wildcards_metadata)
 
 # fixtures
 
@@ -42,7 +47,6 @@ def get_configuration(request):
 ])
 def test_run_on_start(tags_to_apply, custom_callback, custom_error_message, get_configuration,
                       configure_environment, restart_modulesd):
-
     """
     Check if modulesd detects the vulnerability detector scan after starting.
 

--- a/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_run_on_start/test_run_on_start.py
@@ -5,8 +5,8 @@ from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vuln_detector import callback_detect_vulnerability_start_scan, \
-    callback_detect_vulnerability_end_scan
+from wazuh_testing.vulnerability_detector import callback_detect_vulnerability_scan_started, \
+    callback_detect_vulnerability_scan_finished
 
 
 # Marks
@@ -21,34 +21,52 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 p = [{'RUN_ON_START': 'yes'}, {'RUN_ON_START': 'no'}]
 m = [{'run_on_start': 'yes'}, {'run_on_start': 'no'}]
 
-# Lista de configuraciones para cada uno de los p
+# Configuration data
 configurations = load_wazuh_configurations(
     configurations_path, __name__, params=p, metadata=m)
 
 # fixtures
-
 
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+# Tests
 
-@pytest.mark.parametrize('tags_to_apply, _callback', [
-    ({'run_on_start'}, callback_detect_vulnerability_start_scan),
-    ({'run_on_start'}, callback_detect_vulnerability_end_scan),
+@pytest.mark.parametrize('tags_to_apply, custom_callback, custom_error_message ', [
+    ({'run_on_start'}, callback_detect_vulnerability_scan_started,
+        'Could not find vulnerability starting scan log'),
+    ({'run_on_start'}, callback_detect_vulnerability_scan_finished,
+        'Could not find vulnerability scanning finished log'),
 ])
-def test_run_on_start(tags_to_apply, _callback, get_configuration, configure_environment, restart_modulesd):
+def test_run_on_start(tags_to_apply, custom_callback, custom_error_message, get_configuration,
+                      configure_environment, restart_modulesd):
+
+    """
+    Check if modulesd detects the vulnerability detector scan after starting.
+
+    If we have set the parameter run_on_start to 'yes', modulesd will have to report the
+    vulnerability detector scan, and in case of the value 'no', do not report anything
+
+    Parameters
+    ----------
+    custom_callback : function
+        Callback that will be applied to the value of tags to apply.
+    custom_error_message : str
+        Custom error message that will be shown if the test fails.
+    """
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     if get_configuration['metadata']['run_on_start'] == 'yes':
 
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                         callback=_callback,
-                                         error_message='Could not find start scan log')
+                                callback=custom_callback,
+                                error_message=custom_error_message)
     else:
         with pytest.raises(TimeoutError):
             event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=_callback)
+                                            callback=custom_callback,
+                                            error_message=custom_error_message)
             raise AttributeError(f'Unexpected event {event}')


### PR DESCRIPTION
Hello team,

This PR adds what is necessary to test the `run_on_start` parameter for vulnerability detector.

The testing is done by checking the debug events that are stored in the `ossec.log`.

Closes #666 

### Tests logic

- If `run_on_start` is active (*yes*), when starting `modulesd` the following logs must be shown:

```
2020/04/30 12:16:07 wazuh-modulesd:vulnerability-detector: INFO: (5452): Starting vulnerability scanning.
2020/04/30 12:16:07 wazuh-modulesd:vulnerability-detector: INFO: (5453): Vulnerability scanning finished.
```
- If `run_on_start` is not active (*no*), when starting `modulesd`  that logs do not have to be shown:

### Tests checks

- When the expected behavior occurs:

```
========================================== test session starts ==========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-26-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.1', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'testinfra': '5.0.0', 'metadata': '1.8.0'}}
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.8.0
collected 2 items                                                                                       

test_vulnerability_detector/test_run_on_start/test_run_on_start.py::test_run_on_start[get_configuration0-tags_to_apply0] PASSED [ 50%]
test_vulnerability_detector/test_run_on_start/test_run_on_start.py::test_run_on_start[get_configuration1-tags_to_apply0] PASSED [100%]

========================================== 2 passed in 10.52s ===========================================
```


- When the module fails and does not start the scan after starting `modulesd` despite having `run_on_start` to *yes*:

```
========================================== test session starts ==========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-26-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.1', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'testinfra': '5.0.0', 'metadata': '1.8.0'}}
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.8.0
collected 2 items                                                                                       

test_vulnerability_detector/test_run_on_start/test_run_on_start.py::test_run_on_start[get_configuration0-tags_to_apply0] FAILED [ 50%]
test_vulnerability_detector/test_run_on_start/test_run_on_start.py::test_run_on_start[get_configuration1-tags_to_apply0] PASSED [100%]

----------------------------------------- Captured stderr call ------------------------------------------
2020-05-05 10:28:16,622 - wazuh_testing - ERROR - Could not find vulnerability starting scan log
2020-05-05 10:28:16,623 - wazuh_testing - ERROR - Results accumulated: 0
2020-05-05 10:28:16,623 - wazuh_testing - ERROR - Results expected: 1
------------------------------------------- Captured log call -------------------------------------------
ERROR    wazuh_testing:monitoring.py:401 Could not find vulnerability starting scan log
ERROR    wazuh_testing:monitoring.py:402 Results accumulated: 0
ERROR    wazuh_testing:monitoring.py:404 Results expected: 1
======================================== short test summary info ========================================
FAILED test_vulnerability_detector/test_run_on_start/test_run_on_start.py::test_run_on_start[get_configuration0-tags_to_apply0]
===================================== 1 failed, 1 passed in 15.88s ======================================
```

Best regards.

