### PR TITLE
Vulnerability detector: Add test invald field values for Redhat feeds

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -81,7 +81,7 @@ def random_string(length, encode=None):
 
 
 def read_file(file_path):
-    with open(file_path, 'r') as f:
+    with open(file_path) as f:
         data = f.read()
     return data
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -447,7 +447,7 @@ def check_feed_imported_successfully(wazuh_log_monitor, log_system_name, expecte
     check_vulnerability_event(
         wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
         callback=rf"INFO: \(\d+\): The update of the '{log_system_name}' feed finished successfully.",
-        error_message=f"Could not find the message: 'Red Hat Enterprise Linux' feed finished successfully"
+        error_message=f"Could not find the message: '{log_system_name}' feed finished successfully"
     )
 
     check_vulnerabilities_number(expected_number=expected_vulnerabilities_number)

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -35,6 +35,8 @@ NVD_TABLES = [
     {"name": "NVD_CPE", "path": CVE_DB_PATH},
 ]
 
+REDHAT_KEY_FIELDS_FEEDS = ['CVE', 'bugzilla_description', 'affected_packages']
+
 UpdateFromYearResult = namedtuple('UpdateFromYearResult', 'result actual_provider actual_update_from')
 
 nvd_check_feed_download_regex = r'.* wazuh-modulesd.*Downloading.*nvd\.nist\.gov\/feeds.*-(.*)\.(json|meta).*'

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -24,6 +24,10 @@ REAL_NVD_FEED = 'real_nvd_feed.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'
 CUSTOM_NVD_VULNERABILITIES_1 = 'nvd_vulnerabilities_1.json'
 CUSTOM_NVD_VULNERABILITIES_2 = 'nvd_vulnerabilities_2.json'
+INVALID_RHEL_FEEDS = 'wazuh_invalid_redhat_feeds.yaml'
+
+NVD_LOG = 'National Vulnerability Database'
+REDHAT_LOG = 'Red Hat Enterprise Linux'
 
 NVD_TABLES = [
     {"name": "NVD_REFERENCE", "path": CVE_DB_PATH},
@@ -433,3 +437,31 @@ def set_custom_system(**kwargs):
     modify_system(**kwargs)
 
     control_service('start', daemon='wazuh-db')
+
+
+def check_feed_imported_successfully(wazuh_log_monitor, log_system_name, expected_vulnerabilities_number,
+                                     update_position=False, timeout=VULN_DETECTOR_GLOBAL_TIMEOUT):
+    """
+    Check that redhat OVAL feeds have been imported successfully
+    """
+    check_vulnerability_event(
+        wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
+        callback=rf"INFO: \(\d+\): The update of the '{log_system_name}' feed finished successfully.",
+        error_message=f"Could not find the message: 'Red Hat Enterprise Linux' feed finished successfully"
+    )
+
+    check_vulnerabilities_number(expected_number=expected_vulnerabilities_number)
+
+
+def check_failure_when_importing_feed(wazuh_log_monitor, expected_vulnerabilities_number=0, update_position=False,
+                                      timeout=VULN_DETECTOR_GLOBAL_TIMEOUT):
+    """
+    Check an error message when importing redhat OVAL feeds and checks that the vulnerabilities table is empty
+    """
+    check_vulnerability_event(
+        wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
+        callback=r"ERROR: \(\d+\): CVE database could not be updated.",
+        error_message=f"Could not find the message: CVE database could not be updated"
+    )
+
+    check_vulnerabilities_number(expected_number=expected_vulnerabilities_number)

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_redhat_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_redhat_feeds.yaml
@@ -2,8 +2,10 @@
 # conf 1
 - tags:
   - test_missing_fields_redhat_feeds
+  - test_invalid_values_redhat_feeds
   apply_to_modules:
   - test_missing_fields_redhat_feeds
+  - test_invalid_values_redhat_feeds
   sections:
   - section: vulnerability-detector
     elements:

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import json
+from time import sleep
+import itertools
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.file import truncate_file, read_file, write_file
+from wazuh_testing.vulnerability_detector import CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
+                                                 REDHAT_KEY_FIELDS_FEEDS, set_custom_system, \
+                                                 check_vulnerability_event, check_vulnerabilities_number, \
+                                                 clean_vuln_and_sys_programs_tables
+from wazuh_testing.tools.services import control_service
+
+# Marks
+pytestmark = pytest.mark.tier(level=1)
+
+# Variables
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_invalid_redhat_feeds.yaml')
+vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', CUSTOM_NVD_VULNERABILITIES_1)
+custom_nvd_json_path = os.path.join(test_data_path, 'feeds', CUSTOM_NVD_FEED)
+custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', 'custom_redhat_oval_feed.json')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# Set configuration
+parameters = [{'NVD_JSON_PATH': custom_nvd_json_path, 'REDHAT_JSON_PATH': custom_redhat_oval_feed_path}]
+metadata = [{'nvd_json_path': custom_nvd_json_path, 'redhat_json_path': custom_redhat_oval_feed_path}]
+ids = ['REDHAT_configuration']
+
+# Read JSON data template
+with open(vulnerabilities_data_path, 'r') as f:
+    nvd_vulnerabilities = json.loads(f.read())
+
+system_data = {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"}
+
+expected_error_message = r"ERROR: \(\d+\): CVE database could not be updated."
+expected_success_message = r"INFO: \(\d+\): The update of the 'Red Hat Enterprise Linux' feed finished successfully."
+
+# Custom inputs to check
+inputs = [None, "", "dummy value", 12345, ['1', '2', '3', '4', '5'], "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار"]
+str_type = "<class 'str'>"
+list_type = "<class 'list'>"
+
+# Redhat fields to check
+field_data = [
+    {"field": "CVE", "type": str_type},
+    {"field": "severity", "input": "", "type": str_type},
+    {"field": "public_date", "type": str_type},
+    {"field": "advisories", "type": list_type},
+    {"field": "bugzilla", "type": str_type},
+    {"field": "bugzilla_description", "type": str_type},
+    {"field": "cvss_score", "type": str_type},
+    {"field": "cvss_scoring_vector", "type": str_type},
+    {"field": "CWE", "type": str_type},
+    {"field": "affected_packages", "type": list_type},
+    {"field": "resource_url", "type": str_type},
+    {"field": "cvss3_scoring_vector", "type": str_type},
+    {"field": "cvss3_score", "type": str_type}
+]
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture()
+def modify_feed(field_info, custom_input, request):
+    """
+    Modify the redhat OVAL feeds, setting a test field value
+    """
+    backup_data = json.loads(read_file(custom_redhat_oval_feed_path))[0]
+
+    modified_data = dict(backup_data)
+
+    modified_data[field_info['field']] = custom_input
+
+    write_file(custom_redhat_oval_feed_path, json.dumps([modified_data], indent=4, ensure_ascii=False))
+
+    clean_vuln_and_sys_programs_tables()
+
+    control_service('restart', daemon='wazuh-modulesd')
+
+    set_custom_system(os_name=system_data['os_name'], os_major=system_data['os_major'],
+                      os_minor=system_data['os_minor'], name=system_data['name'])
+
+    yield
+
+    write_file(custom_redhat_oval_feed_path, json.dumps([backup_data], indent=4))
+
+    clean_vuln_and_sys_programs_tables()
+
+    truncate_file(LOG_FILE_PATH)
+
+
+def check_feed_imported_successfully():
+    """
+    Check that redhat OVAL feeds have been imported successfully
+    """
+    check_vulnerability_event(
+        wazuh_log_monitor=wazuh_log_monitor, update_position=False, timeout=10,
+        callback=expected_success_message,
+        error_message=f"Could not find the message: 'Red Hat Enterprise Linux' feed finished successfully"
+    )
+
+    check_vulnerabilities_number(expected_number=5)
+
+
+def check_failure_when_importing_feed():
+    """
+    Check an error message when importing redhat OVAL feeds and checks that the vulnerabilities table is empty
+    """
+    check_vulnerability_event(
+        wazuh_log_monitor=wazuh_log_monitor, update_position=False, timeout=10,
+        callback=expected_error_message,
+        error_message=f"Could not find the message: CVE database could not be updated"
+    )
+
+    check_vulnerabilities_number(expected_number=0)
+
+
+@pytest.mark.parametrize('field_info, custom_input', itertools.product(field_data, inputs))
+def test_invalid_redhat_feed(field_info, custom_input, get_configuration, configure_environment, restart_modulesd,
+                             modify_feed):
+    """
+    Check if vulnerability detector behaves as expected when importing redhat OVAL feeds with wrong field values
+    """
+    if field_info['field'] == 'affected_packages':
+        pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5151")
+
+    if field_info['field'] in REDHAT_KEY_FIELDS_FEEDS:
+        if str(type(custom_input)) == field_info['type']:
+            check_feed_imported_successfully()
+        else:
+            check_failure_when_importing_feed()
+    else:
+        check_feed_imported_successfully()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
@@ -13,18 +13,19 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file, read_file, write_file
 from wazuh_testing.vulnerability_detector import CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
-                                                 REDHAT_KEY_FIELDS_FEEDS, set_custom_system, \
+                                                 REDHAT_KEY_FIELDS_FEEDS, INVALID_RHEL_FEEDS, REDHAT_LOG, \
                                                  check_vulnerability_event, check_vulnerabilities_number, \
-                                                 clean_vuln_and_sys_programs_tables
+                                                 clean_vuln_and_sys_programs_tables, set_custom_system, \
+                                                 check_feed_imported_successfully, check_failure_when_importing_feed
 from wazuh_testing.tools.services import control_service
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_invalid_redhat_feeds.yaml')
+configurations_path = os.path.join(test_data_path, 'configuration', INVALID_RHEL_FEEDS)
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', 'custom_redhat_oval_feed.json')
@@ -42,29 +43,24 @@ with open(vulnerabilities_data_path, 'r') as f:
 
 system_data = {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"}
 
-expected_error_message = r"ERROR: \(\d+\): CVE database could not be updated."
-expected_success_message = r"INFO: \(\d+\): The update of the 'Red Hat Enterprise Linux' feed finished successfully."
-
 # Custom inputs to check
 inputs = [None, "", "dummy value", 12345, ['1', '2', '3', '4', '5'], "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار"]
-str_type = "<class 'str'>"
-list_type = "<class 'list'>"
 
 # Redhat fields to check
 field_data = [
-    {"field": "CVE", "type": str_type},
-    {"field": "severity", "input": "", "type": str_type},
-    {"field": "public_date", "type": str_type},
-    {"field": "advisories", "type": list_type},
-    {"field": "bugzilla", "type": str_type},
-    {"field": "bugzilla_description", "type": str_type},
-    {"field": "cvss_score", "type": str_type},
-    {"field": "cvss_scoring_vector", "type": str_type},
-    {"field": "CWE", "type": str_type},
-    {"field": "affected_packages", "type": list_type},
-    {"field": "resource_url", "type": str_type},
-    {"field": "cvss3_scoring_vector", "type": str_type},
-    {"field": "cvss3_score", "type": str_type}
+    {"field": "CVE", "type": str},
+    {"field": "severity", "input": "", "type": str},
+    {"field": "public_date", "type": str},
+    {"field": "advisories", "type": list},
+    {"field": "bugzilla", "type": str},
+    {"field": "bugzilla_description", "type": str},
+    {"field": "cvss_score", "type": str},
+    {"field": "cvss_scoring_vector", "type": str},
+    {"field": "CWE", "type": str},
+    {"field": "affected_packages", "type": list},
+    {"field": "resource_url", "type": str},
+    {"field": "cvss3_scoring_vector", "type": str},
+    {"field": "cvss3_score", "type": str}
 ]
 
 # Configuration data
@@ -107,32 +103,6 @@ def modify_feed(field_info, custom_input, request):
     truncate_file(LOG_FILE_PATH)
 
 
-def check_feed_imported_successfully():
-    """
-    Check that redhat OVAL feeds have been imported successfully
-    """
-    check_vulnerability_event(
-        wazuh_log_monitor=wazuh_log_monitor, update_position=False, timeout=10,
-        callback=expected_success_message,
-        error_message=f"Could not find the message: 'Red Hat Enterprise Linux' feed finished successfully"
-    )
-
-    check_vulnerabilities_number(expected_number=5)
-
-
-def check_failure_when_importing_feed():
-    """
-    Check an error message when importing redhat OVAL feeds and checks that the vulnerabilities table is empty
-    """
-    check_vulnerability_event(
-        wazuh_log_monitor=wazuh_log_monitor, update_position=False, timeout=10,
-        callback=expected_error_message,
-        error_message=f"Could not find the message: CVE database could not be updated"
-    )
-
-    check_vulnerabilities_number(expected_number=0)
-
-
 @pytest.mark.parametrize('field_info, custom_input', itertools.product(field_data, inputs))
 def test_invalid_redhat_feed(field_info, custom_input, get_configuration, configure_environment, restart_modulesd,
                              modify_feed):
@@ -142,10 +112,9 @@ def test_invalid_redhat_feed(field_info, custom_input, get_configuration, config
     if field_info['field'] == 'affected_packages':
         pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5151")
 
-    if field_info['field'] in REDHAT_KEY_FIELDS_FEEDS:
-        if str(type(custom_input)) == field_info['type']:
-            check_feed_imported_successfully()
-        else:
-            check_failure_when_importing_feed()
+    # If the field is "key" and the input type is not the field type, then look for error messages
+    if field_info['field'] in REDHAT_KEY_FIELDS_FEEDS and not type(custom_input) is field_info['type']:
+        check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
     else:
-        check_feed_imported_successfully()
+        check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=5,
+                                         log_system_name=REDHAT_LOG)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
@@ -12,12 +12,8 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file, read_file, write_file
-from wazuh_testing.vulnerability_detector import CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
-                                                 REDHAT_KEY_FIELDS_FEEDS, INVALID_RHEL_FEEDS, REDHAT_LOG, \
-                                                 check_vulnerability_event, check_vulnerabilities_number, \
-                                                 clean_vuln_and_sys_programs_tables, set_custom_system, \
-                                                 check_feed_imported_successfully, check_failure_when_importing_feed
 from wazuh_testing.tools.services import control_service
+import wazuh_testing.vulnerability_detector as vd
 
 # Marks
 pytestmark = pytest.mark.tier(level=2)
@@ -25,9 +21,9 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', INVALID_RHEL_FEEDS)
-vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', CUSTOM_NVD_VULNERABILITIES_1)
-custom_nvd_json_path = os.path.join(test_data_path, 'feeds', CUSTOM_NVD_FEED)
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS)
+vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
+custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', 'custom_redhat_oval_feed.json')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -87,18 +83,18 @@ def modify_feed(field_info, custom_input, request):
 
     write_file(custom_redhat_oval_feed_path, json.dumps([modified_data], indent=4, ensure_ascii=False))
 
-    clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
-    set_custom_system(os_name=system_data['os_name'], os_major=system_data['os_major'],
+    vd.set_custom_system(os_name=system_data['os_name'], os_major=system_data['os_major'],
                       os_minor=system_data['os_minor'], name=system_data['name'])
 
     yield
 
     write_file(custom_redhat_oval_feed_path, json.dumps([backup_data], indent=4))
 
-    clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 
@@ -113,8 +109,8 @@ def test_invalid_redhat_feed(field_info, custom_input, get_configuration, config
         pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5151")
 
     # If the field is "key" and the input type is not the field type, then look for error messages
-    if field_info['field'] in REDHAT_KEY_FIELDS_FEEDS and not type(custom_input) is field_info['type']:
-        check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
+    if field_info['field'] in vd.REDHAT_KEY_FIELDS_FEEDS and not type(custom_input) is field_info['type']:
+        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
     else:
-        check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=5,
-                                         log_system_name=REDHAT_LOG)
+        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=5,
+                                         log_system_name=vd.REDHAT_LOG)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
@@ -11,8 +11,8 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file, read_file, write_file
-from wazuh_testing.vulnerability_detector import insert_custom_package, modify_system, clean_vd_tables, \
-                                                 CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
+from wazuh_testing.vulnerability_detector import CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
+                                                 REDHAT_KEY_FIELDS_FEEDS, insert_custom_package, \
                                                  check_vulnerability_event, check_vulnerabilities_number, \
                                                  clean_vuln_and_sys_programs_tables, set_custom_system
 from wazuh_testing.tools.services import control_service
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.tier(level=1)
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_missing_fields_redhat_feeds.yaml')
+configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_invalid_redhat_feeds.yaml')
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', 'custom_redhat_oval_feed.json')
@@ -48,8 +48,6 @@ fields = ['CVE', 'severity', 'public_date', 'advisories', 'bugzilla', 'bugzilla_
           'cvss_scoring_vector', 'CWE', 'affected_packages', 'resource_url', 'cvss3_scoring_vector', 'cvss3_score']
 
 field_ids = [f"field_{field}" for field in fields]
-
-key_fields = ['CVE', 'bugzilla_description', 'affected_packages']
 
 expected_error_messages = [
     r"DEBUG: \(\d+\): Null elements needing value have been found in a node of the feed. The update will not continue.",
@@ -101,13 +99,13 @@ def remove_field_feed(request):
 
 def test_invalid_redhat_feed(get_configuration, configure_environment, restart_modulesd, remove_field_feed):
     """
-    Check if a redhat OVAL feed with some missing fields, vulnerability detector behaves as expected
+    Check if vulnerability detector behaves as expected when importing redhat OVAL feeds with missing fields
     """
     if remove_field_feed == 'affected_packages':
         pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5151")
 
     # If the field removed is essential, then look for error messages
-    if remove_field_feed in key_fields:
+    if remove_field_feed in REDHAT_KEY_FIELDS_FEEDS:
         for expected_event_message in expected_error_messages:
             check_vulnerability_event(wazuh_log_monitor=wazuh_log_monitor, callback=expected_event_message,
                                       error_message=f"Could not find the following event: {expected_event_message}",

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
@@ -11,12 +11,8 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file, read_file, write_file
-from wazuh_testing.vulnerability_detector import CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
-                                                 REDHAT_KEY_FIELDS_FEEDS, INVALID_RHEL_FEEDS, \
-                                                 check_vulnerability_event, check_vulnerabilities_number, \
-                                                 clean_vuln_and_sys_programs_tables, set_custom_system, \
-                                                 insert_custom_package
 from wazuh_testing.tools.services import control_service
+import wazuh_testing.vulnerability_detector as vd
 
 # Marks
 pytestmark = pytest.mark.tier(level=2)
@@ -24,9 +20,9 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', INVALID_RHEL_FEEDS)
-vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', CUSTOM_NVD_VULNERABILITIES_1)
-custom_nvd_json_path = os.path.join(test_data_path, 'feeds', CUSTOM_NVD_FEED)
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS)
+vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
+custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', 'custom_redhat_oval_feed.json')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -80,20 +76,20 @@ def remove_field_feed(request):
 
     write_file(custom_redhat_oval_feed_path, json.dumps([data_removed_field], indent=4))
 
-    clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables()
 
-    insert_custom_package(**nvd_vulnerabilities['vulnerabilities'][0]['package'], format='rpm')
+    vd.insert_custom_package(**nvd_vulnerabilities['vulnerabilities'][0]['package'], format='rpm')
 
     control_service('restart', daemon='wazuh-modulesd')
 
-    set_custom_system(os_name=system_data[0]['os_name'], os_major=system_data[0]['os_major'],
+    vd.set_custom_system(os_name=system_data[0]['os_name'], os_major=system_data[0]['os_major'],
                       os_minor=system_data[0]['os_minor'], name=system_data[0]['name'])
 
     yield request.param
 
     write_file(custom_redhat_oval_feed_path, json.dumps([backup_data], indent=4))
 
-    clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 
@@ -106,26 +102,26 @@ def test_invalid_redhat_feed(get_configuration, configure_environment, restart_m
         pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5151")
 
     # If the field removed is essential, then look for error messages
-    if remove_field_feed in REDHAT_KEY_FIELDS_FEEDS:
+    if remove_field_feed in vd.REDHAT_KEY_FIELDS_FEEDS:
         for expected_event_message in expected_error_messages:
-            check_vulnerability_event(wazuh_log_monitor=wazuh_log_monitor, callback=expected_event_message,
+            vd.check_vulnerability_event(wazuh_log_monitor=wazuh_log_monitor, callback=expected_event_message,
                                       error_message=f"Could not find the following event: {expected_event_message}",
                                       update_position=False, timeout=30)
 
-        check_vulnerabilities_number(expected_number=0)
+        vd.check_vulnerabilities_number(expected_number=0)
     # If the field removed is not essential then check db and alerts
     else:
         package = nvd_vulnerabilities['vulnerabilities'][0]['package']['name']
         cve = nvd_vulnerabilities['vulnerabilities'][0]['cve']['cveid']
 
-        check_vulnerability_event(
+        vd.check_vulnerability_event(
             wazuh_log_monitor=wazuh_log_monitor, update_position=False, timeout=SCAN_TIMEOUT,
             callback=f"The OVAL found a total of '1' potential vulnerabilities for agent .*",
             error_message=f"The expected number of OVAL vulnerabilities for NVD have not been found")
 
-        check_vulnerability_event(
+        vd.check_vulnerability_event(
             wazuh_log_monitor=wazuh_log_monitor, update_position=False, timeout=SCAN_TIMEOUT,
             callback=f"The '{package}' package .* from agent .* is vulnerable to '{cve}'",
             error_message=f"Could not find the report which says that the package {package} is vulnerable with {cve}")
 
-        check_vulnerabilities_number(expected_number=5)
+        vd.check_vulnerabilities_number(expected_number=5)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
@@ -12,18 +12,19 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file, read_file, write_file
 from wazuh_testing.vulnerability_detector import CUSTOM_NVD_VULNERABILITIES_1, CUSTOM_NVD_FEED, \
-                                                 REDHAT_KEY_FIELDS_FEEDS, insert_custom_package, \
+                                                 REDHAT_KEY_FIELDS_FEEDS, INVALID_RHEL_FEEDS, \
                                                  check_vulnerability_event, check_vulnerabilities_number, \
-                                                 clean_vuln_and_sys_programs_tables, set_custom_system
+                                                 clean_vuln_and_sys_programs_tables, set_custom_system, \
+                                                 insert_custom_package
 from wazuh_testing.tools.services import control_service
 
 # Marks
-pytestmark = pytest.mark.tier(level=1)
+pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_invalid_redhat_feeds.yaml')
+configurations_path = os.path.join(test_data_path, 'configuration', INVALID_RHEL_FEEDS)
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', 'custom_redhat_oval_feed.json')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feeds.py
@@ -110,7 +110,7 @@ def check_vulnerability_event(package, cve):
     )
 
 
-def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_debian_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
                                        mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
@@ -129,8 +129,8 @@ def check_vulnerability_event(package, cve):
     )
 
 
-def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
-                                       mock_vulnerability_scan):
+def test_nvd_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+                                    mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
@@ -136,8 +136,8 @@ def check_vulnerability_event(package, cve):
     )
 
 
-def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
-                                       mock_vulnerability_scan):
+def test_nvd_and_oval_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+                                             mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check the vulnerability detector behavior when some field value in Redhat feed is wrong, wrong type, null, or has rare characters.

Closes #749

# Tests logic

From a customized JSON feed, a set of tests are performed in which a field value is changed and the behavior of the vulnerability detector is observed.

For each field in the redhat feed, the following values have been entered:

```
[None, "", "dummy value", 12345, ['1', '2', '3', '4', '5'], "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار"]
```
The tested results are as follows

- If the field is **key** (`['CVE', 'bugzilla_description', 'affected_packages']`), then feeds will only be inserted when the data type corresponds to the expected one. To do this, the following log is checked

  **If the type of data is as expected**

  ```
  INFO: (5430): The update of the 'Red Hat Enterprise Linux' feed finished successfully.
  ```

  **If the type of data is not as expected**

  ```
  ERROR: (5513): CVE database could not be updated.
  ```

  and a count is made of the vulnerabilities inserted in the `vulnerabilities` table.

- If the field is not a key, then the feed will be inserted regardless of what data is added to it.

  ```
  INFO: (5430): The update of the 'Red Hat Enterprise Linux' feed finished successfully.
  ```
  and a count is made of the vulnerabilities inserted in the `vulnerabilities` table.

# Results

```
  ========================================== test session starts ==========================================
  platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
  rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
  plugins: html-2.0.1, testinfra-5.0.0, metadata-1.8.0
  collected 130 items  
  test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py ...................... [ 16%]
  ....................................................................xxxxxxxxxx................... [ 91%]
  ...........                                                                                       [100%]

  ============================= 120 passed, 10 xfailed in 1257.75s (0:20:57) ==============================
```

> Note: In the case of `affected_packages` no such message is reported, so this issue has been opened https://github.com/wazuh/wazuh/issues/5151. These tests are set as `xfail`.

Best regards.