### PR TITLE
 Vulnerability detector: Add test to check the feeds format type

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -10,6 +10,7 @@ import filetype
 import requests
 import gzip
 import bz2
+import zipfile
 from os.path import exists
 
 
@@ -162,3 +163,8 @@ def decompress_gzip(gzip_file_path, dest_file_path):
 def decompress_bz2(bz2_file_path, dest_file_path):
     with open(bz2_file_path, 'rb') as source, open(dest_file_path, 'wb') as dest:
         dest.write(bz2.decompress(source.read()))
+
+
+def decompress_zip(zip_file_path, dest_file_path):
+    with zipfile.ZipFile(zip_file_path, 'r') as zip_reference:
+        zip_reference.extractall(dest_file_path)

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -25,9 +25,16 @@ DEFAULT_VULNERABILITY_ID = "WVE-000"
 REAL_NVD_FEED = 'real_nvd_feed.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'
 CUSTOM_REDHAT_OVAL_FEED = 'custom_redhat_oval_feed.json'
+CUSTOM_CANONICAL_OVAL_FEED = 'custom_canonical_oval_feed.xml'
+CUSTOM_DEBIAN_OVAL_FEED = 'custom_debian_oval_feed.xml'
 CUSTOM_NVD_VULNERABILITIES_1 = 'nvd_vulnerabilities_1.json'
 CUSTOM_NVD_VULNERABILITIES_2 = 'nvd_vulnerabilities_2.json'
 INVALID_RHEL_FEEDS = 'wazuh_invalid_redhat_feeds.yaml'
