### PR TITLE
Test enabled parameter to download feeds from providers

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -60,7 +60,4 @@ def make_vuln_callback(pattern):
     pattern = r'\s+'.join(pattern.split())
     regex = re.compile(r'{}{}'.format(vulnerability_detector_prefix, pattern))
 
-    def _callback(line):
-        match = regex.match(line)
-        return match is not None
-    return _callback
+    return lambda line: regex.match(line) is not None

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -60,6 +60,7 @@ def make_callback(pattern):
     pattern = r'\s+'.join(pattern.split())
     msg = modulesd_prefix + pattern
     regex = re.compile(msg)
+
     def _callback(line):
         match = regex.match(line)
         return match is not None

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -5,6 +5,9 @@
 import re
 
 
+modulesd_prefix = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+'
+
+
 def callback_detect_vulnerability_scan_started(line):
     msg = r'.*wazuh-modulesd:vulnerability-detector.* INFO:.*Starting vulnerability scanning'
     match = re.match(msg, line)
@@ -47,11 +50,17 @@ def make_callback(pattern):
 
     It already contains the vulnerability-detector prefix.
 
+    Parameters
+    ----------
+    pattern : str
+        String to match on the log
+
     >>> callback_bionic_update_started = make_callback("Starting Ubuntu Bionic database update")
     """
     pattern = r'\s+'.join(pattern.split())
+    msg = modulesd_prefix + pattern
+    regex = re.compile(msg)
     def _callback(line):
-        msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+{}'.format(pattern)
-        match = re.match(msg, line)
+        match = regex.match(line)
         return match is not None
     return _callback

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -64,3 +64,14 @@ def make_callback(pattern):
         match = regex.match(line)
         return match is not None
     return _callback
+
+
+def callback_detect_no_feeds_downloaded(line):
+    """This tests that no feeds are being downloaded"""
+    update_regex = re.compile(modulesd_prefix + 'Starting.*database\s+update')
+    scan_regex = re.compile(modulesd_prefix + 'Starting\s+vulnerability\s+scanning')
+    update = update_regex.match(line)
+    if update:
+        raise Exception("A feed download was detected")
+    scan = scan_regex.match(line)  # success: scan started without downloading any feeds
+    return scan is not None

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -39,3 +39,19 @@ def callback_detect_vulnerability_detector_enabled(line):
     match2 = re.match(msg, line)
 
     return match1 is not None and match2 is None
+
+
+def make_callback(pattern):
+    """
+    Creates a callback function from a text pattern.
+
+    It already contains the vulnerability-detector prefix.
+
+    >>> callback_bionic_update_started = make_callback("Starting Ubuntu Bionic database update")
+    """
+    pattern = r'\s+'.join(pattern.split())
+    def _callback(line):
+        msg = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+{}'.format(pattern)
+        match = re.match(msg, line)
+        return match is not None
+    return _callback

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -5,7 +5,7 @@
 import re
 
 
-modulesd_prefix = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+'
+vulnerability_detector_prefix = r'.*wazuh-modulesd:vulnerability-detector:\s+INFO:\s+\(\d+\):\s+'
 
 
 def callback_detect_vulnerability_scan_started(line):
@@ -44,7 +44,7 @@ def callback_detect_vulnerability_detector_enabled(line):
     return match1 is not None and match2 is None
 
 
-def make_callback(pattern):
+def make_vuln_callback(pattern):
     """
     Creates a callback function from a text pattern.
 
