### PR TITLE
Add test vulnerability detector scan for redhat packages using redhat feeds

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -6,6 +6,7 @@ import re
 import os
 import sqlite3
 import datetime
+from time import time
 from collections import namedtuple
 from wazuh_testing.tools import WAZUH_PATH
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -11,6 +11,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
+GLOBAL_DB_PATH = f"{WAZUH_PATH}/var/db/global.db"
 DEFAULT_PACKAGE_NAME = "WazuhIntegrationPackage"
 DEFAULT_VULNERABILITY_ID = "WVE-000"
 
@@ -140,7 +141,15 @@ def clean_table(db_path, table):
     make_query(db_path, [query_string])
 
 
-def insert_package_in_db(agent = "000", scan_id = 99999999, format = "rpm", name = DEFAULT_PACKAGE_NAME,
+def update_last_scan(last_scan = 0, agent = "000"):
+    """
+    Changes the value of the last scan of an agent.
+    """
+    path =  os.path.join(PACKAGES_DB_PATH,f"{agent}.db")
+    query_string = f"UPDATE vuln_metadata SET LAST_SCAN={last_scan}"
+    make_query(path, [query_string])
+
+def insert_package(agent = "000", scan_id = int(time()), format = "rpm", name = DEFAULT_PACKAGE_NAME,
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
     architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package",
     source = "Wazuh Integration tests mock package", location = "", triaged = 0,
@@ -178,13 +187,15 @@ def insert_vulnerability(cveid = DEFAULT_VULNERABILITY_ID, target = "RHEL7", tar
     vulnerabilities_query_string = f"""INSERT INTO VULNERABILITIES
         (cveid, target, target_minor, pending, package, operation, operation_value)
         VALUES
-        (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\", \"{operation_value}\")"""
+        (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\",
+        \"{operation_value}\")"""
     query_vulnerabilities_info_query_string = f"""INSERT INTO VULNERABILITIES_INFO
         (ID, title, severity, published, updated, reference, target, rationale, cvss, cvss_vector, CVSS3,
         bugzilla_reference, cwe, advisories)
         VALUES
-        (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\", \"{rationale}\", \"{cvss}\",
-        \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\", \"{advisories}\")"""
+        (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\",
+        \"{rationale}\", \"{cvss}\", \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\",
+        \"{advisories}\")"""
     make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string])
 
 
@@ -214,3 +225,12 @@ def delete_vulnerability(cveid):
     delete_vulnerabilities_query_string = f"DELETE FROM VULNERABILITIES WHERE cveid=\"{cveid}\";"
     delete_vulnerabilities_info_query_string = f"DELETE FROM VULNERABILITIES_INFO WHERE id=\"{cveid}\";"
     make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])
+
+
+def modify_system(os_name = "CentOS Linux", os_major = "7", name = "centos7"):
+    """
+    Modify the system of the manager.
+    Used to select the feed that will be used to search vulnerabilities.
+    """
+    query_string = f"update AGENT set OS_NAME=\"{os_name}\", OS_MAJOR=\"{os_major}\", NAME=\"{name}\""
+    make_query(GLOBAL_DB_PATH, [query_string])

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -142,6 +142,20 @@ def clean_table(db_path, table):
     make_query(db_path, [query_string])
 
 
+def clean_vd_tables(agent):
+    """
+    Clean the tables involved with vuln detector packages and feeds
+    """
+    tables = [
+        {"name": "sys_programs", "path": os.path.join(PACKAGES_DB_PATH,f"{agent}.db")},
+        {"name": "vulnerabilities", "path": CVE_DB_PATH},
+        {"name": "vulnerabilities_info", "path": CVE_DB_PATH}
+    ]
+
+    for item in tables:
+        clean_table(item['path'], item['name'])
+
+
 def update_last_scan(last_scan = 0, agent = "000"):
     """
     Changes the value of the last scan of an agent.
@@ -231,7 +245,7 @@ def delete_vulnerability(cveid):
     make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])
 
 
-def modify_system(os_name = "CentOS Linux", os_major = "7", os_minor = "1", name = "centos7", agent_id = 0):
+def modify_system(os_name = "CentOS Linux", os_major = "7", name = "centos7", agent_id = 0, os_minor = "1"):
     """
     Modify the system of the manager.
     Used to select the feed that will be used to search vulnerabilities.

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -227,10 +227,11 @@ def delete_vulnerability(cveid):
     make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])
 
 
