### PR TITLE
Vulnerability detector: Add new vulnerabilities to custom Red Hat feed

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -616,8 +616,8 @@ def insert_data_redhat_feed(data, field_name, field_value, append_data):
         data['replace_me'] = field_value
         string_data = json.dumps(data, indent=4, ensure_ascii=False).replace('"replace_me"', f"{field_name}")
 
-    string_data += ',\n' + json.dumps(append_data, indent=4, ensure_ascii=False)
+    string_data += f",\n{json.dumps(append_data, indent=4, ensure_ascii=False)}"
 
-    string_data = "[\n" + string_data + "\n]"
+    string_data = f"[\n{string_data}\n]"
 
     return string_data

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -594,7 +594,7 @@ def set_system(system):
         pass
 
 
-def insert_data_redhat_feed(data, field_name, field_value):
+def insert_data_redhat_feed(data, field_name, field_value, append_data):
     """
     Allow insert key:value pair as string, since otherwise, you could not insert lists or dictionaries as a key
 
@@ -606,6 +606,8 @@ def insert_data_redhat_feed(data, field_name, field_value):
         Field name to insert
     field_value: str
         Field value to insert
+    append_data: dict
+        Additional data to insert
     """
     if type(field_name) is str:
         data[field_name] = field_value
@@ -613,6 +615,8 @@ def insert_data_redhat_feed(data, field_name, field_value):
     else:
         data['replace_me'] = field_value
         string_data = json.dumps(data, indent=4, ensure_ascii=False).replace('"replace_me"', f"{field_name}")
+
+    string_data += ',\n' + json.dumps(append_data, indent=4, ensure_ascii=False)
 
     string_data = "[\n" + string_data + "\n]"
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/feeds/custom_redhat_oval_feed.json
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/feeds/custom_redhat_oval_feed.json
@@ -23,5 +23,26 @@
     "resource_url":"",
     "cvss3_scoring_vector":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H",
     "cvss3_score":"8.6"
+  },
+  {
+    "CVE":"CVE-001",
+    "severity":"medium",
+    "public_date":"2020-01-12T00:00:00Z",
+    "advisories":[
+       "RHSA-2020:0221",
+       "RHSA-2020:0223",
+       "RHSA-2020:262"
+    ],
+    "bugzilla":"1829530",
+    "bugzilla_description":"CVE-001 wazuhintegrationpackage-0 testing",
+    "cvss_score":null,
+    "cvss_scoring_vector":null,
+    "CWE":"(CWE-152|CWE-210)",
+    "affected_packages":[
+       "wazuhintegrationpackage-1-0:1.0.el8_1.2"
+    ],
+    "resource_url":"",
+    "cvss3_scoring_vector":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H",
+    "cvss3_score":"7.2"
   }
 ]

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -60,14 +60,14 @@ for provider, values in provider_info.items():
     for os in values['os']:
         parameters.append({'PROVIDER_NAME': provider, 'OS': os, 'UPDATE_FROM_YEAR': values['update_from_year']})
         metadata.append({'provider_name': provider, 'os': os, 'update_from_year': values['update_from_year'],
-                     'system_log': values['system_log'], 'download_timeout': values['download_timeout']})
+                         'system_log': values['system_log'], 'download_timeout': values['download_timeout']})
         ids.append(f"{provider}_{os}")
 
-  # If empty os list
+    # If empty os list
     if len(values['os']) == 0:
         parameters.append({'PROVIDER_NAME': provider, 'OS': '', 'UPDATE_FROM_YEAR': values['update_from_year']})
         metadata.append({'provider_name': provider, 'os': '', 'update_from_year': values['update_from_year'],
-                     'system_log': values['system_log'], 'download_timeout': values['download_timeout']})
+                         'system_log': values['system_log'], 'download_timeout': values['download_timeout']})
         ids.append(f"{provider}")
 
 # Configuration data

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_extra_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_extra_fields_redhat_feeds.py
@@ -55,12 +55,13 @@ def modify_feed(test_values, request):
     """
     Modify the redhat OVAL feeds, setting a test field value
     """
