### PR TITLE
FIM: Modify windows registries integration test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -199,9 +199,12 @@ def create_registry(key, subkey, arch):
         The key of the registry (HKEY_* constants).
     subkey : str
         The subkey (name) of the registry.
+    arch : int   
+        Architecture of the registry. Can be KEY_WOW64_32KEY or KEY_WOW64_64KEY
+    
     """
-    sys.platform == 'win32' and winreg.CreateKeyEx(key, subkey, access=arch)
-
+    if sys.platform == 'win32':
+        winreg.CreateKeyEx(key, subkey, access=winreg.KEY_WRITE | arch)
 
 def _create_fifo(path, name):
     """
@@ -338,7 +341,7 @@ def delete_registry(key, subkey, arch):
     sys.platform == 'win32' and winreg.DeleteKeyEx(key, subkey, access=arch)
 
 
-def modify_registry(key, subkey, value):
+def modify_registry(key, subkey, value, arch):
     """
     Modify the content of REG_SZ in a registry
 
@@ -352,7 +355,9 @@ def modify_registry(key, subkey, value):
         The value to be set.
     """
     logger.info("Modifying windows registry.")
-    sys.platform == 'win32' and winreg.SetValue(key, subkey, winreg.REG_SZ, value)
+    if sys.platform == 'win32':
+        oppened_key = winreg.OpenKeyEx(key, subkey, 0, access=(arch | winreg.KEY_WRITE))
+        winreg.SetValueEx(oppened_key, "test_value", 0, winreg.REG_SZ, value)
 
 
 def modify_file_content(path, name, new_content=None, is_binary=False):

--- a/tests/integration/test_fim/test_windows_registry/data/wazuh_conf_attr.yaml
+++ b/tests/integration/test_fim/test_windows_registry/data/wazuh_conf_attr.yaml
@@ -3,7 +3,9 @@
 - tags:
   - ossec_conf_2
   apply_to_modules:
-  - test_windows_registry
+  - test_windows_registry_32bit
+  - test_windows_registry_64bit
+  - test_windows_registry_both
   sections:
   - section: syscheck
     elements:

--- a/tests/integration/test_fim/test_windows_registry/data/wazuh_conf_no_attr.yaml
+++ b/tests/integration/test_fim/test_windows_registry/data/wazuh_conf_no_attr.yaml
@@ -3,7 +3,9 @@
 - tags:
   - ossec_conf
   apply_to_modules:
-  - test_windows_registry
+  - test_windows_registry_32bit
+  - test_windows_registry_64bit
+  - test_windows_registry_both
   sections:
   - section: syscheck
     elements:

