### PR TITLE
Remove audit path from schema and event validators

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/syscheck_event.json
+++ b/deps/wazuh_testing/wazuh_testing/data/syscheck_event.json
@@ -265,7 +265,6 @@
             "group_id",
             "group_name",
             "process_name",
-            "path",
             "audit_uid",
             "audit_name",
             "effective_uid",
@@ -320,15 +319,6 @@
                 "/usr/bin/touch"
               ],
               "pattern": "^(.*)$"
-            },
-            "path": {
-              "$id": "#/properties/data/properties/audit/properties/path",
-              "type": "string",
-              "default": "",
-              "examples": [
-                "/testdir1/example"
-              ],
-              "pattern": "^(?:\\/[^\\/]+)*$"
             },
             "audit_uid": {
               "$id": "#/properties/data/properties/audit/properties/audit_uid",

--- a/deps/wazuh_testing/wazuh_testing/data/syscheck_event_windows.json
+++ b/deps/wazuh_testing/wazuh_testing/data/syscheck_event_windows.json
@@ -273,23 +273,12 @@
           "$id": "#/properties/data/properties/audit",
           "type": "object",
           "required": [
-            "path",
             "process_id",
             "process_name",
             "user_id",
             "user_name"
           ],
           "properties": {
-            "path": {
-              "$id": "#/properties/data/properties/audit/properties/path",
-              "type": "string",
-              "default": "",
-              "examples": [
-                "/testdir1/example",
-                "c:/testdir1/example"
-              ],
-              "pattern": "^(?:([a-zA-Z]\\:|\\/)[^\\/]+)*$"
-            },
             "process_id": {
               "$id": "#/properties/data/properties/audit/properties/process_id",
               "type": "integer",

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1042,7 +1042,6 @@ class EventChecker:
 
         def check_events_path(events, folder, file_list=['testfile0'], mode=None):
             mode = global_parameters.current_configuration['metadata']['fim_mode'] if mode is None else mode
-            audit_path = filter_events(events, ".[].data.audit.path") if mode == "whodata" else None
             data_path = filter_events(events, ".[].data.path")
             for file_name in file_list:
                 expected_path = os.path.join(folder, file_name)
@@ -1050,22 +1049,12 @@ class EventChecker:
                 if self.encoding is not None:
                     for index, item in enumerate(data_path):
                         data_path[index] = item.encode(encoding=self.encoding)
-                    if audit_path:
-                        for index, item in enumerate(audit_path):
-                            audit_path[index] = item.encode(encoding=self.encoding)
                 if sys.platform == 'darwin' and self.encoding and self.encoding != 'utf-8':
                     logger.info(f'Not asserting {expected_path} in event.data.path. '
                                  f'Reason: using non-utf-8 encoding in darwin.')
                 else:
                     error_msg = f"Expected data path was '{expected_path}' but event data path is '{data_path}'"
                     assert (expected_path in data_path), error_msg
-                    if audit_path:
-                        try:
-                            error_msg = f"Expected audit path was '{expected_path}' " \
-                                        f"but event audit path is '{audit_path}'"
-                            assert (expected_path in audit_path), error_msg
-                        except AssertionError:
-                            pytest.xfail(reason='Xfailed due to issue: https://github.com/wazuh/wazuh/issues/4729')
 
         def filter_events(events, mask):
             """Returns a list of elements matching a specified mask in the events list using jq module."""


### PR DESCRIPTION
|Related wazuh/wazuh issue|Related wazuh/wazuh PR|
|---|---|
|https://github.com/wazuh/wazuh/issues/4864|https://github.com/wazuh/wazuh/pull/5096|

## Description
Hello team,
I removed the audit.path field, because it was the same as data.path, and it was not necessary. It was causing us some problems when these paths were different.
I modified the schemas and some checks in fim.py.

Best regards.