-    backup_data = read_json_file(custom_redhat_oval_feed_path)[0]
+    backup_data = read_json_file(custom_redhat_oval_feed_path)
 
-    modified_data = dict(backup_data)
+    modified_data = dict(backup_data[0])
 
     # Insert key:value pair as string, since otherwise, you could not insert lists or dictionaries as a key
-    modified_string_data = vd.insert_data_redhat_feed(modified_data, test_values[0], test_values[1])
+    modified_string_data = vd.insert_data_redhat_feed(data=modified_data, field_name=test_values[0],
+                                                      field_value=test_values[1], append_data=backup_data[1])
 
     write_file(custom_redhat_oval_feed_path, modified_string_data)
 
@@ -74,7 +75,7 @@ def modify_feed(test_values, request):
 
     control_service('restart', daemon='wazuh-modulesd')
 
-    write_json_file(custom_redhat_oval_feed_path, [backup_data])
+    write_json_file(custom_redhat_oval_feed_path, backup_data)
 
     vd.clean_vuln_and_sys_programs_tables()
 
@@ -93,9 +94,7 @@ def test_extra_fields_redhat_feed(test_values, get_configuration, configure_envi
         vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=expected_log_event)
 
         vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.REDHAT_LOG,
-                                            expected_vulnerabilities_number=5)
-
-        vd.check_vulnerabilities_number(expected_number=5)
+                                            expected_vulnerabilities_number=6)
     else:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, parser_error=True)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_syntax_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_syntax_redhat_feeds.py
@@ -38,42 +38,42 @@ nvd_vulnerabilities = read_json_file(vulnerabilities_data_path)
 
 test_data = [
     # CURLY BRACKETS
-    {"pattern": r'(\{).*\n.*"CVE"', "update": '', "description": "Delete initial '{'"},
-    {"pattern": r'cvss3_score".*\n.*(\})', "update": '', "description": "Delete the final '}'"},
-    {"pattern": r'(\{)\n.*', "update": '{{', "description": "Add '{{'"},
-    {"pattern": r'"cvss3_score".*\n.*(\})', "update": '}}', "description": "Add '}}'"},
+    {"pattern": r'(\{)', "update": '', "description": "Delete '{'"},
+    {"pattern": r'(\})', "update": '', "description": "Delete '}'"},
+    {"pattern": r'(\{)', "update": '{{', "description": "Add '{{'"},
+    {"pattern": r'(\})', "update": '}}', "description": "Add '}}'"},
     {"pattern": r'"CVE":.*(,)', "update": ',{', "description": "Add '{' in the middle of feed"},
     {"pattern": r'"CVE":.*(,)', "update": ',}', "description": "Add '}' in the middle of feed"},
     {"pattern": r'"CVE":.*(,)', "update": ',{}', "description": "Add '{}' in the middle of feed"},
 
     # COMMA
-    {"pattern": r'.*"CVE":.*(,)', "update": '', "description": "Delete key:value comma ','"},
-    {"pattern": r'.*"CVE"(:)', "update": ': ,', "description": "Add a comma before value key: ,value,"},
-    {"pattern": r'\{\n.*("CVE")', "update": ', "CVE"', "description": "Add a comma before any key value ', key:value'"},
-    {"pattern": r'"cvss3_score":.*\n.*(\})', "update": ',}', "description": "Add a comma at the end ',}'"},
+    {"pattern": r'"CVE":.*(,)', "update": '', "description": "Delete key:value comma ','"},
+    {"pattern": r'"CVE"(:)', "update": ': ,', "description": "Add a comma before value key: ,value,"},
+    {"pattern": r'(")CVE":.*', "update": ',"', "description": "Add a comma before any key value ', key:value'"},
+    {"pattern": r'(\})', "update": ",}" ,"description": "Add a comma at the end of vulnerability ',}'"},
     {"pattern": r'.*"CVE":.*(,)', "update": ',,', "description": "Add double comma after key:value,,"},
-    {"pattern": r'".*package-0-0:1.0.el5_0.2"(,)', "update": ',,', "description": "Add double comma after list value,,"},
+    {"pattern": r'".*el5_0.2"(,)', "update": ',,', "description": "Add double comma after list value,,"},
 
     # QUOTES
     {"pattern": r'"CVE"(:)', "update": '":', "description": "Close a key with double quotation marks"},
     {"pattern": r'"CVE":.*(,)', "update": '",', "description": "Close a value with double quotation marks"},
 
-    #SEMICOLON
+    # SEMICOLON
     {"pattern": r'"CVE":.*(,)', "update": ';', "description": "Replace a comma with semicolon"},
     {"pattern": r'"CVE"(:)', "update": ';', "description": "Replace a colon with semicolon"},
 
     # BRACKETS
     {"pattern": r'"affected_packages":.*(\[)', "update": '', "description": "Missing open bracket"},
-    {"pattern": r'el8_1.2"\n.*(\])', "update": '', "description": "Missing close bracket"},
+    {"pattern": r'affected_packages.*(\])', "update": '', "description": "Missing close bracket"},
 
     # MISSING INFO
     {"pattern": r'.*bug(.*)', "update": '', "description": "Delete some information"},
 ]
 
 # Add EXTRA CHARS to test_data
