### PR TITLE
Add a table with totals for each test file to summary

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -182,6 +182,9 @@ def pytest_runtest_makereport(item, call):
     report.markers = ', '.join(mark.name for mark in item.iter_markers() if
                                mark.name != 'tier' and mark.name != 'parametrize')
 
+    if report.location[0] not in results:
+        results[report.location[0]] = {'passed': 0, 'failed': 0, 'skipped': 0, 'xfailed': 0, 'error': 0}
+
     extra = getattr(report, 'extra', [])
     if report.when == 'call':
         # Apply hack to fix length filename problem
@@ -215,13 +218,13 @@ def pytest_runtest_makereport(item, call):
         if not report.passed and not report.skipped:
             report.extra = extra
 
-        if report.location[0] not in results:
-            results[report.location[0]] = {'passed': 0, 'failed': 0, 'skipped': 0, 'xfailed': 0, 'error': 0}
-
         if report.longrepr is not None and report.longreprtext.split()[-1] == 'XFailed':
             results[report.location[0]]['xfailed'] += 1
         else:
             results[report.location[0]][report.outcome] += 1
+
+    elif report.outcome == 'failed':
+        results[report.location[0]]['error'] += 1
 
 
 class SummaryTable(html):
@@ -231,7 +234,7 @@ class SummaryTable(html):
     class td(html.td):
         style = html.Style(padding='5px', border='1px solid #E6E6E6', text_align='left')
 
-    class th(td):
+    class th(html.th):
         style = html.Style(padding='5px', border='1px solid #E6E6E6', text_align='left', font_weight='bold')
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -216,19 +216,23 @@ def pytest_runtest_makereport(item, call):
             report.extra = extra
 
         if report.location[0] not in results:
-            results[report.location[0]] = {'passed': 0, 'failed': 0, 'skipped': 0}
-        results[report.location[0]][report.outcome] += 1
+            results[report.location[0]] = {'passed': 0, 'failed': 0, 'skipped': 0, 'xfailed': 0, 'error': 0}
+
+        if report.longrepr is not None and report.longreprtext.split()[-1] == 'XFailed':
+            results[report.location[0]]['xfailed'] += 1
+        else:
+            results[report.location[0]][report.outcome] += 1
 
 
 class SummaryTable(html):
     class table(html.table):
-        style = html.Style(border='1px solid #e6e6e6', color='#999', font_size='12px')
+        style = html.Style(border='1px solid #e6e6e6', margin='16px 0px', color='#999', font_size='12px')
 
     class td(html.td):
-        style = html.Style(padding='5px', border='1px solid #E6E6E6',text_align='left')
+        style = html.Style(padding='5px', border='1px solid #E6E6E6', text_align='left')
 
     class th(td):
-        style = html.Style(font_weight='bold')
+        style = html.Style(padding='5px', border='1px solid #E6E6E6', text_align='left', font_weight='bold')
 
 
 def pytest_html_results_summary(prefix, summary, postfix):
@@ -236,15 +240,19 @@ def pytest_html_results_summary(prefix, summary, postfix):
         html.thead(
             html.tr([
                 SummaryTable.th("Tests"),
-                SummaryTable.th("Passed"),
-                SummaryTable.th("Failed")]
+                SummaryTable.th("Failed"),
+                SummaryTable.th("Success"),
+                SummaryTable.th("XFail"),
+                SummaryTable.th("Error")]
             ),
         ),
         [html.tbody(
             html.tr([
                 SummaryTable.td(k),
-                SummaryTable.td(v['passed']),
                 SummaryTable.td(v['failed']),
+                SummaryTable.td(v['passed']),
+                SummaryTable.td(v['xfailed']),
+                SummaryTable.td(v['error']),
             ])
         ) for k, v in results.items()])])
 


### PR DESCRIPTION
|Related issue|
|---|
|#672|

## Description
This PR aims at adding a simple table with the results for the tests that are run, so it's easier to identify and keep track of failures and errors.

## Tests
- Mixture of results
![imagen](https://user-images.githubusercontent.com/20206636/80953870-a2279700-8dfc-11ea-9c6c-d49a19db58d0.png)

- Tests throwing errors
![imagen](https://user-images.githubusercontent.com/20206636/80953571-1877c980-8dfc-11ea-9982-3a6080828df7.png)