@@ -58,21 +58,9 @@ def make_callback(pattern):
     >>> callback_bionic_update_started = make_callback("Starting Ubuntu Bionic database update")
     """
     pattern = r'\s+'.join(pattern.split())
-    msg = modulesd_prefix + pattern
-    regex = re.compile(msg)
+    regex = re.compile(r'{}{}'.format(vulnerability_detector_prefix, pattern))
 
     def _callback(line):
         match = regex.match(line)
         return match is not None
     return _callback
-
-
-def callback_detect_no_feeds_downloaded(line):
-    """This tests that no feeds are being downloaded"""
-    update_regex = re.compile(modulesd_prefix + 'Starting.*database\s+update')
-    scan_regex = re.compile(modulesd_prefix + 'Starting\s+vulnerability\s+scanning')
-    update = update_regex.match(line)
-    if update:
-        raise Exception("A feed download was detected")
-    scan = scan_regex.match(line)  # success: scan started without downloading any feeds
-    return scan is not None

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+
+
+@pytest.fixture(scope='module')
+def restart_modulesd(get_configuration, request):
+    # Reset ossec.log and start a new monitor
+    control_service('stop', daemon='wazuh-modulesd')
+    truncate_file(LOG_FILE_PATH)
+    file_monitor = FileMonitor(LOG_FILE_PATH)
+    setattr(request.module, 'wazuh_log_monitor', file_monitor)
+    control_service('start', daemon='wazuh-modulesd')

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -1,7 +1,6 @@
 ---
-# conf 1 - Canonical
 - tags:
-  - test_canonical_provider
+  - test_provider_enabled
   apply_to_modules:
   - test_enabled
   sections:
@@ -14,60 +13,6 @@
         - enabled:
             value: ENABLED
         - os:
-            value: 'bionic'
+            value: OS
         attributes:
-        - name: 'canonical'
-# conf 2 - Debian
-- tags:
-  - test_debian_provider
-  apply_to_modules:
-  - test_enabled
-  sections:
-  - section: vulnerability-detector
-    elements:
-    - enabled:
-        value: 'yes'
-    - provider:
-        elements:
-        - enabled:
-            value: ENABLED
-        - os:
-            value: 'buster'
-        attributes:
-        - name: 'debian'
-#conf 3 - RedHat
-- tags:
-  - test_redhat_provider
-  apply_to_modules:
-  - test_enabled
-  sections:
-  - section: vulnerability-detector
-    elements:
-    - enabled:
-        value: 'yes'
-    - provider:
-        elements:
-        - enabled:
-            value: ENABLED
-        - update_from_year:
-            value: '2010'
-        attributes:
-        - name: 'redhat'
-#conf 4 - NVD
-- tags:
-  - test_nvd_provider
-  apply_to_modules:
-  - test_enabled
-  sections:
-  - section: vulnerability-detector
-    elements:
-    - enabled:
-        value: 'yes'
-    - provider:
-        elements:
-        - enabled:
-            value: 'ENABLED'
-        - update_from_year:
-            value: '2010'
-        attributes:
-        - name: 'nvd'
+        - name: PROVIDER

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -1,7 +1,7 @@
 ---
 # conf 1
 - tags:
-  - canonical_provider
+  - test_canonical_provider
   apply_to_modules:
   - test_enabled
   sections:
@@ -9,9 +9,21 @@
     elements:
     - enabled:
         value: 'yes'
-    - provider:
-      attributes:
-        - name: 'canonical'
-      elements:
-      - enabled:
+    - interval:
+        value: '5m'
+    - ignore_time:
+        value: '6h'
+    - run_on_start:
         value: 'yes'
+    - provider:
+        elements:
+        - enabled:
+            value: 'yes'
+        - os:
+            value: 'bionic'
+        - os:
+            value: 'xenial'
+        - update_interval:
+            value: '1h'
+        attributes:
+        - name: 'canonical'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -1,0 +1,17 @@
+---
+# conf 1
+- tags:
+  - canonical_provider
+  apply_to_modules:
+  - test_enabled
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - provider:
+      attributes:
+        - name: 'canonical'
+      elements:
+      - enabled:
+        value: 'yes'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -23,6 +23,8 @@
             value: 'bionic'
         - os:
             value: 'xenial'
+        - os:
+            value: 'trusty'
         - update_interval:
             value: '1h'
         attributes:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -1,5 +1,5 @@
 ---
-# conf 1
+# conf 1 - Canonical
 - tags:
   - test_canonical_provider
   apply_to_modules:
@@ -9,27 +9,33 @@
     elements:
     - enabled:
         value: 'yes'
-    - interval:
-        value: '5m'
-    - ignore_time:
-        value: '6h'
-    - run_on_start:
-        value: 'yes'
     - provider:
         elements:
         - enabled:
             value: 'yes'
         - os:
             value: 'bionic'
-        - os:
-            value: 'xenial'
-        - os:
-            value: 'trusty'
-        - update_interval:
-            value: '1h'
         attributes:
         - name: 'canonical'
-#conf 2
+# conf 2 - Debian
+- tags:
+  - test_debian_provider
+  apply_to_modules:
+  - test_enabled
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - provider:
+        elements:
+        - enabled:
+            value: 'yes'
+        - os:
+            value: 'buster'
+        attributes:
+        - name: 'debian'
+#conf 3 - RedHat
 - tags:
   - test_redhat_provider
   apply_to_modules:
@@ -39,11 +45,23 @@
     elements:
     - enabled:
         value: 'yes'
-    - interval:
-        value: '5m'
-    - ignore_time:
-        value: '6h'
-    - run_on_start:
+    - provider:
+        elements:
+        - enabled:
+            value: 'yes'
+        - update_from_year:
+            value: '2010'
+        attributes:
+        - name: 'redhat'
+#conf 4 - NVD
+- tags:
+  - test_nvd_provider
+  apply_to_modules:
+  - test_enabled
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
         value: 'yes'
     - provider:
         elements:
@@ -51,7 +69,5 @@
             value: 'yes'
         - update_from_year:
             value: '2010'
-        - update_interval:
-            value: '1h'
         attributes:
-        - name: 'redhat'
+        - name: 'nvd'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -12,7 +12,7 @@
     - provider:
         elements:
         - enabled:
-            value: 'yes'
+            value: ENABLED
         - os:
             value: 'bionic'
         attributes:
@@ -30,7 +30,7 @@
     - provider:
         elements:
         - enabled:
-            value: 'yes'
+            value: ENABLED
         - os:
             value: 'buster'
         attributes:
@@ -48,7 +48,7 @@
     - provider:
         elements:
         - enabled:
-            value: 'yes'
+            value: ENABLED
         - update_from_year:
             value: '2010'
         attributes:
@@ -66,7 +66,7 @@
     - provider:
         elements:
         - enabled:
-            value: 'yes'
+            value: 'ENABLED'
         - update_from_year:
             value: '2010'
         attributes:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_enabled.yaml
@@ -29,3 +29,29 @@
             value: '1h'
         attributes:
         - name: 'canonical'
+#conf 2
+- tags:
+  - test_redhat_provider
+  apply_to_modules:
+  - test_enabled
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - interval:
+        value: '5m'
+    - ignore_time:
+        value: '6h'
+    - run_on_start:
+        value: 'yes'
+    - provider:
+        elements:
+        - enabled:
+            value: 'yes'
+        - update_from_year:
+            value: '2010'
+        - update_interval:
+            value: '1h'
+        attributes:
+        - name: 'redhat'

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -96,7 +96,7 @@ def test_enabled(
 
     check_apply_test(tags_to_apply, get_configuration["tags"])
     wazuh_log_monitor.start(
-            timeout=15,
+            timeout=30,
             callback=custom_callback,
             error_message=custom_error_message,
         )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -5,7 +5,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_callback
+from wazuh_testing.vulnerability_detector import make_callback, callback_detect_no_feeds_downloaded
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -16,9 +16,16 @@ configurations_path = os.path.join(test_data_path, "wazuh_providers_enabled.yaml
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
+params = [{'ENABLED': 'yes'}, {'ENABLED': 'no'}]
+metadata = [{'enabled': 'yes'}, {'enabled': 'no'}]
 
-# Configuration data
-configurations = load_wazuh_configurations(configurations_path, __name__)
+# configuration data
+configurations = load_wazuh_configurations(
+    configurations_path,
+    __name__,
+    params=params,
+    metadata=metadata
+)
 
 
 # fixtures
@@ -28,14 +35,11 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
-# Callbacks
+# callbacks
 
 callback_bionic_update_starting = make_callback("Starting Ubuntu Bionic database update")
-
 callback_buster_update_starting = make_callback("Starting Debian Buster database update")
-
 callback_redhat_update_starting = make_callback("Starting Red Hat Enterprise Linux database update")
-
 callback_nvd_update_started = make_callback("Starting National Vulnerability Database database update")
 
 # Tests
@@ -85,6 +89,9 @@ def test_enabled(
     custom_error_message : str
         Custom error message that will be shown if the test fails.
     """
