### PR TITLE
Fix for JWT token duration and rbac mode

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -27,7 +27,7 @@ else:
     WAZUH_PATH = os.path.join('/', 'var', 'ossec')
     WAZUH_CONF = os.path.join(WAZUH_PATH, 'etc', 'ossec.conf')
     WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')
-    WAZUH_RBAC_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'rbac.yaml')
+    WAZUH_SECURITY_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'security.yaml')
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
     LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -2,9 +2,10 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import grp
 import os
+import pwd
 import sys
-
 
 if sys.platform == 'win32':
     WAZUH_PATH = os.path.join("C:", os.sep, "Program Files (x86)", "ossec-agent")
@@ -26,11 +27,14 @@ else:
     WAZUH_PATH = os.path.join('/', 'var', 'ossec')
     WAZUH_CONF = os.path.join(WAZUH_PATH, 'etc', 'ossec.conf')
     WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')
+    WAZUH_RBAC_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'rbac.yaml')
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
     LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
     GEN_OSSEC = os.path.join(WAZUH_SOURCES, 'gen_ossec.sh')
     PREFIX = os.sep
+    OSSEC_UID = pwd.getpwnam("ossec").pw_uid
+    OSSEC_GID = grp.getgrnam("ossec").gr_gid
 
 if sys.platform == 'darwin' or sys.platform == 'win32' or sys.platform == 'sunos5':
     WAZUH_SERVICE = 'wazuh.agent'

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import WAZUH_PATH, GEN_OSSEC, WAZUH_CONF, PREFIX
+from wazuh_testing.tools import WAZUH_PATH, GEN_OSSEC, WAZUH_CONF, PREFIX, OSSEC_UID, OSSEC_GID
 
 
 # customize _serialize_xml to avoid lexicographical order in XML attributes