-extra_chars = ['.', ':', '@', '#', '*', '-', '_', "'",'"', '/', '=', '<', '>', '!', '?', '%', '&', '`']
+extra_chars = ['.', ':', '@', '#', '*', '-', '_', "'", '"', '/', '=', '<', '>', '!', '?', '%', '&', '`']
 for item in extra_chars:
-  test_data.append({"pattern": r'"CVE":.*(,)', "update": item, "description": f"Replace ',' with '{item}'"})
+    test_data.append({"pattern": r'"CVE":.*(,)', "update": item, "description": f"Replace ',' with '{item}'"})
 
 test_ids = [item['description'] for item in test_data]
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_syntax_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_syntax_redhat_feeds.py
@@ -93,11 +93,14 @@ def modify_feed(test_data, request):
     """
     Modify the redhat OVAL feeds, setting a test field value
     """
-    backup_data = read_json_file(custom_redhat_oval_feed_path)[0]
+    backup_data = read_json_file(custom_redhat_oval_feed_path)
 
-    modified_data = dict(backup_data)
+    modified_data = json.dumps(dict(backup_data[0]))
 
-    modified_string_data = replace_regex_group(test_data['pattern'], test_data['update'], str(modified_data))
+    modified_string_data = replace_regex_group(pattern=test_data['pattern'], new_value=test_data['update'],
+                                               data=modified_data)
+
+    modified_string_data = '[\n' + modified_string_data + ',\n' + json.dumps(backup_data[1]) + '\n]'
 
     write_file(custom_redhat_oval_feed_path, modified_string_data)
 
@@ -111,7 +114,7 @@ def modify_feed(test_data, request):
 
     control_service('restart', daemon='wazuh-modulesd')
 
-    write_json_file(custom_redhat_oval_feed_path, [backup_data])
+    write_json_file(custom_redhat_oval_feed_path, backup_data)
 
     vd.clean_vuln_and_sys_programs_tables()
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_syntax_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_syntax_redhat_feeds.py
@@ -100,7 +100,7 @@ def modify_feed(test_data, request):
     modified_string_data = replace_regex_group(pattern=test_data['pattern'], new_value=test_data['update'],
                                                data=modified_data)
 
-    modified_string_data = '[\n' + modified_string_data + ',\n' + json.dumps(backup_data[1]) + '\n]'
+    modified_string_data = f"[\n{modified_string_data},\n{json.dumps(backup_data[1])}\n]"
 
     write_file(custom_redhat_oval_feed_path, modified_string_data)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_values_redhat_feeds.py