+    if get_configuration['metadata']['enabled'] == 'no':
+        custom_callback = callback_detect_no_feeds_downloaded
+        custom_error_message = "A feed download was detected with enabled set to no"
 
     check_apply_test(tags_to_apply, get_configuration["tags"])
     wazuh_log_monitor.start(

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -44,22 +44,22 @@ callback_xenial_update_finished = make_callback("The update of the Ubuntu Xenial
     "tags_to_apply, custom_callback, custom_error_message ",
     [
         (
-            {"canonical_provider"},
+            {"test_canonical_provider"},
             callback_bionic_update_starting,
             "Could not find Bionic update starting log",
         ),
         (
-            {"canonical_provider"},
+            {"test_canonical_provider"},
             callback_bionic_update_finished,
             "Could not find Bionic update finished log",
         ),
         (
-            {"canonical_provider"},
+            {"test_canonical_provider"},
             callback_xenial_update_starting,
             "Could not find Xenial update starting log",
         ),
         (
-            {"canonical_provider"},
+            {"test_canonical_provider"},
             callback_xenial_update_finished,
             "Could not find Xenial update finished log",
         ),
@@ -88,7 +88,7 @@ def test_run_on_start(
 
     check_apply_test(tags_to_apply, get_configuration["tags"])
     wazuh_log_monitor.start(
-            timeout=global_parameters.default_timeout,
+            timeout=15,
             callback=custom_callback,
             error_message=custom_error_message,
         )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -35,6 +35,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # callbacks
 
 callback_bionic_update_starting = make_callback("Starting Ubuntu Bionic database update")
@@ -43,6 +44,7 @@ callback_redhat_update_starting = make_callback("Starting Red Hat Enterprise Lin
 callback_nvd_update_started = make_callback("Starting National Vulnerability Database database update")
 
 # Tests
+
 
 @pytest.mark.parametrize(
     "tags_to_apply, custom_callback, custom_error_message ",
@@ -81,7 +83,6 @@ def test_enabled(
     """
     Check if modulesd downloads the feeds from different providers when enabled is set to yes.
 
-    
     Parameters
     ----------
     custom_callback : function

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -5,7 +5,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_vuln_callback, callback_detect_no_feeds_downloaded
+from wazuh_testing.vulnerability_detector import make_vuln_callback
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -33,10 +33,10 @@ metadata = [
     {'enabled': 'yes', 'provider_name': 'Debian Buster'},
     {'enabled': 'yes', 'provider_name': 'Red Hat Enterprise Linux'},
     {'enabled': 'yes', 'provider_name': 'National Vulnerability Database'},
-    {'enabled': 'no'},
-    {'enabled': 'no'},
-    {'enabled': 'no'},
-    {'enabled': 'no'}
+    {'enabled': 'no', 'provider_name': 'Ubuntu Bionic'},
+    {'enabled': 'no', 'provider_name': 'Debian Buster'},
+    {'enabled': 'no', 'provider_name': 'Red Hat Enterprise Linux'},
+    {'enabled': 'no', 'provider_name': 'National Vulnerability Database'},
     ]
 
 # configuration data
@@ -60,13 +60,13 @@ def test_enabled(get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd downloads the feeds from different providers when enabled is set to yes.
     """
+    provider_name = get_configuration['metadata']['provider_name']
     if get_configuration['metadata']['enabled'] == 'no':
         with pytest.raises(TimeoutError):
             wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
             callback=make_vuln_callback("Starting.+database update"))
-            raise AttributeError(f'Unexpected event database updating')
+            raise AttributeError(f'Unexpected event {} database updating'.format(provider_name))
     else:
-        provider_name = get_configuration['metadata']['provider_name']
         wazuh_log_monitor.start(
                 timeout=global_parameters.default_timeout,
                 callback=make_vuln_callback("Starting {} database update".format(provider_name)),

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -39,9 +39,11 @@ callback_xenial_update_finished = make_callback("The update of the Ubuntu Xenial
 callback_trusty_update_starting = make_callback("Starting Ubuntu Trusty database update")
 callback_trusty_update_finished = make_callback("The update of the Ubuntu Trusty feed finished successfully")
 
+callback_redhat_update_starting = make_callback("Starting Red Hat Enterprise Linux database update")
+callback_redhat_update_finished = make_callback("The update of the Red Hat Enterprise Linux feed finished successfully")
+
 
 # Tests
-
 
 @pytest.mark.parametrize(
     "tags_to_apply, custom_callback, custom_error_message ",
@@ -75,6 +77,16 @@ callback_trusty_update_finished = make_callback("The update of the Ubuntu Trusty
             {"test_canonical_provider"},
             callback_trusty_update_finished,
             "Could not find Trusty update finished log",
+        ),
+        (
+            {"test_redhat_provider"},
+            callback_redhat_update_starting,
+            "Could not find RedHat update starting log",
+        ),
+        (
+            {"test_redhat_provider"},
+            callback_redhat_update_finished,
+            "Could not find RedHat update finished log",
         ),
     ],
 )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -65,10 +65,10 @@ def test_enabled(get_configuration, configure_environment, restart_modulesd):
         with pytest.raises(TimeoutError):
             wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
             callback=make_vuln_callback("Starting.+database update"))
-            raise AttributeError(f'Unexpected event {} database updating'.format(provider_name))
+            raise AttributeError(f"Unexpected event {provider_name} database updating")
     else:
         wazuh_log_monitor.start(
                 timeout=global_parameters.default_timeout,
-                callback=make_vuln_callback("Starting {} database update".format(provider_name)),
-                error_message="Could not find {} update starting log".format(provider_name),
+                callback=make_vuln_callback(f"Starting {provider_name} database update"),
+                error_message=f"Could not find {provider_name} update starting log",
             )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -36,6 +36,9 @@ callback_bionic_update_finished = make_callback("The update of the Ubuntu Bionic
 callback_xenial_update_starting = make_callback("Starting Ubuntu Xenial database update")
 callback_xenial_update_finished = make_callback("The update of the Ubuntu Xenial feed finished successfully")
 
+callback_trusty_update_starting = make_callback("Starting Ubuntu Trusty database update")
+callback_trusty_update_finished = make_callback("The update of the Ubuntu Trusty feed finished successfully")
+
 
 # Tests
 
@@ -62,6 +65,16 @@ callback_xenial_update_finished = make_callback("The update of the Ubuntu Xenial
             {"test_canonical_provider"},
             callback_xenial_update_finished,
             "Could not find Xenial update finished log",
+        ),
+        (
+            {"test_canonical_provider"},
+            callback_trusty_update_starting,
+            "Could not find Trusty update starting log",
+        ),
+        (
+            {"test_canonical_provider"},
+            callback_trusty_update_finished,
+            "Could not find Trusty update finished log",
         ),
     ],
 )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -5,10 +5,10 @@ from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_callback, callback_detect_no_feeds_downloaded
+from wazuh_testing.vulnerability_detector import make_vuln_callback, callback_detect_no_feeds_downloaded
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=0)
 
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
@@ -38,10 +38,11 @@ def get_configuration(request):
 
 # callbacks
 
-callback_bionic_update_starting = make_callback("Starting Ubuntu Bionic database update")
-callback_buster_update_starting = make_callback("Starting Debian Buster database update")
-callback_redhat_update_starting = make_callback("Starting Red Hat Enterprise Linux database update")
-callback_nvd_update_started = make_callback("Starting National Vulnerability Database database update")
+callback_bionic_update_starting = make_vuln_callback("Starting Ubuntu Bionic database update")
+callback_buster_update_starting = make_vuln_callback("Starting Debian Buster database update")
+callback_redhat_update_starting = make_vuln_callback("Starting Red Hat Enterprise Linux database update")
+callback_nvd_update_started = make_vuln_callback("Starting National Vulnerability Database database update")
+callback_provider_update = make_vuln_callback("Starting.+database update")
 
 # Tests
 
@@ -71,15 +72,8 @@ callback_nvd_update_started = make_callback("Starting National Vulnerability Dat
         ),
     ],
 )
-def test_enabled(
-    tags_to_apply,
-    custom_callback,
-    custom_error_message,
-    get_configuration,
-    configure_environment,
-    restart_modulesd,
-):
-
+def test_enabled(tags_to_apply, custom_callback, custom_error_message,
+    get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd downloads the feeds from different providers when enabled is set to yes.
 
@@ -90,13 +84,16 @@ def test_enabled(
     custom_error_message : str
         Custom error message that will be shown if the test fails.
     """
-    if get_configuration['metadata']['enabled'] == 'no':
-        custom_callback = callback_detect_no_feeds_downloaded
-        custom_error_message = "A feed download was detected with enabled set to no"
-
     check_apply_test(tags_to_apply, get_configuration["tags"])
-    wazuh_log_monitor.start(
-            timeout=30,
-            callback=custom_callback,
-            error_message=custom_error_message,
-        )
+
+    if get_configuration['metadata']['enabled'] == 'no':
+        with pytest.raises(TimeoutError):
+            wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+            callback=callback_provider_update)
+            raise AttributeError(f'Unexpected event database updating')
+    else:
+        wazuh_log_monitor.start(
+                timeout=global_parameters.default_timeout,
+                callback=custom_callback,
+                error_message=custom_error_message,
+            )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -31,17 +31,12 @@ def get_configuration(request):
 # Callbacks
 
 callback_bionic_update_starting = make_callback("Starting Ubuntu Bionic database update")
-callback_bionic_update_finished = make_callback("The update of the Ubuntu Bionic feed finished successfully")
 
-callback_xenial_update_starting = make_callback("Starting Ubuntu Xenial database update")
-callback_xenial_update_finished = make_callback("The update of the Ubuntu Xenial feed finished successfully")
-
-callback_trusty_update_starting = make_callback("Starting Ubuntu Trusty database update")
-callback_trusty_update_finished = make_callback("The update of the Ubuntu Trusty feed finished successfully")
+callback_buster_update_starting = make_callback("Starting Debian Buster database update")
 
 callback_redhat_update_starting = make_callback("Starting Red Hat Enterprise Linux database update")
-callback_redhat_update_finished = make_callback("The update of the Red Hat Enterprise Linux feed finished successfully")
 
+callback_nvd_update_started = make_callback("Starting National Vulnerability Database database update")
 
 # Tests
 
@@ -51,32 +46,12 @@ callback_redhat_update_finished = make_callback("The update of the Red Hat Enter
         (
             {"test_canonical_provider"},
             callback_bionic_update_starting,
-            "Could not find Bionic update starting log",
+            "Could not find Canonical update starting log",
         ),
         (
-            {"test_canonical_provider"},
-            callback_bionic_update_finished,
-            "Could not find Bionic update finished log",
-        ),
-        (
-            {"test_canonical_provider"},
-            callback_xenial_update_starting,
-            "Could not find Xenial update starting log",
-        ),
-        (
-            {"test_canonical_provider"},
-            callback_xenial_update_finished,
-            "Could not find Xenial update finished log",
-        ),
-        (
-            {"test_canonical_provider"},
-            callback_trusty_update_starting,
-            "Could not find Trusty update starting log",
-        ),
-        (
-            {"test_canonical_provider"},
-            callback_trusty_update_finished,
-            "Could not find Trusty update finished log",
+            {"test_debian_provider"},
+            callback_buster_update_starting,
+            "Could not find Debian update starting log",
         ),
         (
             {"test_redhat_provider"},
@@ -84,13 +59,13 @@ callback_redhat_update_finished = make_callback("The update of the Red Hat Enter
             "Could not find RedHat update starting log",
         ),
         (
-            {"test_redhat_provider"},
-            callback_redhat_update_finished,
-            "Could not find RedHat update finished log",
+            {"test_nvd_provider"},
+            callback_nvd_update_started,
+            "Could not find NVD update starting log",
         ),
     ],
 )
-def test_run_on_start(
+def test_enabled(
     tags_to_apply,
     custom_callback,
     custom_error_message,

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -1,0 +1,94 @@
+import os
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.vulnerability_detector import make_callback
+
+# Marks
+pytestmark = pytest.mark.tier(level=1)
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+configurations_path = os.path.join(test_data_path, "wazuh_providers_enabled.yaml")
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+
+# fixtures
+
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Callbacks
+
+callback_bionic_update_starting = make_callback("Starting Ubuntu Bionic database update")
+callback_bionic_update_finished = make_callback("The update of the Ubuntu Bionic feed finished successfully")
+
+callback_xenial_update_starting = make_callback("Starting Ubuntu Xenial database update")
+callback_xenial_update_finished = make_callback("The update of the Ubuntu Xenial feed finished successfully")
+
+
+# Tests
+
+
+@pytest.mark.parametrize(
+    "tags_to_apply, custom_callback, custom_error_message ",
+    [
+        (
+            {"canonical_provider"},
+            callback_bionic_update_starting,
+            "Could not find Bionic update starting log",
+        ),
+        (
+            {"canonical_provider"},
+            callback_bionic_update_finished,
+            "Could not find Bionic update finished log",
+        ),
+        (
+            {"canonical_provider"},
+            callback_xenial_update_starting,
+            "Could not find Xenial update starting log",
+        ),
+        (
+            {"canonical_provider"},
+            callback_xenial_update_finished,
+            "Could not find Xenial update finished log",
+        ),
+    ],
+)
+def test_run_on_start(
+    tags_to_apply,
+    custom_callback,
+    custom_error_message,
+    get_configuration,
+    configure_environment,
+    restart_modulesd,
+):
+
+    """
+    Check if modulesd downloads the feeds from different providers when enabled is set to yes.
+
+    
+    Parameters
+    ----------
+    custom_callback : function
+        Callback that will be applied to the value of tags to apply.
+    custom_error_message : str
+        Custom error message that will be shown if the test fails.
+    """
+
+    check_apply_test(tags_to_apply, get_configuration["tags"])
+    wazuh_log_monitor.start(
+            timeout=global_parameters.default_timeout,
+            callback=custom_callback,
+            error_message=custom_error_message,
+        )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -16,8 +16,28 @@ configurations_path = os.path.join(test_data_path, "wazuh_providers_enabled.yaml
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-params = [{'ENABLED': 'yes'}, {'ENABLED': 'no'}]
-metadata = [{'enabled': 'yes'}, {'enabled': 'no'}]
+params = [
+    {'ENABLED': 'yes', 'PROVIDER': 'canonical', 'OS': 'bionic'},
+    {'ENABLED': 'yes', 'PROVIDER': 'debian', 'OS': 'buster'},
+    {'ENABLED': 'yes', 'PROVIDER': 'redhat', 'OS': ''},
+    {'ENABLED': 'yes', 'PROVIDER': 'nvd', 'OS': ''},
+
+    {'ENABLED': 'no', 'PROVIDER': 'canonical', 'OS': 'bionic'},
+    {'ENABLED': 'no', 'PROVIDER': 'debian', 'OS': 'buster'},
+    {'ENABLED': 'no', 'PROVIDER': 'redhat', 'OS': ''},
+    {'ENABLED': 'no', 'PROVIDER': 'nvd', 'OS': ''},
+]
+
+metadata = [
+    {'enabled': 'yes', 'provider_name': 'Ubuntu Bionic'},
+    {'enabled': 'yes', 'provider_name': 'Debian Buster'},
+    {'enabled': 'yes', 'provider_name': 'Red Hat Enterprise Linux'},
+    {'enabled': 'yes', 'provider_name': 'National Vulnerability Database'},
+    {'enabled': 'no'},
+    {'enabled': 'no'},
+    {'enabled': 'no'},
+    {'enabled': 'no'}
+    ]
 
 # configuration data
 configurations = load_wazuh_configurations(
@@ -36,64 +56,19 @@ def get_configuration(request):
     return request.param
 
 
-# callbacks
-
-callback_bionic_update_starting = make_vuln_callback("Starting Ubuntu Bionic database update")
-callback_buster_update_starting = make_vuln_callback("Starting Debian Buster database update")
-callback_redhat_update_starting = make_vuln_callback("Starting Red Hat Enterprise Linux database update")
-callback_nvd_update_started = make_vuln_callback("Starting National Vulnerability Database database update")
-callback_provider_update = make_vuln_callback("Starting.+database update")
-
-# Tests
-
-
-@pytest.mark.parametrize(
-    "tags_to_apply, custom_callback, custom_error_message ",
-    [
-        (
-            {"test_canonical_provider"},
-            callback_bionic_update_starting,
-            "Could not find Canonical update starting log",
-        ),
-        (
-            {"test_debian_provider"},
-            callback_buster_update_starting,
-            "Could not find Debian update starting log",
-        ),
-        (
-            {"test_redhat_provider"},
-            callback_redhat_update_starting,
-            "Could not find RedHat update starting log",
-        ),
-        (
-            {"test_nvd_provider"},
-            callback_nvd_update_started,
-            "Could not find NVD update starting log",
-        ),
-    ],
-)
-def test_enabled(tags_to_apply, custom_callback, custom_error_message,
-    get_configuration, configure_environment, restart_modulesd):
+def test_enabled(get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd downloads the feeds from different providers when enabled is set to yes.
-
-    Parameters
-    ----------
-    custom_callback : function
-        Callback that will be applied to the value of tags to apply.
-    custom_error_message : str
-        Custom error message that will be shown if the test fails.
     """
-    check_apply_test(tags_to_apply, get_configuration["tags"])
-
     if get_configuration['metadata']['enabled'] == 'no':
         with pytest.raises(TimeoutError):
             wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-            callback=callback_provider_update)
+            callback=make_vuln_callback("Starting.+database update"))
             raise AttributeError(f'Unexpected event database updating')
     else:
+        provider_name = get_configuration['metadata']['provider_name']
         wazuh_log_monitor.start(
                 timeout=global_parameters.default_timeout,
-                callback=custom_callback,
-                error_message=custom_error_message,
+                callback=make_vuln_callback("Starting {} database update".format(provider_name)),
+                error_message="Could not find {} update starting log".format(provider_name),
             )


### PR DESCRIPTION
This PR adds the tests for the parameter `enabled` to download feeds from providers in the vulnerability-detector module.

The testing is done by checking debug events on `ossec.log`.

Closes #669


### Tests logic

- When `enabled` is set to **yes** the "database update" events are checked.

```
2020/05/06 16:56:59 wazuh-modulesd:vulnerability-detector: INFO: (5461): Starting Red Hat Enterprise Linux database update.
```

- With enabled set to **no** then it is checked for the "Starting vulnerability scanning" without any update events being triggered before.

```
2020/05/06 16:57:26 wazuh-modulesd:vulnerability-detector: INFO: (5452): Starting vulnerability scanning.
```


### Test checks

Expected behavior, all 4 providers are tested with enabled set to yes and then to no. There must be 8 passed tests.

```
[root@centos-manager integration]# python3 -m pytest -vvx test_vulnerability_detector/test_providers/test_enabled.py 
=============================================================== test session starts ===============================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-1127.el7.x86_64-x86_64-with-centos-7.8.2003-Core', 'Packages': {'pytest': '5.4.1', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'testinfra': '5.0.0', 'metadata': '1.8.0', 'html': '2.0.1'}}
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: testinfra-5.0.0, metadata-1.8.0, html-2.0.1
collected 8 items                                                                                                                                 

test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration0] PASSED                                         [ 12%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration1] PASSED                                         [ 25%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration2] PASSED                                         [ 37%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration3] PASSED                                         [ 50%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration4] PASSED                                         [ 62%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration5] PASSED                                         [ 75%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration6] PASSED                                         [ 87%]
test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[get_configuration7] PASSED                                         [100%]

========================================================== 8 passed in 67.38s (0:01:07) ===========================================================
```

