### PR TITLE
Test vulnerability detector scan for Debian packages using Debian feeds

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/debian_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/debian_vulnerabilities.json
@@ -1,0 +1,282 @@
+[
+  {
+    "target": "BUSTER",
+    "os_name": "Debian GNU/Linux",
+    "os_version": "10",
+    "os_major": "10",
+    "os_minor": "",
+    "name": "debian10",
+    "vulnerabilities": [
+      {
+        "package": {
+          "name": "tor",
+          "version": "0.3.4",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-10592",
+          "operation": "less than",
+          "operation_value": "0.3.5.10-1"
+        }
+      },
+      {
+        "package": {
+          "name": "firefox-esr",
+          "version": "68.4",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-6796",
+          "operation": "less than",
+          "operation_value": "68.5.0esr-1~deb10u1"
+        }
+      },
+      {
+        "package": {
+          "name": "awl",
+          "version": "0.59",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-11729",
+          "operation": "less than",
+          "operation_value": "0.60-1+deb10u1"
+        }
+      },
+      {
+        "package": {
+          "name": "wordpress",
+          "version": "5.0.3",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-11029",
+          "operation": "less than",
+          "operation_value": "5.0.4+dfsg1-1+deb10u2"
+        }
+      },
+      {
+        "package": {
+          "name": "openldap",
+          "version": "2.4.46",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-12243",
+          "operation": "less than",
+          "operation_value": "2.4.47+dfsg-3+deb10u2"
+        }
+      }
+    ]
+  },
+  {
+    "target": "STRETCH",
+    "os_name": "Debian GNU/Linux",
+    "os_version": "9",
+    "os_major": "9",
+    "os_minor": "",
+    "name": "debian9",
+    "vulnerabilities": [
+      {
+        "package": {
+          "name": "python3.5",
+          "version": "3.5.2",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2017-1000158",
+          "operation": "less than",
+          "operation_value": "0:3.5.3-1+deb9u1"
+        }
+      },
+      {
+        "package": {
+          "name": "ruby2.3",
+          "version": "2.3.2",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2019-8320",
+          "operation": "less than",
+          "operation_value": "0:2.3.3-1+deb9u6"
+        }
+      },
+      {
+        "package": {
+          "name": "ansible",
+          "version": "2.2.0",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2019-3828",
+          "operation": "less than",
+          "operation_value": "0:2.2.1.0-2+deb9u1"
+        }
+      },
+      {
+        "package": {
+          "name": "php7.0",
+          "version": "7.0.32",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-7060",
+          "operation": "less than",
+          "operation_value": "0:7.0.33-0+deb9u7"
+        }
+      },
+      {
+        "package": {
+          "name": "asterisk",
+          "version": "3.11.1",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2016-7550",
+          "operation": "less than",
+          "operation_value": "0:1:13.11.2~dfsg-1"
+        }
+      }
+    ]
+  },
+  {
+    "target": "JESSIE",
+    "os_name": "Debian GNU/Linux",
+    "os_version": "8",
+    "os_major": "8",
+    "os_minor": "",
+    "name": "debian8",
+    "vulnerabilities": [
+      {
+        "package": {
+          "name": "ansible",
+          "version": "1.7.1",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2015-6240",
+          "operation": "less than",
+          "operation_value": "0:1.7.2+dfsg-2+deb8u2"
+        }
+      },
+      {
+        "package": {
+          "name": "gunicorn",
+          "version": "18.0",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2018-1000164",
+          "operation": "less than",
+          "operation_value": "0:19.0-1+deb8u1"
+        }
+      },
+      {
+        "package": {
+          "name": "tomcat8",
+          "version": "8.0.13",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2019-12418",
+          "operation": "less than",
+          "operation_value": "0:8.0.14-1+deb8u16"
+        }
+      },
+      {
+        "package": {
+          "name": "php",
+          "version": "5.6.39",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2020-7064",
+          "operation": "less than",
+          "operation_value": "0:5.6.40+dfsg-0+deb8u11"
+        }
+      },
+      {
+        "package": {
+          "name": "dnsmasq",
+          "version": "2.65",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2013-0198",
+          "operation": "less than",
+          "operation_value": "0:2.66-1"
+        }
+      }
+    ]
+  },
+  {
+    "target": "WHEEZY",
+    "os_name": "Debian GNU/Linux",
+    "os_version": "7",
+    "os_major": "7",
+    "os_minor": "",
+    "name": "debian7",
+    "vulnerabilities": [
+      {
+        "package": {
+          "name": "libxml-security-java",
+          "version": "1.4.4",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2013-2172",
+          "operation": "less than",
+          "operation_value": "0:1.4.5-1+deb7u1"
+        }
+      },
+      {
+        "package": {
+          "name": "python2.7",
+          "version": "2.7.2",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2013-4238",
+          "operation": "less than",
+          "operation_value": "0:2.7.3-6+deb7u2"
+        }
+      },
+      {
+        "package": {
+          "name": "git",
+          "version": "1.7.9",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2016-2315",
+          "operation": "less than",
+          "operation_value": "0:1:1.7.10.4-1+wheezy3"
+        }
+      },
+      {
+        "package": {
+          "name": "nginx",
+          "version": "1.2.0",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2016-0742",
+          "operation": "less than",
+          "operation_value": "0:1.2.1-2.2+wheezy4"
+        }
+      },
+      {
+        "package": {
+          "name": "apache2",
+          "version": "2.2.23",
+          "format": "deb"
+        },
+        "cve": {
+          "cveid": "CVE-2012-0216",
+          "operation": "less than",
+          "operation_value": "0:2.2.22-4"
+        }
+      }
+    ]
+  }
+]

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/debian_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/debian_vulnerabilities.json
@@ -9,62 +9,62 @@
     "vulnerabilities": [
       {
         "package": {
-          "name": "tor",
-          "version": "0.3.4",
+          "name": "postgresql-11",
+          "version": "0:11.6",
           "format": "deb"
         },
         "cve": {
-          "cveid": "CVE-2020-10592",
+          "cveid": "CVE-2020-1720",
           "operation": "less than",
-          "operation_value": "0.3.5.10-1"
+          "operation_value": "0:11.7-0+deb10u1"
         }
       },
       {
         "package": {
-          "name": "firefox-esr",
-          "version": "68.4",
+          "name": "mariadb-10.3",
+          "version": "0:1:10.3.22",
           "format": "deb"
         },
         "cve": {
-          "cveid": "CVE-2020-6796",
+          "cveid": "CVE-2020-2574",
           "operation": "less than",
-          "operation_value": "68.5.0esr-1~deb10u1"
+          "operation_value": "0:1:10.3.22-0+deb10u1"
         }
       },
       {
         "package": {
-          "name": "awl",
-          "version": "0.59",
+          "name": "python3.7",
+          "version": "0:3.7.0-6",
           "format": "deb"
         },
         "cve": {
-          "cveid": "CVE-2020-11729",
+          "cveid": "CVE-2018-20406",
           "operation": "less than",
-          "operation_value": "0.60-1+deb10u1"
+          "operation_value": "0:3.7.0-7"
         }
       },
       {
         "package": {
-          "name": "wordpress",
-          "version": "5.0.3",
+          "name": "php7.3",
+          "version": "0:7.3.9",
           "format": "deb"
         },
         "cve": {
-          "cveid": "CVE-2020-11029",
+          "cveid": "CVE-2019-11036",
           "operation": "less than",
-          "operation_value": "5.0.4+dfsg1-1+deb10u2"
+          "operation_value": "0:7.3.9-1~deb10u1"
         }
       },
       {
         "package": {
-          "name": "openldap",
-          "version": "2.4.46",
+          "name": "bash",
+          "version": "0:4.3",
           "format": "deb"
         },
         "cve": {
-          "cveid": "CVE-2020-12243",
+          "cveid": "CVE-2019-9924",
           "operation": "less than",
-          "operation_value": "2.4.47+dfsg-3+deb10u2"
+          "operation_value": "0:4.4-1"
         }
       }
     ]