-def modify_system(os_name = "CentOS Linux", os_major = "7", name = "centos7"):
+def modify_system(os_name = "CentOS Linux", os_major = "7", os_minor = "1", name = "centos7", agent_id = 0):
     """
     Modify the system of the manager.
     Used to select the feed that will be used to search vulnerabilities.
     """
-    query_string = f"update AGENT set OS_NAME=\"{os_name}\", OS_MAJOR=\"{os_major}\", NAME=\"{name}\""
+    query_string = f"update AGENT set OS_NAME=\"{os_name}\", OS_MAJOR=\"{os_major}\", NAME=\"{name}\", \
+                     OS_MINOR=\"{os_minor}\" WHERE id=\"{agent_id}\""
     make_query(GLOBAL_DB_PATH, [query_string])

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -11,6 +11,8 @@ from wazuh_testing.tools import WAZUH_PATH
 
 PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
+DEFAULT_PACKAGE_NAME = "WazuhIntegrationPackage"
+DEFAULT_VULNERABILITY_ID = "WVE-000"
 
 UpdateFromYearResult = namedtuple('UpdateFromYearResult', 'result actual_provider actual_update_from')
 
@@ -130,11 +132,20 @@ def make_query(db_path, query_list):
         db[0].close()
 
 
-def insert_package_in_db(agent = "000", format = "rpm", name = "WazuhIntegrationPackage", 
+def clean_table(db_path, table):
+    """
+    Deletes all entries in a table of a database.
+    """
+    query_string = f"DELETE FROM {table}"
+    make_query(db_path, [query_string])
+
+
+def insert_package_in_db(agent = "000", scan_id = 99999999, format = "rpm", name = DEFAULT_PACKAGE_NAME,
     priority = "", section = "Unspecified", size= 99, vendor = "WazuhIntegrationTests", version = "1.0.0-1.el7",
-    architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package", 
-    source = "Wazuh Integration tests mock package", location = "", triaged = 0, cpe = "",
-    install_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
+    architecture = "x86_64", multiarch = "", description = "Wazuh Integration tests mock package",
+    source = "Wazuh Integration tests mock package", location = "", triaged = 0,
+    install_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
+    scan_time = datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")
 ):
     """
     Insert a new package in the installed package database, with the parameters given as arguments.
@@ -143,20 +154,21 @@ def insert_package_in_db(agent = "000", format = "rpm", name = "WazuhIntegration
     path =  os.path.join(PACKAGES_DB_PATH,f"{agent}.db")
     query_string = f"""INSERT INTO sys_programs
         (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, \
-            architecture, multiarch, source, description, location, triaged, cpe)
-        SELECT scan_id, scan_time, \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\", \"{install_time}\", \"{version}\",
-        \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\", \"{location}\", \"{triaged}\", \"{cpe}\"
-        FROM sys_programs LIMIT 1
+            architecture, multiarch, source, description, location, triaged)
+        VALUES
+        ({scan_id}, \"{scan_time}\", \"{format}\", \"{name}\", \"{priority}\", \"{section}\", \"{size}\", \"{vendor}\",
+        \"{install_time}\", \"{version}\", \"{architecture}\", \"{multiarch}\", \"{source}\", \"{description}\",
+        \"{location}\", \"{triaged}\")
         """
-    make_query(path, [query_string])        
+    make_query(path, [query_string])
 
 
-def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", pending = 0, 
-    package = "WazuhIntegrationPackage", operation = "less than", operation_value = "2.0.0-1.el7",
+def insert_vulnerability(cveid = DEFAULT_VULNERABILITY_ID, target = "RHEL7", target_minor= "", pending = 0,
+    package = DEFAULT_PACKAGE_NAME, operation = "less than", operation_value = "2.0.0-1.el7",
     title = "", severity = "critical", published =  datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
-    updated = "", reference = "https://github.com/wazuh/wazuh-qa", target_v = "REDHAT", cvss = "10.000000", 
-    cvss_vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C", rationale = "Wazuh integration test vulnerability", 
-    CVSS3 = "", bugzilla_reference = "https://github.com/wazuh/wazuh-qa", cwe = "WVE-000 -> WVE-001", 
+    updated = "", reference = "https://github.com/wazuh/wazuh-qa", target_v = "REDHAT", cvss = "10.000000",
+    cvss_vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C", rationale = "Wazuh integration test vulnerability",
+    CVSS3 = "", bugzilla_reference = "https://github.com/wazuh/wazuh-qa", cwe = "WVE-000 -> WVE-001",
     advisories = "RHSA-2010:0029"
 ):
     """
@@ -165,12 +177,12 @@ def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", 
     """
     vulnerabilities_query_string = f"""INSERT INTO VULNERABILITIES
         (cveid, target, target_minor, pending, package, operation, operation_value)
-        VALUES 
+        VALUES
         (\"{cveid}\", \"{target}\", \"{target_minor}\", \"{pending}\", \"{package}\", \"{operation}\", \"{operation_value}\")"""
-    query_vulnerabilities_info_query_string = f"""INSERT INTO VULNERABILITIES_INFO 
-        (ID, title, severity, published, updated, reference, target, rationale, cvss, cvss_vector, CVSS3, 
+    query_vulnerabilities_info_query_string = f"""INSERT INTO VULNERABILITIES_INFO
+        (ID, title, severity, published, updated, reference, target, rationale, cvss, cvss_vector, CVSS3,
         bugzilla_reference, cwe, advisories)
-        VALUES 
+        VALUES
         (\"{cveid}\", \"{title}\", \"{severity}\", \"{published}\", \"{updated}\", \"{reference}\", \"{target_v}\", \"{rationale}\", \"{cvss}\",
         \"{cvss_vector}\", \"{CVSS3}\", \"{bugzilla_reference}\", \"{cwe}\", \"{advisories}\")"""
     make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string])
@@ -178,9 +190,27 @@ def insert_vulnerability(cveid = "WVE-000", target = "RHEL7", target_minor= "", 
 
 def update_package(version, package, agent = "000"):
     """
-    Update version of installed package in databas.
+    Update version of installed package in database.
     Used to simulate upgrades and downgrades of the package given as argument.
     """
     path =  os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
-    update_query_string = f"UPDATE sys_programs SET version={version} WHERE name={package};"
+    update_query_string = f"UPDATE sys_programs SET version=\"{version}\" WHERE name=\"{package}\";"
     make_query(path, [update_query_string])
+
+def delete_package(package, agent = "000"):
+    """
+    Remove package from database.
+    Used to simulate uninstall of the package given as argument or remove a package after a test.
+    """
+    path =  os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    delete_query_string = f"DELETE FROM sys_programs WHERE name=\"{package}\";"
+    make_query(path, [delete_query_string])
+
+def delete_vulnerability(cveid):
+    """
+    Update version of installed package in database.
+    Used to simulate uninstall of the package given as argument or remove a package after a test.
+    """
+    delete_vulnerabilities_query_string = f"DELETE FROM VULNERABILITIES WHERE cveid=\"{cveid}\";"
+    delete_vulnerabilities_info_query_string = f"DELETE FROM VULNERABILITIES_INFO WHERE id=\"{cveid}\";"
+    make_query(CVE_DB_PATH, [delete_vulnerabilities_query_string,delete_vulnerabilities_info_query_string])

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -9,6 +9,7 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
 
+
 @pytest.fixture(scope='module')
 def restart_modulesd(get_configuration, request):
     # Reset ossec.log and start a new monitor

--- a/tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_download_feeds.py
@@ -45,7 +45,7 @@ provider_info = {
         'os': [],
         'update_from_year': 2002,
         'system_log': 'National Vulnerability Database',
-        'download_timeout': 900
+        'download_timeout': 1200
     }
 }
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
@@ -44,7 +44,7 @@ for item in time_units:
         {'provider_name': 'nvd', 'os': '', 'interval': item}
     ])
 
