### PR TITLE
Add ignore_time parameter integration test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -12,6 +12,7 @@ from wazuh_testing.tools import WAZUH_PATH
 PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
 DEFAULT_PACKAGE_NAME = "WazuhIntegrationPackage"
+DEFAULT_VULNERABILITY_ID = "WVE-000"
 
 UpdateFromYearResult = namedtuple('UpdateFromYearResult', 'result actual_provider actual_update_from')
 
@@ -131,11 +132,20 @@ def make_query(db_path, query_list):
         db[0].close()
 
 
-def insert_package_in_db(agent = "000", format = "rpm", name = DEFAULT_PACKAGE_NAME, 
+def clean_table(db_path, table):
+    """
+    Deletes all entries in a table of a database.
+    """
+    query_string = f"DELETE FROM {table}"
+    make_query(db_path, [query_string])
+
+
+def insert_package_in_db(agent = "000", scan_id = 99999999, format = "rpm", name = DEFAULT_PACKAGE_NAME, 
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
     architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package", 
-    source = "Wazuh Integration tests mock package", location = "", triaged = 0, cpe = "",
-    install_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
+    source = "Wazuh Integration tests mock package", location = "", triaged = 0,
+    install_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
+    scan_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
 ):
     """
     Insert a new package in the installed package database, with the parameters given as arguments.
@@ -144,15 +154,16 @@ def insert_package_in_db(agent = "000", format = "rpm", name = DEFAULT_PACKAGE_N
     path =  os.path.join(PACKAGES_DB_PATH,f"{agent}.db")
     query_string = f"""INSERT INTO sys_programs
         (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, \
-            architecture, multiarch, source, description, location, triaged, cpe)
-        SELECT scan_id, scan_time, \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\", \"{install_time}\", \"{version}\",
-        \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\", \"{location}\", \"{triaged}\", \"{cpe}\"
-        FROM sys_programs LIMIT 1
+            architecture, multiarch, source, description, location, triaged)
+        VALUES
+        ({scan_id}, \"{scan_time}\", \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\", 
+        \"{install_time}\", \"{version}\", \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\",
+        \"{location}\", \"{triaged}\")
         """
     make_query(path, [query_string])        
 
 
-def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", pending = 0, 
+def insert_vulnerability(cveid = DEFAULT_VULNERABILITY_ID, target = "RHEL7", target_minor= "", pending = 0, 
     package = DEFAULT_PACKAGE_NAME, operation = "less than", operation_value = "2.0.0-1.el7",
     title = "", severity = "critical", published =  datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
     updated = "", reference = "https://github.com/wazuh/wazuh-qa", target_v = "REDHAT", cvss = "10.000000", 
@@ -179,9 +190,27 @@ def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", 
 
 def update_package(version, package, agent = "000"):
     """
-    Update version of installed package in databas.
+    Update version of installed package in database.
     Used to simulate upgrades and downgrades of the package given as argument.
     """
     path =  os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
-    update_query_string = f"UPDATE sys_programs SET version={version} WHERE name={package};"
+    update_query_string = f"UPDATE sys_programs SET version=\"{version}\" WHERE name=\"{package}\";"
     make_query(path, [update_query_string])
+
+def delete_package(package, agent = "000"):
+    """
+    Remove package from database.
+    Used to simulate uninstall of the package given as argument or remove a package after a test.
+    """
+    path =  os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    delete_query_string = f"DELETE FROM sys_programs WHERE name=\"{package}\";"
+    make_query(path, [delete_query_string])
+
+def delete_vulnerability(cveid):
+    """
+    Update version of installed package in database.
+    Used to simulate uninstall of the package given as argument or remove a package after a test.
+    """
+    delete_vulnerabilities_query_string = f"DELETE FROM VULNERABILITIES WHERE cveid=\"{cveid}\";"
+    delete_vulnerabilities_info_query_string = f"DELETE FROM VULNERABILITIES_INFO WHERE id=\"{cveid}\";"
+    make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -150,6 +150,7 @@ def update_last_scan(last_scan = 0, agent = "000"):
     query_string = f"UPDATE vuln_metadata SET LAST_SCAN={last_scan}"
     make_query(path, [query_string])
 
+
 def insert_package(agent = "000", scan_id = int(time()), format = "rpm", name = DEFAULT_PACKAGE_NAME, 
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
     architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package", 
@@ -162,14 +163,14 @@ def insert_package(agent = "000", scan_id = int(time()), format = "rpm", name = 
     If used in conjunction with insert_vulnerability using the default arguments it will generate an alert.
     """
     path =  os.path.join(PACKAGES_DB_PATH,f"{agent}.db")
-    query_string = f"""INSERT INTO sys_programs
+    query_string = f'''INSERT INTO sys_programs
         (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, \
             architecture, multiarch, source, description, location, triaged)
         VALUES
-        ({scan_id}, \"{scan_time}\", \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\",
-        \"{install_time}\", \"{version}\", \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\",
-        \"{location}\", \"{triaged}\")
-        """
+        ({scan_id}, "{scan_time}", "{format}", "{name}", "{priority}", "{section}", "{size}", "{vendor}",
+        "{install_time}", "{version}", "{architecture}", "{multiarch}", "{source}", "{description}",
+        "{location}", "{triaged}")
+        '''
     make_query(path, [query_string])
 
 
@@ -185,18 +186,18 @@ def insert_vulnerability(cveid = DEFAULT_VULNERABILITY_ID, target = "RHEL7", tar
     Insert a new vulnerability in the database of vulnerabilities, with the parameters given as arguments.
     If used in conjunction with insert_package_in_db using the default arguments it will generate an alert.
     """
-    vulnerabilities_query_string = f"""INSERT INTO VULNERABILITIES
+    vulnerabilities_query_string = f'''INSERT INTO VULNERABILITIES
         (cveid, target, target_minor, pending, package, operation, operation_value)
         VALUES 
-        (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\",
-        \"{operation_value}\")"""
-    query_vulnerabilities_info_query_string = f"""INSERT INTO VULNERABILITIES_INFO 
+        ("{cveid}", "{target}", "{target_minor}", "{pending}", "{package}", "{operation}",
+        "{operation_value}")'''
+    query_vulnerabilities_info_query_string = f'''INSERT INTO VULNERABILITIES_INFO 
         (ID, title, severity, published, updated, reference, target, rationale, cvss, cvss_vector, CVSS3, 
         bugzilla_reference, cwe, advisories)
         VALUES 
-        (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\",
-        \"{rationale}\", \"{cvss}\", \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\",
-        \"{advisories}\")"""
+        ("{cveid}", "{title}", "{severity}", "{published}", "{updated}", "{reference}", "{target_v}",
+        "{rationale}", "{cvss}", "{cvss_vector}", "{CVSS3}", "{bugzilla_reference}", "{cwe}",
+        "{advisories}")'''
     make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string])
 
 
@@ -206,8 +207,9 @@ def update_package(version, package, agent = "000"):
     Used to simulate upgrades and downgrades of the package given as argument.
     """
     path =  os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
-    update_query_string = f"UPDATE sys_programs SET version=\"{version}\" WHERE name=\"{package}\";"
+    update_query_string = f'UPDATE sys_programs SET version="{version}" WHERE name="{package}"'
     make_query(path, [update_query_string])
+
 
 def delete_package(package, agent = "000"):
     """
@@ -215,16 +217,17 @@ def delete_package(package, agent = "000"):
     Used to simulate uninstall of the package given as argument or remove a package after a test.
     """
     path =  os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
-    delete_query_string = f"DELETE FROM sys_programs WHERE name=\"{package}\";"
+    delete_query_string = f'DELETE FROM sys_programs WHERE name="{package}"'
     make_query(path, [delete_query_string])
+
 
 def delete_vulnerability(cveid):
     """
     Update version of installed package in database.
     Used to simulate uninstall of the package given as argument or remove a package after a test.
     """
-    delete_vulnerabilities_query_string = f"DELETE FROM VULNERABILITIES WHERE cveid=\"{cveid}\";"
-    delete_vulnerabilities_info_query_string = f"DELETE FROM VULNERABILITIES_INFO WHERE id=\"{cveid}\";"
+    delete_vulnerabilities_query_string = f'DELETE FROM VULNERABILITIES WHERE cveid="{cveid}"'
+    delete_vulnerabilities_info_query_string = f'DELETE FROM VULNERABILITIES_INFO WHERE id="{cveid}"'
     make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])
 
 
@@ -233,5 +236,5 @@ def modify_system(os_name = "CentOS Linux", os_major = "7", name = "centos7"):
     Modify the system of the manager.
     Used to select the feed that will be used to search vulnerabilities.
     """
-    query_string = f"update AGENT set OS_NAME=\"{os_name}\", OS_MAJOR=\"{os_major}\", NAME=\"{name}\""
+    query_string = f'update AGENT set OS_NAME="{os_name}", OS_MAJOR="{os_major}", NAME="{name}"'
     make_query(GLOBAL_DB_PATH, [query_string])

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -102,7 +102,7 @@ def make_vuln_callback(pattern):
     pattern : str
         String to match on the log
 
-    >>> callback_bionic_update_started = make_callback("Starting Ubuntu Bionic database update")
+    >>> callback_bionic_update_started = make_vuln_callback("Starting Ubuntu Bionic database update")
     """
     pattern = r'\s+'.join(pattern.split())
     regex = re.compile(r'{}{}'.format(vulnerability_detector_prefix, pattern))
@@ -166,13 +166,13 @@ def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", 
     vulnerabilities_query_string = f"""INSERT INTO VULNERABILITIES
         (cveid, target, target_minor, pending, package, operation, operation_value)
         VALUES 
-        \"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\", \"{operation_value}\""""
+        (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\", \"{operation_value}\")"""
     query_vulnerabilities_info_query_string = f"""INSERT INTO VULNERABILITIES_INFO 
         (ID, title, severity, published, updated, reference, target, rationale, cvss, cvss_vector, CVSS3, 
         bugzilla_reference, cwe, advisories)
         VALUES 
-        \"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\", \"{rationale}\", \"{cvss}\",
-        \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\", \"{advisories}\""""
+        (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\", \"{rationale}\", \"{cvss}\",
+        \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\", \"{advisories}\")"""
     make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string])
 
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -12,6 +12,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
+GLOBAL_DB_PATH = f"{WAZUH_PATH}/var/db/global.db"
 DEFAULT_PACKAGE_NAME = "WazuhIntegrationPackage"
 DEFAULT_VULNERABILITY_ID = "WVE-000"
 
@@ -149,7 +150,7 @@ def update_last_scan(last_scan = 0, agent = "000"):
     query_string = f"UPDATE vuln_metadata SET LAST_SCAN={last_scan}"
     make_query(path, [query_string])
 
-def insert_package_in_db(agent = "000", scan_id = int(time()), format = "rpm", name = DEFAULT_PACKAGE_NAME, 
+def insert_package(agent = "000", scan_id = int(time()), format = "rpm", name = DEFAULT_PACKAGE_NAME, 
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
     architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package", 
     source = "Wazuh Integration tests mock package", location = "", triaged = 0,
@@ -165,7 +166,7 @@ def insert_package_in_db(agent = "000", scan_id = int(time()), format = "rpm", n
         (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, \
             architecture, multiarch, source, description, location, triaged)
         VALUES
-        ({scan_id}, \"{scan_time}\", \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\", 
+        ({scan_id}, \"{scan_time}\", \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\",
         \"{install_time}\", \"{version}\", \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\",
         \"{location}\", \"{triaged}\")
         """
@@ -187,13 +188,15 @@ def insert_vulnerability(cveid = DEFAULT_VULNERABILITY_ID, target = "RHEL7", tar
     vulnerabilities_query_string = f"""INSERT INTO VULNERABILITIES
         (cveid, target, target_minor, pending, package, operation, operation_value)
         VALUES 
-        (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\", \"{operation_value}\")"""
+        (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\",
+        \"{operation_value}\")"""
     query_vulnerabilities_info_query_string = f"""INSERT INTO VULNERABILITIES_INFO 
         (ID, title, severity, published, updated, reference, target, rationale, cvss, cvss_vector, CVSS3, 
         bugzilla_reference, cwe, advisories)
         VALUES 
-        (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\", \"{rationale}\", \"{cvss}\",
-        \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\", \"{advisories}\")"""
+        (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\",
+        \"{rationale}\", \"{cvss}\", \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\",
+        \"{advisories}\")"""
     make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string])
 
 
@@ -223,3 +226,12 @@ def delete_vulnerability(cveid):
     delete_vulnerabilities_query_string = f"DELETE FROM VULNERABILITIES WHERE cveid=\"{cveid}\";"
     delete_vulnerabilities_info_query_string = f"DELETE FROM VULNERABILITIES_INFO WHERE id=\"{cveid}\";"
     make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])
+
+
+def modify_system(os_name = "CentOS Linux", os_major = "7", name = "centos7"):
+    """
+    Modify the system of the manager.
+    Used to select the feed that will be used to search vulnerabilities.
+    """
+    query_string = f"update AGENT set OS_NAME=\"{os_name}\", OS_MAJOR=\"{os_major}\", NAME=\"{name}\""
+    make_query(GLOBAL_DB_PATH, [query_string])

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -6,6 +6,7 @@ import re
 import os
 import sqlite3
 import datetime
+from time import time
 from collections import namedtuple
 from wazuh_testing.tools import WAZUH_PATH
 
@@ -140,7 +141,15 @@ def clean_table(db_path, table):
     make_query(db_path, [query_string])
 
 
-def insert_package_in_db(agent = "000", scan_id = 99999999, format = "rpm", name = DEFAULT_PACKAGE_NAME, 
+def update_last_scan(last_scan = 0, agent = "000"):
+    """
+    Changes the value of the last scan of an agent.
+    """
+    path =  os.path.join(PACKAGES_DB_PATH,f"{agent}.db")
+    query_string = f"UPDATE vuln_metadata SET LAST_SCAN={last_scan}"
+    make_query(path, [query_string])
+
+def insert_package_in_db(agent = "000", scan_id = int(time()), format = "rpm", name = DEFAULT_PACKAGE_NAME, 
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
     architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package", 
     source = "Wazuh Integration tests mock package", location = "", triaged = 0,
@@ -160,7 +169,7 @@ def insert_package_in_db(agent = "000", scan_id = 99999999, format = "rpm", name
         \"{install_time}\", \"{version}\", \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\",
         \"{location}\", \"{triaged}\")
         """
-    make_query(path, [query_string])        
+    make_query(path, [query_string])
 
 
 def insert_vulnerability(cveid = DEFAULT_VULNERABILITY_ID, target = "RHEL7", target_minor= "", pending = 0, 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -11,6 +11,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
+DEFAULT_PACKAGE_NAME = "WazuhIntegrationPackage"
 
 UpdateFromYearResult = namedtuple('UpdateFromYearResult', 'result actual_provider actual_update_from')
 
@@ -130,7 +131,7 @@ def make_query(db_path, query_list):
         db[0].close()
 
 
-def insert_package_in_db(agent = "000", format = "rpm", name = "WazuhIntegrationPackage", 
+def insert_package_in_db(agent = "000", format = "rpm", name = DEFAULT_PACKAGE_NAME, 
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
     architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package", 
     source = "Wazuh Integration tests mock package", location = "", triaged = 0, cpe = "",
@@ -152,7 +153,7 @@ def insert_package_in_db(agent = "000", format = "rpm", name = "WazuhIntegration
 
 
 def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", pending = 0, 
-    package = "WazuhIntegrationPackage", operation = "less than", operation_value = "2.0.0-1.el7",
+    package = DEFAULT_PACKAGE_NAME, operation = "less than", operation_value = "2.0.0-1.el7",
     title = "", severity = "critical", published =  datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
     updated = "", reference = "https://github.com/wazuh/wazuh-qa", target_v = "REDHAT", cvss = "10.000000", 
     cvss_vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C", rationale = "Wazuh integration test vulnerability", 

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -2,8 +2,6 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import os
-import time
 import pytest
 
 from wazuh_testing.tools import LOG_FILE_PATH

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -8,6 +8,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package_in_db
 
 @pytest.fixture(scope='module')
 def restart_modulesd(get_configuration, request):
@@ -20,3 +21,11 @@ def restart_modulesd(get_configuration, request):
         control_service('start', daemon='wazuh-modulesd')
     except:
       pass
+
+
+@pytest.fixture(scope='module')
+def generate_alert():
+    control_service('stop', daemon='wazuh-db')
+    insert_package_in_db()
+    insert_vulnerability()
+    control_service('start', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -6,14 +6,10 @@ import os
 import time
 import pytest
 
-import wazuh_testing.vulnerability_detector
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.vulnerability_detector import  delete_vulnerability, update_last_scan, modify_system
-from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package, clean_table
-from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID, PACKAGES_DB_PATH
 
 @pytest.fixture(scope='module')
 def restart_modulesd(get_configuration, request):
@@ -26,22 +22,3 @@ def restart_modulesd(get_configuration, request):
         control_service('start', daemon='wazuh-modulesd')
     except:
       pass
-
-
-@pytest.fixture(scope='module')
-def generate_default_alert():
-    control_service('stop', daemon='wazuh-db')
-    time.sleep(10)
-    clean_table(os.path.join(PACKAGES_DB_PATH,f"000.db"), 'sys_programs')
-    delete_vulnerability(DEFAULT_VULNERABILITY_ID)
-    insert_package()
-    insert_vulnerability()
-    modify_system()
-    control_service('start', daemon='wazuh-db')
-
-
-@pytest.fixture(scope='module')
-def reset_last_scan():
-    control_service('stop', daemon='wazuh-db')
-    update_last_scan()
-    control_service('start', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -2,16 +2,17 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import pytest
 import os
+import time
+import pytest
 
 import wazuh_testing.vulnerability_detector
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package_in_db, clean_table
-from wazuh_testing.vulnerability_detector import  delete_vulnerability, update_last_scan
+from wazuh_testing.vulnerability_detector import  delete_vulnerability, update_last_scan, modify_system
+from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package, clean_table
 from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID, PACKAGES_DB_PATH
 
 @pytest.fixture(scope='module')
@@ -30,10 +31,12 @@ def restart_modulesd(get_configuration, request):
 @pytest.fixture(scope='module')
 def generate_default_alert():
     control_service('stop', daemon='wazuh-db')
+    time.sleep(10)
     clean_table(os.path.join(PACKAGES_DB_PATH,f"000.db"), 'sys_programs')
     delete_vulnerability(DEFAULT_VULNERABILITY_ID)
-    insert_package_in_db()
+    insert_package()
     insert_vulnerability()
+    modify_system()
     control_service('start', daemon='wazuh-db')
 
 

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -3,12 +3,16 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import pytest
+import os
 
+import wazuh_testing.vulnerability_detector
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package_in_db
+from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package_in_db, clean_table
+from wazuh_testing.vulnerability_detector import  delete_vulnerability, update_last_scan
+from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID, PACKAGES_DB_PATH
 
 @pytest.fixture(scope='module')
 def restart_modulesd(get_configuration, request):
@@ -24,8 +28,17 @@ def restart_modulesd(get_configuration, request):
 
 
 @pytest.fixture(scope='module')
-def generate_alert():
+def generate_default_alert():
     control_service('stop', daemon='wazuh-db')
+    clean_table(os.path.join(PACKAGES_DB_PATH,f"000.db"), 'sys_programs')
+    delete_vulnerability(DEFAULT_VULNERABILITY_ID)
     insert_package_in_db()
     insert_vulnerability()
+    control_service('start', daemon='wazuh-db')
+
+
+@pytest.fixture(scope='module')
+def reset_last_scan():
+    control_service('stop', daemon='wazuh-db')
+    update_last_scan()
     control_service('start', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
@@ -9,7 +9,7 @@
     - enabled:
         value: 'yes'
     - run_on_start:
-        value: 'no'
+        value: 'yes'
     - interval:
         value: INTERVAL
     - ignore_time: 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
@@ -1,0 +1,22 @@
+# conf 1
+- tags:
+  - test_ignore_time
+  apply_to_modules:
+  - test_ignore_time
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'no'
+    - interval:
+        value: '10s'
+    - provider:
+        attributes:
+        - name: redhat
+        elements:
+        - enabled:
+            value: 'yes'
+        - update_interval:
+            value: '100d'

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
@@ -2,7 +2,7 @@
 - tags:
   - test_ignore_time
   apply_to_modules:
-  - test_ignore_time
+  - test_general_settings_ignore_time
   sections:
   - section: vulnerability-detector
     elements:
@@ -11,7 +11,9 @@
     - run_on_start:
         value: 'no'
     - interval:
-        value: '10s'
+        value: INTERVAL
+    - ignore_time: 
+        value: IGNORE_TIME
     - provider:
         attributes:
         - name: redhat

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from datetime import datetime, timedelta
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, \
+    check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.vulnerability_detector import insert_package_in_db, insert_vulnerability, make_vuln_callback
+from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_enabled.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+parameters = [{'IGNORE_TIME': '1h'}]
+metadata= [{'ignore_time': '1h'}]
+
+
+# Configuration data
+configurations = load_wazuh_configurations(
+    configurations_path, __name__, params=parameters, metadata=metadata)
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Tests
+
+@pytest.mark.parametrize('tags_to_apply, custom_callback', [
+    ({'ignore_time'}, make_vuln_callback(DEFAULT_PACKAGE_NAME))
+])
+def test_ignore_time(tags_to_apply, custom_callback, custom_error_message, 
+                  get_configuration, configure_environment,
+                  restart_modulesd, generate_alert):
+    """
+    Check if an alert is not fired during the ingnore time  interval
+    """
+
+    ignore_time = get_configuration['metadata']['ignore_time']
+    seconds_to_travel = time_to_seconds(interval_update_time)/2 + 1
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                        callback=custom_callback,
+                        error_message='Alert did not appear at the start of the test')
+
+    # Travels the time set in the update interval parameter
+    check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
+
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                        callback=custom_callback,
+                        error_message=custom_error_message)
+        raise AttributeError('Alert appeared before ignore_time was finished')
+
+    # Travels the time set in the update interval parameter
+    check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
+      
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                        callback=custom_callback,
+                        error_message='Alert did not appear at the end of the test')
+
+    

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -5,27 +5,31 @@
 import os
 import pytest
 from datetime import datetime, timedelta
+from time import sleep
 
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH
-from wazuh_testing.tools.configuration import load_wazuh_configurations, \
-    check_apply_test
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import insert_package_in_db, insert_vulnerability, make_vuln_callback
-from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME
+from wazuh_testing.fim import check_time_travel
+from wazuh_testing.vulnerability_detector import make_vuln_callback
+from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID
+from wazuh_testing.tools.time import time_to_seconds
+from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
 
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_enabled.yaml')
+configurations_path = os.path.join(test_data_path, 'wazuh_ignore_time.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-parameters = [{'IGNORE_TIME': '1h'}]
-metadata= [{'ignore_time': '1h'}]
+callback_string = f"{DEFAULT_PACKAGE_NAME}.+is vulnerable to {DEFAULT_VULNERABILITY_ID}"
 
+parameters = [{'IGNORE_TIME': '3600s', 'INTERVAL': '5s'}]
+metadata= [{'ignore_time': '3600s', 'timeout': 60, 'interval': '5s'}]
 
 # Configuration data
 configurations = load_wazuh_configurations(
@@ -41,36 +45,29 @@ def get_configuration(request):
 # Tests
 
 @pytest.mark.parametrize('tags_to_apply, custom_callback', [
-    ({'ignore_time'}, make_vuln_callback(DEFAULT_PACKAGE_NAME))
+    ({'test_ignore_time'}, make_vuln_callback(callback_string))
 ])
-def test_ignore_time(tags_to_apply, custom_callback, custom_error_message, 
-                  get_configuration, configure_environment,
-                  restart_modulesd, generate_alert):
+def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd, 
+    generate_default_alert, reset_last_scan):
     """
     Check if an alert is not fired during the ingnore time  interval
     """
-
     ignore_time = get_configuration['metadata']['ignore_time']
-    seconds_to_travel = time_to_seconds(interval_update_time)/2 + 1
+    seconds_to_travel = time_to_seconds(ignore_time)/2
 
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+    wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                         callback=custom_callback,
                         error_message='Alert did not appear at the start of the test')
 
-    # Travels the time set in the update interval parameter
     check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
 
     with pytest.raises(TimeoutError):
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                        callback=custom_callback,
-                        error_message=custom_error_message)
+        wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
+                                callback=custom_callback)
         raise AttributeError('Alert appeared before ignore_time was finished')
 
-    # Travels the time set in the update interval parameter
     check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
-      
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                        callback=custom_callback,
-                        error_message='Alert did not appear at the end of the test')
 
-    
+    wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
+                    callback=custom_callback,
+                    error_message='Alert did not appear at the end of the test')

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -9,13 +9,15 @@ from time import sleep
 
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
-from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.fim import check_time_travel
-from wazuh_testing.vulnerability_detector import make_vuln_callback
-from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID
 from wazuh_testing.tools.time import time_to_seconds
+from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.vulnerability_detector import  delete_vulnerability, update_last_scan, modify_system
+from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID, PACKAGES_DB_PATH
+from wazuh_testing.vulnerability_detector import insert_vulnerability, insert_package, clean_table, make_vuln_callback
+
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -28,8 +30,11 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 callback_string = f"{DEFAULT_PACKAGE_NAME}.+is vulnerable to {DEFAULT_VULNERABILITY_ID}"
 
-parameters = [{'IGNORE_TIME': '3600s', 'INTERVAL': '5s'}]
-metadata= [{'ignore_time': '3600s', 'timeout': 60, 'interval': '5s'}]
+parameters = [{'IGNORE_TIME': '3600s', 'INTERVAL': '5s'}, {'IGNORE_TIME': '60m', 'INTERVAL': '5s'}, 
+    {'IGNORE_TIME': '1h', 'INTERVAL': '5s'}]
+metadata= [{'ignore_time': '3600s', 'timeout': 60, 'interval': '5s'}, 
+    {'ignore_time': '60m', 'timeout': 60, 'interval': '5s'}, 
+    {'ignore_time': '1h', 'timeout': 60, 'interval': '5s'}]
 
 # Configuration data
 configurations = load_wazuh_configurations(
@@ -42,16 +47,36 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
+#functions
+
+def generate_default_alert():
+    control_service('stop', daemon='wazuh-db')
+    sleep(10)
+    clean_table(os.path.join(PACKAGES_DB_PATH,f"000.db"), 'sys_programs')
+    delete_vulnerability(DEFAULT_VULNERABILITY_ID)
+    insert_package()
+    insert_vulnerability()
+    modify_system()
+    control_service('start', daemon='wazuh-db')
+
+
+def reset_last_scan():
+    control_service('stop', daemon='wazuh-db')
+    update_last_scan()
+    control_service('start', daemon='wazuh-db')
+
 # Tests
 
 @pytest.mark.parametrize('tags_to_apply, custom_callback', [
     ({'test_ignore_time'}, make_vuln_callback(callback_string))
 ])
-def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd, 
-    generate_default_alert, reset_last_scan):
+def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd):
     """
     Check if an alert is not fired during the ingnore time  interval
     """
+    reset_last_scan()
+    generate_default_alert()
     ignore_time = get_configuration['metadata']['ignore_time']
     seconds_to_travel = time_to_seconds(ignore_time)/2
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -66,6 +66,7 @@ def reset_last_scan():
     update_last_scan()
     control_service('start', daemon='wazuh-db')
 
+
 # Tests
 
 @pytest.mark.parametrize('tags_to_apply, custom_callback', [

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
@@ -59,7 +59,7 @@ def get_configuration(request):
     return request.param
 
 # Tests
-def test_update_interval(get_configuration, configure_environment, restart_modulesd):
+def test_update_interval(get_configuration, configure_environment, restart_modulesd, reset_last_scan):
     """
     Check if the provider database update is triggered after the set interval time has passed
     """


### PR DESCRIPTION
Hello team,

This PR adds the ignore_time parameter test to the vulnerability detector integration test suite.

Closes #665 

# Tests logic

The test follows this structure:
1. Check if an alert appears at the start of the test.
2. Jump half of the ignore time and check if the alert does not appear.
3. Jump half of the ignore time and check if the alert appears again.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)
- [ ] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`

## RPM manager

- When the expected behavior occurs:

```
[root@centos7 wazuh-qa]# python3 -m pytest tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py -v
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-957.12.2.el7.x86_64-x86_64-with-centos-7.6.1810-Core', 'Packages': {'pytest': '5.4.1', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}
rootdir: /home/vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 3 items                                                                                      

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] PASSED [ 33%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration1-tags_to_apply0-<lambda>] PASSED [ 66%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration2-tags_to_apply0-<lambda>] PASSED [100%]

==================================== 3 passed in 291.61s (0:04:51) =====================================
```
## DEB manager

- When the expected behavior occurs:

```
root@ubuntu18LTS:/home/vagrant/wazuh-qa# python3 -m pytest -v tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py 
========================================== test session starts ==========================================
platform linux -- Python 3.6.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.9', 'Platform': 'Linux-4.15.0-99-generic-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'pytest': '5.4.2', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'metadata': '1.9.0', 'testinfra': '5.0.0'}}
rootdir: /home/vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.9.0, testinfra-5.0.0
collected 3 items                                                                                       

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] PASSED [ 33%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration1-tags_to_apply0-<lambda>] PASSED [ 66%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration2-tags_to_apply0-<lambda>] PASSED [100%]

===================================== 3 passed in 288.04s (0:04:48) =====================================
```

## DEB/RPM manager

- When the module fails because of initial alert not appearing:

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 3 items                                                                                                                                                                                                 

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py FFF                                                                                                [100%]

==================================================================================================== FAILURES =====================================================================================================
__________________________________________________________________________ test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] ___________________________________________________________________________

tags_to_apply = {'test_ignore_time'}, custom_callback = <function make_vuln_callback.<locals>.<lambda> at 0x7f5afc945048>
get_configuration = {'apply_to_modules': ['test_general_settings_ignore_time'], 'metadata': {'ignore_time': '3600s', 'interval': '5s', 'ti...ider': {'attributes': [...], 'elements': [...]}}], 'section': 'vulnerability-detector'}], 'tags': ['test_ignore_time']}
configure_environment = None, restart_modulesd = None

    @pytest.mark.parametrize('tags_to_apply, custom_callback', [
        ({'test_ignore_time'}, make_vuln_callback(callback_string))
    ])
    def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd):
        """
        Check if an alert is not fired during the ingnore time  interval
        """
        reset_last_scan()
        generate_default_alert()
        ignore_time = get_configuration['metadata']['ignore_time']
        seconds_to_travel = time_to_seconds(ignore_time)/2
    
        wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                            callback=custom_callback,
>                           error_message='Alert did not appear at the start of the test')

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py:85: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.6/site-packages/wazuh_testing/tools/monitoring.py:187: in start
    error_message=error_message).result()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <wazuh_testing.tools.monitoring.QueueMonitor object at 0x7f5afc6bf198>, timeout = 60, callback = <function make_vuln_callback.<locals>.<lambda> at 0x7f5afc945048>, accum_results = 1
update_position = True, timeout_extra = 0, error_message = 'Alert did not appear at the start of the test'

    def start(self, timeout=-1, callback=_callback_default, accum_results=1, update_position=True, timeout_extra=0,
              error_message=''):
        """Start the queue monitoring until the stop method is called."""
        if not self._continue:
            self._continue = True
            self._abort = False
    
            while self._continue:
                if self._abort:
                    self.stop()
                    if error_message:
                        logger.error(error_message)
                        logger.error(f"Results accumulated: "
                                     f"{len(self._result) if isinstance(self._result, list) else 0}")
                        logger.error(f"Results expected: {accum_results}")
>                   raise TimeoutError()
E                   TimeoutError

/usr/local/lib/python3.6/site-packages/wazuh_testing/tools/monitoring.py:408: TimeoutError
---------------------------------------------------------------------------------------------- Captured stderr setup ----------------------------------------------------------------------------------------------
2020/05/18 10:17:51 wazuh-modulesd[11234] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2020/05/18 10:17:51 wazuh-modulesd[11234] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2020/05/18 10:17:51 wazuh-modulesd[11234] wmodules-vuln-detector.c:708 at wm_vuldet_read_provider(): DEBUG: Added redhat feed. Interval: 8640000s | Multi path: 'none' | Multi url: 'none' | Update since: 2010.
---------------------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------------------
2020-05-18 10:19:01,635 - wazuh_testing - ERROR - Alert did not appear at the start of the test
2020-05-18 10:19:01,636 - wazuh_testing - ERROR - Results accumulated: 0
2020-05-18 10:19:01,636 - wazuh_testing - ERROR - Results expected: 1
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
ERROR    wazuh_testing:monitoring.py:404 Alert did not appear at the start of the test
ERROR    wazuh_testing:monitoring.py:405 Results accumulated: 0
ERROR    wazuh_testing:monitoring.py:407 Results expected: 1
```

- When the module fails because of alert appearing before ignore time:

```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-957.12.2.el7.x86_64-x86_64-with-centos-7.6.1810-Core', 'Packages': {'pytest': '5.4.1', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}
rootdir: /home/vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 3 items                                                                                                                                                                                                 

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] FAILED                               [ 33%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration1-tags_to_apply0-<lambda>] FAILED                               [ 66%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration2-tags_to_apply0-<lambda>] FAILED                               [100%]

==================================================================================================== FAILURES =====================================================================================================
__________________________________________________________________________ test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] ___________________________________________________________________________

tags_to_apply = {'test_ignore_time'}, custom_callback = <function make_vuln_callback.<locals>.<lambda> at 0x7fa4a4285400>
get_configuration = {'apply_to_modules': ['test_general_settings_ignore_time'], 'metadata': {'ignore_time': '3600s', 'interval': '5s', 'ti...ider': {'attributes': [...], 'elements': [...]}}], 'section': 'vulnerability-detector'}], 'tags': ['test_ignore_time']}
configure_environment = None, restart_modulesd = None

    @pytest.mark.parametrize('tags_to_apply, custom_callback', [
        ({'test_ignore_time'}, make_vuln_callback(callback_string))
    ])
    def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd):
        """
        Check if an alert is not fired during the ingnore time  interval
        """
        reset_last_scan()
        generate_default_alert()
        ignore_time = get_configuration['metadata']['ignore_time']
        seconds_to_travel = time_to_seconds(ignore_time)/2
    
        wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                            callback=custom_callback,
                            error_message='Alert did not appear at the start of the test')
    
        check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
    
        with pytest.raises(TimeoutError):
            wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                                    callback=custom_callback)
>           raise AttributeError('Alert appeared before ignore_time was finished')
E           AttributeError: Alert appeared before ignore_time was finished

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py:92: AttributeError
---------------------------------------------------------------------------------------------- Captured stderr setup ----------------------------------------------------------------------------------------------
2020/05/18 10:25:42 wazuh-modulesd[11666] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2020/05/18 10:25:42 wazuh-modulesd[11666] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2020/05/18 10:25:42 wazuh-modulesd[11666] wmodules-vuln-detector.c:708 at wm_vuldet_read_provider(): DEBUG: Added redhat feed. Interval: 8640000s | Multi path: 'none' | Multi url: 'none' | Update since: 2010.
---------------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------------
2020-05-18T10:56:10.1589799370
---------------------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------------------
2020-05-18 10:56:11,500 - wazuh_testing - INFO - Changing the system clock from 2020-05-18 10:26:10.654593 to 2020-05-18 10:56:11.500621
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
INFO     wazuh_testing:fim.py:868 Changing the system clock from 2020-05-18 10:26:10.654593 to 2020-05-18 10:56:11.500621
__________________________________________________________________________ test_ignore_time[get_configuration1-tags_to_apply0-<lambda>] ___________________________________________________________________________

tags_to_apply = {'test_ignore_time'}, custom_callback = <function make_vuln_callback.<locals>.<lambda> at 0x7fa4a4285400>
get_configuration = {'apply_to_modules': ['test_general_settings_ignore_time'], 'metadata': {'ignore_time': '60m', 'interval': '5s', 'time...ider': {'attributes': [...], 'elements': [...]}}], 'section': 'vulnerability-detector'}], 'tags': ['test_ignore_time']}
configure_environment = None, restart_modulesd = None

    @pytest.mark.parametrize('tags_to_apply, custom_callback', [
        ({'test_ignore_time'}, make_vuln_callback(callback_string))
    ])
    def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd):
        """
        Check if an alert is not fired during the ingnore time  interval
        """
        reset_last_scan()
        generate_default_alert()
        ignore_time = get_configuration['metadata']['ignore_time']
        seconds_to_travel = time_to_seconds(ignore_time)/2
    
        wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                            callback=custom_callback,
                            error_message='Alert did not appear at the start of the test')
    
        check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
    
        with pytest.raises(TimeoutError):
            wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                                    callback=custom_callback)
>           raise AttributeError('Alert appeared before ignore_time was finished')
E           AttributeError: Alert appeared before ignore_time was finished

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py:92: AttributeError
---------------------------------------------------------------------------------------------- Captured stdout setup ----------------------------------------------------------------------------------------------
2020-05-18T10:27:03.1589797623
---------------------------------------------------------------------------------------------- Captured stderr setup ----------------------------------------------------------------------------------------------
2020/05/18 10:27:04 wazuh-modulesd[11741] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2020/05/18 10:27:04 wazuh-modulesd[11741] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2020/05/18 10:27:04 wazuh-modulesd[11741] wmodules-vuln-detector.c:708 at wm_vuldet_read_provider(): DEBUG: Added redhat feed. Interval: 8640000s | Multi path: 'none' | Multi url: 'none' | Update since: 2010.
---------------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------------
2020-05-18T10:57:15.1589799435
---------------------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------------------
2020-05-18 10:57:16,500 - wazuh_testing - INFO - Changing the system clock from 2020-05-18 10:27:15.620308 to 2020-05-18 10:57:16.500594
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
INFO     wazuh_testing:fim.py:868 Changing the system clock from 2020-05-18 10:27:15.620308 to 2020-05-18 10:57:16.500594
```
- When the module fails because of alert not  appearing adter the ignore time:

```
=============================================== FAILURES ===============================================
_____________________ test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] _____________________

tags_to_apply = {'test_ignore_time'}
custom_callback = <function make_vuln_callback.<locals>.<lambda> at 0x7fb8f269f378>
get_configuration = {'apply_to_modules': ['test_general_settings_ignore_time'], 'metadata': {'ignore_time': '3600s', 'interval': '5s', 'ti...ider': {'attributes': [...], 'elements': [...]}}], 'section': 'vulnerability-detector'}], 'tags': ['test_ignore_time']}
configure_environment = None, restart_modulesd = None

    @pytest.mark.parametrize('tags_to_apply, custom_callback', [
        ({'test_ignore_time'}, make_vuln_callback(callback_string))
    ])
    def test_ignore_time(tags_to_apply, custom_callback, get_configuration, configure_environment, restart_modulesd):
        """
        Check if an alert is not fired during the ingnore time  interval
        """
        reset_last_scan()
        generate_default_alert()
        ignore_time = get_configuration['metadata']['ignore_time']
        seconds_to_travel = time_to_seconds(ignore_time)/2
    
        wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                            callback=custom_callback,
                            error_message='Alert did not appear at the start of the test')
    
        check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
    
        with pytest.raises(TimeoutError):
            wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                                    callback=custom_callback)
            raise AttributeError('Alert appeared before ignore_time was finished')
    
        check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
    
        wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],
                        callback=custom_callback,
>                       error_message='Alert did not appear at the end of the test')

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py:98: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.6/site-packages/wazuh_testing/tools/monitoring.py:187: in start
    error_message=error_message).result()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <wazuh_testing.tools.monitoring.QueueMonitor object at 0x7fb8f245eba8>, timeout = 60
callback = <function make_vuln_callback.<locals>.<lambda> at 0x7fb8f269f378>, accum_results = 1
update_position = True, timeout_extra = 0, error_message = 'Alert did not appear at the end of the test'

    def start(self, timeout=-1, callback=_callback_default, accum_results=1, update_position=True, timeout_extra=0,
              error_message=''):
        """Start the queue monitoring until the stop method is called."""
        if not self._continue:
            self._continue = True
            self._abort = False
    
            while self._continue:
                if self._abort:
                    self.stop()
                    if error_message:
                        logger.error(error_message)
                        logger.error(f"Results accumulated: "
                                     f"{len(self._result) if isinstance(self._result, list) else 0}")
                        logger.error(f"Results expected: {accum_results}")
>                   raise TimeoutError()
E                   TimeoutError

/usr/local/lib/python3.6/site-packages/wazuh_testing/tools/monitoring.py:408: TimeoutError
---------------------------------------- Captured stderr setup -----------------------------------------
2020/05/18 10:34:41 wazuh-modulesd[11856] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2020/05/18 10:34:41 wazuh-modulesd[11856] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2020/05/18 10:34:41 wazuh-modulesd[11856] wmodules-vuln-detector.c:708 at wm_vuldet_read_provider(): DEBUG: Added redhat feed. Interval: 8640000s | Multi path: 'none' | Multi url: 'none' | Update since: 2010.
----------------------------------------- Captured stdout call -----------------------------------------
2020-05-18T11:05:12.1589799912
2020-05-18T11:36:12.1589801772
----------------------------------------- Captured stderr call -----------------------------------------
2020-05-18 11:05:12,500 - wazuh_testing - INFO - Changing the system clock from 2020-05-18 10:35:12.100356 to 2020-05-18 11:05:12.500607
2020-05-18 11:36:13,500 - wazuh_testing - INFO - Changing the system clock from 2020-05-18 11:06:12.597525 to 2020-05-18 11:36:13.500652
2020-05-18 11:37:13,883 - wazuh_testing - ERROR - Alert did not appear at the end of the test
2020-05-18 11:37:13,883 - wazuh_testing - ERROR - Results accumulated: 0
2020-05-18 11:37:13,883 - wazuh_testing - ERROR - Results expected: 1
------------------------------------------ Captured log call -------------------------------------------
INFO     wazuh_testing:fim.py:868 Changing the system clock from 2020-05-18 10:35:12.100356 to 2020-05-18 11:05:12.500607
INFO     wazuh_testing:fim.py:868 Changing the system clock from 2020-05-18 11:06:12.597525 to 2020-05-18 11:36:13.500652
ERROR    wazuh_testing:monitoring.py:404 Alert did not appear at the end of the test
ERROR    wazuh_testing:monitoring.py:405 Results accumulated: 0
ERROR    wazuh_testing:monitoring.py:407 Results expected: 1
======================================= short test summary info ========================================
FAILED tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0-tags_to_apply0-<lambda>]
=============================== 1 failed, 2 passed in 349.86s (0:05:49) ================================

```
## Integrity check with other tests


```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-957.12.2.el7.x86_64-x86_64-with-centos-7.6.1810-Core', 'Packages': {'pytest': '5.4.1', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}
rootdir: /home/vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collecting ... collected 79 items

tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration0-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled] PASSED [  1%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration0-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled] SKIPPED [  2%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration1-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled] SKIPPED [  3%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration1-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled] PASSED [  5%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0-tags_to_apply0-<lambda>] PASSED [  6%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration1-tags_to_apply0-<lambda>] PASSED [  7%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration2-tags_to_apply0-<lambda>] PASSED [  8%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1s] PASSED [ 10%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1m] PASSED [ 11%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1h] PASSED [ 12%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1d] PASSED [ 13%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2s] PASSED [ 15%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2m] PASSED [ 16%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2h] PASSED [ 17%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2d] PASSED [ 18%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5s] PASSED [ 20%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5m] PASSED [ 21%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5h] PASSED [ 22%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5d] PASSED [ 24%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_yes] PASSED [ 25%]
tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_no] PASSED [ 26%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[redhat] PASSED [ 27%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[canonical_trusty] PASSED [ 29%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[canonical_xenial] PASSED [ 30%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[canonical_bionic] PASSED [ 31%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[debian_wheezy] PASSED [ 32%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[debian_jessie] PASSED [ 34%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[debian_stretch] PASSED [ 35%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[debian_buster] PASSED [ 36%]
tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py::test_download_feeds[nvd] PASSED [ 37%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-canonical] PASSED [ 39%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-debian] PASSED [ 40%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-redhat] PASSED [ 41%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-nvd] PASSED [ 43%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-canonical] PASSED [ 44%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-debian] PASSED [ 45%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-redhat] PASSED [ 46%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-nvd] PASSED [ 48%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[canonical-trusty] PASSED [ 49%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[canonical-xenial] PASSED [ 50%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[canonical-bionic] PASSED [ 51%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[debian-wheezy] PASSED [ 53%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[debian-stretch] PASSED [ 54%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[debian-jessie] PASSED [ 55%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[debian-buster] PASSED [ 56%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[redhat-] PASSED [ 58%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[nvd-] PASSED [ 59%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_1998] PASSED [ 60%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_1999] PASSED [ 62%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2001] PASSED [ 63%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2002] PASSED [ 64%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2005] PASSED [ 65%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2010] PASSED [ 67%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2015] PASSED [ 68%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2020] PASSED [ 69%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_1998] PASSED [ 70%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_1999] FAILED [ 72%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2001] FAILED [ 73%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2002] PASSED [ 74%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2005] PASSED [ 75%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2010] PASSED [ 77%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2015] PASSED [ 78%]
tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2020] PASSED [ 79%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Redhat_60s] PASSED [ 81%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Canonical60s] PASSED [ 82%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Debian60s] PASSED [ 83%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[NVD60s] PASSED [ 84%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Redhat_60m] PASSED [ 86%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Canonical60m] PASSED [ 87%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Debian60m] PASSED [ 88%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[NVD60m] PASSED [ 89%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Redhat_1h] PASSED [ 91%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Canonical1h] PASSED [ 92%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Debian1h] PASSED [ 93%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[NVD1h] PASSED [ 94%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Redhat_1d] PASSED [ 96%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Canonical1d] PASSED [ 97%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[Debian1d] PASSED [ 98%]
tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py::test_update_interval[NVD1d] PASSED [100%]

```

Best regards.
Daniel Folch
