### PR TITLE
Fixing missed tst:4 from debian buster mocked feed

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/feeds/debian_buster_feed_oval.xml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/feeds/debian_buster_feed_oval.xml
@@ -39,9 +39,9 @@
     <uname_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="at_least_one_exists" comment="Installed architecture is all" id="oval:org.debian.oval:tst:2" version="1">
       <object object_ref="oval:org.debian.oval:obj:2"/>
     </uname_test>
-    <dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="None is earlier than 2.5.7-1" id="oval:org.debian.oval:tst:3" version="1">
-      <object object_ref="oval:org.debian.oval:obj:3"/>
-      <state state_ref="oval:org.debian.oval:ste:2"/>
+    <dpkginfo_test check="all" check_existence="at_least_one_exists" comment="gzip is earlier than 1.3.5-6" id="oval:org.debian.oval:tst:4" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+      <object object_ref="oval:org.debian.oval:obj:4"/>
+      <state state_ref="oval:org.debian.oval:ste:3"/>
     </dpkginfo_test>
   </tests>
   <objects>


### PR DESCRIPTION
This PR fixes an issue that was present in the Debian BUSTER mocked feed. Basically, during the feed reduction, it was missed the `tst:4` and instead was added the `tst:3`. This resulted in an empty `VULNERABILITIES` table in the `cve.db`.

It was verified that now the table is built properly. Here a snippet.

![image](https://user-images.githubusercontent.com/5703274/83295104-d35d7200-a1c4-11ea-9216-ffd45eed414b.png)
