### PR TITLE
Fix HostMonitor in monitoring.py module

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -747,7 +747,7 @@ class HostMonitor:
         """This method creates and destroy the needed processes for the messages founded in messages_path.
         It creates one file composer (process) for every file to be monitored in every host."""
         for host, payload in self.test_cases.items():
-            monitored_files = set({case['path'] for case in payload})
+            monitored_files = {case['path'] for case in payload}
             if len(monitored_files) == 0:
                 raise AttributeError('There is no path to monitor. Exiting...')
             for path in monitored_files:

--- a/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
@@ -1,0 +1,44 @@
+---
+wazuh-master:
+  - regex: ".*Agent key generated for agent.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: '.*Received request:.*{"arguments":{"daemon_name":"authd","message":{"arguments":{"name":.*,"ip":"any","force":0},"function":"add"}},"function":"send_sync"}.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: '.*Worker wazuh-worker1.*Finished integrity synchronization.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+
+
+wazuh-worker1:
+  - regex: ".*Received request for a new agent.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: ".*Dispatching request to master node.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: ".*Agent key generated for.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: '.*Processing file \/etc\/client\.keys.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: '.*Updating files: End.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+
+
+wazuh-agent1:
+  - regex: ".*Starting enrollment process to server.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: ".*Received response with agent key.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: ".*Valid key created. Finished.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60
+  - regex: ".*Connection closed.*"
+    path: "/var/ossec/logs/ossec.log"
+    timeout: 60

--- a/tests/system/test_cluster/test_agent_enrollment/data/messages_cluster.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages_cluster.yml
@@ -1,8 +1,0 @@
----
-wazuh-master:
-  - regex: '.*Received request:.*{"arguments":{"daemon_name":"authd","message":{"arguments":{"name":.*,"ip":"any","force":0},"function":"add"}},"function":"send_sync"}.*'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 60
-  - regex: '.*Finished integrity synchronization.*'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 60

--- a/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
+++ b/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
@@ -22,9 +22,10 @@ host_manager = HostManager(inventory_path)
 @pytest.fixture(scope='module')
 def clean_environment():
     yield
+    agent_id = host_manager.run_command('wazuh-master', f'cut -c 1-3 {WAZUH_PATH}/etc/client.keys')
+    host_manager.get_host('wazuh-master').ansible("command", f'{WAZUH_PATH}/bin/manage_agents -r {agent_id}', check=False)
     host_manager.control_service(host='wazuh-agent1', service='wazuh', state="stopped")
     host_manager.clear_file(host='wazuh-agent1',  file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
-    host_manager.get_host('wazuh-master').ansible("command", f'{WAZUH_PATH}/bin/manage_agents -r 001', check=False)
 
 
 def test_agent_enrollment(clean_environment):
@@ -45,15 +46,14 @@ def test_agent_enrollment(clean_environment):
     local_path = os.path.dirname(os.path.abspath(__file__))
 
     # Run the callback checks for the ossec.log and the cluster.log
-    for messages in ['data/messages_ossec.yml', 'data/messages_cluster.yml']:
-        HostMonitor(inventory_path=inventory_path,
-                    messages_path=os.path.join(local_path, messages),
-                    tmp_path=os.path.join(local_path, 'tmp')).run()
-
-    # Make sure the agent's client.keys is not empty
-    assert host_manager.get_file_content('wazuh-worker1', os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
+    HostMonitor(inventory_path=inventory_path,
+                messages_path=os.path.join(local_path, 'data/messages.yml'),
+                tmp_path=os.path.join(local_path, 'tmp')).run()
 
     # Make sure the worker's client.keys is not empty
+    assert host_manager.get_file_content('wazuh-worker1', os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
+
+    # Make sure the agent's client.keys is not empty
     assert host_manager.get_file_content('wazuh-agent1', os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
 
     # Check if the agent is active


### PR DESCRIPTION
Hello team,

This PR updates `monitoring.py` module to fix our `HostMonitor` class. Currently our `HostMonitor` doesn't work as expected if we try to monitor several different log files in different hosts. In that case, HostMonitor could try to monitor a given log file in all the hosts instead of in a single one.

Another fix this PR applies is the way the payload of the messages.yaml is sent to the File Monitors for each host. With this, any file monitor will receive only the messages that must be found in a given file log instead of every single one for that host.

Finally, `test_agent_enrollment` system test has been updated to use those improvements, allowing us to have only one yaml file for this test.

Regards.



