### PR TITLE
Fix NVD feed scan tests

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
@@ -34,6 +34,7 @@ SCAN_TIMEOUT = 40
 parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, CUSTOM_NVD_FEED)}]
 metadata = [{'nvd_json_path': os.path.join(test_data_path, CUSTOM_NVD_FEED)}]
 ids = ['scan_nvd_configuration']
+vulnerabilities_number = 0
 
 
 # Read JSON data template
@@ -73,6 +74,11 @@ def mock_vulnerability_scan(request):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
+    global vulnerabilities_number
+    if "RHEL" in request.param['target']:
+        vulnerabilities_number = 0
+    else:
+        vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
@@ -130,22 +136,22 @@ def check_vulnerability_event(package, cve):
 
 
 def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
-                                       mock_vulnerability_scan):
+                                       mock_vulnerability_scan, request):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
-    vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
+    # Check the vulnerabilities of packages inserted
+    if vulnerabilities_number != 0:
+        for item in nvd_vulnerabilities['vulnerabilities']:
+            check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
 
     # Check that the number of NVD vulnerabilities is the expected
+    print(f"A total of '{vulnerabilities_number}' vulnerabilities have been reported for agent '.*' thanks to the 'NVD' feed.")
     wazuh_log_monitor.start(
         timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
-            f"The NVD found a total of '{vulnerabilities_number}' potential vulnerabilities for agent .*"
+            f"A total of '{vulnerabilities_number}' vulnerabilities have been reported for agent '.*' thanks to the 'NVD' feed."
         ),
         error_message=f"The expected number of vulnerabilities for NVD have not been found",
     )
-
-    # Check the vulnerabilities of packages inserted
-    for item in nvd_vulnerabilities['vulnerabilities']:
-        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
@@ -43,10 +43,10 @@ with open(vulnerabilities_data_path, 'r') as f:
 
 
 system_data = [
-    { "target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8" },
-    { "target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7" },
-    { "target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6" },
-    { "target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5" },
+    # { "target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8" },
+    # { "target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7" },
+    # { "target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6" },
+    # { "target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5" },
     { "target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic" },
     { "target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial" },
     { "target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty" },
@@ -97,8 +97,8 @@ def mock_vulnerability_scan(request):
 
     # Add custom vulnerabilities and feeds
     for vulnerability in nvd_vulnerabilities['vulnerabilities']:
-        insert_package(**vulnerability['package'], format='rpm')
-
+        insert_package(**vulnerability['package'], source=vulnerability['package']['name'])
+        
     control_service('start', daemon='wazuh-db')
 
     # Truncate ossec.log
@@ -135,7 +135,7 @@ def check_vulnerability_event(package, cve):
     )
 
 
-def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
                                        mock_vulnerability_scan, request):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
@@ -34,7 +34,6 @@ SCAN_TIMEOUT = 40
 parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, CUSTOM_NVD_FEED)}]
 metadata = [{'nvd_json_path': os.path.join(test_data_path, CUSTOM_NVD_FEED)}]
 ids = ['scan_nvd_configuration']
-vulnerabilities_number = 0
 
 
 # Read JSON data template
