### PR TITLE
Change enrollment config block qa

### DIFF
--- a/tests/integration/test_agentd/data/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/data/wazuh_conf.yaml
@@ -120,10 +120,10 @@
                 value: 'yes'
             - crypto_method:
                 value: 'aes'
-            - auto_enrollment:
+            - enrollment:
                 elements:
                 - enabled:
-                    value: 'AUTO_ENROLL'
+                    value: 'ENROLL'
             - server:
                 elements:
                 - address: 

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -104,14 +104,14 @@ def override_wazuh_conf(configuration):
 def get_temp_yaml(param):
     temp = os.path.join(test_data_path,'temp.yaml')
     with open(configurations_path , 'r') as conf_file:
-        auto_enroll_conf = {'auto_enrollment' : {'elements' : []}}
+        enroll_conf = {'enrollment' : {'elements' : []}}
         for elem in param:
             if elem == 'password':
                 continue
-            auto_enroll_conf['auto_enrollment']['elements'].append({elem : {'value': param[elem]}})
-        print(auto_enroll_conf)
+            enroll_conf['enrollment']['elements'].append({elem : {'value': param[elem]}})
+        print(enroll_conf)
         temp_conf_file = yaml.safe_load(conf_file)
-        temp_conf_file[0]['sections'][0]['elements'].append(auto_enroll_conf)
+        temp_conf_file[0]['sections'][0]['elements'].append(enroll_conf)
     with open(temp, 'w') as temp_file:
         yaml.safe_dump(temp_conf_file, temp_file)
     return temp

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -21,17 +21,17 @@ configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 
 params = [
     #Different parameters on UDP
-    {'PROTOCOL':'udp','MAX_RETRIES':1,'RETRY_INTERVAL':1,'AUTO_ENROLL':'no'},
-    {'PROTOCOL':'udp','MAX_RETRIES':5,'RETRY_INTERVAL':5,'AUTO_ENROLL':'no'},
-    {'PROTOCOL':'udp','MAX_RETRIES':10,'RETRY_INTERVAL':4,'AUTO_ENROLL':'no'},
-    {'PROTOCOL':'udp','MAX_RETRIES':3,'RETRY_INTERVAL':12,'AUTO_ENROLL':'no'},
+    {'PROTOCOL':'udp','MAX_RETRIES':1,'RETRY_INTERVAL':1,'ENROLL':'no'},
+    {'PROTOCOL':'udp','MAX_RETRIES':5,'RETRY_INTERVAL':5,'ENROLL':'no'},
+    {'PROTOCOL':'udp','MAX_RETRIES':10,'RETRY_INTERVAL':4,'ENROLL':'no'},
+    {'PROTOCOL':'udp','MAX_RETRIES':3,'RETRY_INTERVAL':12,'ENROLL':'no'},
     #Different parameters on TCP
-    {'PROTOCOL':'tcp','MAX_RETRIES':3,'RETRY_INTERVAL':3,'AUTO_ENROLL':'no'},
-    {'PROTOCOL':'tcp','MAX_RETRIES':5,'RETRY_INTERVAL':5,'AUTO_ENROLL':'no'},
-    {'PROTOCOL':'tcp','MAX_RETRIES':10,'RETRY_INTERVAL':10,'AUTO_ENROLL':'no'},
+    {'PROTOCOL':'tcp','MAX_RETRIES':3,'RETRY_INTERVAL':3,'ENROLL':'no'},
+    {'PROTOCOL':'tcp','MAX_RETRIES':5,'RETRY_INTERVAL':5,'ENROLL':'no'},
+    {'PROTOCOL':'tcp','MAX_RETRIES':10,'RETRY_INTERVAL':10,'ENROLL':'no'},
     #Enrollment enabled
-    {'PROTOCOL':'udp','MAX_RETRIES':2,'RETRY_INTERVAL':2,'AUTO_ENROLL':'yes'},
-    {'PROTOCOL':'tcp','MAX_RETRIES':5,'RETRY_INTERVAL':5,'AUTO_ENROLL':'yes'},
+    {'PROTOCOL':'udp','MAX_RETRIES':2,'RETRY_INTERVAL':2,'ENROLL':'yes'},
+    {'PROTOCOL':'tcp','MAX_RETRIES':5,'RETRY_INTERVAL':5,'ENROLL':'yes'},
 ]
 
 metadata = params
@@ -198,7 +198,7 @@ def test_agentd_parametrized_reconnections(configure_authd_server, start_authd, 
     PROTOCOL = protocol=get_configuration['metadata']['PROTOCOL']
     RETRIES = get_configuration['metadata']['MAX_RETRIES']
     INTERVAL = get_configuration['metadata']['RETRY_INTERVAL']
-    AUTO_ENROLL = get_configuration['metadata']['AUTO_ENROLL']
+    ENROLL = get_configuration['metadata']['ENROLL']
         
     control_service('stop')
     clean_logs()
@@ -211,14 +211,14 @@ def test_agentd_parametrized_reconnections(configure_authd_server, start_authd, 
     if PROTOCOL == 'udp':
         interval += RECV_TIMEOUT
     
-    if AUTO_ENROLL == 'yes':
+    if ENROLL == 'yes':
         total_retries = RETRIES + 1
     else :
         total_retries = RETRIES
    
     for retry in range(total_retries):
         # 3 If auto enrollment is enabled, retry check enrollment and retries after that
-        if AUTO_ENROLL == 'yes' and retry == total_retries-1:
+        if ENROLL == 'yes' and retry == total_retries-1:
             #Wait succesfull enrollment
             try:
                 log_monitor.start(timeout=20, callback=wait_enrollment)
@@ -250,7 +250,7 @@ def test_agentd_parametrized_reconnections(configure_authd_server, start_authd, 
     # 5 Check ammount of retriesand enrollment
     (connect, enroll) = count_retry_mesages()
     assert connect == total_retries
-    if AUTO_ENROLL == 'yes':
+    if ENROLL == 'yes':
         assert enroll == 1
     else:
         assert enroll == 0


### PR DESCRIPTION
Hello team,

`Authd agent context integration tests`

Closes #5631

Adapt Agentd integration tests to work with new < enrollment > block instead of <auto_enrollment>

```

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

Best regards.