### PR TITLE
Add test to check if whodata thread has started with ambiguous configuration

### DIFF
--- a/tests/integration/test_fim/test_ambiguous_confs/data/wazuh_conf_whodata_thread.yaml
+++ b/tests/integration/test_fim/test_ambiguous_confs/data/wazuh_conf_whodata_thread.yaml
@@ -1,0 +1,38 @@
+---
+# conf 1
+- tags:
+  - whodata_disabled_conf
+  apply_to_modules:
+  - test_ambiguous_whodata_thread
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - whodata: 'yes'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - whodata: 'no'
+
+# conf 2
+- tags:
+  - whodata_enabled_conf
+  apply_to_modules:
+  - test_ambiguous_whodata_thread
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - whodata: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - whodata: 'yes'

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_whodata_thread.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_whodata_thread.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, callback_real_time_whodata_started
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=2)]
+
+# Variables
+test_directories = [os.path.join(PREFIX, 'testdir1')]
+
+directory_str = ','.join(test_directories)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_whodata_thread.yaml')
+testdir1 = test_directories[0]
+
+# Configurations
+
+
+p, m = generate_params(extra_params={"TEST_DIRECTORIES": testdir1}, modes=['whodata'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Tests
+
+
+@pytest.mark.parametrize('tags_to_apply', [
+    {'whodata_disabled_conf'},
+    {'whodata_enabled_conf'}
+])
+def test_ambiguous_whodata_thread(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
+    """
+    Check if the whodata thread is started when the configuration is ambiguous.
+
+    Configure directory to be monitored both with and without whodata. Depending on the order, the whodata thread should
+    or shouldn't start.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    if tags_to_apply == 'whodata_enabled_conf':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_real_time_whodata_started,
+                                error_message='Did not receive expected '
+                                              '"File integrity monitoring real-time Whodata engine started" event')
+    else:
+        with pytest.raises(TimeoutError):
+            event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                            callback=callback_real_time_whodata_started)
+            raise AttributeError(f'Unexpected event {event}')

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_whodata_thread.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_whodata_thread.py
@@ -15,7 +15,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 # Marks
 
 
-pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=2)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=2)]
 
 # Variables
 test_directories = [os.path.join(PREFIX, 'testdir1')]
@@ -64,5 +64,5 @@ def test_ambiguous_whodata_thread(tags_to_apply, get_configuration, configure_en
     else:
         with pytest.raises(TimeoutError):
             event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=callback_real_time_whodata_started)
+                                            callback=callback_real_time_whodata_started).result()
             raise AttributeError(f'Unexpected event {event}')

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_whodata_thread.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_whodata_thread.py
@@ -44,11 +44,12 @@ def get_configuration(request):
 # Tests
 
 
-@pytest.mark.parametrize('tags_to_apply', [
-    {'whodata_disabled_conf'},
-    {'whodata_enabled_conf'}
+@pytest.mark.parametrize('whodata_enabled, tags_to_apply', [
+    (False, {'whodata_disabled_conf'}),
+    (True, {'whodata_enabled_conf'})
 ])
-def test_ambiguous_whodata_thread(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
+def test_ambiguous_whodata_thread(whodata_enabled, tags_to_apply, get_configuration, configure_environment,
+                                  restart_syscheckd):
     """
     Check if the whodata thread is started when the configuration is ambiguous.
 
@@ -57,12 +58,12 @@ def test_ambiguous_whodata_thread(tags_to_apply, get_configuration, configure_en
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    if tags_to_apply == 'whodata_enabled_conf':
+    if whodata_enabled:
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_real_time_whodata_started,
                                 error_message='Did not receive expected '
                                               '"File integrity monitoring real-time Whodata engine started" event')
     else:
         with pytest.raises(TimeoutError):
-            event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=callback_real_time_whodata_started).result()
-            raise AttributeError(f'Unexpected event {event}')
+            wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                    callback=callback_real_time_whodata_started)
+            raise AttributeError(f'Unexpected event "File integrity monitoring real-time Whodata engine started"')


### PR DESCRIPTION
| Wazuh PR                 |
|---------------------|
| wazuh/wazuh#5010 |

## Description

This pull request adds a test that checks if the _whodata_ thread has started with ambiguous configurations.

If a directory is configured with _whodata_ enabled first and disabled after that, _the whodata_ thread should not start. The thread should start if _whodata_ is disabled first and enabled after that.

This pull request closes #695.