### PR TITLE
Fix an error when counting the timeout in QueueMonitor

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -366,6 +366,7 @@ class QueueMonitor:
             if extra_timer >= timeout_extra > 0:
                 self.stop()
                 break
+            tic = time.time()
             try:
                 if update_position:
                     item = callback(self._queue.get(block=True, timeout=self._time_step))
@@ -377,10 +378,12 @@ class QueueMonitor:
                     if len(result_list) == accum_results and timeout_extra > 0 and not extra_timer_is_running:
                         extra_timer_is_running = True
             except queue.Empty:
-                time.sleep(time_wait)
-                timer += self._time_step + time_wait
+                pass
+            finally:
+                time_count = time.time() - tic
+                timer += time_count
                 if extra_timer_is_running:
-                    extra_timer += self._time_step + time_wait
+                    extra_timer += time_count
 
         if len(result_list) == 1:
             return result_list[0]


### PR DESCRIPTION
Hello team,

This PR fixes a timeout bug in `QueueMonitor` class in the `monitoring` module.

This bug sometimes caused the time that had elapsed not to be correctly counted.

Thanks to @vicferpoy for the solution provided.

Best regards.