### PR TITLE
Vulnerability detector: Add test invald field values for Canonical feeds

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='wazuh_testing',
-      version='3.11.0',
+      version='3.13.0',
       description='Wazuh testing utilites to help programmers automate tests',
       url='https://github.com/wazuh',
       author='Wazuh',

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -29,7 +29,7 @@ def replace_regex_group(pattern, new_value, data):
     """
     compiled_pattern = re.compile(pattern, re.DOTALL)
 
-    return re.sub(compiled_pattern, rf"\1{new_value}\3", data)
+    return re.sub(compiled_pattern, rf"\g<1>{new_value}\g<3>", data)
 
 
 def replace_regex(pattern, new_value, data):

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -16,7 +16,7 @@ def replace_regex_group(pattern, new_value, data):
     Parameters
     ----------
     pattern: str
-        Regex pattern.Important
+        Regex pattern
     new_value: str
         String to replace the grouped text
     data: str

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -9,10 +9,14 @@ def replace_regex_group(pattern, new_value, data):
     """
     Replace a grouped text string with a regex, with a new one.
 
+    Important: the regex must be composed of 3 groups, group 2 being the string that is modified.
+    Example:
+        r'(hello )(world)(!) --> hello test!
+
     Parameters
     ----------
     pattern: str
-        Regex pattern, for instance: r"CVE:(),"
+        Regex pattern.Important
     new_value: str
         String to replace the grouped text
     data: str