@@ -43,17 +42,28 @@ with open(vulnerabilities_data_path, 'r') as f:
 
 
 system_data = [
-    {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"},
-    {"target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7"},
-    {"target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6"},
-    {"target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5"},
-    {"target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic"},
-    {"target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial"},
-    {"target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty"},
-    {"target": "BUSTER", "os_name": "Debian GNU/Linux", "os_major": "10", "os_minor": "", "name": "debian10"},
-    {"target": "STRETCH", "os_name": "Debian GNU/Linux", "os_major": "9", "os_minor": "", "name": "debian9"},
-    {"target": "JESSIE", "os_name": "Debian GNU/Linux", "os_major": "8", "os_minor": "", "name": "debian8"},
-    {"target": "WHEEZY", "os_name": "Debian GNU/Linux", "os_major": "7", "os_minor": "", "name": "debian7"},
+    { "target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8",
+        "format": "rpm", "vulnerabilities_number": 0},
+    { "target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7",
+        "format": "rpm", "vulnerabilities_number": 0},
+    { "target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6",
+        "format": "rpm", "vulnerabilities_number": 0},
+    { "target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5",
+        "format": "rpm", "vulnerabilities_number": 0},
+    { "target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
+    { "target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
+    { "target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
+    { "target": "BUSTER", "os_name": "Debian GNU/Linux", "os_major": "10", "os_minor": "", "name": "debian10",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
+    { "target": "STRETCH", "os_name": "Debian GNU/Linux", "os_major": "9", "os_minor": "", "name": "debian9",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
+    { "target": "JESSIE", "os_name": "Debian GNU/Linux", "os_major": "8", "os_minor": "", "name": "debian8",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
+    { "target": "WHEEZY", "os_name": "Debian GNU/Linux", "os_major": "7", "os_minor": "", "name": "debian7",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities'])},
 ]
 system_data_ids = [system['target'] for system in system_data]
 
@@ -74,11 +84,6 @@ def mock_vulnerability_scan(request):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    global vulnerabilities_number
-    if "RHEL" in request.param['target']:
-        vulnerabilities_number = 0
-    else:
-        vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
@@ -136,11 +141,12 @@ def check_vulnerability_event(package, cve):
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
-                                mock_vulnerability_scan, request):
+                                mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
     # Check the vulnerabilities of packages inserted
+    vulnerabilities_number = mock_vulnerability_scan["vulnerabilities_number"]
     if vulnerabilities_number != 0:
         for item in nvd_vulnerabilities['vulnerabilities']:
             check_vulnerability_event(item['package']['name'], item['cve']['cveid'])

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
@@ -150,7 +150,7 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
         timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
-            f"A total of '{vulnerabilities_number}' vulnerabilities have been reported for agent '.*'" +
+            f"A total of '{vulnerabilities_number}' vulnerabilities have been reported for agent '.*' " +
             "thanks to the 'NVD' feed."
         ),
         error_message=f"The expected number of vulnerabilities for NVD have not been found",

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
@@ -27,8 +27,6 @@ test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_provider_and_nvd_configuration.yaml')
 nvd_vulnerabilities_data_path = os.path.join(test_data_path, CUSTOM_NVD_VULNERABILITIES_1)
 provider_vulnerabilities_data_path = os.path.join(test_data_path, CUSTOM_NVD_VULNERABILITIES_2)
-nvd_vulnerabilities_number = 0
-provider_vulnerabilities_number = 0
 
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -48,20 +46,36 @@ with open(nvd_vulnerabilities_data_path, 'r') as f:
 with open(provider_vulnerabilities_data_path, 'r') as f:
     provider_vulnerabilities = json.loads(f.read())
 
-total_vulnerabilities = []
-
 system_data = [
-    {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"},
-    {"target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7"},
-    {"target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6"},
-    {"target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5"},
-    {"target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic"},
-    {"target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial"},
-    {"target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty"},
-    {"target": "BUSTER", "os_name": "Debian GNU/Linux", "os_major": "10", "os_minor": "", "name": "debian10"},
-    {"target": "STRETCH", "os_name": "Debian GNU/Linux", "os_major": "9", "os_minor": "", "name": "debian9"},
-    {"target": "JESSIE", "os_name": "Debian GNU/Linux", "os_major": "8", "os_minor": "", "name": "debian8"},
-    {"target": "WHEEZY", "os_name": "Debian GNU/Linux", "os_major": "7", "os_minor": "", "name": "debian7"},
+    { "target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8",
+        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7",
+        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6",
+        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5",
+        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "BUSTER", "os_name": "Debian GNU/Linux", "os_major": "10", "os_minor": "", "name": "debian10",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "STRETCH", "os_name": "Debian GNU/Linux", "os_major": "9", "os_minor": "", "name": "debian9",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "JESSIE", "os_name": "Debian GNU/Linux", "os_major": "8", "os_minor": "", "name": "debian8",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
+    { "target": "WHEEZY", "os_name": "Debian GNU/Linux", "os_major": "7", "os_minor": "", "name": "debian7",
+        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['nvd_vulnerabilities_data_path']) +
+        len(nvd_vulnerabilities['provider_vulnerabilities'])},
 ]
 system_data_ids = [system['target'] for system in system_data]
 
@@ -82,14 +96,6 @@ def mock_vulnerability_scan(request):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    global nvd_vulnerabilities_number, provider_vulnerabilities_number, total_vulnerabilities
-    if "RHEL" in request.param['target']:
-        nvd_vulnerabilities_number = 0
-        total_vulnerabilities = provider_vulnerabilities['vulnerabilities']
-    else:
-        nvd_vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
-        total_vulnerabilities = nvd_vulnerabilities['vulnerabilities'] + provider_vulnerabilities['vulnerabilities']
-    provider_vulnerabilities_number = len(provider_vulnerabilities['vulnerabilities'])
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
@@ -89,7 +89,7 @@ def mock_vulnerability_scan(request):
     else:
         nvd_vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
         total_vulnerabilities = nvd_vulnerabilities['vulnerabilities'] + provider_vulnerabilities['vulnerabilities']
-    provider_vulnerabilities_number = len(provider_vulnerabilities)
+    provider_vulnerabilities_number = len(provider_vulnerabilities['vulnerabilities'])
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
@@ -152,15 +152,9 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
-    # Check that the number of NVD vulnerabilities is the expected
-    wazuh_log_monitor.start(
-        timeout=SCAN_TIMEOUT,
-        update_position=False,
-        callback=make_vuln_callback(
-            f"A total of '{nvd_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' thanks to the 'NVD' feed."
-        ),
-        error_message=f"The expected number of vulnerabilities for NVD have not been found",
-    )
+    # Check the vulnerabilities of packages inserted
+    for item in total_vulnerabilities:
+        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
 
     # Check that the number of NVD vulnerabilities is the expected
     wazuh_log_monitor.start(
@@ -172,6 +166,12 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
         error_message=f"The expected number of vulnerabilities for vendot have not been found",
     )
 
-    # Check the vulnerabilities of packages inserted
-    for item in total_vulnerabilities:
-        check_vulnerability_event(item['package']['name'], item['cve']['cveid'])
+    wazuh_log_monitor.start(
+        timeout=SCAN_TIMEOUT,
+        update_position=False,
+        callback=make_vuln_callback(
+            f"A total of '{nvd_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' thanks to the 'NVD' feed."
+        ),
+        error_message=f"The expected number of vulnerabilities for NVD have not been found",
+    )
+

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
@@ -27,6 +27,9 @@ test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_provider_and_nvd_configuration.yaml')
 nvd_vulnerabilities_data_path = os.path.join(test_data_path, CUSTOM_NVD_VULNERABILITIES_1)
 provider_vulnerabilities_data_path = os.path.join(test_data_path, CUSTOM_NVD_VULNERABILITIES_2)
+nvd_vulnerabilities_number = 0
+provider_vulnerabilities_number = 0
+
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 SCAN_TIMEOUT = 40
@@ -45,7 +48,7 @@ with open(nvd_vulnerabilities_data_path, 'r') as f:
 with open(provider_vulnerabilities_data_path, 'r') as f:
     provider_vulnerabilities = json.loads(f.read())
 
-total_vulnerabilities = nvd_vulnerabilities['vulnerabilities'] + provider_vulnerabilities['vulnerabilities']
+total_vulnerabilities = []
 
 system_data = [
     { "target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8" },
@@ -79,6 +82,14 @@ def mock_vulnerability_scan(request):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
+    global nvd_vulnerabilities_number, provider_vulnerabilities_number, total_vulnerabilities
+    if "RHEL" in request.param['target']:
+        nvd_vulnerabilities_number = 0
+        total_vulnerabilities = provider_vulnerabilities['vulnerabilities']
+    else:
+        nvd_vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
+        total_vulnerabilities = nvd_vulnerabilities['vulnerabilities'] + provider_vulnerabilities['vulnerabilities']
+    provider_vulnerabilities_number = len(provider_vulnerabilities)
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
@@ -141,15 +152,12 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
     """
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
-    nvd_vulnerabilities_number = len(nvd_vulnerabilities['vulnerabilities'])
-    provider_vulnerabilities_number = len(provider_vulnerabilities['vulnerabilities'])
-
     # Check that the number of NVD vulnerabilities is the expected
     wazuh_log_monitor.start(
         timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
-            f"The NVD found a total of '{nvd_vulnerabilities_number}' potential vulnerabilities for agent .*"
+            f"A total of '{nvd_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' thanks to the 'NVD' feed."
         ),
         error_message=f"The expected number of vulnerabilities for NVD have not been found",
     )
@@ -159,9 +167,9 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
         timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
-            f"The OVAL found a total of '{provider_vulnerabilities_number}' potential vulnerabilities for agent .*"
+            f"A total of '{provider_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' thanks to the 'vendor' feed."
         ),
-        error_message=f"The expected number of vulnerabilities for OVAL have not been found",
+        error_message=f"The expected number of vulnerabilities for vendot have not been found",
     )
 
     # Check the vulnerabilities of packages inserted

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py
@@ -161,18 +161,18 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
         timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
-            f"A total of '{provider_vulnerabilities_number}' vulnerabilities have been reported for agent '.*'" +
+            f"A total of '{provider_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' " +
             "thanks to the 'vendor' feed."
         ),
-        error_message=f"The expected number of vulnerabilities for vendot have not been found",
+        error_message=f"The expected number of vulnerabilities for vendor have not been found",
     )
 
     wazuh_log_monitor.start(
         timeout=SCAN_TIMEOUT,
         update_position=False,
         callback=make_vuln_callback(
-            f"A total of '{nvd_vulnerabilities_number}' vulnerabilities have been reported for agent '.*'" +
-            "thanks to the 'vendor' feed."
+            f"A total of '{nvd_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' " +
+            "thanks to the 'NVD' feed."
         ),
         error_message=f"The expected number of vulnerabilities for NVD have not been found",
     )


### PR DESCRIPTION
Hello team,

This PR closes #778.

We have fixed some problems that appeared in the tests that use NVD feeds due to a change in the behaviour of vulnerability detector.

```
[root@centos7 wazuh-qa]# python3 -m pytest -vvx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py
```
```
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [  9%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 18%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 27%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 36%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 45%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 54%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 63%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 72%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 81%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-JESSIE] PASSED [ 90%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-WHEEZY] PASSED [100%]

==================================== 11 passed in 234.50s (0:03:54) ====================================
```

```
[root@centos7 wazuh-qa]# python3 -m pytest -vvx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py 
```
```
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [  9%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 18%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 27%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 36%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 45%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 54%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 63%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 72%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 81%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-JESSIE] PASSED [ 90%]
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feeds.py::test_vulnerabilities_report[scan_nvd_configuration-WHEEZY] PASSED [100%]

==================================== 11 passed in 262.45s (0:04:22) ====================================
```

Regards,
Daniel Folch