### PR TITLE
Vulnerability detector: Add test to validate the content and format of the feeds

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -25,7 +25,9 @@ setup(name='wazuh_testing',
       include_package_data=True,
       install_requires=[
             'lockfile==0.12.2',
-            'testinfra==5.0.0'
+            'testinfra==5.0.0',
+            'filetype==1.0.7',
+            'requests==2.23.0'
       ],
       zip_safe=False
       )

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -10,6 +10,7 @@ import filetype
 import requests
 import gzip
 import bz2
+from os.path import exists
 
 
 def truncate_file(file_path):
@@ -119,25 +120,21 @@ def write_json_file(file_path, data, ensure_ascii=False):
     write_file(file_path, json.dumps(data, indent=4, ensure_ascii=ensure_ascii))
 
 
-def check_file_exist(file_path):
-    return os.path.exists(file_path)
-
-
 def download_file(source_url, dest_path):
-    r = requests.get(source_url, allow_redirects=True)
-    with open(dest_path, 'wb') as f:
-        f.write(r.content)
+    request = requests.get(source_url, allow_redirects=True)
+    with open(dest_path, 'wb') as dest_file:
+        dest_file.write(request.content)
 
 
 def remove_file(file_path):
-    if check_file_exist(file_path):
+    if exists(file_path):
         os.remove(file_path)
 
 
 def validate_json_file(file_path):
     try:
-        with open(file_path) as f:
-            json.loads(f.read())
+        with open(file_path) as file:
+            json.loads(file.read())
         return True
     except json.decoder.JSONDecodeError:
         return False
@@ -151,14 +148,10 @@ def validate_xml_file(file_path):
         return False
 
 
-def get_file_extension(file_path):
-    if check_file_exist(file_path) and filetype.guess(file_path) is not None:
-        return filetype.guess(file_path).extension
-
-
-def get_file_mime_type(file_path):
-    if check_file_exist(file_path) and filetype.guess(file_path) is not None:
-        return filetype.guess(file_path).mime
+def get_file_info(file_path, info_type="extension"):
+    if exists(file_path) and filetype.guess(file_path) is not None:
+        file = filetype.guess(file_path)
+        return file.extension if info_type == "extension" else file.mime
 
 
 def decompress_gzip(gzip_file_path, dest_file_path):

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -4,6 +4,12 @@
 import random
 import string
 import json
+import os
+import xml.etree.ElementTree as ET
+import filetype
+import requests
+import gzip
+import bz2
 
 
 def truncate_file(file_path):
