### PR TITLE
Adapt agentd test cases to new enrollment log messages

### DIFF
--- a/tests/integration/test_agentd/conftest.py
+++ b/tests/integration/test_agentd/conftest.py
@@ -54,7 +54,7 @@ def clean_client_keys_file():
 def check_client_keys_file():
     """Wait until client key has been written"""
     def wait_key_changes(line):
-        if 'Valid key created. Finished.' in line:
+        if 'Valid key received' in line:
             return line
         return None
 

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -137,7 +137,7 @@ def check_time_to_connect(timeout):
         lines = log_file.readlines()
         #find enrollment end
         for line in lines:
-            if "INFO: Valid key created. Finished." in line:
+            if "INFO: Valid key received" in line:
                 initial_line = line
                 break
     

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -49,11 +49,11 @@ metadata = [
         'LOG_MONITOR_STR' : [
             [ # Stage 1
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f'Starting enrollment process to server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
+                f'Requesting a key to server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f'Starting enrollment process to server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
+                f'Requesting a key to server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
-                f'Starting enrollment process to server: {SERVER_HOSTS[2]}/{SERVER_ADDRESS}'
+                f'Requesting a key to server: {SERVER_HOSTS[2]}/{SERVER_ADDRESS}'
             ]
         ]
     },
@@ -71,14 +71,14 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [ # Stage 1 - Enroll to first server
-                f'Starting enrollment process to server: {SERVER_HOSTS[0]}',
-                f'Valid key created. Finished',
+                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
             ],
             [ # Stage 2 - Pass second server and connect to third
-                f'Starting enrollment process to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key to server: {SERVER_HOSTS[0]}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f'Starting enrollment process to server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
+                f'Requesting a key to server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
                 f'Connected to the server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
                 f"Received message: '#!-agent ack '"
@@ -99,8 +99,8 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [ # Stage 1 - Enroll and connect to first server
-                f'Starting enrollment process to server: {SERVER_HOSTS[0]}',
-                f'Valid key created. Finished',
+                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
@@ -128,15 +128,15 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [ # Stage 1 - Enroll and connect to first server
-                f'Starting enrollment process to server: {SERVER_HOSTS[0]}',
-                f'Valid key created. Finished',
+                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
             ],
             [ 
                 f'Server unavailable. Setting lock.',
-                f'Starting enrollment process to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key to server: {SERVER_HOSTS[0]}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
                 f'Connected to the server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
                 f"Received message: '#!-agent ack '",
@@ -214,14 +214,14 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [
-                 f'Starting enrollment process to server: {SERVER_HOSTS[0]}',
+                 f'Requesting a key to server: {SERVER_HOSTS[0]}',
                  f'ERROR: SSL read',
-                 f'Starting enrollment process to server: {SERVER_HOSTS[1]}',
+                 f'Requesting a key to server: {SERVER_HOSTS[1]}',
                  f'ERROR: SSL read',
             ],
             [
-                f'Starting enrollment process to server: {SERVER_HOSTS[2]}',
-                f'Valid key created. Finished',
+                f'Requesting a key to server: {SERVER_HOSTS[2]}',
+                f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '",

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -49,11 +49,11 @@ metadata = [
         'LOG_MONITOR_STR' : [
             [ # Stage 1
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f'Requesting a key to server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f'Requesting a key to server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
+                f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
-                f'Requesting a key to server: {SERVER_HOSTS[2]}/{SERVER_ADDRESS}'
+                f'Requesting a key from server: {SERVER_HOSTS[2]}/{SERVER_ADDRESS}'
             ]
         ]
     },
@@ -71,14 +71,14 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [ # Stage 1 - Enroll to first server
-                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
             ],
             [ # Stage 2 - Pass second server and connect to third
-                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f'Requesting a key to server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
+                f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
                 f'Connected to the server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
                 f"Received message: '#!-agent ack '"
@@ -99,7 +99,7 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [ # Stage 1 - Enroll and connect to first server
-                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
@@ -128,7 +128,7 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [ # Stage 1 - Enroll and connect to first server
-                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
@@ -136,7 +136,7 @@ metadata = [
             ],
             [ 
                 f'Server unavailable. Setting lock.',
-                f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
                 f'Connected to the server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
                 f"Received message: '#!-agent ack '",
@@ -214,13 +214,13 @@ metadata = [
         },
         'LOG_MONITOR_STR' : [
             [
-                 f'Requesting a key to server: {SERVER_HOSTS[0]}',
+                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
                  f'ERROR: SSL read',
-                 f'Requesting a key to server: {SERVER_HOSTS[1]}',
+                 f'Requesting a key from server: {SERVER_HOSTS[1]}',
                  f'ERROR: SSL read',
             ],
             [
-                f'Requesting a key to server: {SERVER_HOSTS[2]}',
+                f'Requesting a key from server: {SERVER_HOSTS[2]}',
                 f'Valid key received',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -139,14 +139,14 @@ def count_retry_mesages():
         for line in log_lines:
             if 'Trying to connect to server' in line:
                 connect += 1
-            if 'Valid key created. Finished.' in line:
+            if 'Valid key received' in line:
                 enroll += 1
             if "Unable to connect to any server" in line:
                 return (connect,enroll)
     return (connect,enroll)
 
 def wait_enrollment(line):
-    if 'Valid key created. Finished.' in line:
+    if 'Valid key received' in line:
         return line
     return None
 

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -126,12 +126,12 @@ def wait_notify(line):
     return None 
 
 def wait_enrollment(line):
-    if 'Valid key created. Finished.' in line:
+    if 'Valid key received' in line:
         return line
     return None
 
 def wait_enrollment_try(line):
-    if 'Starting enrollment process' in line:
+    if 'Requesting a key' in line:
         return line
     return None
 


### PR DESCRIPTION
Hello team,

`Authd agent context integration tests`

Closes #5714

Adapt Agentd integration tests to work with new enrollment log messages

```

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

Best regards.