### PR TITLE
Invalid input on socket analisysd

### DIFF
--- a/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
+++ b/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
@@ -1,0 +1,65 @@
+---
+-
+  name: "Json malformed (Missing \")"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": kTy234Sdvtp7","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format": "syslog","location": "master->/var/log/syslog"}'
+    output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 10, ... {\\\"token\\\": kTy234Sdvt ...\"],\"codemsg\":-2}"
+    stage: 'Json malformed (Missing ")'
+-
+  name: "Missing event"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4","log_format": "syslog","location": "master->/var/log/syslog"}'
+    output: "{\"messages\":[\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing event'
+-
+  name: "Missing log_format"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location": "master->/var/log/syslog"}'
+    output: "{\"messages\":[\"ERROR: (7308): 'log_format' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing log_format'
+-
+  name: "Missing location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format": "syslog"}'
+    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing location'
+-
+  name: "Missing event/log_format"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4","location": "master->/var/log/syslog"}'
+    output: "{\"messages\":[\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing event/log_format'
+-
+  name: "Missing event/location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4","log_format": "syslog"}'
+    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing event/location'
+-
+  name: "Missing log_format/location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756."}'
+    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'log_format' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing log_format/location'
+-
+  name: "Missing event/log_format/location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"token": "4885bbf4"}'
+    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    stage: 'Missing event/log_format/location'

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+import yaml
+
+from wazuh_testing import global_parameters
+from wazuh_testing.analysis import callback_fim_error
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations    
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+messages_path = os.path.join(test_data_path, 'invalid_socket_input.yaml')
+with open(messages_path) as f:
+    test_cases = yaml.safe_load(f)
+
+# Variables
+
+log_monitor_paths = [LOG_FILE_PATH]
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+
+receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
+
+receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
+
+
+# Tests
+
+@pytest.mark.parametrize('test_case',
+                         [test_case['test_case'] for test_case in test_cases],
+                         ids=[test_case['name'] for test_case in test_cases])
+def test_invalid_socket_input(connect_to_sockets_function, test_case: list):
+    """Check that every input message in logtest socket generates the adequate output
+
+    Parameters
+    ----------
+    test_case : list
+        List of test_case stages (dicts with input, output and stage keys)
+    """
+    stage = test_case[0]
+    receiver_sockets[0].send(stage['input'])
+    result = receiver_sockets[0].receive().decode()
+
+    assert stage['output'] in result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,
+                                                                                 stage['stage'])
+


### PR DESCRIPTION
Hello team,

This PR adds tests for invalid input for the client request. We implement tests that send invalid inputs to logtest (writing the wazuh-logtest unix socket) and check error or warning message is expected.

Closes #834

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Tested and passed in Jenkins.

# Results

- When the expected behavior occurs:

```
======================================== test session starts ========================================
platform linux -- Python 3.6.8, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-1062.4.3.el7.x86_64-x86_64-with-centos-7.7.1908-Core', 'Packages': {'pytest': '6.0.1', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'testinfra': '5.0.0', 'metadata': '1.8.0', 'html': '2.0.1'}}
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-1.8.0, html-2.0.1
collected 8 items                                                                                   

test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Json malformed (Missing ")] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing event] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing log_format] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing location] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing event/log_format] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing event/location] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing log_format/location] PASSED
test_logtest/test_invalid_socket_input/test_invalid_socket_input.py::test_invalid_socket_input[Missing event/log_format/location] PASSED

------------------------- generated html file: file:///vagrant/report.html --------------------------
========================================= 8 passed in 0.10s =========================================
```

Best regards,
Juan Cabrera