-    ids.extend([f"Redhat_{item}", f"Canonical{item}", f"Debian{item}", f"NVD{item}"])
+    ids.extend([f"Redhat_{item}", f"Canonical_{item}", f"Debian_{item}", f"NVD_{item}"])
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/redhat_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/redhat_vulnerabilities.json
@@ -1,0 +1,278 @@
+[
+    {
+        "target": "RHEL8",
+        "os_name": "CentOS Linux",
+        "os_major": "8",
+        "os_minor": "1",
+        "name": "centos8",
+        "vulnerabilities": [
+            {
+                "package": {
+                    "name": "firefox-0",
+                    "version": "68.1.0",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-11764",
+                    "operation": "less than",
+                    "operation_value": "68.2.0-2.el8_0"
+                }
+            },
+            {
+                "package": {
+                    "name": "glibc-0",
+                    "version": "2.27",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-19126",
+                    "operation": "less than",
+                    "operation_value": "2.28-101.el8"
+                }
+            },
+            {
+                "package": {
+                    "name": "sqlite-0",
+                    "version": "3.25.0",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-13753",
+                    "operation": "less than",
+                    "operation_value": "3.26.0-6.el8"
+                }
+            },
+            {
+                "package": {
+                    "name": "git-0",
+                    "version": "2.18.1",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-1352",
+                    "operation": "less than",
+                    "operation_value": "2.18.2-1.el8_1"
+                }
+            },
+            {
+                "package": {
+                    "name": "haproxy-0",
+                    "version": "2.0.12",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-19330",
+                    "operation": "less than",
+                    "operation_value": "2.0.13-3.el8"
+                 }
+            }
+        ]
+    },
+    {
+        "target": "RHEL7",
+        "os_name": "CentOS Linux",
+        "os_major": "7",
+        "os_minor": "8",
+        "name": "centos7",
+        "vulnerabilities": [
+            {
+                "package": {
+                    "name": "nodejs",
+                    "version": "11.0",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-16776",
+                    "operation": "less than",
+                    "operation_value": "12-8010020200116150415.c27ad7f8"
+                }
+            },
+            {
+                "package": {
+                    "name": "firefox-0",
+                    "version": "68.1",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-11764",
+                    "operation": "less than",
+                    "operation_value": "68.2.0-1.el7_7"
+                }
+            },
+            {
+                "package": {
+                    "name": "ansible-0",
+                    "version": "2.8.0",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-14864",
+                    "operation": "less than",
+                    "operation_value": "2.8.7-1.el7ae"
+                }
+            },
+            {
+                "package": {
+                    "name": "php",
+                    "version": "7.1",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-11043",
+                    "operation": "less than",
+                    "operation_value": "7.2-8000020191113103901.5d58a046"
+                }
+            },
+            {
+                "package": {
+                    "name": "samba-0",
+                    "version": "4.10.3",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-10218",
+                    "operation": "less than",
+                    "operation_value": "4.10.4-10.el7"
+                 }
+            }
+        ]
+    },
+    {
+        "target": "RHEL6",
+        "os_name": "CentOS Linux",
+        "os_major": "6",
+        "os_minor": "10",
+        "name": "centos6",
+        "vulnerabilities": [
+            {
+                "package": {
+                    "name": "python-twisted-web-0",
+                    "version": "8.1.0",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2020-10108",
+                    "operation": "less than",
+                    "operation_value": "8.2.0-6.el6_10"
+                }
+            },
+            {
+                "package": {
+                    "name": "squid",
+                    "version": "3",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-12519",
+                    "operation": "less than",
+                    "operation_value": "4-8000020200428154754.f8e95b4e"
+                }
+            },
+            {
+                "package": {
+                    "name": "vim-2",
+                    "version": "7.3",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-12735",
+                    "operation": "less than",
+                    "operation_value": "7.4.629-5.el6_10.2"
+                }
+            },
+            {
+                "package": {
+                    "name": "rh-java-common-xmlrpc-1",
+                    "version": "3.1.2",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-17570",
+                    "operation": "less than",
+                    "operation_value": "3.1.3-8.17.el6"
+                }
+            },
+            {
+                "package": {
+                    "name": "chromium-browser-0",
+                    "version": "69.0",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2019-13724",
+                    "operation": "less than",
+                    "operation_value": "78.0.3904.108-1.el6_10"
+                 }
+            }
+        ]
+    },
+    {
+        "target": "RHEL5",
+        "os_name": "CentOS Linux",
+        "os_major": "5",
+        "os_minor": "11",
+        "name": "centos5",
+        "vulnerabilities": [
+            {
+                "package": {
+                    "name": "pam-0",
+                    "version": "0.98.0",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2010-3853",
+                    "operation": "less than",
+                    "operation_value": "0.99.6.2-6.el5_5.2"
+                }
+            },
+            {
+                "package": {
+                    "name": "seamonkey-0",
+                    "version": "1.0.8",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2010-3180",
+                    "operation": "less than",
+                    "operation_value": "1.0.9-0.61.el3"
+                }
+            },
+            {
+                "package": {
+                    "name": "subversion",
+                    "version": "1.9",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-0203",
+                    "operation": "less than",
+                    "operation_value": "1.10-8000020190807153138.a27fc728"
+                }
+            },
+            {
+                "package": {
+                    "name": "mariadb",
+                    "version": "10.2",
+                    "format": "rpm"
+            },
+                "cve": {
+                    "cveid": "CVE-2019-2739",
+                    "operation": "less than",
+                    "operation_value": "10.3-8010020190902091509.cdc1202b"
+                }
+            },
+            {
+                "package": {
+                    "name": "thunderbird-0",
+                    "version": "3.1.5",
+                    "format": "rpm"
+                },
+                "cve": {
+                    "cveid": "CVE-2010-3175",
+                    "operation": "less than",
+                    "operation_value": "3.1.6-1.el6_0"
+                }
+            }
+        ]
+    }
+]

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_redhat_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_redhat_inventory.yaml
@@ -1,0 +1,33 @@
+---
+# conf 1
+- tags:
+  - test_redhat_inventory_redhat_feeds
+  apply_to_modules:
+  - test_redhat_inventory_redhat_feeds
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'no'
+    - interval:
+        value: '10s'
+    - provider:
+        attributes:
+        - name: 'redhat'
+        elements:
+        - enabled:
+            value: 'yes'
+    - provider:
+        attributes:
+        - name: 'canonical'
+        elements:
+        - enabled:
+            value: 'yes'
+    - provider:
+        attributes:
+        - name: 'debian'
+        elements:
+        - enabled:
+            value: 'yes'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
@@ -8,12 +8,12 @@ import json
 import time
 
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, \
-                                                 insert_vulnerability, modify_system
+                                                 insert_vulnerability, modify_system, clean_vd_tables
 from wazuh_testing.tools.services import control_service
 
 # Marks