@@ -23,18 +27,9 @@ def replace_regex_group(pattern, new_value, data):
     data: str
         Data string with the new changes made
     """
-    match = re.search(pattern, data)
+    compiled_pattern = re.compile(pattern, re.DOTALL)
 
-    if match is not None:
-        try:
-            string_matched = match.group(0)
-            string_to_replace = match.group(1)
-            new_string = string_matched.replace(string_to_replace, new_value)
-            data = re.sub(pattern, new_string, data)
-        except IndexError:
-            pass
-
-    return data
+    return re.sub(compiled_pattern, rf"\1{new_value}\3", data)
 
 
 def replace_regex(pattern, new_value, data):

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -58,6 +58,14 @@ NVD_TABLES = [
 
 REDHAT_KEY_FIELDS_FEEDS = ['CVE', 'bugzilla_description', 'affected_packages']
 
+XML_FEED_NAMESPACES = [
+    {'name': '', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5'},
+    {'name': 'ind-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#independent'},
+    {'name': 'oval', 'url': 'http://oval.mitre.org/XMLSchema/oval-common-5'},
+    {'name': 'unix-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#unix'},
+    {'name': 'linux-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#linux'}
+]
+
 UpdateFromYearResult = namedtuple('UpdateFromYearResult', 'result actual_provider actual_update_from')
 
 nvd_check_feed_download_regex = r'.* wazuh-modulesd.*Downloading.*nvd\.nist\.gov\/feeds.*-(.*)\.(json|meta).*'

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
@@ -1,0 +1,163 @@
+
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import itertools
+import re
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools import file
+from wazuh_testing.tools.utils import replace_regex_group
+from wazuh_testing.tools.services import control_service
+import wazuh_testing.vulnerability_detector as vd
+
+# Marks
+pytestmark = pytest.mark.tier(level=2)
+
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_CANONICAL_FEEDS_CONF)
+custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# Set configuration
+parameters = [{'CANONICAL_CUSTOM_FEED': custom_canonical_oval_feed_path}]
+metadata = [{'canonical_custom_feed': custom_canonical_oval_feed_path}]
+ids = ['CANONICAL_configuration']
+
+system_data = vd.SYSTEM_DATA['BIONIC']
+
+all_fields = [
+    # Generator element
+    {'name': 'generator', 'regex': r'(<generator>)(.*)(<\/generator>)'},
+    # Generator child elements
+    {'name': 'product_name', 'regex': r'(<oval:product_name>)(.*)(<\/oval:product_name>)'},
+    {'name': 'product_version', 'regex': r'(<oval:product_version>)(.*)(<\/oval:product_version>)'},
+    {'name': 'schema_version', 'regex': r'(<oval:schema_version>)(.*)(<\/oval:schema_version>)'},
+    {'name': 'schema_version', 'regex': r'(<oval:timestamp>)(2020-05-28T14:13:36)(</oval:timestamp>)'},
+    # Definitions element
+    {'name': 'definitions', 'regex': r'(<definitions>)(.*)(<\/definitions>)'},
+    # Definitions child elements
+    {'name': 'definition', 'regex': r'(<definition.*version="1">)(.*)(<\/definition>)'},
+    # Definition child elements
+    {'name': 'metadata', 'regex': r'(<metadata>)(.*)(<\/metadata>)'},
+    # Metadata child elements
+    {'name': 'title', 'regex': r'(<title.*>)(.*)(<\/title>)'},
+    {'name': 'description', 'regex': r'(<description.*>)(.*)(<\/description>)'},
+    {'name': 'affected', 'regex': r'(<affected.*family="unix">)(.*)(<\/affected>)'},
+    # Affected child elements
+    {'name': 'platform', 'regex': r'(<platform.*>)(.*)(<\/platform>)'},
+    # Reference element
+    {'name': 'reference', 'regex': r'(<reference.*ref_id=")(.*)("\s.*name=CVE-000"\s*\/>)'},
+    {'name': 'advisory', 'regex': r'(<advisory>)(.*)(<\/advisory>)'},
+    # Advisory elements
+    {'name': 'severity', 'regex': r'(<severity>)(.*)(<\/severity>)'},
+    {'name': 'public_date', 'regex': r'(<public_date>)(.*)(<\/public_date>)'},
+    {'name': 'bug', 'regex': r'(<ref>)(.*)(<\/ref>)'},
+    # Criteria element
+    {'name': 'criteria', 'regex': r'(<criteria>)(.*)(<\/criteria>)'},
+    {'name': 'extend_definition', 'regex': r'(<extend_definition .*_ref=")(.*100)(".*"true"\s*\/>)'},
+    {'name': 'criterion', 'regex': r'<(criterion test_ref=")(.*:1)(".*vulnerable"\s*\/>)'},
+    # Tests element
+    {'name': 'tests', 'regex': r'(<tests>)(.*)(<\/tests>)'},
+    # Tests child elements
+    {'name': 'dpkginfo_test', 'regex': r'(<linux-def:dpkginfo_test\s*id=")(.*tst:1)(".*<\/linux-def:dpkginfo_test>)'},
+    {'name': 'test_object', 'regex': r'(<linux-def:object object_ref=")(.*obj:1)("\s*\/>)'},
+    # Objects element
+    {'name': 'objects', 'regex': r'(<objects>)(.*)(<\/objects>)'},
+    {'name': 'dpkginfo_object', 'regex': r'(<linux-def:dpkginfo_ob.*id=")(.*obj:1)(".*>.*<\/.*pkginfo_object>)'},
+    {'name': 'object_element', 'regex': r'(<linux-def:name\s*var_ref=")(.*var:1)(".*\/>)'},
+    # States element
+    {'name': 'states', 'regex': r'(<states>)(.*)(<\/states>)'},
+    {'name': 'dpkginfo_state', 'regex': r'(<linux-def:dpkginfo_state id=")(.*:1)(".*>.*<\/linux-def:dpkginfo_state>)'},
+    {'name': 'state_object', 'regex': r'(<linux-def:evr.*>)(.*)(<\/linux-def:evr>)'},
+    # Variables element
+    {'name': 'variables', 'regex': r'(<variables>)(.*)(<\/variables>)'},
+    {'name': 'constant_variable', 'regex': r'(<constant_variable id=")(.*:1)(".*<\/constant_variable>)'},
+    {'name': 'variable_value', 'regex': r'(<constant_variable.*<value>)(.*)(<\/value>.*<\/constant_variable>)'}
+]
+
+# Necessary fields to import successfully the vulnerabilities
+key_fields = ['definitions', 'definition', 'metadata', 'criteria', 'criterion', 'tests', 'dpkginfo_test', 'test_object',
+              'dpkginfo_object', 'object_element', 'dpkginfo_state', 'state_object', 'constant_variable',
+              'variable_value']
+
+# Fields where entering a wrong value does not import vulnerabilities
+fail_basic_fields = ['definitions', 'definition', 'metadata', 'criteria', 'criterion', 'tests', 'dpkginfo_test']
+
+# Add key fields indexes
+basic_fields_indexes = [all_fields.index(field) for field in all_fields if field['name'] in key_fields]
+
+# Add some non key indexes
+basic_fields_indexes.extend([all_fields.index(field) for extra_field in ['product_name', 'affected', 'platform']
+                            for field in all_fields if field['name'] == extra_field])
+
+# Sub-list for testing a minimum of fields
+basic_fields = [all_fields[index] for index in basic_fields_indexes]
+
+# Custom inputs to check
+inputs = [None, "", "dummy value", 12345, ['1', '2', '3', '4', '5'], "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار"]
+
+basic_field_ids = [f"field_{field['name']}_value_{value}" for field in basic_fields for value in inputs]
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture
+def modify_feed(field_info, custom_input, request):
+    """
+    Modify the Canonical OVAL feeds, setting a test field value
+    """
+    backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
+
+    modified_data = str(backup_data)
+
+    modified_data = replace_regex_group(field_info['regex'], custom_input, modified_data)
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    control_service('restart', daemon='wazuh-modulesd')
+
+    vd.set_system(system='BIONIC')
+
+    yield
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    truncate_file(LOG_FILE_PATH)
+
+
+@pytest.mark.parametrize('field_info, custom_input', itertools.product(basic_fields, inputs), ids=basic_field_ids)
+def test_invalid_canonical_feed(field_info, custom_input, get_configuration, configure_environment, restart_modulesd,
+                                modify_feed):
+    """
+    Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with wrong field values
+    """
+    if field_info['name'] == 'dpkginfo_test':
+        pytest.xfail('Xfailing due to vuln detector says that vulnerabilities has been added successfully when this ' +
+                     'has not been the case')
+
+    if field_info['name'] in fail_basic_fields:
+        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=0)
+    else:
+        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
+                                            expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
@@ -153,8 +153,7 @@ def test_invalid_canonical_feed(field_info, custom_input, get_configuration, con
     Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with wrong field values
     """
     if field_info['name'] == 'dpkginfo_test':
