### PR TITLE
Remove xfail in quick_changes.py, except in windows

### DIFF
--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
@@ -4,6 +4,7 @@
 
 import os
 import time
+import sys
 
 import pytest
 
@@ -82,7 +83,7 @@ def test_regular_file_changes(sleep, tags_to_apply, get_configuration, configure
         for ev in events:
             validate_event(ev)
     except TimeoutError as e:
-        if get_configuration['metadata']['fim_mode'] == 'whodata':
+        if get_configuration['metadata']['fim_mode'] == 'whodata' and sys.platform == 'win32':
             pytest.xfail(reason='Xfailing due to issue: https://github.com/wazuh/wazuh/issues/4710')
         else:
             raise e


### PR DESCRIPTION

## Description

Hello team,
This PR is only to remove an xfail in `test_basic_usage_quick_changes.py` because it is no longer needed. Fix only affect to unix system, windows need xfail yet.

It has been fixed in the issue:
https://github.com/wazuh/wazuh/issues/4710
PR:
https://github.com/wazuh/wazuh/pull/4988