### PR TITLE
Vulnerability detector: Add test extra fields for Canonical feed

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -205,3 +205,26 @@ def delete_dbs():
     for root, dirs, files in os.walk(QUEUE_DB_PATH):
         for file in files:
             os.remove(os.path.join(root, file))
+
+
+def check_if_process_is_running(process_name):
+    """
+    Check if proccess is running
+
+    Parameters
+    ----------
+    proccess_name: str
+        Name of process
+
+    Returns
+    -------
+    boolean:
+        True if process is running, False otherwise
+    """
+    is_running = False
+    try:
+        is_running = process_name in (p.name() for p in psutil.process_iter())
+    except psutil.NoSuchProcess:
+        pass
+
+    return is_running

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -53,3 +53,36 @@ def replace_regex(pattern, new_value, data):
     compiled_pattern = re.compile(pattern, re.DOTALL)
 
     return re.sub(compiled_pattern, new_value, data)
+
+
+def insert_xml_tag(pattern, tag, value, data):
+    """
+    Function to insert a xml tag in a string data.
+
+    Parameters
+    ----------
+    pattern: str
+        regex pattern.
+        Important: the regex must be composed of 3 groups. The inserted data will be added between group 1 and group 2.
+        Example:
+            r'(.*</tag1>)(<my_custom_tag>)(<tag2>)
+                </tag1>
+                <my_custom_tag>custom_value</my_custom_tag>
+                <tag2>
+                ...
+    tag: str
+        new xml tag
+    value: str
+        value of new xml tag
+    data: str
+        XML string data
+
+    Returns
+    -------
+    str:
+        new XML string data
+    """
+    xml_tag = f"\n  <{tag}>{value}</{tag}>"
+    compiled_pattern = re.compile(pattern, re.DOTALL)
+
+    return re.sub(compiled_pattern, rf"\g<1>{xml_tag}\n  \g<2>\g<3>", data)

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -11,7 +11,7 @@ from time import time, sleep
 from collections import namedtuple
 
 from wazuh_testing.tools import WAZUH_PATH
-from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.services import control_service, check_if_process_is_running
 
 VULN_DETECTOR_GLOBAL_TIMEOUT = 10
 VULN_DETECTOR_SCAN_TIMEOUT = 40
@@ -233,12 +233,15 @@ def clean_vd_tables(agent="000"):
     ]
 
     # Clean providers and sys_programs tables
-    for item in tables:
-        clean_table(item['path'], item['name'])
+    try:
+        for item in tables:
+            clean_table(item['path'], item['name'])
 
-    # Clean NVD tables
-    for item in NVD_TABLES:
-        clean_table(item['path'], item['name'])
+        # Clean NVD tables
+        for item in NVD_TABLES:
+            clean_table(item['path'], item['name'])
+    except sqlite3.OperationalError:
+        pass
 
 
 def update_last_scan(last_scan=0, agent="000"):
@@ -637,3 +640,7 @@ def insert_data_redhat_feed(data, field_name, field_value, append_data):
     string_data = f"[\n{string_data}\n]"
 
     return string_data
+
+
+def check_if_modulesd_is_running():
+    assert check_if_process_is_running('wazuh-modulesd'), "wazuh-modulesd is not running!"

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -233,15 +233,18 @@ def clean_vd_tables(agent="000"):
     ]
 
     # Clean providers and sys_programs tables
-    try:
-        for item in tables:
+    for item in tables:
+        try:
             clean_table(item['path'], item['name'])
+        except sqlite3.OperationalError:
+            pass
 
-        # Clean NVD tables
-        for item in NVD_TABLES:
+    # Clean NVD tables
+    for item in NVD_TABLES:
+        try:
             clean_table(item['path'], item['name'])
-    except sqlite3.OperationalError:
-        pass
+        except sqlite3.OperationalError:
+            pass
 
 
 def update_last_scan(last_scan=0, agent="000"):

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_fields_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_fields_canonical_feeds.py
@@ -1,0 +1,94 @@
+
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools import file
+from wazuh_testing.tools.utils import insert_xml_tag
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.services import control_service
+import wazuh_testing.vulnerability_detector as vd
+
+# Marks
+pytestmark = pytest.mark.tier(level=2)
+
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_CANONICAL_FEEDS_CONF)
+custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# Set configuration
+parameters = [{'CANONICAL_CUSTOM_FEED': custom_canonical_oval_feed_path}]
+metadata = [{'canonical_custom_feed': custom_canonical_oval_feed_path}]
+ids = ['CANONICAL_configuration']
+
+system_data = vd.SYSTEM_DATA['BIONIC']
+
+test_data = [[1, 2, 3], {"a": 1, "b": 2}, "extra_field", 12345, "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار", " ", ""]
+test_values = [(field, value) for field in test_data for value in test_data]
+
+field_ids = [f"field_{value[0]}_value_{value[1]}" for value in test_values]
+
+# Insert extra fields before <generator> tag
+insert_pattern = r'(.*)(<generator>)(.*)'
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture
+def modify_feed(test_values, request):
+    """
+    Modify the Canonical OVAL feed, setting a test field value
+    """
+    backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
+
+    modified_data = str(backup_data)
+
+    modified_data = insert_xml_tag(pattern=insert_pattern, tag=test_values[0], value=test_values[1], data=modified_data)
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    control_service('restart', daemon='wazuh-modulesd')
+
+    vd.set_system(system='BIONIC')
+
+    yield
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    truncate_file(LOG_FILE_PATH)
+
+
+@pytest.mark.parametrize('test_values', test_values, ids=field_ids)
+def test_extra_fields_canonical_feed(test_values, get_configuration, configure_environment, modify_feed):
+    """
+    Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with extra fields
+    """
+    inserted_tag = test_values[0]
+    if inserted_tag != ' ' and type(inserted_tag) is str or type(inserted_tag) is int:
+        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
+                                            expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
+    else:
+        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
+
+    vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
@@ -6,7 +6,6 @@
 import os
 import pytest
 import itertools
-import re
 
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.monitoring import FileMonitor

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
@@ -3,9 +3,11 @@
 - tags:
   - test_missing_fields_canonical_feeds
   - test_invalid_values_canonical_feeds
+  - test_extra_fields_canonical_feeds
   apply_to_modules:
   - test_missing_fields_canonical_feeds
   - test_invalid_values_canonical_feeds
+  - test_extra_fields_canonical_feeds
   sections:
   - section: vulnerability-detector
     elements:


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check the vulnerability detector behavior when there's an extra field in the Canonical feed.

Closes #787 

# Tests logic

From a customized XML feed, a set of tests is performed in which extra fields are added and the behavior of the vulnerability detector is observed.

A `<tag>value</tag>` pair has been created with the Cartesian product from the following list:

```
[[1, 2, 3], {"a": 1, "b": 2}, "extra_field", 12345, "ñ", "テスト", "ИСПЫТАНИЕ",
 "测试", "اخ, " ", ""]
```

For each of these cases, the following behavior has been observed and verified:

- If the tag and value is a blank space `< > < />`  then the feed **is not imported correctly**

- If the type of tag is not `string` or `integer` then the feed **is not imported correctly**.

- For all other cases, the feed **is imported correctly**.


# Results

```
========================================= test session starts ==========================================
platform linux -- Python 3.7.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, metadata-1.9.0, testinfra-5.0.0
collected 121 items                                                                                    

test_vulnerability_detector/test_feeds/canonical/test_extra_fields_canonical_feeds.py .......... [  8%]
................................................................................................ [ 87%]
...............                                                                                  [100%]

=================================== 121 passed in 1173.47s (0:19:33) ===================================

```

Best regards.