@@ -74,13 +74,13 @@ def modify_feed(field_info, custom_input, request):
     """
     Modify the redhat OVAL feeds, setting a test field value
     """
-    backup_data = read_json_file(custom_redhat_oval_feed_path)[0]
+    backup_data = read_json_file(custom_redhat_oval_feed_path)
 
-    modified_data = dict(backup_data)
+    modified_data = dict(backup_data[0])
 
     modified_data[field_info['field']] = custom_input
 
-    write_json_file(custom_redhat_oval_feed_path, [modified_data])
+    write_json_file(custom_redhat_oval_feed_path, [modified_data, backup_data[1]])
 
     vd.clean_vuln_and_sys_programs_tables()
 
@@ -90,7 +90,7 @@ def modify_feed(field_info, custom_input, request):
 
     yield
 
-    write_json_file(custom_redhat_oval_feed_path, [backup_data])
+    write_json_file(custom_redhat_oval_feed_path, backup_data)
 
     vd.clean_vuln_and_sys_programs_tables()
 
@@ -109,6 +109,8 @@ def test_invalid_redhat_feed(field_info, custom_input, get_configuration, config
     # If the field is "key" and the input type is not the field type, then look for error messages
     if field_info['field'] in vd.REDHAT_KEY_FIELDS_FEEDS and not type(custom_input) is field_info['type']:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
+
+        vd.check_vulnerabilities_number(expected_number=0)
     else:
-        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=5,
+        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=6,
                                             log_system_name=vd.REDHAT_LOG)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_missing_fields_redhat_feeds.py
@@ -65,13 +65,13 @@ def remove_field_feed(request):
     """
     It allows to modify the feed by removing a certain field and loading the new feed configuration
     """
-    backup_data = read_json_file(custom_redhat_oval_feed_path)[0]
+    backup_data = read_json_file(custom_redhat_oval_feed_path)
 
-    data_removed_field = dict(backup_data)
+    data_removed_field = dict(backup_data[0])
 
     data_removed_field.pop(request.param, None)
 
-    write_json_file(custom_redhat_oval_feed_path, [data_removed_field])
+    write_json_file(custom_redhat_oval_feed_path, [data_removed_field, backup_data[1]])
 
     vd.clean_vuln_and_sys_programs_tables()
 
@@ -83,7 +83,7 @@ def remove_field_feed(request):
 
     yield request.param
 
-    write_json_file(custom_redhat_oval_feed_path, [backup_data])
+    write_json_file(custom_redhat_oval_feed_path, backup_data)
 
     vd.clean_vuln_and_sys_programs_tables()
 
@@ -111,6 +111,6 @@ def test_invalid_redhat_feed(get_configuration, configure_environment, restart_m
         vd.check_detected_vulnerabilities_number(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=1,
                                                  feed_source='OVAL')
 
-        vd.check_package_vulnerable_report(wazuh_log_monitor=wazuh_log_monitor, package=package, cve=cve)
+        vd.check_vulnerabilities_number(expected_number=6)
 
-        vd.check_vulnerabilities_number(expected_number=5)
+        vd.check_package_vulnerable_report(wazuh_log_monitor=wazuh_log_monitor, package=package, cve=cve)


### PR DESCRIPTION
Hello team,

This PR updates Redhat's custom feed to add more vulnerabilities to check what happens to the other vulnerabilities if there is a malformed vulnerability.

Closes #759 

This PR does not add any new tests, but has updated the Redhat custom feed, and the parser to make changes to it.

Now, the feed consists of two vulnerabilities, in order to evaluate in the future the behavior of the detector vulnerability when there are some malformed vulnerabilities and others well-formed.

The only case that breaks this rule is with the `affected_pakages` field. If it has a wrong value, the rest of the vulnerabilities continue to be imported. This case has not yet been taken into account when testing, due to the bug described in the issue https://github.com/wazuh/wazuh/issues/5151.

When this issue is closed, then the check will be added in the tests, taking advantage of the changes made in this issue.

Best regards.