@@ -62,13 +62,8 @@ def mock_vulnerability_scan(request):
     # Wait until modulesd is restarted to avoid overwriting the system
     time.sleep(5)
 
-    local_db_path = os.path.join(WAZUH_PATH, 'queue/db/000.db')
-    cve_db_path = os.path.join(WAZUH_PATH, 'queue/vulnerabilities/cve.db')
-
     # Clean tables
-    clean_table(local_db_path, 'sys_programs')
-    clean_table(cve_db_path, 'vulnerabilities')
-    clean_table(cve_db_path, 'vulnerabilities_info')
+    clean_vd_tables(agent='000')
 
     # Mock system
     modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
@@ -90,9 +85,7 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Clean tables
-    clean_table(local_db_path, 'sys_programs')
-    clean_table(cve_db_path, 'vulnerabilities')
-    clean_table(cve_db_path, 'vulnerabilities_info')
+    clean_vd_tables(agent='000')
 
     control_service('start', daemon='wazuh-db')
 
@@ -108,7 +101,6 @@ def check_vulnerability_event(package, cve):
     cve : str
         Package CVE. Example: 'CVE-2019-11764'
     """
-    print(f"Checking {package} -- {cve}")
     wazuh_log_monitor.start(
         timeout=scan_timeout,
         update_position=False,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import shutil
+import uuid
+import json
+import time
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, \
+                                                 insert_vulnerability, modify_system
+from wazuh_testing.tools.services import control_service
+
+# Marks
+pytestmark = pytest.mark.tier(level=1)
+
+
+# Variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_redhat_inventory.yaml')
+vulnerabilities_data_path = os.path.join(test_data_path, 'redhat_vulnerabilities.json')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+redhat_download_feed_timeout = 360
+scan_timeout = 40
+
+
+# Set configuration
+parameters = [{}]
+metadata = [{}]
+ids = []
+
+
+# Read JSON data template
+with open(vulnerabilities_data_path, 'r') as f:
+    redhat_vulnerabilities = json.loads(f.read())
+
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope='module', params=redhat_vulnerabilities)
+
+def mock_vulnerability_scan(request):
+    """
+    It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
+    """
+    control_service('stop', daemon='wazuh-db')
+
+    local_db_path = os.path.join(WAZUH_PATH, 'queue/db/000.db')
+    cve_db_path = os.path.join(WAZUH_PATH, 'queue/vulnerabilities/cve.db')
+    global_db_path = os.path.join(WAZUH_PATH, 'var/db/global.db')
+    local_db_backup = os.path.join('/tmp', str(uuid.uuid4()))
+    cve_db_backup = os.path.join('/tmp', str(uuid.uuid4()))
+    global_db_backup = os.path.join('/tmp', str(uuid.uuid4()))
+
+    # Make a backup of DB files that will be modified
+    shutil.copyfile(local_db_path, local_db_backup)
+    shutil.copyfile(cve_db_path, cve_db_backup)
+    shutil.copyfile(global_db_path, global_db_backup)
+
+    # Clean tables
+    clean_table(local_db_path, 'sys_programs')
+    clean_table(cve_db_path, 'vulnerabilities')
+    clean_table(cve_db_path, 'vulnerabilities_info')
+
+    # Wait until modulesd is restarted to avoid overwriting the system
+    time.sleep(5)
+
+    # Mock system
+    modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
+                  os_minor=request.param['os_minor'], name=request.param['name'])
+
+    # Add custom vulnerabilities and feeds
+    for vulnerability in request.param['vulnerabilities']:
+        insert_package(**vulnerability['package'])
+        insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
+                             target=request.param['target'])
+
+    control_service('start', daemon='wazuh-db')
+
+    # Truncate ossec.log
+    truncate_file(LOG_FILE_PATH)
+
+    yield request.param
+
+    control_service('stop', daemon='wazuh-db')
+
+    # Restore DBs
+    shutil.move(local_db_backup, local_db_path)
+    shutil.move(cve_db_backup, cve_db_path)
+    shutil.move(global_db_backup, global_db_path)
+
+    control_service('start', daemon='wazuh-db')
+
+
+def check_vulnerability_event(package, cve):
+    """
+    Check if inserted vulnerable packages are reported by vulnerability detector.
+
+    Parameters
+    ----------
+    package: str
+        Name of custom package to check. Example: 'firefox-0'
+    cve : str
+        Package CVE. Example: 'CVE-2019-11764'
+    """
+    print(f"Checking {package} -- {cve}")
+    wazuh_log_monitor.start(
+        timeout=scan_timeout,
+        update_position=False,
+        callback=make_vuln_callback(f"The '{package}' package from agent .* is vulnerable to {cve}"),
+        error_message=f"Could not find the report which says that the package {package} is vulnerable with {cve}",
+    )
+
+
+def test_redhat_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+                                       mock_vulnerability_scan):
+    """
+    Check if inserted vulnerable packages are reported by vulnerability detector
+    """
+    for item in mock_vulnerability_scan['vulnerabilities']:
+        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
@@ -55,32 +55,22 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=redhat_vulnerabilities)
-
 def mock_vulnerability_scan(request):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
     control_service('stop', daemon='wazuh-db')
 
+    # Wait until modulesd is restarted to avoid overwriting the system
+    time.sleep(5)
+
     local_db_path = os.path.join(WAZUH_PATH, 'queue/db/000.db')
     cve_db_path = os.path.join(WAZUH_PATH, 'queue/vulnerabilities/cve.db')
-    global_db_path = os.path.join(WAZUH_PATH, 'var/db/global.db')
-    local_db_backup = os.path.join('/tmp', str(uuid.uuid4()))
-    cve_db_backup = os.path.join('/tmp', str(uuid.uuid4()))
-    global_db_backup = os.path.join('/tmp', str(uuid.uuid4()))
-
-    # Make a backup of DB files that will be modified
-    shutil.copyfile(local_db_path, local_db_backup)
-    shutil.copyfile(cve_db_path, cve_db_backup)
-    shutil.copyfile(global_db_path, global_db_backup)
 
     # Clean tables
     clean_table(local_db_path, 'sys_programs')
     clean_table(cve_db_path, 'vulnerabilities')
     clean_table(cve_db_path, 'vulnerabilities_info')
-
-    # Wait until modulesd is restarted to avoid overwriting the system
-    time.sleep(5)
 
     # Mock system
     modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
@@ -101,10 +91,10 @@ def mock_vulnerability_scan(request):
 
     control_service('stop', daemon='wazuh-db')
 
-    # Restore DBs
-    shutil.move(local_db_backup, local_db_path)
-    shutil.move(cve_db_backup, cve_db_path)
-    shutil.move(global_db_backup, global_db_path)
+    # Clean tables
+    clean_table(local_db_path, 'sys_programs')
+    clean_table(cve_db_path, 'vulnerabilities')
+    clean_table(cve_db_path, 'vulnerabilities_info')
 
     control_service('start', daemon='wazuh-db')
 


### PR DESCRIPTION
Hello team,

This PR adds the vulnerability scan integration test using redhat as provider and inventory.

Closes #710

# Tests logic

These tests consists of verifying that a series of expected vulnerabilities are reported. To do this, custom packages and feeds are inserted, and finally it is verified that reports are generated in the `ossec.log` as the following:

```
The 'thunderbird-0' package from agent 0 is vulnerable to CVE-2012-3995.
```
These tests is also responsible for making the necessary modifications to run this test on any Linux system, since it is responsible for mocking the system in the agent.

The packages and feeds checked in these tests are:

- RHEL8
- RHEL7
- RHEL6
- RHEL5

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)
- [ ] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`

## RPM manager

- When the expected behavior occurs:

```
================================================ test session starts =================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 4 items                                                                                                    

test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py ....                       [100%]

============================================ 4 passed in 83.12s (0:01:23) ============================================
```

- When the module fails because it does not report the vulnerable packages:

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py FFFF         [100%]
==================================== 4 failed in 185.67s (0:03:05) =====================================

```

## DEB manager

- When the expected behavior occurs:

```
========================================= test session starts ==========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.8.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py ....         [100%]

===================================== 4 passed in 80.38s (0:01:20) =====================================
```

- When the module fails because it does not report the vulnerable packages:

```
========================================= test session starts ==========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.8.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py FFFF         [100%]
==================================== 4 failed in 182.11s (0:03:02) =====================================

```

## Integrity check with other tests


```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 83 items                                                                                     

test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py .ss.          [  4%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py ...       [  8%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py ............ [ 22%]
                                                                                                 [ 22%]
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py ..       [ 25%]
test_vulnerability_detector/test_providers/test_download_feeds.py .........                      [ 36%]
test_vulnerability_detector/test_providers/test_providers_enabled.py ........                    [ 45%]
test_vulnerability_detector/test_providers/test_providers_os.py .........                        [ 56%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py .........FF.....   [ 75%]
test_vulnerability_detector/test_providers/test_update_interval.py ................              [ 95%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py ....         [100%]

========================= 2 failed, 79 passed, 2 skipped in 2027.66s (0:33:47) =========================
```

Best regards.