@@ -111,3 +117,55 @@ def write_json_file(file_path, data, ensure_ascii=False):
         escaped. If ensure_ascii is false, these characters will be output as-is.
     """
     write_file(file_path, json.dumps(data, indent=4, ensure_ascii=ensure_ascii))
+
+
+def check_file_exist(file_path):
+    return os.path.exists(file_path)
+
+
+def download_file(source_url, dest_path):
+    r = requests.get(source_url, allow_redirects=True)
+    with open(dest_path, 'wb') as f:
+        f.write(r.content)
+
+
+def remove_file(file_path):
+    if check_file_exist(file_path):
+        os.remove(file_path)
+
+
+def validate_json_file(file_path):
+    try:
+        with open(file_path) as f:
+            json.loads(f.read())
+        return True
+    except json.decoder.JSONDecodeError:
+        return False
+
+
+def validate_xml_file(file_path):
+    try:
+        ET.parse(file_path)
+        return True
+    except ET.ParseError:
+        return False
+
+
+def get_file_extension(file_path):
+    if check_file_exist(file_path) and filetype.guess(file_path) is not None:
+        return filetype.guess(file_path).extension
+
+
+def get_file_mime_type(file_path):
+    if check_file_exist(file_path) and filetype.guess(file_path) is not None:
+        return filetype.guess(file_path).mime
+
+
+def decompress_gzip(gzip_file_path, dest_file_path):
+    with gzip.open(gzip_file_path, 'rb') as source, open(dest_file_path, 'wb') as dest:
+        dest.write(source.read())
+
+
+def decompress_bz2(bz2_file_path, dest_file_path):
+    with open(bz2_file_path, 'rb') as source, open(dest_file_path, 'wb') as dest:
+        dest.write(bz2.decompress(source.read()))

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import datetime
+import pytest
+
+import wazuh_testing.tools.file as file
+
+
+current_year = datetime.datetime.now().year
+
+format_feed_data = [
+    # Red Hat
+    {'feed': 'redhat', 'os': 'generic', 'expected_format': 'json', 'path': '/tmp/cve.json', 'extension': 'json',
+     'url': 'https://access.redhat.com/labs/securitydataapi/cve.json?after=1999-01-01'},
+
+    # Canonical
+    {'feed': 'canonical', 'os': 'bionic', 'expected_format': 'application/x-bzip2',
+     'path': '/tmp/com.ubuntu.bionic.cve.oval.xml.bz2', 'extension': 'bz2', 'decompressed_file': '/tmp/bionic.xml',
+     'url': 'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2'},
+    {'feed': 'canonical', 'os': 'xenial', 'expected_format': 'application/x-bzip2',
+     'path': '/tmp/com.ubuntu.xenial.cve.oval.xml.bz2', 'extension': 'bz2', 'decompressed_file': '/tmp/xenial.xml',
+     'url':  'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2'},
+    {'feed': 'canonical', 'os': 'trusty', 'expected_format': 'application/x-bzip2',
+     'path': '/tmp/com.ubuntu.trusty.cve.oval.xml.bz2', 'extension': 'bz2', 'decompressed_file': '/tmp/trusty.xml',
+     'url':  'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2'},
+
+    # Debian
+    {'feed': 'debian', 'os': 'buster', 'expected_format': 'xml', 'path': '/tmp/oval-definitions-buster.xml',
+     'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-buster.xml'},
+    {'feed': 'debian', 'os': 'stretch', 'expected_format': 'xml',  'path': '/tmp/oval-definitions-stretch.xml',
+     'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-stretch.xml'},
+    {'feed': 'debian', 'os': 'jessie', 'expected_format': 'xml',  'path': '/tmp/oval-definitions-jessie.xml',
+     'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-jessie.xml'},
+    {'feed': 'debian', 'os': 'wheezy', 'expected_format': 'xml',  'path': '/tmp/oval-definitions-wheezy.xml',
+     'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-wheezy.xml'}
+]
+
+# NVD
+for year in range(2002, current_year):
+    format_feed_data.append({'feed': 'nvd', 'os': year, 'expected_format': 'application/gzip',
+                             'path': f'/tmp/nvdcve-1.0-{year}.json.gz', 'extension': 'gz',
+                             'url': f'https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-{year}.json.gz',
+                             'decompressed_file': f'/tmp/nvd-{year}.json'})
+
+format_feed_data_ids = [f"{item['feed']}_{item['os']}" for item in format_feed_data]
+
+
+@pytest.fixture
+def manage_file(feed, request):
+    """
+    Download and clean test files
+
+    Parameters
+    ----------
+    feed: dict
+        Feed information which comes from an element of 'format_feed_data' list
+    """
+    # Download the file
+    file.download_file(source_url=feed['url'], dest_path=feed['path'])
+
+    # Decompress files
+    if feed['expected_format'] == 'application/gzip':
+        file.decompress_gzip(gzip_file_path=feed['path'], dest_file_path=feed['decompressed_file'])
+    elif feed['expected_format'] == 'application/x-bzip2':
+        file.decompress_bz2(bz2_file_path=feed['path'], dest_file_path=feed['decompressed_file'])
+
+    yield
+
+    # Clean downloaded file/s
+    file.remove_file(file_path=feed['path'])
+
+    if feed['expected_format'] == 'application/gzip' or feed['expected_format'] == 'application/x-bzip2':
+        file.remove_file(file_path=feed['decompressed_file'])
+
+
+@pytest.mark.parametrize('feed', format_feed_data, ids=format_feed_data_ids)
+def test_validate_feed_content(feed, manage_file):
+    """
+    Check if the downloaded feeds have the expected format
+    """
+    feed_source = feed['feed']
+    error_file_extension_message = f"File extension not expected."\
+                                   f"Got {file.get_file_extension(file_path=feed['path'])} and expected"\
+                                   f" {feed['extension']}"
+
+    error_file_mime_type_message = f"File mime type not expected."\
+                                   f"Got {file.get_file_mime_type(file_path=feed['path'])} and expected" \
+                                   f" {feed['expected_format']}"
+
+    if feed_source == 'redhat':
+        assert file.validate_json_file(file_path=feed['path']), f"{feed_source} file is not JSON parseable"
+    elif feed_source == 'canonical':
+        assert file.get_file_extension(file_path=feed['path']) == feed['extension'], error_file_extension_message
+        assert file.get_file_mime_type(file_path=feed['path']) == feed['expected_format'], error_file_mime_type_message
+        assert file.validate_xml_file(file_path=feed['decompressed_file']), f"{feed_source} file is not XML parseable"
+    elif feed_source == 'debian':
+        assert file.validate_xml_file(file_path=feed['path']), f"{feed_source} file is not XML parseable"
+    elif feed_source == 'nvd':
+        assert file.get_file_extension(file_path=feed['path']) == feed['extension'], error_file_extension_message
+        assert file.get_file_mime_type(file_path=feed['path']) == feed['expected_format'], error_file_mime_type_message
+        assert file.validate_json_file(file_path=feed['decompressed_file']), f"{feed_source} file is not JSON parseable"

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -2,13 +2,14 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import datetime
+
 import pytest
+from datetime import datetime
 
 import wazuh_testing.tools.file as file
 
 
-current_year = datetime.datetime.now().year
+current_year = datetime.now().year
 
 format_feed_data = [
     # Red Hat
@@ -82,22 +83,26 @@ def test_validate_feed_content(feed, manage_file):
     """
     feed_source = feed['feed']
     error_file_extension_message = f"File extension not expected."\
