### PR TITLE
Vulnerability detector: Add test missing field for Canonical feeds

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -168,3 +168,31 @@ def decompress_bz2(bz2_file_path, dest_file_path):
 def decompress_zip(zip_file_path, dest_file_path):
     with zipfile.ZipFile(zip_file_path, 'r') as zip_reference:
         zip_reference.extractall(dest_file_path)
+
+
+def read_xml_file(file_path, namespaces=None):
+    """
+    Function to read XML file as string
+
+    Parameters
+    ----------
+    file_path: str
+        File path where is the XML file
+    namespaces: list
+        List with data {name: namespace, url: url_namespace}
+
+    Returns
+    -------
+    str:
+        XML string data
+    """
+    xml_root = ET.parse(file_path).getroot()
+
+    if namespaces is not None:
+        for namespace in namespaces:
+            try:
+                ET.register_namespace(namespace['name'], namespace['url'])
+            except KeyError:
+                pass
+
+    return ET.tostring(xml_root).decode()

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -35,3 +35,26 @@ def replace_regex_group(pattern, new_value, data):
             pass
 
     return data
+
+
+def replace_regex(pattern, new_value, data):
+    """
+    Function to replace a patter string in a data text
+
+    Parameters
+    ----------
+    pattern: str
+        Regular expresion pattern
+    new_value: str
+        New replaced string
+    data: str
+        String to search and replace
+
+    Returns
+    -------
+    str:
+        New replaced text
+    """
+    compiled_pattern = re.compile(pattern, re.DOTALL)
+
+    return re.sub(compiled_pattern, new_value, data)

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -29,7 +29,8 @@ CUSTOM_CANONICAL_OVAL_FEED = 'custom_canonical_oval_feed.xml'
 CUSTOM_DEBIAN_OVAL_FEED = 'custom_debian_oval_feed.xml'
 CUSTOM_NVD_VULNERABILITIES_1 = 'nvd_vulnerabilities_1.json'
 CUSTOM_NVD_VULNERABILITIES_2 = 'nvd_vulnerabilities_2.json'
-INVALID_RHEL_FEEDS = 'wazuh_invalid_redhat_feeds.yaml'
+INVALID_RHEL_FEEDS_CONF = 'wazuh_invalid_redhat_feeds.yaml'
+INVALID_CANONICAL_FEEDS_CONF = 'wazuh_invalid_canonical_feeds.yaml'
 
 REDHAT_NUM_CUSTOM_VULNERABILITIES = 6
 CANONICAL_NUM_CUSTOM_VULNERABILITIES = 1