+
+REDHAT_NUM_CUSTOM_VULNERABILITIES = 6
+CANONICAL_NUM_CUSTOM_VULNERABILITIES = 1
+DEBIAN_NUM_CUSTOM_VULNERABILITIES = 1
+NVD_NUM_CUSTOM_VULNERABILITIES = 5
 
 SYSTEM_DATA = {
     "RHEL8": {

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -8,6 +8,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.vulnerability_detector import clean_vd_tables
 
 
 @pytest.fixture(scope='module')
@@ -19,5 +20,15 @@ def restart_modulesd(get_configuration, request):
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
     try:
         control_service('start', daemon='wazuh-modulesd')
-    except:
-      pass
+    except ValueError:
+        pass
+
+
+@pytest.fixture(scope='module')
+def clean_vuln_tables(request):
+    """ Clean vulnerabilities tables """
+    clean_vd_tables()
+
+    yield
+
+    clean_vd_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_type_custom_feed.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_type_custom_feed.yaml
@@ -1,0 +1,49 @@
+---
+# conf 1
+- tags:
+  - test_invalid_type_custom_feeds
+  apply_to_modules:
+  - test_invalid_type_custom_feeds
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'yes'
+    - provider:
+        attributes:
+        - name: 'redhat'
+        elements:
+        - enabled:
+            value: REDHAT_ENABLED
+        - path:
+            value: REDHAT_CUSTOM_FEED
+    - provider:
+        attributes:
+        - name: 'canonical'
+        elements:
+        - enabled:
+            value: CANONICAL_ENABLED
+        - os:
+            attributes:
+            - path: CANONICAL_CUSTOM_FEED
+            value: 'bionic'
+    - provider:
+        attributes:
+        - name: 'debian'
+        elements:
+        - enabled:
+            value: DEBIAN_ENABLED
+        - os:
+            attributes:
+            - path: DEBIAN_CUSTOM_FEED
+            value: 'buster'
+    - provider:
+        attributes:
+        - name: 'nvd'
+        elements:
+        - enabled:
+            value: NVD_ENABLED
+        - path:
+            value: NVD_CUSTOM_FEED

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/feeds/custom_debian_oval_feed.xml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/feeds/custom_debian_oval_feed.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<oval_definitions xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+  <generator>
+    <oval:product_name>Debian</oval:product_name>
+    <oval:schema_version>5.11.2</oval:schema_version>
+    <oval:timestamp>2020-05-28T11:31:53.188-04:00</oval:timestamp>
+  </generator>
+  <definitions>
+    <definition class="vulnerability" id="oval:org.debian:def:19991332" version="1">
+      <metadata>
+        <title>CVE-1999-1332</title>
+        <affected family="unix">
+          <platform>Debian GNU/Linux 10</platform>
+          <product>gzip</product>
+        </affected>
+        <reference ref_id="CVE-1999-1332" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-1332" source="CVE"/>
+        <description>gzexe in the gzip package on Red Hat Linux 5.0 and earlier allows local users to overwrite files of other users via a symlink attack on a temporary file.</description>
+        <debian>
+          <date>2003-06-06</date>
+          <moreinfo/>
+        </debian>
+      </metadata>
+      <criteria comment="Release section" operator="AND">
+        <criterion comment="Debian 10 is installed" test_ref="oval:org.debian.oval:tst:1"/>
+        <criteria comment="Architecture section" operator="OR">
+          <criteria comment="Architecture independent section" operator="AND">
+            <criterion comment="all architecture" test_ref="oval:org.debian.oval:tst:2"/>
+            <criterion comment="gzip DPKG is earlier than 1.3.5-6" test_ref="oval:org.debian.oval:tst:4"/>
+          </criteria>
+        </criteria>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="Debian GNU/Linux 10 is installed" id="oval:org.debian.oval:tst:1" version="1">
+      <object object_ref="oval:org.debian.oval:obj:1"/>
+      <state state_ref="oval:org.debian.oval:ste:1"/>
+    </textfilecontent54_test>
+    <uname_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="at_least_one_exists" comment="Installed architecture is all" id="oval:org.debian.oval:tst:2" version="1">
+      <object object_ref="oval:org.debian.oval:obj:2"/>
+    </uname_test>
+    <dpkginfo_test check="all" check_existence="at_least_one_exists" comment="gzip is earlier than 1.3.5-6" id="oval:org.debian.oval:tst:4" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+      <object object_ref="oval:org.debian.oval:obj:4"/>
+      <state state_ref="oval:org.debian.oval:ste:3"/>
+    </dpkginfo_test>
+  </tests>
+  <objects>
+    <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.debian.oval:obj:1" version="1">
+      <path>/etc</path>
+      <filename>debian_version</filename>
+      <pattern operation="pattern match">(\d+)\.\d</pattern>
+      <instance datatype="int">1</instance>
+    </textfilecontent54_object>
+    <uname_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:org.debian.oval:obj:2" version="1"/>
+    <dpkginfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:org.debian.oval:obj:4" version="1">
+      <name>gzip</name>
+    </dpkginfo_object>
+  </objects>
+  <states>
+    <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.debian.oval:ste:1" version="1">
+      <subexpression operation="equals">10</subexpression>
+    </textfilecontent54_state>
+    <dpkginfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:org.debian.oval:ste:3" version="1">
+      <evr datatype="debian_evr_string" operation="less than">0:1.3.5-6</evr>
+    </dpkginfo_state>
+  </states>
+</oval_definitions>

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -4,12 +4,14 @@
 
 import pytest
 import os
+import tempfile
 
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
 import wazuh_testing.vulnerability_detector as vd
+
 
 # Marks
 pytestmark = pytest.mark.tier(level=2)
@@ -19,7 +21,7 @@ pytestmark = pytest.mark.tier(level=2)
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_invalid_type_custom_feed.yaml')
-files_path = '/tmp'
+files_path = tempfile.gettempdir()
 
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)
 custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
@@ -31,12 +33,13 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
 
-well_imported_feeds = [custom_redhat_oval_feed_path, custom_canonical_oval_feed_path, custom_debian_oval_feed_path,
-                       custom_nvd_json_path]
+correctly_imported_feeds = [custom_redhat_oval_feed_path, custom_canonical_oval_feed_path, custom_debian_oval_feed_path,
+                            custom_nvd_json_path]
 
 # Data files
-zip_data_url = 'http://ci.wazuh.com/trash/test.zip'
-zip_data_file_name = 'test.zip'
+zip_data_file_name = 'invalid_feed_format_files.zip'
+zip_data_url = f'https://ci.wazuh.com/qa/3.13/vulnerability_detector/{zip_data_file_name}'
+
 zip_dest_path = os.path.join(files_path, zip_data_file_name)
 
 custom_extensions = ['', '.avi', '.doc', '.jpg', '.json', '.xml', '.mp3', '.pdf', '.zip']
@@ -119,7 +122,7 @@ def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configur
     if get_configuration['metadata']['feed'] == 'nvd':
         pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5210")
 
-    if get_configuration['metadata']['custom_feed'] in well_imported_feeds:
+    if get_configuration['metadata']['custom_feed'] in correctly_imported_feeds:
         vd.check_feed_imported_successfully(
             wazuh_log_monitor=wazuh_log_monitor,
             log_system_name=get_configuration['metadata']['log_system_name'],

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+import os
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools import file
+import wazuh_testing.vulnerability_detector as vd
+
+# Marks
+pytestmark = pytest.mark.tier(level=2)
+
+
+# Variables
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', 'wazuh_invalid_type_custom_feed.yaml')
+files_path = '/tmp'
+
+custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)
+custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
+custom_debian_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+
+# Set configuration
+
+well_imported_feeds = [custom_redhat_oval_feed_path, custom_canonical_oval_feed_path, custom_debian_oval_feed_path,
+                       custom_nvd_json_path]
+
+# Data files
+zip_data_url = 'http://ci.wazuh.com/trash/test.zip'
+zip_data_file_name = 'test.zip'
+zip_dest_path = os.path.join(files_path, zip_data_file_name)
+
+custom_extensions = ['', '.avi', '.doc', '.jpg', '.json', '.xml', '.mp3', '.pdf', '.zip']
+custom_files = [os.path.join(files_path, f"dummy{extension}") for extension in custom_extensions]
+
+# Red Hat configurations
+redhat_custom_files = custom_files + [custom_redhat_oval_feed_path]
+redhat_configurations = [{'REDHAT_ENABLED': 'yes', 'REDHAT_CUSTOM_FEED': custom_file, 'CANONICAL_ENABLED': 'no',
+                          'DEBIAN_ENABLED': 'no', 'NVD_ENABLED': 'no'} for custom_file in redhat_custom_files]
+redhat_metadata = [{'feed': 'redhat', 'custom_feed': custom_file, 'log_system_name': 'Red Hat Enterprise Linux',
+                    'expected_num_vulnerabilities': vd.REDHAT_NUM_CUSTOM_VULNERABILITIES}
+                   for custom_file in redhat_custom_files]
+redhat_ids = [f"RedHat_{custom_file}" for custom_file in redhat_custom_files]
+
+# Canonical configurations
+canonical_custom_files = custom_files + [custom_canonical_oval_feed_path]
+canonical_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'yes',
+                             'CANONICAL_CUSTOM_FEED': custom_file, 'DEBIAN_ENABLED': 'no',
+                             'NVD_ENABLED': 'no'} for custom_file in canonical_custom_files]
+canonical_metadata = [{'feed': 'canonical', 'custom_feed': custom_file, 'log_system_name': 'Ubuntu Bionic',
+                       'expected_num_vulnerabilities': vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES}
+                      for custom_file in canonical_custom_files]
+canonical_ids = [f"Canonical_{custom_file}" for custom_file in canonical_custom_files]
+
+# Debian configurations
+debian_custom_files = custom_files + [custom_debian_oval_feed_path]
+debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
+                          'DEBIAN_CUSTOM_FEED': custom_file, 'NVD_ENABLED': 'no'}
+                         for custom_file in debian_custom_files]
+debian_metadata = [{'feed': 'debian', 'custom_feed': custom_file, 'log_system_name': 'Debian Buster',
+                    'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
+                   for custom_file in debian_custom_files]
+debian_ids = [f"Debian_{custom_file}" for custom_file in debian_custom_files]
+
+# NVD configurations
+nvd_custom_files = custom_files + [custom_debian_oval_feed_path]
+nvd_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'NVD_ENABLED': 'yes',
+                       'NVD_CUSTOM_FEED': custom_file} for custom_file in nvd_custom_files]
+nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_file, 'log_system_name': 'National Vulnerability Database',
+                 'expected_num_vulnerabilities': vd.NVD_NUM_CUSTOM_VULNERABILITIES}
+                for custom_file in nvd_custom_files]
+nvd_ids = [f"NVD_{custom_file}" for custom_file in nvd_custom_files]
+
+# Global configuration
+parameters = redhat_configurations + canonical_configurations + debian_configurations + nvd_configurations
+metadata = redhat_metadata + canonical_metadata + debian_metadata + nvd_metadata
+ids = redhat_ids + canonical_ids + debian_ids + nvd_ids
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def manage_files(request):
+    """Download and clean files used for testing"""
+    file.download_file(source_url=zip_data_url, dest_path=zip_dest_path)
+
+    file.decompress_zip(zip_file_path=zip_dest_path, dest_file_path=files_path)
+
+    yield
+
+    for extracted_file in custom_files:
+        file.remove_file(extracted_file)
+
+    file.remove_file(zip_dest_path)
+
+
+def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configuration, configure_environment,
+                                   restart_modulesd):
+    """
+    Check that when importing bad feed files, vulnerability report a log parse error otherwise they are imported
+    correctly
+    """
+    if get_configuration['metadata']['feed'] == 'nvd':
+        pytest.xfail("Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5210")
+
+    if get_configuration['metadata']['custom_feed'] in well_imported_feeds:
+        vd.check_feed_imported_successfully(
+            wazuh_log_monitor=wazuh_log_monitor,
+            log_system_name=get_configuration['metadata']['log_system_name'],
+            expected_vulnerabilities_number=get_configuration['metadata']['expected_num_vulnerabilities']
+        )
+
+        vd.clean_vd_tables()
+    else:
+        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check the vulnerability detector behavior when we introduce a non expected format file in the parameter `<path>` and os `path="">`

Closes #766 

# Tests logic

The tests are based on downloading the different files: `.mp3`, `.pdf`, `.jpg`... and use these files as feeds to vulnerability detector.

For a list of different file formats,

```
['', '.avi', '.doc', '.jpg', '.json', '.xml', '.mp3', '.pdf', '.zip']
```

it is introduced as a feed from `Redhat`, `Canonical`, `Debian`, and `NVD` by modifying the `ossec.conf` `path` parameter

The following behaviors were observed:

- In the case of `Redhat`, `Canonical`, and `Debian`, it is reported that the format of the feed is not as expected and that it has not been possible to insert the feeds.

- In the case of `NVD`, no error is reported, and log says that it imports all the feeds when in fact it does not. For this case, an issue has been opened  https://github.com/wazuh/wazuh/issues/5210 describing this problem.

For the latter case (NVD feeds) the tests have been marked as *xfail*, pending the resolution of their corresponding issue

# Results

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0
collected 40 items                                                                                     

test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py ....................... [ 57%]
.......xxxxxxxxxx                                                                                [100%]

============================== 30 passed, 10 xfailed in 76.30s (0:01:16) ===============================
```


Best regards.