@@ -80,7 +80,7 @@
       {
         "package": {
           "name": "python3.5",
-          "version": "3.5.2",
+          "version": "0:3.5.3",
           "format": "deb"
         },
         "cve": {
@@ -92,7 +92,7 @@
       {
         "package": {
           "name": "ruby2.3",
-          "version": "2.3.2",
+          "version": "0:2.3.3-1+deb9u5",
           "format": "deb"
         },
         "cve": {
@@ -104,7 +104,7 @@
       {
         "package": {
           "name": "ansible",
-          "version": "2.2.0",
+          "version": "0:2.2.1.0",
           "format": "deb"
         },
         "cve": {
@@ -116,7 +116,7 @@
       {
         "package": {
           "name": "php7.0",
-          "version": "7.0.32",
+          "version": "0:7.0.32",
           "format": "deb"
         },
         "cve": {
@@ -128,7 +128,7 @@
       {
         "package": {
           "name": "asterisk",
-          "version": "3.11.1",
+          "version": "0:1:13.11.1",
           "format": "deb"
         },
         "cve": {
@@ -150,7 +150,7 @@
       {
         "package": {
           "name": "ansible",
-          "version": "1.7.1",
+          "version": "0:1.7.1",
           "format": "deb"
         },
         "cve": {
@@ -162,7 +162,7 @@
       {
         "package": {
           "name": "gunicorn",
-          "version": "18.0",
+          "version": "0:19.0",
           "format": "deb"
         },
         "cve": {
@@ -174,7 +174,7 @@
       {
         "package": {
           "name": "tomcat8",
-          "version": "8.0.13",
+          "version": "0:8.0.12",
           "format": "deb"
         },
         "cve": {
@@ -186,7 +186,7 @@
       {
         "package": {
           "name": "php",
-          "version": "5.6.39",
+          "version": "0:5.6.40",
           "format": "deb"
         },
         "cve": {
@@ -198,7 +198,7 @@
       {
         "package": {
           "name": "dnsmasq",
-          "version": "2.65",
+          "version": "0:2.65",
           "format": "deb"
         },
         "cve": {
@@ -220,7 +220,7 @@
       {
         "package": {
           "name": "libxml-security-java",
-          "version": "1.4.4",
+          "version": "0:1.4.5",
           "format": "deb"
         },
         "cve": {
@@ -232,7 +232,7 @@
       {
         "package": {
           "name": "python2.7",
-          "version": "2.7.2",
+          "version": "0:2.7.3-6+deb7u1",
           "format": "deb"
         },
         "cve": {
@@ -244,7 +244,7 @@
       {
         "package": {
           "name": "git",
-          "version": "1.7.9",
+          "version": "0:1:1.7.10.4-1+wheezy1",
           "format": "deb"
         },
         "cve": {
@@ -256,7 +256,7 @@
       {
         "package": {
           "name": "nginx",
-          "version": "1.2.0",
+          "version": "0:1.2.0",
           "format": "deb"
         },
         "cve": {
@@ -268,7 +268,7 @@
       {
         "package": {
           "name": "apache2",
-          "version": "2.2.23",
+          "version": "0:2.2.21",
           "format": "deb"
         },
         "cve": {

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_debian_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_debian_inventory.yaml
@@ -1,0 +1,51 @@
+---
+# conf 1
+- tags:
+  - test_debian_inventory_debian_feeds
+  apply_to_modules:
+  - test_debian_inventory_debian_feeds
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'no'
+    - interval:
+        value: '5'
+    - provider:
+        attributes:
+        - name: 'redhat'
+        elements:
+        - enabled:
+            value: 'yes'
+    - provider:
+        attributes:
+        - name: 'canonical'
+        elements:
+        - enabled:
+            value: 'yes'
+    - provider:
+        attributes:
+        - name: 'debian'
+        elements:
+        - enabled:
+            value: 'yes'
+        - os:
+            value: 'buster'
+        - os:
+            value: 'stretch'
+        - os:
+            value: 'jessie'
+        - os:
+            value: 'wheezy'
+    - provider:
+        attributes:
+        - name: 'nvd'
+        elements:
+        - enabled:
+            value: 'yes'
+        - path:
+            value: NVD_JSON_PATH
+        - update_interval:
+            value: '10s'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import json
+import time
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, \
+                                                 insert_vulnerability, modify_system, clean_vd_tables
+from wazuh_testing.tools.services import control_service
+
+# Marks
+pytestmark = pytest.mark.tier(level=1)
+
+
+# Variables
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_debian_inventory.yaml')
+vulnerabilities_data_path = os.path.join(test_data_path, 'debian_vulnerabilities.json')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+scan_timeout = 40
+
+
+# Set configuration
+parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, 'nvd_feed.json')}]
+metadata = [{'nvd_json_path': os.path.join(test_data_path, 'nvd_feed.json')}]
+ids = ['debian_scan_configuration']
+
+
+# Read JSON data template
+with open(vulnerabilities_data_path, 'r') as f:
+    debian_vulnerabilities = json.loads(f.read())
+
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope='module', params=debian_vulnerabilities)
+def mock_vulnerability_scan(request):
+    """
+    It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
+    """
+    control_service('stop', daemon='wazuh-db')
+
+    # Wait until modulesd is restarted to avoid overwriting the system
+    time.sleep(5)
+
+    # Clean tables
+    clean_vd_tables(agent='000')
+
+    # Mock system
+    modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
+                  os_minor=request.param['os_minor'], name=request.param['name'])
+
+    # Add custom vulnerabilities and feeds
+    for vulnerability in request.param['vulnerabilities']:
+        insert_package(**vulnerability['package'], architecture='amd64')
+        insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
+                             target=request.param['target'])
+
+    control_service('start', daemon='wazuh-db')
+
+    # Truncate ossec.log
+    truncate_file(LOG_FILE_PATH)
+
+    yield request.param
+
+    control_service('stop', daemon='wazuh-db')
+
+    # Clean tables
+    clean_vd_tables(agent='000')
+
+    time.sleep(1)
+
+    control_service('start', daemon='wazuh-db')
+
+
+def check_vulnerability_event(package, cve):
+    """
+    Check if inserted vulnerable packages are reported by vulnerability detector.
+
+    Parameters
+    ----------
+    package: str
+        Name of custom package to check. Example: 'firefox-0'
+    cve : str
+        Package CVE. Example: 'CVE-2019-11764'
+    """
+    wazuh_log_monitor.start(
+        timeout=scan_timeout,
+        update_position=False,
+        callback=make_vuln_callback(f"The '{package}' package .* from agent .* is vulnerable to '{cve}'"),
+        error_message=f"Could not find the report which says that the package {package} is vulnerable with {cve}",
+    )
+
+
+def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+                                       mock_vulnerability_scan):
+    """
+    Check if inserted vulnerable packages are reported by vulnerability detector
+    """
+    for item in mock_vulnerability_scan['vulnerabilities']:
+        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
@@ -5,13 +5,13 @@
 import os
 import pytest
 import json
-import time
+from time import sleep
 
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, \
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, NVD_FEED, \
                                                  insert_vulnerability, modify_system, clean_vd_tables
 from wazuh_testing.tools.services import control_service
 
@@ -23,15 +23,17 @@ pytestmark = pytest.mark.tier(level=1)
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_debian_inventory.yaml')
-vulnerabilities_data_path = os.path.join(test_data_path, 'debian_vulnerabilities.json')
+vulnerabilities_data_path = os.path.join(test_data_path, 'nvd_vulnerabilities.json')
+#vulnerabilities_data_path = os.path.join(test_data_path, 'debian_vulnerabilities.json')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-scan_timeout = 40
+SCAN_TIMEOUT = 40
 
+custom_nvd_feed = 'custom_nvd_feed.json'
 
 # Set configuration
-parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, 'nvd_feed.json')}]
-metadata = [{'nvd_json_path': os.path.join(test_data_path, 'nvd_feed.json')}]
+parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, custom_nvd_feed)}]
+metadata = [{'nvd_json_path': os.path.join(test_data_path, custom_nvd_feed)}]
 ids = ['debian_scan_configuration']
 
 
@@ -59,20 +61,24 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
-    time.sleep(5)
+    sleep(5)
 
     # Clean tables
     clean_vd_tables(agent='000')
 
     # Mock system
-    modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                  os_minor=request.param['os_minor'], name=request.param['name'])
+    # modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
+    #               os_minor=request.param['os_minor'], name=request.param['name'])
 
     # Add custom vulnerabilities and feeds
-    for vulnerability in request.param['vulnerabilities']:
-        insert_package(**vulnerability['package'], architecture='amd64')
-        insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
-                             target=request.param['target'])
+    #for vulnerability in request.param['vulnerabilities']:
+        # insert_package(**vulnerability['package'], architecture='amd64')
+        # insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
+        #                      target=request.param['target'])
+
+    for i in range(5):
+        insert_package(name=f'wazuhinteasdsagrationpackage-{i}', version='0.9', format='deb', architecture='amd64', source=f'wazuhintegrationpackage-{i}')
+        insert_vulnerability(cveid=f'CVE-00{i}', operation='less than', operation_value='1.0.0', package=f'wazuhintegrationpackage-{i}', target='BUSTER')
 
     control_service('start', daemon='wazuh-db')
 
@@ -86,7 +92,7 @@ def mock_vulnerability_scan(request):
     # Clean tables
     clean_vd_tables(agent='000')
 
-    time.sleep(1)
+    sleep(1)
 
     control_service('start', daemon='wazuh-db')
 
@@ -103,7 +109,7 @@ def check_vulnerability_event(package, cve):
         Package CVE. Example: 'CVE-2019-11764'
     """
     wazuh_log_monitor.start(
-        timeout=scan_timeout,
+        timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(f"The '{package}' package .* from agent .* is vulnerable to '{cve}'"),
         error_message=f"Could not find the report which says that the package {package} is vulnerable with {cve}",
@@ -115,5 +121,7 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
-    for item in mock_vulnerability_scan['vulnerabilities']:
-        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
+    #for item in mock_vulnerability_scan['vulnerabilities']:
+    #    check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
+    for i in range(5):
+        check_vulnerability_event(f'wazuhintegrationpackage-{i}', f'CVE-00{i}')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
@@ -23,17 +23,15 @@ pytestmark = pytest.mark.tier(level=1)
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_debian_inventory.yaml')
-vulnerabilities_data_path = os.path.join(test_data_path, 'nvd_vulnerabilities.json')
-#vulnerabilities_data_path = os.path.join(test_data_path, 'debian_vulnerabilities.json')
+vulnerabilities_data_path = os.path.join(test_data_path, 'debian_vulnerabilities.json')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 SCAN_TIMEOUT = 40
 
-custom_nvd_feed = 'custom_nvd_feed.json'
 
 # Set configuration
-parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, custom_nvd_feed)}]
-metadata = [{'nvd_json_path': os.path.join(test_data_path, custom_nvd_feed)}]
+parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, NVD_FEED)}]
+metadata = [{'nvd_json_path': os.path.join(test_data_path, NVD_FEED)}]
 ids = ['debian_scan_configuration']
 
 
@@ -67,18 +65,14 @@ def mock_vulnerability_scan(request):
     clean_vd_tables(agent='000')
 
     # Mock system
-    # modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-    #               os_minor=request.param['os_minor'], name=request.param['name'])
+    modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
+                  os_minor=request.param['os_minor'], name=request.param['name'])
 
     # Add custom vulnerabilities and feeds
-    #for vulnerability in request.param['vulnerabilities']:
-        # insert_package(**vulnerability['package'], architecture='amd64')
-        # insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
-        #                      target=request.param['target'])
-
-    for i in range(5):
-        insert_package(name=f'wazuhinteasdsagrationpackage-{i}', version='0.9', format='deb', architecture='amd64', source=f'wazuhintegrationpackage-{i}')
-        insert_vulnerability(cveid=f'CVE-00{i}', operation='less than', operation_value='1.0.0', package=f'wazuhintegrationpackage-{i}', target='BUSTER')
+    for vulnerability in request.param['vulnerabilities']:
+        insert_package(**vulnerability['package'], source=vulnerability['package']['name'])
+        insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
+                             target=request.param['target'])
 
     control_service('start', daemon='wazuh-db')
 
@@ -121,7 +115,6 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
-    #for item in mock_vulnerability_scan['vulnerabilities']:
-    #    check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
-    for i in range(5):
-        check_vulnerability_event(f'wazuhintegrationpackage-{i}', f'CVE-00{i}')
+    for item in mock_vulnerability_scan['vulnerabilities']:
+        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
+

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
@@ -16,7 +16,7 @@ from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_pack
 from wazuh_testing.tools.services import control_service
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=0)
 
 
 # Variables

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
@@ -16,7 +16,7 @@ from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_pack
 from wazuh_testing.tools.services import control_service
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=0)
 
 
 # Variables
@@ -119,7 +119,7 @@ def test_redhat_vulnerabilities_report(get_configuration, configure_environment,
 
     # Check that the number of OVAL vulnerabilities is the expected
     wazuh_log_monitor.start(
-        timeout=scan_timeout,
+        timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
             f"The OVAL found a total of '{vulnerabilities_number}' potential vulnerabilities for agent .*"

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py
@@ -12,7 +12,7 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, NVD_FEED, \
-                                                 insert_vulnerability, modify_system, clean_vd_tables,
+                                                 insert_vulnerability, modify_system, clean_vd_tables
 from wazuh_testing.tools.services import control_service
 
 # Marks

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
@@ -16,7 +16,7 @@ from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_pack
 from wazuh_testing.tools.services import control_service
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=0)
 
 
 # Variables

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feeds.py
@@ -16,7 +16,7 @@ from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_pack
 from wazuh_testing.tools.services import control_service
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=0)
 
 
 # Variables
@@ -119,7 +119,7 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
 
     # Check that the number of OVAL vulnerabilities is the expected
     wazuh_log_monitor.start(
-        timeout=scan_timeout,
+        timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
             f"The OVAL found a total of '{vulnerabilities_number}' potential vulnerabilities for agent .*"


### PR DESCRIPTION
Hello team,

This PR adds the vulnerability scan integration test using Debian as provider and inventory.

Closes #706 

# Tests logic

These tests consists of verifying that a series of expected vulnerabilities are reported. To do this, custom packages and feeds are inserted, and finally it is verified that reports are generated in the `ossec.log` as the following:

```
The 'thunderbird-0' package from agent 0 is vulnerable to CVE-2012-3995.
```
These tests is also responsible for making the necessary modifications to run this test on any Linux system, since it is responsible for mocking the system in the agent.

The packages and feeds checked in these tests are:

- BUSTER
- STRETCH
- JESSIE
- WHEEZY

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)
- [x] Tested and passed in Jenkins. Build URL: https://jenkins-production.wazuh.info/job/test_integration_vulnerability_detector/58/

## RPM manager

- When the expected behavior occurs:

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py ....         [100%]

===================================== 4 passed in 77.65s (0:01:17) =====================================
```

- When the module fails because the source field does not match the package name:

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py FFFF         [100%]
==================================== 4 failed in 188.07s (0:03:08) =====================================
```

## DEB manager

- When the expected behavior occurs:

```
========================================= test session starts ==========================================
platform linux -- Python 3.7.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.9.0, testinfra-5.0.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py ....         [100%]

===================================== 4 passed in 77.15s (0:01:17) =====================================
```

- When the module fails because the source field does not match the package name:

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 4 items                                                                                      

test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py FFFF         [100%]
==================================== 4 failed in 188.07s (0:03:08) =====================================
```

## Integrity check with other tests


```
========================================= test session starts ==========================================
platform linux -- Python 3.7.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.9.0, testinfra-5.0.0
collected 101 items                                                                                    

test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py .ss.          [  3%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py ...       [  6%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py ............ [ 18%]
                                                                                                 [ 18%]
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py ..       [ 20%]
test_vulnerability_detector/test_providers/test_download_feeds.py .........                      [ 29%]
test_vulnerability_detector/test_providers/test_providers_enabled.py ........                    [ 37%]
test_vulnerability_detector/test_providers/test_providers_os.py .........                        [ 46%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py ................   [ 62%]
test_vulnerability_detector/test_providers/test_update_interval.py ................              [ 78%]
test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py ....         [ 82%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feeds.py ....         [ 86%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py ...........                 [ 97%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feeds.py ...       [100%]

============================== 99 passed, 2 skipped in 1993.73s (0:33:13) ==============================
```

Best regards.