-        pytest.xfail('Xfailing due to vuln detector says that vulnerabilities has been added successfully when this ' +
-                     'has not been the case')
+        pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/5275')
 
     if field_info['name'] in fail_basic_fields:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, expected_vulnerabilities_number=0)

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
@@ -21,29 +21,16 @@ pytestmark = pytest.mark.tier(level=2)
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, '..', 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_CANONICAL_FEEDS_CONF)
-vulnerabilities_data_path = os.path.join(test_data_path, 'vulnerabilities', vd.CUSTOM_NVD_VULNERABILITIES_1)
-custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'NVD_JSON_PATH': custom_nvd_json_path, 'CANONICAL_CUSTOM_FEED': custom_canonical_oval_feed_path}]
-metadata = [{'nvd_json_path': custom_nvd_json_path, 'canonical_custom_feed': custom_canonical_oval_feed_path}]
+parameters = [{'CANONICAL_CUSTOM_FEED': custom_canonical_oval_feed_path}]
+metadata = [{'canonical_custom_feed': custom_canonical_oval_feed_path}]
 ids = ['CANONICAL_configuration']
 
-# Read JSON data template
-nvd_vulnerabilities = read_json_file(vulnerabilities_data_path)
-
 system_data = vd.SYSTEM_DATA['BIONIC']