--- a/tests/integration/test_fim/test_windows_registry/test_windows_registry_32bit.py
+++ b/tests/integration/test_fim/test_windows_registry/test_windows_registry_32bit.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_registry, modify_registry, delete_registry, \
+    timedelta, callback_detect_event, check_time_travel
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+if sys.platform == 'win32':
+    import winreg
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+test_directories = []
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+monitoring_modes = ['scheduled']
+
+sub_key = os.path.join('SOFTWARE', 'testkey')
+registry = os.path.join('HKEY_LOCAL_MACHINE', sub_key)
+frequency = 4
+
+# Configurations
+
+conf_params = {'WINDOWS_REGISTRY': registry, 'FREQUENCY': frequency}
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_no_attr.yaml')
+p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
+configurations1 = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+attributes = [{'tags': 'test_tag'}]
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_attr.yaml')
+p, m = generate_params(extra_params=conf_params, apply_to_all=({'ATTRIBUTE': attr} for attr in attributes),
+                       modes=monitoring_modes)
+configurations2 = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+configurations = configurations1 + configurations2
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+def extra_configuration_before_yield():
+    # It makes sure to delete the registry if it already exists.
+    try:
+        delete_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_32KEY)
+    except OSError:
+        pass
+
+@pytest.mark.parametrize('tag, tags_to_apply', [
+    (None, {'ossec_conf'}),
+    ("test_tag", {'ossec_conf_2'})
+])
+
+def test_windows_registry(tag, tags_to_apply,
+                          get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """Check the correct monitoring of Windows Registries.
+
+    This test creates a new registry in windows, adds a value, modifies
+    it and then deletes the registry. It verifies that syscheck correctly monitors
+    certain events while applying different settings.
+
+    Parameters
+    ----------
+    arch_list : list
+        Selected architectures.
+    tag : str
+        Name of the tag to look for in the event.
+    tags_to_apply : set
+         Run test if matches with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+
+    # Check that configuration is applying to the correct test
+    if (tag and 'tags' not in get_configuration['metadata']['attribute'].keys()):
+        pytest.skip("Does not apply to this config file")
+
+    # Check that windows_registry does not trigger alerts for new keys
+    create_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                error_message='Did not receive expected "Sending FIM event: ..." event',
+                                accum_results=1)
+    # Check that windows_registry trigger alerts when adding an entry
+    modify_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, 'test_add', winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x32]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'added', f'Event type not equal')
+        if tag:
+            assert event[0]['data']['tags'] == tag, f'{tag} not found in event'
+
+    # Check that windows_registry trigger alerts when modifying existing entries
+    # and check arch and tag values match with the ones in event
+    modify_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, 'test_modify', winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x32]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'modified', f'Event type not equal')
+
+        # Check that windows_registry trigger alerts when deleting a key
+    delete_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x32]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'deleted', f'{event[0]["data"]["type"]} type not equal to deleted')

--- a/tests/integration/test_fim/test_windows_registry/test_windows_registry_both.py
+++ b/tests/integration/test_fim/test_windows_registry/test_windows_registry_both.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_registry, modify_registry, delete_registry, \
+    timedelta, callback_detect_event, check_time_travel
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+if sys.platform == 'win32':
+    import winreg
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+test_directories = []
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+monitoring_modes = ['scheduled']
+
+sub_key = os.path.join('SOFTWARE', 'testkey')
+registry = os.path.join('HKEY_LOCAL_MACHINE', sub_key)
+frequency = 4
+
+# Configurations
+
+conf_params = {'WINDOWS_REGISTRY': registry, 'FREQUENCY': frequency}
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_no_attr.yaml')
+p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
+configurations1 = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+attributes = [{'tags': 'test_tag'}]
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_attr.yaml')
+p, m = generate_params(extra_params=conf_params, apply_to_all=({'ATTRIBUTE': attr} for attr in attributes),
+                       modes=monitoring_modes)
+configurations2 = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+configurations = configurations1 + configurations2
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+def extra_configuration_before_yield():
+    # It makes sure to delete the registry if it already exists.
+    try:
+        delete_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_32KEY)
+        delete_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_64KEY)
+    except OSError:
+        pass
+
+@pytest.mark.parametrize('tag, tags_to_apply', [
+    (None, {'ossec_conf'}),
+    ("test_tag", {'ossec_conf_2'})
+])
+
+def test_windows_registry(tag, tags_to_apply,
+                          get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+    """Check the correct monitoring of Windows Registries.
+
+    This test creates a new registry in windows, adds a value, modifies
+    it and then deletes the registry. It verifies that syscheck correctly monitors
+    certain events while applying different settings.
+
+    Parameters
+    ----------
+    arch_list : list
+        Selected architectures.
+    tag : str
+        Name of the tag to look for in the event.
+    tags_to_apply : set
+         Run test if matches with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+
+    # Check that configuration is applying to the correct test
+    if (tag and 'tags' not in get_configuration['metadata']['attribute'].keys()):
+        pytest.skip("Does not apply to this config file")
+
+    #Create 64 bits registry
+    # Check that windows_registry does not trigger alerts for new keys
+    create_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_64KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                error_message='Did not receive expected "Sending FIM event: ..." event',
+                                accum_results=1)
+    # Check that windows_registry trigger alerts when adding an entry
+    modify_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, 'test_add', winreg.KEY_WOW64_64KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x64]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'added', f'Event type not equal')
+        if tag:
+            assert event[0]['data']['tags'] == tag, f'{tag} not found in event'
+
+    # Create 32 bits registry
+    create_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                error_message='Did not receive expected "Sending FIM event: ..." event',
+                                accum_results=1)
+    # Check that windows_registry trigger alerts when adding an entry
+    modify_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, 'test_add', winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x32]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'added', f'Event type not equal')
+        if tag:
+            assert event[0]['data']['tags'] == tag, f'{tag} not found in event'
+
+    # Modify 64 registry
+    # Check that windows_registry trigger alerts when modifying existing entries
+    # and check arch and tag values match with the ones in event
+    modify_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, 'test_modify', winreg.KEY_WOW64_64KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x64]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'modified', f'Event type not equal')
+
+
+    # Modify 32 registry
+    # Check that windows_registry trigger alerts when modifying existing entries
+    # and check arch and tag values match with the ones in event
+    modify_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, 'test_modify', winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x32]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'modified', f'Event type not equal')
+
+    # Delete 64 registry
+    # Check that windows_registry trigger alerts when deleting a key
+    delete_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_64KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x64]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'deleted', f'{event[0]["data"]["type"]} type not equal to deleted')
+
+    # Delete 32 registry
+    # Check that windows_registry trigger alerts when deleting a key
+    delete_registry(winreg.HKEY_LOCAL_MACHINE, sub_key, winreg.KEY_WOW64_32KEY)
+    check_time_travel(time_travel=True, interval=timedelta(seconds=frequency), monitor=wazuh_log_monitor)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
+                                    error_message='Did not receive expected "Sending FIM event: ..." event',
+                                    accum_results=1).result()
+    if not isinstance(event, list):
+        event = [event]
+        assert (event[0]['data']['path'][:5] == '[x32]', f'Registry architecture not equal') and (event[0]['data']['type'] == 'deleted', f'{event[0]["data"]["type"]} type not equal to deleted')


### PR DESCRIPTION
Hello team,

After developing a fix for #4262 it was necessary to change the `windows_registry` test. 
Now, there are 3 test related to windows registries: 
- One will create a 32-bit registry in `HKEY_LOCAL_MACHINE\SOFTWARE` and it will check that the alert will be generated only for 32-bit registry.
- The second is the same as the first, but using 64-bit registries. 
- The last one will create 64-bit and 32-bit registries and it will check that the alerts are generated correctly. 

Closes #817 

# Tests logic

The three tests have the same structure: 
- It will create a 32-bit and/or 64-bit registry.
- After, it will create new value for the registry.
- The test will modify the created value.
- Finally, the registry will be removed.

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail
- [ ] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`

Best regards.