@@ -37,13 +38,13 @@ DEBIAN_NUM_CUSTOM_VULNERABILITIES = 1
 NVD_NUM_CUSTOM_VULNERABILITIES = 5
 
 SYSTEM_DATA = {
-    "RHEL8": {
-        "target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"
-    }
+    "RHEL8": {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"},
+    "BIONIC": {"target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic"}
 }
 
 NVD_LOG = 'National Vulnerability Database'
 REDHAT_LOG = 'Red Hat Enterprise Linux'
+BIONIC_LOG = 'Ubuntu Bionic'
 
 NVD_TABLES = [
     {"name": "NVD_REFERENCE", "path": CVE_DB_PATH},

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
@@ -47,60 +47,60 @@ xml_namespaces = [
 
 fields = [
     # Generator element
-    {'name': 'generator', 'regex': r'<generator>.*<\/generator>', 'key': False},
+    {'name': 'generator', 'regex': r'<generator>.*<\/generator>'},
     # Generator child elements
-    {'name': 'product_name', 'regex': r'<oval:product_name>.*<\/oval:product_name>', 'key': False},
-    {'name': 'product_version', 'regex': r'<oval:product_version>.*<\/oval:product_version>', 'key': False},
-    {'name': 'schema_version', 'regex': r'<oval:schema_version>.*<\/oval:schema_version>', 'key': False},
-    {'name': 'schema_version', 'regex': r'<oval:timestamp>2020-05-28T14:13:36</oval:timestamp>', 'key': False},
+    {'name': 'product_name', 'regex': r'<oval:product_name>.*<\/oval:product_name>'},
+    {'name': 'product_version', 'regex': r'<oval:product_version>.*<\/oval:product_version>'},
+    {'name': 'schema_version', 'regex': r'<oval:schema_version>.*<\/oval:schema_version>'},
+    {'name': 'schema_version', 'regex': r'<oval:timestamp>2020-05-28T14:13:36</oval:timestamp>'},
     # Definitions element
-    {'name': 'definitions', 'regex': r'<definitions>.*<\/definitions>', 'key': True, 'xfail': True},
+    {'name': 'definitions', 'regex': r'<definitions>.*<\/definitions>'},
     # Definitions child elements
-    {'name': 'definition', 'regex': r'<definition\s.*>.*<\/definition>', 'key': True},
+    {'name': 'definition', 'regex': r'<definition\s.*>.*<\/definition>'},
     # Definition child elements
-    {'name': 'metadata', 'regex': r'<metadata.*>.*<\/metadata>', 'key': True, 'xfail': True},
+    {'name': 'metadata', 'regex': r'<metadata.*>.*<\/metadata>'},
     # Metadata child elements
-    {'name': 'title', 'regex': r'<title.*>.*<\/title>', 'key': False},
-    {'name': 'description', 'regex': r'<description.*>.*<\/description>', 'key': False},
-    {'name': 'affected', 'regex': r'<affected.*>.*<\/affected>', 'key': False},
+    {'name': 'title', 'regex': r'<title.*>.*<\/title>'},
+    {'name': 'description', 'regex': r'<description.*>.*<\/description>'},
+    {'name': 'affected', 'regex': r'<affected.*>.*<\/affected>'},
     # Affected child elements
-    {'name': 'platform', 'regex': r'<platform.*>.*<\/platform>', 'key': False},
+    {'name': 'platform', 'regex': r'<platform.*>.*<\/platform>'},
     # Reference element
-    {'name': 'reference', 'regex': r'<reference.*name=CVE-000"\s+\/>', 'key': True, 'xfail': True},
-    {'name': 'advisory', 'regex': r'<advisory>.*<\/advisory>', 'key': False},
+    {'name': 'reference', 'regex': r'<reference.*name=CVE-000"\s+\/>'},
+    {'name': 'advisory', 'regex': r'<advisory>.*<\/advisory>'},
     # Advisory elements
-    {'name': 'severity', 'regex': r'<severity>.*<\/severity>', 'key': False},
-    {'name': 'public_date', 'regex': r'<public_date>.*<\/public_date>', 'key': False},
-    {'name': 'bug', 'regex': r'<ref>.*<\/ref>', 'key': False},
+    {'name': 'severity', 'regex': r'<severity>.*<\/severity>'},
+    {'name': 'public_date', 'regex': r'<public_date>.*<\/public_date>'},
+    {'name': 'bug', 'regex': r'<ref>.*<\/ref>'},
     # Criteria element
-    {'name': 'criteria', 'regex': r'<criteria>.*<\/criteria>', 'key': True, 'xfail': True},
-    {'name': 'extend_definition', 'regex': r'<extend_definition.*applicability_check="true"\s+\/>', 'key': False},
-    {'name': 'criterion', 'regex': r'<criterion.*vulnerable"\s+\/>', 'key': True},
+    {'name': 'criteria', 'regex': r'<criteria>.*<\/criteria>'},
+    {'name': 'extend_definition', 'regex': r'<extend_definition.*applicability_check="true"\s+\/>'},
+    {'name': 'criterion', 'regex': r'<criterion.*vulnerable"\s+\/>'},
     # Tests element
-    {'name': 'tests', 'regex': r'<tests>.*<\/tests>', 'key': True, 'xfail': True},
+    {'name': 'tests', 'regex': r'<tests>.*<\/tests>'},
     # Tests child elements
-    {'name': 'dpkginfo_test', 'regex': r'<linux-def:dpkginfo_test.*<\/linux-def:dpkginfo_test>', 'key': True},
-    {'name': 'test_object', 'regex': r'<linux-def:object object_ref="oval:com.ubuntu.bionic:obj:1"\s+\/>',
-     'key': True},
+    {'name': 'dpkginfo_test', 'regex': r'<linux-def:dpkginfo_test.*<\/linux-def:dpkginfo_test>'},
+    {'name': 'test_object', 'regex': r'<linux-def:object object_ref="oval:com.ubuntu.bionic:obj:1"\s+\/>'},
     # Objects element
-    {'name': 'objects', 'regex': r'<objects>.*<\/objects>', 'key': False},
-    {'name': 'dpkginfo_object', 'regex': r'<linux-def:dpkginfo_object.*">.*<\/linux-def:dpkginfo_object>',
-     'key': True},
-    {'name': 'object_element', 'regex': r'<linux-def:name.*var_check="at least one"\s+\/>', 'key': True},
+    {'name': 'objects', 'regex': r'<objects>.*<\/objects>'},
+    {'name': 'dpkginfo_object', 'regex': r'<linux-def:dpkginfo_object.*">.*<\/linux-def:dpkginfo_object>'},
+    {'name': 'object_element', 'regex': r'<linux-def:name.*var_check="at least one"\s+\/>'},
     # States element
-    {'name': 'states', 'regex': r'<states>.*<\/states>', 'key': False},
-    {'name': 'dpkginfo_state', 'regex': r'<linux-def:dpkginfo_state.*>.*<\/linux-def:dpkginfo_state>', 'key': True},
-    {'name': 'state_object', 'regex': r'<linux-def:evr.*>.*<\/linux-def:evr>', 'key': True},
+    {'name': 'states', 'regex': r'<states>.*<\/states>'},
+    {'name': 'dpkginfo_state', 'regex': r'<linux-def:dpkginfo_state.*>.*<\/linux-def:dpkginfo_state>'},
+    {'name': 'state_object', 'regex': r'<linux-def:evr.*>.*<\/linux-def:evr>'},
     # Variables element
-    {'name': 'variables', 'regex': r'<variables>.*<\/variables>', 'key': False},
-    {'name': 'constant_variable', 'regex': r'<constant_variable.*>.*<\/constant_variable>', 'key': True},
-    {'name': 'variable_value', 'regex': r'<constant_variable.*(<value>.*<\/value>).*<\/constant_variable>',
-     'key': True}
+    {'name': 'variables', 'regex': r'<variables>.*<\/variables>'},
+    {'name': 'constant_variable', 'regex': r'<constant_variable.*>.*<\/constant_variable>'},
+    {'name': 'variable_value', 'regex': r'<constant_variable.*(<value>.*<\/value>).*<\/constant_variable>'}
 ]
 
 key_fields = ['definitions', 'definition', 'metadata', 'criteria', 'criterion', 'tests', 'dpkginfo_test', 'test_object',
               'dpkginfo_object', 'object_element', 'dpkginfo_state', 'state_object', 'constant_variable',
               'variable_value']
+
+xfail_fields = ['definitions', 'metadata', 'reference', 'criteria', 'tests']
+
 
 field_ids = [f"missing_{field['name']}_field" for field in fields]
 
@@ -146,7 +146,7 @@ def remove_field_feed(request):
 
 def test_missing_canonical_feed(get_configuration, configure_environment, restart_modulesd, remove_field_feed):
     """Test to check vulnerability detector behavior when importing canonical feeds with missing fields"""
-    if 'xfail' in remove_field_feed:
+    if remove_field_feed['name'] in xfail_fields:
         pytest.xfail("Add error messages to this case use")
 
     if remove_field_feed['name'] in key_fields:

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.file import read_json_file, write_file, truncate_file
+from wazuh_testing.tools.utils import replace_regex
+from wazuh_testing.tools import file
+from wazuh_testing.tools.services import control_service
+import wazuh_testing.vulnerability_detector as vd
+
+
+# Marks
+pytestmark = pytest.mark.tier(level=2)
+
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_CANONICAL_FEEDS_CONF)
+vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
+custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
+custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# Set configuration
+parameters = [{'NVD_JSON_PATH': custom_nvd_json_path, 'CANONICAL_CUSTOM_FEED': custom_canonical_oval_feed_path}]
+metadata = [{'nvd_json_path': custom_nvd_json_path, 'canonical_custom_feed': custom_canonical_oval_feed_path}]
+ids = ['CANONICAL_configuration']
+
+# Read JSON data template
+nvd_vulnerabilities = read_json_file(vulnerabilities_data_path)
+
+system_data = vd.SYSTEM_DATA['BIONIC']
+
+xml_namespaces = [
+    {'name': '', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5'},
+    {'name': 'ind-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#independent'},
+    {'name': 'oval', 'url': 'http://oval.mitre.org/XMLSchema/oval-common-5'},
+    {'name': 'unix-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#unix'},
+    {'name': 'linux-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#linux'}
+]
+
+fields = [
+    # Generator element
+    {'name': 'generator', 'regex': r'<generator>.*<\/generator>', 'key': False},
+    # Generator child elements
+    {'name': 'product_name', 'regex': r'<oval:product_name>.*<\/oval:product_name>', 'key': False},
+    {'name': 'product_version', 'regex': r'<oval:product_version>.*<\/oval:product_version>', 'key': False},
+    {'name': 'schema_version', 'regex': r'<oval:schema_version>.*<\/oval:schema_version>', 'key': False},
+    {'name': 'schema_version', 'regex': r'<oval:timestamp>2020-05-28T14:13:36</oval:timestamp>', 'key': False},
+    # Definitions element
+    {'name': 'definitions', 'regex': r'<definitions>.*<\/definitions>', 'key': True, 'xfail': True},
+    # Definitions child elements
+    {'name': 'definition', 'regex': r'<definition\s.*>.*<\/definition>', 'key': True},
+    # Definition child elements
+    {'name': 'metadata', 'regex': r'<metadata.*>.*<\/metadata>', 'key': True, 'xfail': True},
+    # Metadata child elements
+    {'name': 'title', 'regex': r'<title.*>.*<\/title>', 'key': False},
+    {'name': 'description', 'regex': r'<description.*>.*<\/description>', 'key': False},
+    {'name': 'affected', 'regex': r'<affected.*>.*<\/affected>', 'key': False},
+    # Affected child elements
+    {'name': 'platform', 'regex': r'<platform.*>.*<\/platform>', 'key': False},
+    # Reference element
+    {'name': 'reference', 'regex': r'<reference.*name=CVE-000"\s+\/>', 'key': True, 'xfail': True},
+    {'name': 'advisory', 'regex': r'<advisory>.*<\/advisory>', 'key': False},
+    # Advisory elements
+    {'name': 'severity', 'regex': r'<severity>.*<\/severity>', 'key': False},
+    {'name': 'public_date', 'regex': r'<public_date>.*<\/public_date>', 'key': False},
+    {'name': 'bug', 'regex': r'<ref>.*<\/ref>', 'key': False},
+    # Criteria element
+    {'name': 'criteria', 'regex': r'<criteria>.*<\/criteria>', 'key': True, 'xfail': True},
+    {'name': 'extend_definition', 'regex': r'<extend_definition.*applicability_check="true"\s+\/>', 'key': False},
+    {'name': 'criterion', 'regex': r'<criterion.*vulnerable"\s+\/>', 'key': True},
+    # Tests element
+    {'name': 'tests', 'regex': r'<tests>.*<\/tests>', 'key': True, 'xfail': True},
+    # Tests child elements
+    {'name': 'dpkginfo_test', 'regex': r'<linux-def:dpkginfo_test.*<\/linux-def:dpkginfo_test>', 'key': True},
+    {'name': 'test_object', 'regex': r'<linux-def:object object_ref="oval:com.ubuntu.bionic:obj:1"\s+\/>',
+     'key': True},
+    # Objects element
+    {'name': 'objects', 'regex': r'<objects>.*<\/objects>', 'key': False},
+    {'name': 'dpkginfo_object', 'regex': r'<linux-def:dpkginfo_object.*">.*<\/linux-def:dpkginfo_object>',
+     'key': True},
+    {'name': 'object_element', 'regex': r'<linux-def:name.*var_check="at least one"\s+\/>', 'key': True},
+    # States element
+    {'name': 'states', 'regex': r'<states>.*<\/states>', 'key': False},
+    {'name': 'dpkginfo_state', 'regex': r'<linux-def:dpkginfo_state.*>.*<\/linux-def:dpkginfo_state>', 'key': True},
+    {'name': 'state_object', 'regex': r'<linux-def:evr.*>.*<\/linux-def:evr>', 'key': True},
+    # Variables element
+    {'name': 'variables', 'regex': r'<variables>.*<\/variables>', 'key': False},
+    {'name': 'constant_variable', 'regex': r'<constant_variable.*>.*<\/constant_variable>', 'key': True},
+    {'name': 'variable_value', 'regex': r'<constant_variable.*(<value>.*<\/value>).*<\/constant_variable>',
+     'key': True}
+]
+
+key_fields = ['definitions', 'definition', 'metadata', 'criteria', 'criterion', 'tests', 'dpkginfo_test', 'test_object',
+              'dpkginfo_object', 'object_element', 'dpkginfo_state', 'state_object', 'constant_variable',
+              'variable_value']
+
+field_ids = [f"missing_{field['name']}_field" for field in fields]
+
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope='module', params=fields, ids=field_ids)
+def remove_field_feed(request):
+    """
+    It allows to modify the feed by removing a certain field and loading the new feed configuration
+    """
+    backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=xml_namespaces)
+
+    data_removed_field = str(backup_data)
+
+    data_removed_field = replace_regex(request.param['regex'], '', data_removed_field)
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=data_removed_field)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    control_service('restart', daemon='wazuh-modulesd')
+
+    vd.set_system(system='BIONIC')
+
+    yield request.param
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    truncate_file(LOG_FILE_PATH)
+
+
+def test_missing_canonical_feed(get_configuration, configure_environment, restart_modulesd, remove_field_feed):
+    """Test to check vulnerability detector behavior when importing canonical feeds with missing fields"""
+    if 'xfail' in remove_field_feed:
+        pytest.xfail("Add error messages to this case use")
+
+    if remove_field_feed['name'] in key_fields:
+        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=0)
+    else:
+        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
+                                            expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
@@ -1,0 +1,33 @@
+---
+# conf 1
+- tags:
+  - test_missing_fields_canonical_feeds
+  apply_to_modules:
+  - test_missing_fields_canonical_feeds
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'yes'
+    - provider:
+        attributes:
+        - name: 'canonical'
+        elements:
+        - enabled:
+            value: 'yes'
+        - os:
+            attributes:
+            - path: CANONICAL_CUSTOM_FEED
+            value: 'bionic'
+    - provider:
+        attributes:
+        - name: 'nvd'
+        elements:
+        - enabled:
+            value: 'yes'
+        - path:
+            value: NVD_JSON_PATH
+        - update_interval:
+            value: '10s'

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feeds.py
@@ -19,8 +19,8 @@ pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
-test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS)
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS_CONF)
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feeds.py
@@ -20,8 +20,8 @@ pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
-test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS)
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS_CONF)
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feeds.py
@@ -20,8 +20,8 @@ pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
-test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS)
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS_CONF)
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feeds.py
@@ -19,8 +19,8 @@ pytestmark = pytest.mark.tier(level=2)
 
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
-test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS)
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_RHEL_FEEDS_CONF)
 vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)
