### PR TITLE
Vulnerability detector: Add test invalid syntax for Canonical feed

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_fields_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_fields_canonical_feeds.py
@@ -58,9 +58,8 @@ def modify_feed(test_values, request):
     """
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
-    modified_data = str(backup_data)
-
-    modified_data = insert_xml_tag(pattern=insert_pattern, tag=test_values[0], value=test_values[1], data=modified_data)
+    modified_data = insert_xml_tag(pattern=insert_pattern, tag=test_values[0], value=test_values[1],
+                                   data=str(backup_data))
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feeds.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.file import truncate_file
+import wazuh_testing.vulnerability_detector as vd
+from wazuh_testing.tools import file
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.utils import replace_regex_group
+
+# Marks
+pytestmark = pytest.mark.tier(level=2)
+
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, '..', 'data')
+configurations_path = os.path.join(test_data_path, 'configuration', vd.INVALID_CANONICAL_FEEDS_CONF)
+custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# Set configuration
+parameters = [{'CANONICAL_CUSTOM_FEED': custom_canonical_oval_feed_path}]
+metadata = [{'canonical_custom_feed': custom_canonical_oval_feed_path}]
+ids = ['CANONICAL_configuration']
+
+system_data = vd.SYSTEM_DATA['BIONIC']
+
+test_data = [
+    {"regex": r'(.*)(<generator>)(.*)', "update": 'generator>', "description": "Delete '<'", "expected_fail": True},
+    {"regex": r'(.*)(<generator>)(.*)', "update": '<generator', "description": "Delete '>'", "expected_fail": True},
+    {"regex": r'(.*)(<generator>)(.*)', "update": 'generator', "description": "Delete '<>'", "expected_fail": True},
+    {"regex": r'(.*)(<generator>)(.*)', "update": '</generator>', "description": "Close initial tag",
+     "expected_fail": True},
+    {"regex": r'(.*)(<definitions>)(.*)', "update": '', "description": "Delete opening tag", "expected_fail": True},
+    {"regex": r'(.*)(</definitions>)(.*)', "update": '', "description": "Delete closing tag", "expected_fail": True},
+    {"regex": r'(.*)(<definitions>)(.*)', "update": '<><definitions>', "description": "Empty opening tag",
+     "expected_fail": True},
+    {"regex": r'(.*)(<definitions>)(.*)', "update": '</><definitions>', "description": "Empty closing tag",
+     "expected_fail": True},
+    {"regex": r'(.*)(<definitions>)(.*)', "update": 'as.-*!`ñ<definitions>', "description": "Random text before tag",
+     "expected_fail": False},
+    {"regex": r'(<oval_definitions.*)(xmlns:oval.*)(<generator>.*)', "update": '', "description": "Delete info",
+     "expected_fail": True},
+]
+
+# Add EXTRA CHARS to test_data
+extra_chars = ['.', ':', '@', '#', '*', '-', '_', "'", '"', '/', '=', 'ñ', 'ç', '+', '^', '!', '?', '%', '&', '`', '¿',
+               '?', '(', ')', '|', 'º', '$', '½', '¬', '!', '~', '¡', '[', ']', '{', '}']
+
+for item in extra_chars:
+    test_data.append({"regex": r'(.*)(<metadata>)(.*)', "update": f"{item}<metadata>",
+                      "description": f"Add {item} character before <metadata>", "expected_fail": False})
+
+for item in extra_chars:
+    test_data.append({"regex": r'(.*)(<)(metadata>.*)', "update": item,
+                      "description": f"Replace '<' with '{item}' in <metadata>", "expected_fail": True})
+
+test_ids = [item['description'] for item in test_data]
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture
+def modify_feed(test_data, request):
+    """
+    Modify the Canonical OVAL feeds, setting a test field value
+    """
+    backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
+
+    modified_data = str(backup_data)
+
+    modified_data = replace_regex_group(test_data['regex'], test_data['update'], modified_data)
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    control_service('restart', daemon='wazuh-modulesd')
+
+    vd.set_system(system='BIONIC')
+
+    yield
+
+    file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
+
+    vd.clean_vuln_and_sys_programs_tables()
+
+    truncate_file(LOG_FILE_PATH)
+
+
+@pytest.mark.parametrize('test_data', test_data, ids=test_ids)
+def test_invalid_syntax_canonical_feed(test_data, get_configuration, configure_environment, restart_modulesd,
+                                       modify_feed):
+    """
+    Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with syntax errors
+    """
+    if test_data['expected_fail']:
+        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
+    else:
+        vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
+                                            expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
+    vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feeds.py
@@ -56,8 +56,6 @@ extra_chars = ['.', ':', '@', '#', '*', '-', '_', "'", '"', '/', '=', 'ñ', 'ç'
 for item in extra_chars:
     test_data.append({"regex": r'(.*)(<metadata>)(.*)', "update": f"{item}<metadata>",
                       "description": f"Add {item} character before <metadata>", "expected_fail": False})
-
-for item in extra_chars:
     test_data.append({"regex": r'(.*)(<)(metadata>.*)', "update": item,
                       "description": f"Replace '<' with '{item}' in <metadata>", "expected_fail": True})
 
@@ -81,9 +79,7 @@ def modify_feed(test_data, request):
     """
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
-    modified_data = str(backup_data)
-
-    modified_data = replace_regex_group(test_data['regex'], test_data['update'], modified_data)
+    modified_data = replace_regex_group(test_data['regex'], test_data['update'], str(backup_data))
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feeds.py
@@ -146,8 +146,8 @@ def modify_feed(field_info, custom_input, request):
 
 
 @pytest.mark.parametrize('field_info, custom_input', itertools.product(basic_fields, inputs), ids=basic_field_ids)
