### PR TITLE
Logtest configuration test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logtest.py
+++ b/deps/wazuh_testing/wazuh_testing/logtest.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import re
+
+
+# Callbacks
+
+def callback_logtest_started(line):
+    match = re.match(r'.*INFO: \(\d+\): Logtest started', line)
+    if match:
+        return True
+    return None
+
+
+def callback_logtest_disabled(line):
+    match = re.match(r'.*INFO: \(\d+\): Logtest disabled', line)
+    if match:
+        return True
+    return None
+
+
+def callback_configuration_error(line):
+    match = re.match(r'.*ERROR: \(\d+\): Invalid value for element', line)
+    if match:
+        return True
+    return None

--- a/tests/integration/test_logtest/test_configuration/data/wazuh_conf.yaml
+++ b/tests/integration/test_logtest/test_configuration/data/wazuh_conf.yaml
@@ -1,0 +1,130 @@
+# conf 1
+- tags:
+  - valid_conf
+  apply_to_modules:
+  - test_get_configuration_sock
+  - test_configuration_file
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '2'
+    - max_sessions:
+        value: '100'
+    - session_timeout:
+        value: '1200'
+# conf 2
+- tags:
+  - disabled_conf
+  apply_to_modules:
+  - test_get_configuration_sock
+  - test_configuration_file
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'no'
+    - threads:
+        value: '2'
+    - max_sessions:
+        value: '100'
+    - session_timeout:
+        value: '1200'
+# conf 3
+- tags:
+  - invalid_threads_conf
+  apply_to_modules:
+  - test_get_configuration_sock
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '140'
+    - max_sessions:
+        value: '100'
+    - session_timeout:
+        value: '1200'
+# conf 4
+- tags:
+  - invalid_users_conf
+  apply_to_modules:
+  - test_get_configuration_sock
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '2'
+    - max_sessions:
+        value: '1000'
+    - session_timeout:
+        value: '1200'
+# conf 5
+- tags:
+  - invalid_timeout_conf
+  apply_to_modules:
+  - test_get_configuration_sock
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '2'
+    - max_sessions:
+        value: '70'
+    - session_timeout:
+        value: '31536123'
+# conf 6
+- tags:
+  - invalid_threads_conf
+  apply_to_modules:
+  - test_configuration_file
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: 'hello'
+    - max_sessions:
+        value: '100'
+    - session_timeout:
+        value: '1200'
+# conf 7
+- tags:
+  - invalid_users_conf
+  apply_to_modules:
+  - test_configuration_file
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '2'
+    - max_sessions:
+        value: '12345678901234567890'
+    - session_timeout:
+        value: '1200'
+# conf 8
+- tags:
+  - invalid_timeout_conf
+  apply_to_modules:
+  - test_configuration_file
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '2'
+    - max_sessions:
+        value: '70'
+    - session_timeout:
+        value: '1q2w3e4r5t67yu8'

--- a/tests/integration/test_logtest/test_configuration/test_configuration_file.py
+++ b/tests/integration/test_logtest/test_configuration/test_configuration_file.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+import pytest
+import os
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.logtest import (callback_logtest_started, callback_logtest_disabled,
+                                   callback_configuration_error)
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+# Variables
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+
+# Fixture
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Test
+def test_configuration_file(get_configuration, configure_environment, restart_wazuh):
+    """Check multiples logtest configuration
+    """
+
+    callback = None
+    if 'valid_conf' in get_configuration['tags']:
+        callback = callback_logtest_started
+    elif 'disabled_conf' in get_configuration['tags']:
+        callback = callback_logtest_disabled
+    else:
+        callback = callback_configuration_error
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback,
+                            error_message='Event not found')

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+import os
+import re
+
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.monitoring import SocketController
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+# Variables
+logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'analysis'))
+receiver_sockets_params = [(logtest_sock, 'AF_UNIX', 'TCP')]
+receiver_sockets = None
+msg_get_config = "getconfig rule_test"
+
+
+# Fixture
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Test
+def test_get_configuration_sock(get_configuration, configure_environment, restart_wazuh, connect_to_sockets_function):
+    """Check analisis Unix socket returns the correct Logtest configuration
+    """
+
+    configuration = get_configuration['sections'][0]['elements']
+
+    if 'invalid_threads_conf' in get_configuration['tags']:
+        configuration[1]['threads']['value'] = '128'
+    elif 'invalid_users_conf' in get_configuration['tags']:
+        configuration[2]['max_sessions']['value'] = '500'
+    elif 'invalid_timeout_conf' in get_configuration['tags']:
+        configuration[3]['session_timeout']['value'] = '31536000'
+
+    receiver_sockets[0].send(msg_get_config, True)
+    msg_recived = receiver_sockets[0].receive().decode()
+
+    matched = re.match(r'.*{"enabled":"(\S+)","threads":(\d+),"max_sessions":(\d+),"session_timeout":(\d+)}}',
+                       msg_recived)
+    assert matched is not None, f'Real message was: "{msg_recived}"'
+
+    assert matched.group(1) == configuration[0]['enabled']['value'], f"""Expected value in enabled tag:
+           '{configuration[0]['enabled']['value']}'. Value received: '{matched.group(1)}'"""
+
+    assert matched.group(2) == configuration[1]['threads']['value'], f"""Expected value in threads tag:
+           '{configuration[1]['threads']['value']}'. Value received: '{matched.group(2)}'"""
+
+    assert matched.group(3) == configuration[2]['max_sessions']['value'], f"""Expected value in max_sessions tag:
+           '{configuration[2]['max_sessions']['value']}'. Value received: '{matched.group(3)}'"""
+    assert matched.group(4) == configuration[3]['session_timeout']['value'], f"""Expected value in session_timeout tag:
+           '{configuration[3]['session_timeout']['value']}'. Value received: '{matched.group(4)}'"""


### PR DESCRIPTION
| Issues related |
| --- |
|[5408](https://github.com/wazuh/wazuh/issues/5408), [811](https://github.com/wazuh/wazuh-qa/issues/811)|


Hello team,

According to issue number 811, we have to create a test for new wazuh-logtest functionality.
This PR contains the first issue check.
The configuration of wazuh-logtest can found in PR number 5413 of wazuh repository.


**Test output:**

```
eva@eva:~/wazuh/wazuh-qa/tests/integration$ sudo python3 -m pytest test_logtest/test_configuration
========================================== test session starts ===========================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/eva/wazuh/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: testinfra-5.0.0, metadata-1.10.0, html-2.1.1
collected 10 items                                                                                       

test_logtest/test_configuration/test_configuration_file.py .....                                   [ 50%]
test_logtest/test_configuration/test_get_configuration_sock.py .....                               [100%]

===================================== 10 passed in 137.48s (0:02:17) =====================================
eva@eva:~/wazuh/wazuh-qa/tests/integration$

```

Best regards,
Eva
