### PR TITLE
Move auth_token_exp_timeout out of RBAC configuration

### DIFF
--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data/conf_exp_timeout.yaml
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data/conf_exp_timeout.yaml
@@ -2,10 +2,8 @@
 - tags:
   - short_exp_time
   configuration:
-    rbac:
-      auth_token_exp_timeout: 8
+    auth_token_exp_timeout: 8
 - tags:
   - long_exp_time
   configuration:
-    rbac:
-      auth_token_exp_timeout: 800
+    auth_token_exp_timeout: 800

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
@@ -56,7 +56,7 @@ def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_e
         f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
 
     # Request manager info after token expires.
-    time.sleep(10)
+    time.sleep(min(get_configuration['configuration']['auth_token_exp_timeout'] + 2, 10))
     get_response = requests.get(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
 
     # If token has expired, user can't access that information.


### PR DESCRIPTION
Hello team,

this PR is part of this issue's development: https://github.com/wazuh/wazuh/issues/5044

Since the attribute `auth_token_exp_timeout` has been refactored, we needed to adapt the API configuration tests.

# Test results

```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.9.0, html-2.0.1, testinfra-5.0.0
collected 62 items                                                             

test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py . [  1%]
s.ss.s.                                                                  [ 12%]
test_api/test_config/test_cache/test_cache.py .ss.                       [ 19%]
test_api/test_config/test_cors/test_cors.py x.                           [ 22%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.   [ 29%]
test_api/test_config/test_experimental_features/test_experimental_features.py . [ 30%]
ss.                                                                      [ 35%]
test_api/test_config/test_host_port/test_host_port.py .s.ss.s.           [ 48%]
test_api/test_config/test_https/test_https.py .ss.                       [ 54%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py . [ 56%]
ss.                                                                      [ 61%]
test_api/test_config/test_logs/test_logs.py .ss.                         [ 67%]
test_api/test_config/test_rbac/test_rbac_mode.py .ss.                    [ 74%]
test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.s.s [ 87%]
s.s.s.s.                                                                 [100%]

=============================== warnings summary ===============================
test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py: 20 tests with warnings
test_api/test_config/test_cache/test_cache.py: 7 tests with warnings
test_api/test_config/test_cors/test_cors.py: 6 tests with warnings
test_api/test_config/test_experimental_features/test_experimental_features.py: 4 tests with warnings
test_api/test_config/test_host_port/test_host_port.py: 6 tests with warnings
test_api/test_config/test_https/test_https.py: 3 tests with warnings
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py: 6 tests with warnings
test_api/test_config/test_rbac/test_rbac_mode.py: 4 tests with warnings
test_api/test_config/test_use_only_authd/test_use_only_authd.py: 22 tests with warnings
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====== 31 passed, 30 skipped, 1 xfailed, 78 warnings in 260.38s (0:04:20) ======
```

Best regards.
