### PR TITLE
Add Valgrind test for FIM

### DIFF
--- a/tests/integration/test_fim/test_valgrind/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_valgrind/data/wazuh_conf.yaml
@@ -1,0 +1,94 @@
+---
+# conf 1
+- tags:
+  - test_valgrind_big_case
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - tags: 'example'
+        - restrict: '.restricted$'
+        - recursion_level: '4'
+        - report_changes: 'yes'
+        - FIM_MODE
+
+# conf 2
+- tags:
+  - test_valgrind_ignore
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE
+    - ignore:
+        value: ".ignored$"
+        attributes:
+        - type: sregex
+
+# conf 3
+- tags:
+  - test_valgrind_rename
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE
+
+# conf 4
+- tags:
+  - test_valgrind_follow_symbolic
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - follow_symbolic_link: 'yes'
+        - FIM_MODE
+
+# conf 5
+- tags:
+  - test_valgrind_rename
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - nodiff:
+        value: ".nodiff$"
+        attributes:
+        - type: sregex
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - report_changes: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_valgrind/test_valgrind.py
+++ b/tests/integration/test_fim/test_valgrind/test_valgrind.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud, WAZUH_PATH, generate_params
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=2)]
+
+# Variables
+
+test_directories = [os.path.join(PREFIX, 'testdir1')]
+
+directory_str = ','.join(test_directories)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+testdir1 = test_directories[0]
+
+# Configurations
+
+
+p, m = generate_params(extra_params={"TEST_DIRECTORIES": testdir1})
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)


### PR DESCRIPTION
## Description

This pull request adds a test to check `ossec-syscheckd` for memory leaks and segmentation faults.

This test is part of tier 2. This pull request closes #713.

### Platforms
* macOS
* Linux
* Solaris