### PR TITLE
Fix macOS prefix problem

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -27,8 +27,12 @@ else:
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
     LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
-    GEN_OSSEC = os.path.join(WAZUH_SOURCES, 'gen_ossec.sh')
-    PREFIX = os.sep
+    if sys.platform == 'darwin':
+        PREFIX = os.path.join('/', 'private', 'var', 'root') 
+        GEN_OSSEC = None
+    else:
+        PREFIX = os.sep
+        GEN_OSSEC = os.path.join(WAZUH_SOURCES, 'gen_ossec.sh')
     try:
         import grp
         import pwd


### PR DESCRIPTION
Hello team, 

This PR closes #808, we have fixed the issue by adding a conditional to set the `PREFIX` variable for macOS.

https://github.com/wazuh/wazuh-qa/blob/f8ebfbad90f2df8c09798a32cb9acb277c0bf79d/deps/wazuh_testing/wazuh_testing/tools/__init__.py#L30-L35

Test before fix:

PYTEST OUTPUT

```
09:37:49  test_fim/test_ambiguous_confs/test_ambiguous_complex.py::test_ambiguous_complex[get_configuration0-tags_to_apply0] ERROR [  0%]
09:37:49  test_fim/test_ambiguous_confs/test_ambiguous_complex.py::test_ambiguous_complex[get_configuration1-tags_to_apply0] ERROR [  0%]
09:37:49  test_fim/test_ambiguous_confs/test_ambiguous_complex.py::test_ambiguous_complex[get_configuration2-tags_to_apply0] ERROR [  0%]

```

Test after fix:

PYTEST OUTPUT

```
12:12:52  
12:12:52  test_fim/test_ambiguous_confs/test_ambiguous_complex.py::test_ambiguous_complex[get_configuration0-tags_to_apply0] PASSED [ 33%]
12:12:52  test_fim/test_ambiguous_confs/test_ambiguous_complex.py::test_ambiguous_complex[get_configuration1-tags_to_apply0] PASSED [ 66%]
12:12:52  test_fim/test_ambiguous_confs/test_ambiguous_complex.py::test_ambiguous_complex[get_configuration2-tags_to_apply0] PASSED [100%]
12:12:52  
12:12:52  - generated html file: file:///tmp/test_integration_B347_20200707105433/report.html -
12:12:52  ======================== 3 passed in 199.38s (0:03:19) =========================``` 

Regards,
Daniel Folch