### PR TITLE
Added a sleep in test_hard_link.oy to give it more consistency

### DIFF
--- a/tests/integration/test_fim/test_checks/test_hard_link.py
+++ b/tests/integration/test_fim/test_checks/test_hard_link.py
@@ -4,7 +4,7 @@
 
 import os
 import sys
-
+import time
 import pytest
 
 from wazuh_testing import global_parameters
@@ -138,6 +138,7 @@ def test_hard_link(path_file, file_name, path_link, link_name, num_links, get_co
                               mode=get_configuration['metadata']['fim_mode'],
                               expected_hard_links=hardlinks_list)
 
+    time.sleep(1)
     # Modify one of the hard links
     modify_file_content(path_link, hardlinks_list[0], new_content="modified HardLink0")
 


### PR DESCRIPTION
## Description
Hi team,
By removing one of the xfail related to the audit path of the alerts, in this issue and PR:
https://github.com/wazuh/wazuh/issues/4864
https://github.com/wazuh/wazuh/pull/5096

I have realized that this test is inconsistent in certain environments. The failure that is generated is of the type:

`E AssertionError: The event's FIM mode was 'whodata' but was expected to be 'scheduled`

It is also affected by the `rt_delay` variable, and may also fail in realtime mode.
The failure is in the part of the test that modifies the real file, as well as one of its hard links, so that it receives an alert of modified by the real file (in the corresponding mode, whodata or realtime), and another one, by the hard link, in schedule mode (after doing a time_travel). However, both are being received in the realtime/whodata mode.
The solution is to make a small sleep between both modifications so it doesn't depend on the environment.

Greetings!