### PR TITLE
Fix sh version in Pipfile for wazuh-ansible pr tests

### DIFF
--- a/ansible/wazuh-ansible/Pipfile
+++ b/ansible/wazuh-ansible/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 docker-py = "*"
 ansible = "==2.7.16"
 molecule = "==2.22"
+sh == "==1.12.14"
 
 [dev-packages]
 


### PR DESCRIPTION
Hi team,

We recently faced the following error:

```
TypeError: Invalid special arguments:

  'env': value u'/home/anonymous/Desktop/wazuh/wazuh-ansible/.env.yml' of env key 'MOLECULE_ENV_FILE' must be a str
``` 

After some investigation we found that it's related to sh.py package which in its newer versions generates the failure. Confirmed by :  https://github.com/ansible-community/molecule/issues/2676

After fixing `sh == "==1.12.14"` the error no longer appears.

Best regards,

Jose