-                                   f"Got {file.get_file_extension(file_path=feed['path'])} and expected"\
-                                   f" {feed['extension']}"
+                                   f"Got {file.get_file_info(file_path=feed['path'], info_type='extension')} "\
+                                   f" and expected {feed['extension']}"
 
     error_file_mime_type_message = f"File mime type not expected."\
-                                   f"Got {file.get_file_mime_type(file_path=feed['path'])} and expected" \
-                                   f" {feed['expected_format']}"
+                                   f"Got {file.get_file_info(file_path=feed['path'], info_type='mime_type')} "\
+                                   f"and expected {feed['expected_format']}"
 
     if feed_source == 'redhat':
         assert file.validate_json_file(file_path=feed['path']), f"{feed_source} file is not JSON parseable"
     elif feed_source == 'canonical':
-        assert file.get_file_extension(file_path=feed['path']) == feed['extension'], error_file_extension_message
-        assert file.get_file_mime_type(file_path=feed['path']) == feed['expected_format'], error_file_mime_type_message
+        assert file.get_file_info(file_path=feed['path'], info_type="extension") == feed['extension'],\
+            error_file_extension_message
+        assert file.get_file_info(file_path=feed['path'],  info_type="mime_type") == feed['expected_format'],\
+            error_file_mime_type_message
         assert file.validate_xml_file(file_path=feed['decompressed_file']), f"{feed_source} file is not XML parseable"
     elif feed_source == 'debian':
         assert file.validate_xml_file(file_path=feed['path']), f"{feed_source} file is not XML parseable"
     elif feed_source == 'nvd':
-        assert file.get_file_extension(file_path=feed['path']) == feed['extension'], error_file_extension_message
-        assert file.get_file_mime_type(file_path=feed['path']) == feed['expected_format'], error_file_mime_type_message
+        assert file.get_file_info(file_path=feed['path'], info_type="extension") == feed['extension'],\
+            error_file_extension_message
+        assert file.get_file_info(file_path=feed['path'], file_info="mime_type") == feed['expected_format'],\
+            error_file_mime_type_message
         assert file.validate_json_file(file_path=feed['decompressed_file']), f"{feed_source} file is not JSON parseable"


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check that the format of the downloaded feed is the expected.

Closes #765

# Tests logic

The tests are based on downloading the different feed files and seeing if their content is as expected and parseable by the corresponding interpreter.

In the event that the downloaded file corresponds to a compressed file, then the contained file is decompressed and checked.

In summary, the test flow would be as follows:

**Redhat feed**
- Expected format: `JSON`.
- Download page 1 of  `cve` feed file and check that the content is JSON parseable.

**Canonical feed**
- Expected format: `bz2`.
- For each `os` feed:
   - Download the `bz2` file and check the mime type and extension file.
   - Decompress it and check that the content is XML parseable.
 
**Debian feed**
- Expected format: `XML`.
- For each `os` feed:
   - Download the XML file and check that the content is XML parseable

**NVD feed**
- Expected format: `gzip`.
- For each year feed (from 2002 to current year):
   - Download the `gzip` file and check the mime type and extension file.
   - Decompress it and check that the content is JSON parseable.

# Results

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 26 items                                                                                     

test_vulnerability_detector/test_feeds/test_validate_feed_content.py ..........................  [100%]

==================================== 26 passed in 98.11s (0:01:38) =====================================
```

Best regards.