@@ -35,8 +35,7 @@ ids = ['REDHAT_configuration']
 # Read JSON data template
 nvd_vulnerabilities = read_json_file(vulnerabilities_data_path)
 
-system_data = {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8"}
-
+system_data = vd.SYSTEM_DATA['RHEL8']
 
 fields = ['CVE', 'severity', 'public_date', 'advisories', 'bugzilla', 'bugzilla_description', 'cvss_score',
           'cvss_scoring_vector', 'CWE', 'affected_packages', 'resource_url', 'cvss3_scoring_vector', 'cvss3_score']


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check the vulnerability detector behavior when we introduce a canonical feed with missing fields.

Closes #772 

# Tests logic

In each test, it has been deleted a field from the custom XML OVAL feed and then it has been checked if the feed has been imported successfully or not.

The obtained results are as follows:

- The vulnerabilities are not imported when one of the following fields are missing:

 ```
 ['definitions', 'definition', 'metadata', 'criteria', 'criterion', 'tests',
 'dpkginfo_test',  'test_object', 'dpkginfo_object', 'object_element',
 'dpkginfo_state', 'state_object',  'constant_variable', 'variable_value']
```

- For all other cases, the vulnerabilities are successfully imported.

The problem found, is for some cases, vulnerability detector shows the following message

```
The update of the 'Ubuntu Bionic' feed finished successfully
```

when it's really not importing the feed well.

```
sqlite> SELECT count(*) FROM VULNERABILITIES;
0
```

This occurs when one of the following fields is missing:

```
[ 'definitions', 'metadata', 'reference', 'criteria', 'tests']
```

When any of the other key fields are missing, messages are displayed warning that the feed is not correct:

```
Failed when updating 'canonical BIONIC' database
...
CVE database could not be updated.
```

It has been marked as `xfail` the cases in which the vulnerabilities are not imported successfully and vulnerability detector shows a successful importation message.

# Results

```
========================================= test session starts ==========================================
platform linux -- Python 3.7.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.9.0, testinfra-5.0.0
collected 32 items                                                                                     

test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py .....x.x [ 25%]
....x....x..x...........                                                                         [100%]

============================== 27 passed, 5 xfailed in 307.32s (0:05:07) ===============================
```


Best regards.