-
-xml_namespaces = [
-    {'name': '', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5'},
-    {'name': 'ind-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#independent'},
-    {'name': 'oval', 'url': 'http://oval.mitre.org/XMLSchema/oval-common-5'},
-    {'name': 'unix-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#unix'},
-    {'name': 'linux-def', 'url': 'http://oval.mitre.org/XMLSchema/oval-definitions-5#linux'}
-]
 
 fields = [
     # Generator element
@@ -66,7 +53,7 @@ fields = [
     # Affected child elements
     {'name': 'platform', 'regex': r'<platform.*>.*<\/platform>'},
     # Reference element
-    {'name': 'reference', 'regex': r'<reference.*name=CVE-000"\s+\/>'},
+    {'name': 'reference', 'regex': r'<reference.*name=CVE-000"\s*\/>'},
     {'name': 'advisory', 'regex': r'<advisory>.*<\/advisory>'},
     # Advisory elements
     {'name': 'severity', 'regex': r'<severity>.*<\/severity>'},
@@ -74,17 +61,17 @@ fields = [
     {'name': 'bug', 'regex': r'<ref>.*<\/ref>'},
     # Criteria element
     {'name': 'criteria', 'regex': r'<criteria>.*<\/criteria>'},
-    {'name': 'extend_definition', 'regex': r'<extend_definition.*applicability_check="true"\s+\/>'},
-    {'name': 'criterion', 'regex': r'<criterion.*vulnerable"\s+\/>'},
+    {'name': 'extend_definition', 'regex': r'<extend_definition.*applicability_check="true"\s*\/>'},
+    {'name': 'criterion', 'regex': r'<criterion.*vulnerable"\s*\/>'},
     # Tests element
     {'name': 'tests', 'regex': r'<tests>.*<\/tests>'},
     # Tests child elements
     {'name': 'dpkginfo_test', 'regex': r'<linux-def:dpkginfo_test.*<\/linux-def:dpkginfo_test>'},
-    {'name': 'test_object', 'regex': r'<linux-def:object object_ref="oval:com.ubuntu.bionic:obj:1"\s+\/>'},
+    {'name': 'test_object', 'regex': r'<linux-def:object object_ref="oval:com.ubuntu.bionic:obj:1"\s*\/>'},
     # Objects element
     {'name': 'objects', 'regex': r'<objects>.*<\/objects>'},
     {'name': 'dpkginfo_object', 'regex': r'<linux-def:dpkginfo_object.*">.*<\/linux-def:dpkginfo_object>'},
-    {'name': 'object_element', 'regex': r'<linux-def:name.*var_check="at least one"\s+\/>'},
+    {'name': 'object_element', 'regex': r'<linux-def:name.*var_check="at least one"\s*\/>'},
     # States element
     {'name': 'states', 'regex': r'<states>.*<\/states>'},
     {'name': 'dpkginfo_state', 'regex': r'<linux-def:dpkginfo_state.*>.*<\/linux-def:dpkginfo_state>'},
@@ -121,7 +108,7 @@ def remove_field_feed(request):
     """
     It allows to modify the feed by removing a certain field and loading the new feed configuration
     """
-    backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=xml_namespaces)
+    backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     data_removed_field = str(backup_data)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
@@ -2,8 +2,10 @@
 # conf 1
 - tags:
   - test_missing_fields_canonical_feeds
+  - test_invalid_values_canonical_feeds
   apply_to_modules:
   - test_missing_fields_canonical_feeds
+  - test_invalid_values_canonical_feeds
   sections:
   - section: vulnerability-detector
     elements:
@@ -21,13 +23,3 @@
             attributes:
             - path: CANONICAL_CUSTOM_FEED
             value: 'bionic'
-    - provider:
-        attributes:
-        - name: 'nvd'
-        elements:
-        - enabled:
-            value: 'yes'
-        - path:
-            value: NVD_JSON_PATH
-        - update_interval:
-            value: '10s'

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feeds.py
@@ -37,43 +37,39 @@ ids = ['REDHAT_configuration']
 nvd_vulnerabilities = read_json_file(vulnerabilities_data_path)
 
 test_data = [
-    # CURLY BRACKETS
-    {"pattern": r'(\{)', "update": '', "description": "Delete '{'"},
-    {"pattern": r'(\})', "update": '', "description": "Delete '}'"},
-    {"pattern": r'(\{)', "update": '{{', "description": "Add '{{'"},
-    {"pattern": r'(\})', "update": '}}', "description": "Add '}}'"},
-    {"pattern": r'"CVE":.*(,)', "update": ',{', "description": "Add '{' in the middle of feed"},
-    {"pattern": r'"CVE":.*(,)', "update": ',}', "description": "Add '}' in the middle of feed"},
-    {"pattern": r'"CVE":.*(,)', "update": ',{}', "description": "Add '{}' in the middle of feed"},
-
+    #CURLY BRACKETS
+    {"pattern": r'(.*)(\{)(.*)', "update": '', "description": "Delete '{'"},
+    {"pattern": r'(.*)(\})(.*)', "update": '', "description": "Delete '}'"},
+    {"pattern": r'(.*)(\{)(.*)', "update": '{{', "description": "Add '{{'"},
+    {"pattern": r'(.*)(\})(.*)', "update": '}}', "description": "Add '}}'"},
+    {"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": ',{', "description": "Add '{' in the middle of feed"},
+    {"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": ',}', "description": "Add '}' in the middle of feed"},
+    {"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": ',{}', "description": "Add '{}' in the middle of feed"},
     # COMMA
-    {"pattern": r'"CVE":.*(,)', "update": '', "description": "Delete key:value comma ','"},
-    {"pattern": r'"CVE"(:)', "update": ': ,', "description": "Add a comma before value key: ,value,"},
-    {"pattern": r'(")CVE":.*', "update": ',"', "description": "Add a comma before any key value ', key:value'"},
-    {"pattern": r'(\})', "update": ",}" ,"description": "Add a comma at the end of vulnerability ',}'"},
-    {"pattern": r'.*"CVE":.*(,)', "update": ',,', "description": "Add double comma after key:value,,"},
-    {"pattern": r'".*el5_0.2"(,)', "update": ',,', "description": "Add double comma after list value,,"},
-
+    {"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": '', "description": "Delete key:value comma ','"},
+    {"pattern": r'(.*:\s*"CVE-000")(,)(.*)', "update": ': ,', "description": "Add a comma before value key: ,value,"},
+    {"pattern": r'(.*)(")(CVE":\s*.*)', "update": ',"', "description": "Add comma before any key value ', key:value'"},
+    {"pattern": r'(.*)(\})(.*)', "update": ",}" ,"description": "Add a comma at the end of vulnerability ',}'"},
+    {"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": ',,', "description": "Add double comma after key:value,,"},
+    {"pattern": r'(.*".*el5_0.2")(,)(.*)', "update": ',,', "description": "Add double comma after list value,,"},
     # QUOTES
-    {"pattern": r'"CVE"(:)', "update": '":', "description": "Close a key with double quotation marks"},
-    {"pattern": r'"CVE":.*(,)', "update": '",', "description": "Close a value with double quotation marks"},
-
+    {"pattern": r'(.*"CVE")(:)(.*)', "update": '":', "description": "Close a key with double quotation marks"},
+    {"pattern": r'(.*:\s*"CVE-000")(,)(.*)', "update": '",', "description": "Close value with double quotation marks"},
     # SEMICOLON
-    {"pattern": r'"CVE":.*(,)', "update": ';', "description": "Replace a comma with semicolon"},
-    {"pattern": r'"CVE"(:)', "update": ';', "description": "Replace a colon with semicolon"},
-
+    {"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": ';', "description": "Replace a comma with semicolon"},
+    {"pattern": r'(.*"CVE")(:)(\s*"CVE-000)', "update": ';', "description": "Replace a colon with semicolon"},
     # BRACKETS
-    {"pattern": r'"affected_packages":.*(\[)', "update": '', "description": "Missing open bracket"},
-    {"pattern": r'affected_packages.*(\])', "update": '', "description": "Missing close bracket"},
-
+    {"pattern": r'(.*"affected_packages":.*)(\[)(.*)', "update": '', "description": "Missing open bracket"},
+    {"pattern": r'(.*)(\])(,.*)', "update": '', "description": "Missing close bracket"},
     # MISSING INFO
-    {"pattern": r'.*bug(.*)', "update": '', "description": "Delete some information"},
+    {"pattern": r'(.*bug)(.*],)(.*)', "update": '', "description": "Delete some information"},
 ]
 
 # Add EXTRA CHARS to test_data
 extra_chars = ['.', ':', '@', '#', '*', '-', '_', "'", '"', '/', '=', '<', '>', '!', '?', '%', '&', '`']
 for item in extra_chars:
-    test_data.append({"pattern": r'"CVE":.*(,)', "update": item, "description": f"Replace ',' with '{item}'"})
+    test_data.append({"pattern": r'(.*"CVE":\s*"CVE-000")(,)(.*)', "update": item,
+                      "description": f"Replace ',' with '{item}'"})
 
 test_ids = [item['description'] for item in test_data]
 


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check the vulnerability detector behavior when we introduce a canonical feed with invalid values.

Closes #784 

# Tests logic

From a customized OVAL feed, a set of tests is performed in which a field value is changed and the behavior of the vulnerability detector is observed.

For each field in the Canonical OVAL feed, the following values have been entered:

```
[None, "", "dummy value", 12345, ['1', '2', '3', '4', '5'], "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار"]
```
It has been checked the key fields and three additional fields:

```
key_fields = ['definitions', 'definition', 'metadata', 'criteria', 'criterion',
     'tests', 'dpkginfo_test', 'test_object', 'dpkginfo_object', 'object_element',
     'dpkginfo_state', 'state_object', 'constant_variable',  'variable_value']

extra_fields=['product_name', 'affected', 'platform']
```

The tested results are as follows:

- Vulnerabilities are **NOT imported** when there is an invalid value in the following fields:

   ```
   ['definitions', 'definition', 'metadata', 'criteria', 'criterion', 'tests', 'dpkginfo_test']
   ```

- When `dpkginfo_test` has an invalid value, vulnerability detector shows the following message:

   ```
   The update of the 'Ubuntu Bionic' feed finished successfully.
   ```
   when in fact it has not imported the vulnerabilities. These tests have been marked as *xfailed* and it has been reported here https://github.com/wazuh/wazuh/issues/5275.

- For the rest of the fields checked and not included in the above list, it is checked that they are imported correctly.

# Results

```
 ========================================= test session starts ==========================================
 platform linux -- Python 3.7.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
 rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
 plugins: html-2.0.1, metadata-1.9.0, testinfra-5.0.0
 collected 170 items                                                                                    

 test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py ........ [  4%]
 ....................................................xxxxxxxxxx.................................. [ 61%]
 ..................................................................                               [100%]

 ============================= 160 passed, 10 xfailed in 1643.41s (0:27:23) =============================
```

Best regards.