-def test_invalid_canonical_feed(field_info, custom_input, get_configuration, configure_environment, restart_modulesd,
-                                modify_feed):
+def test_invalid_values_canonical_feed(field_info, custom_input, get_configuration, configure_environment,
+                                       restart_modulesd, modify_feed):
     """
     Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with wrong field values
     """

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_fields_canonical_feeds.py
@@ -110,9 +110,7 @@ def remove_field_feed(request):
     """
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
-    data_removed_field = str(backup_data)
-
-    data_removed_field = replace_regex(request.param['regex'], '', data_removed_field)
+    data_removed_field = replace_regex(request.param['regex'], '', str(backup_data))
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=data_removed_field)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration/wazuh_invalid_canonical_feeds.yaml
@@ -4,10 +4,12 @@
   - test_missing_fields_canonical_feeds
   - test_invalid_values_canonical_feeds
   - test_extra_fields_canonical_feeds
+  - test_invalid_syntax_canonical_feeds
   apply_to_modules:
   - test_missing_fields_canonical_feeds
   - test_invalid_values_canonical_feeds
   - test_extra_fields_canonical_feeds
+  - test_invalid_syntax_canonical_feeds
   sections:
   - section: vulnerability-detector
     elements:

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feeds.py
@@ -5,7 +5,6 @@
 import os
 import pytest
 import json
-from time import sleep
 
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations


### PR DESCRIPTION
Hello team,

This PR adds the necessary tests to check the vulnerability detector behavior when there's an invalid syntax in the Canonical feed.

Closes #789 

# Tests logic

From a customized XML feed, a set of tests is performed in which syntax errors have been inserted in the Canonical feed and the behavior of the vulnerability detector is observed.

Each test makes an invalid syntax error in Canonical feed, causing the feed cannot be imported in some cases.

# Results

```
========================================= test session starts ==========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /root/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.8.0
collected 82 items                                                                                     

test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feeds.py ........ [  9%]
..........................................................................                       [100%]

==================================== 82 passed in 795.06s (0:13:15) ====================================
```

Best regards.