@@ -169,6 +169,23 @@ def write_api_conf(path: str, api_conf: dict):
     """
     with open(path, 'w+') as f:
         yaml.dump(api_conf, f)
+
+
+def write_security_conf(path: str, security_conf: dict):
+    """
+    Write a new configuration in 'security.yaml' file.
+
+    Parameters
+    ----------
+    path : str
+        Path of config file.
+    security_conf : dict
+        Dictionary to be written in the security.yaml file.
+    """
+    if not os.path.exists(path):
+        open(path, mode='w').close()
+        os.chown(uid=OSSEC_UID, gid=OSSEC_GID, path=path)
+    write_api_conf(path, security_conf)
 
 
 def set_section_wazuh_conf(sections, template=None):

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -10,8 +10,8 @@ import pytest
 
 from wazuh_testing.api import callback_detect_api_start, get_base_url, get_token_login_api, API_HOST, \
     API_LOGIN_ENDPOINT, API_PASS, API_PORT, API_USER, API_PROTOCOL, API_VERSION
-from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_PATH, WAZUH_API_CONF
-from wazuh_testing.tools.configuration import get_api_conf, write_api_conf
+from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_PATH, WAZUH_API_CONF, WAZUH_RBAC_CONF
+from wazuh_testing.tools.configuration import get_api_conf, write_api_conf, write_rbac_conf
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -23,8 +23,18 @@ def configure_api_environment(get_configuration, request):
     # Save current configuration
     backup_config = get_api_conf(WAZUH_API_CONF)
 
+    # Save current RBAC config
+    backup_rbac_config = get_api_conf(WAZUH_RBAC_CONF) if os.path.exists(WAZUH_RBAC_CONF) else None
+
     # Set new configuration
-    write_api_conf(WAZUH_API_CONF, get_configuration.get('configuration'))
+    api_config = get_configuration.get('configuration', None)
+    if api_config:
+        write_api_conf(WAZUH_API_CONF, api_config)
+
+    # Set RBAC configuration
+    rbac_config = get_configuration.get('rbac_config', None)
+    if rbac_config:
+        write_rbac_conf(WAZUH_RBAC_CONF, rbac_config)
 
     # Create test directories
     if hasattr(request.module, 'test_directories'):
@@ -47,7 +57,14 @@ def configure_api_environment(get_configuration, request):
             shutil.rmtree(test_dir, ignore_errors=True)
 
     # Restore previous configuration
-    write_api_conf(WAZUH_API_CONF, backup_config)
+    if backup_config:
+        write_api_conf(WAZUH_API_CONF, backup_config)
+
+    # Restore previous RBAC configuration
+    if backup_rbac_config:
+        write_rbac_conf(WAZUH_RBAC_CONF, backup_rbac_config)
+    elif rbac_config and not backup_rbac_config:
+        os.remove(WAZUH_RBAC_CONF)
 
     # Call extra functions after yield
     if hasattr(request.module, 'extra_configuration_after_yield'):

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -10,8 +10,8 @@ import pytest
 
 from wazuh_testing.api import callback_detect_api_start, get_base_url, get_token_login_api, API_HOST, \
     API_LOGIN_ENDPOINT, API_PASS, API_PORT, API_USER, API_PROTOCOL, API_VERSION
-from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_PATH, WAZUH_API_CONF, WAZUH_RBAC_CONF
-from wazuh_testing.tools.configuration import get_api_conf, write_api_conf, write_rbac_conf
+from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_PATH, WAZUH_API_CONF, WAZUH_SECURITY_CONF
+from wazuh_testing.tools.configuration import get_api_conf, write_api_conf, write_security_conf
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -23,18 +23,18 @@ def configure_api_environment(get_configuration, request):
     # Save current configuration
     backup_config = get_api_conf(WAZUH_API_CONF)
 
-    # Save current RBAC config
-    backup_rbac_config = get_api_conf(WAZUH_RBAC_CONF) if os.path.exists(WAZUH_RBAC_CONF) else None
+    # Save current security config
+    backup_security_config = get_api_conf(WAZUH_SECURITY_CONF) if os.path.exists(WAZUH_SECURITY_CONF) else None
 
     # Set new configuration
     api_config = get_configuration.get('configuration', None)
     if api_config:
         write_api_conf(WAZUH_API_CONF, api_config)
 
-    # Set RBAC configuration
-    rbac_config = get_configuration.get('rbac_config', None)
-    if rbac_config:
-        write_rbac_conf(WAZUH_RBAC_CONF, rbac_config)
+    # Set security configuration
+    security_config = get_configuration.get('security_config', None)
+    if security_config:
+        write_security_conf(WAZUH_SECURITY_CONF, security_config)
 
     # Create test directories
     if hasattr(request.module, 'test_directories'):
@@ -61,10 +61,10 @@ def configure_api_environment(get_configuration, request):
         write_api_conf(WAZUH_API_CONF, backup_config)
 
     # Restore previous RBAC configuration
-    if backup_rbac_config:
-        write_rbac_conf(WAZUH_RBAC_CONF, backup_rbac_config)
-    elif rbac_config and not backup_rbac_config:
-        os.remove(WAZUH_RBAC_CONF)
+    if backup_security_config:
+        write_security_conf(WAZUH_SECURITY_CONF, backup_security_config)
+    elif security_config and not backup_security_config:
+        os.remove(WAZUH_SECURITY_CONF)
 
     # Call extra functions after yield
     if hasattr(request.module, 'extra_configuration_after_yield'):

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data/conf_exp_timeout.yaml
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data/conf_exp_timeout.yaml
@@ -1,9 +1,9 @@
 ---
 - tags:
   - short_exp_time
-  rbac_config:
+  security_config:
     auth_token_exp_timeout: 8
 - tags:
   - long_exp_time
-  rbac_config:
+  security_config:
     auth_token_exp_timeout: 800

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data/conf_exp_timeout.yaml
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data/conf_exp_timeout.yaml
@@ -1,9 +1,9 @@
 ---
 - tags:
   - short_exp_time
-  configuration:
+  rbac_config:
     auth_token_exp_timeout: 8
 - tags:
   - long_exp_time
-  configuration:
+  rbac_config:
     auth_token_exp_timeout: 800

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
@@ -56,7 +56,7 @@ def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_e
         f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
 
     # Request manager info after token expires.
-    time.sleep(min(get_configuration['configuration']['auth_token_exp_timeout'] + 2, 10))
+    time.sleep(min(get_configuration['rbac_config']['auth_token_exp_timeout'] + 2, 10))
     get_response = requests.get(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
 
     # If token has expired, user can't access that information.

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
@@ -56,7 +56,7 @@ def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_e
         f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
 
     # Request manager info after token expires.
-    time.sleep(min(get_configuration['rbac_config']['auth_token_exp_timeout'] + 2, 10))
+    time.sleep(min(get_configuration['security_config']['auth_token_exp_timeout'] + 2, 10))
     get_response = requests.get(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
 
     # If token has expired, user can't access that information.

--- a/tests/integration/test_api/test_config/test_rbac/data/conf_mode.yaml
+++ b/tests/integration/test_api/test_config/test_rbac/data/conf_mode.yaml
@@ -1,11 +1,9 @@
 ---
 - tags:
   - rbac_white
-  configuration:
-    rbac:
-      mode: white
+  rbac_config:
+    mode: white
 - tags:
   - rbac_black
-  configuration:
-    rbac:
-      mode: black
+  rbac_config:
+    mode: black

--- a/tests/integration/test_api/test_config/test_rbac/data/conf_mode.yaml
+++ b/tests/integration/test_api/test_config/test_rbac/data/conf_mode.yaml
@@ -1,9 +1,9 @@
 ---
 - tags:
   - rbac_white
-  rbac_config:
-    mode: white
+  security_config:
+    rbac_mode: white
 - tags:
   - rbac_black
-  rbac_config:
-    mode: black
+  security_config:
+    rbac_mode: black

--- a/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
+++ b/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
@@ -78,7 +78,7 @@ def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, 
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    rbac_white = get_configuration['configuration']['rbac']['mode'] == 'white'
+    rbac_white = get_configuration['rbac_config']['mode'] == 'white'
     api_details = get_api_details(user='test_user', password='wazuh')
     api_details['base_url'] += '/manager/info'
 

--- a/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
+++ b/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
@@ -78,7 +78,7 @@ def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, 
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    rbac_white = get_configuration['rbac_config']['mode'] == 'white'
+    rbac_white = get_configuration['security_config']['rbac_mode'] == 'white'
     api_details = get_api_details(user='test_user', password='wazuh')
     api_details['base_url'] += '/manager/info'
 


### PR DESCRIPTION
Hello team,

This PR fix the JWT and rbac mode tests.

## Test results
```
root:/vagrant/wazuh-qa/tests/integration # python3 -m pytest -x test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py 
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.8, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.9.0, html-2.0.1, testinfra-5.0.0
collected 4 items

test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                                                      [100%]

====================================================================================== warnings summary =======================================================================================
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration0-tags_to_apply0]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration0-tags_to_apply0]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration0-tags_to_apply0]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration1-tags_to_apply1]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration1-tags_to_apply1]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration1-tags_to_apply1]
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================== 2 passed, 2 skipped, 6 warnings in 42.15s ==========================================================================
```
```bash
root:/vagrant/wazuh-qa/tests/integration # python3 -m pytest -x test_api/test_config/test_rbac/test_rbac_mode.py 
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.6.8, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.9.0, html-2.0.1, testinfra-5.0.0
collected 4 items

test_api/test_config/test_rbac/test_rbac_mode.py .ss.                                                                                                               [100%]

============================================================================ warnings summary =============================================================================
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration0-tags_to_apply0]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration0-tags_to_apply0]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration1-tags_to_apply1]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration1-tags_to_apply1]
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================ 2 passed, 2 skipped, 4 warnings in 17.99s ================================================================

```