### PR TITLE
Add frequency to new_dirs integrity test

### DIFF
--- a/tests/integration/test_fim/test_basic_usage/data/wazuh_conf_new_dirs.yaml
+++ b/tests/integration/test_fim/test_basic_usage/data/wazuh_conf_new_dirs.yaml
@@ -1,0 +1,18 @@
+---
+# conf 1
+- tags:
+  - ossec_conf
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - frequency:
+        value: 30
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_basic_usage/data/wazuh_conf_new_dirs_win32.yaml
+++ b/tests/integration/test_fim/test_basic_usage/data/wazuh_conf_new_dirs_win32.yaml
@@ -1,0 +1,20 @@
+---
+# conf 1
+- tags:
+  - ossec_conf
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - frequency:
+        value: 30
+    - windows_audit_interval:
+        value: WINDOWS_AUDIT_INTERVAL
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
@@ -11,7 +11,7 @@ import pytest
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import detect_initial_scan
-from wazuh_testing.fim import generate_params, regular_file_cud, check_time_travel, callback_non_existing_monitored_dir
+from wazuh_testing.fim import generate_params, regular_file_cud, callback_non_existing_monitored_dir
 from wazuh_testing.tools import PREFIX, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -26,7 +26,8 @@ test_directories = []
 directory_str = os.path.join(PREFIX, 'testdir1')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path,
-                                   'wazuh_conf.yaml' if sys.platform != 'win32' else 'wazuh_conf_win32.yaml')
+                                   'wazuh_conf_new_dirs.yaml' if sys.platform != 'win32'
+                                   else 'wazuh_conf_new_dirs_win32.yaml')
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Configurations
@@ -85,8 +86,6 @@ def test_new_directory(tags_to_apply, get_configuration, configure_environment, 
         regular_file_cud(directory_str, wazuh_log_monitor, file_list=['file1', 'file2', 'file3'],
                          min_timeout=global_parameters.default_timeout, triggers_event=False)
 
-        # Travel to the future to start next scheduled scan
-        check_time_travel(True)
         detect_initial_scan(wazuh_log_monitor)
     else:
         # Wait for syscheck to realize the directories don't exist
@@ -97,4 +96,4 @@ def test_new_directory(tags_to_apply, get_configuration, configure_environment, 
 
     # Assert that events of new CUD actions are raised after next scheduled scan
     regular_file_cud(directory_str, wazuh_log_monitor, file_list=['file4', 'file5', 'file6'],
-                     min_timeout=global_parameters.default_timeout, triggers_event=True)
+                     min_timeout=40, triggers_event=True)


### PR DESCRIPTION
## Description

This Pull Request closes #679. The _time travel_ module was causing problem running this test in Linux in AWS, this pull request adds a frequency for the FIM scan to avoid this problem.