### PR TITLE
Adapt QA Integration and System tests to the Wazuh-api service removal

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -14,7 +14,6 @@ API_HOST = 'localhost'
 API_PORT = '55000'
 API_USER = 'wazuh'
 API_PASS = 'wazuh'
-API_VERSION = 'v4'
 API_LOGIN_ENDPOINT = '/security/user/authenticate'
 
 
@@ -34,10 +33,10 @@ def callback_detect_api_debug(line):
 
 # Functions
 
-def get_base_url(protocol, host, port, version):
+def get_base_url(protocol, host, port):
     """Get complete url of api"""
 
-    return f"{protocol}://{host}:{port}/{version}"
+    return f"{protocol}://{host}:{port}"
 
 
 def get_login_headers(user, password):
@@ -46,10 +45,10 @@ def get_login_headers(user, password):
                      'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
 
 
-def get_token_login_api(protocol, host, port, version, user, password, login_endpoint, timeout):
+def get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout):
     """Get API login token"""
 
-    login_url = f"{get_base_url(protocol, host, port, version)}{login_endpoint}"
+    login_url = f"{get_base_url(protocol, host, port)}{login_endpoint}"
     response = requests.get(login_url, headers=get_login_headers(user, password), verify=False, timeout=timeout)
 
     if response.status_code == 200:

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -197,10 +197,10 @@ class HostManager:
             configuration = {host: api_config for host in host_list}
 
         for host, config in configuration.items():
-            self.modify_file_content(host, path=dest_path, content=yaml.safe_dump(config))
+            self.modify_file_content(host, path=dest_path, content=yaml.dump("" if config is None else config))
 
         for host in host_list:
-            self.control_service(host=host, service='wazuh-api', state='restarted')
+            self.control_service(host=host, service='wazuh-manager', state='restarted')
             if clear_log:
                 self.clear_file(host=host, file_path=API_LOG_FILE_PATH)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import uuid
 from datetime import datetime
-import pdb
 
 import pytest
 from numpydoc.docscrape import FunctionDoc
@@ -57,7 +56,6 @@ def pytest_runtest_setup(item):
 @pytest.fixture(scope='module')
 def restart_wazuh(get_configuration, request):
     # Stop Wazuh
-    pdb.set_trace()
     control_service('stop')
 
     # Reset ossec.log and start a new monitor

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -73,17 +73,17 @@ def configure_api_environment(get_configuration, request):
 
     if hasattr(request.module, 'force_restart_after_restoring'):
         if getattr(request.module, 'force_restart_after_restoring'):
-            subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'wazuh-apid'), 'restart'])
+            subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'ossec-control'), 'restart'])
 
 
 @pytest.fixture(scope='module')
 def restart_api(get_configuration, request):
     # Reset api.log and start a new monitor
-    subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'wazuh-apid'), 'stop'])
+    subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'ossec-control'), 'stop'])
     truncate_file(API_LOG_FILE_PATH)
     file_monitor = FileMonitor(API_LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'wazuh-apid'), 'start'])
+    subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'ossec-control'), 'start'])
 
 
 @pytest.fixture(scope='module')
@@ -96,13 +96,13 @@ def wait_for_start(get_configuration, request):
 
 @pytest.fixture(scope='module')
 def get_api_details():
-    def _get_api_details(protocol=API_PROTOCOL, host=API_HOST, port=API_PORT, version=API_VERSION, user=API_USER,
+    def _get_api_details(protocol=API_PROTOCOL, host=API_HOST, port=API_PORT, user=API_USER,
                          password=API_PASS, login_endpoint=API_LOGIN_ENDPOINT, timeout=10):
         return {
-            'base_url': get_base_url(protocol, host, port, version),
+            'base_url': get_base_url(protocol, host, port),
             'auth_headers': {
                 'Content-Type': 'application/json',
-                'Authorization': f'Bearer {get_token_login_api(protocol, host, port, version, user, password, login_endpoint, timeout)}'
+                'Authorization': f'Bearer {get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout)}'
             }
         }
     return _get_api_details

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -9,7 +9,7 @@ import subprocess
 import pytest
 
 from wazuh_testing.api import callback_detect_api_start, get_base_url, get_token_login_api, API_HOST, \
-    API_LOGIN_ENDPOINT, API_PASS, API_PORT, API_USER, API_PROTOCOL, API_VERSION
+    API_LOGIN_ENDPOINT, API_PASS, API_PORT, API_USER, API_PROTOCOL
 from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_PATH, WAZUH_API_CONF, WAZUH_SECURITY_CONF
 from wazuh_testing.tools.configuration import get_api_conf, write_api_conf, write_security_conf
 from wazuh_testing.tools.file import truncate_file

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -4,16 +4,16 @@
 
 import os
 import shutil
-import subprocess
 
 import pytest
 
 from wazuh_testing.api import callback_detect_api_start, get_base_url, get_token_login_api, API_HOST, \
     API_LOGIN_ENDPOINT, API_PASS, API_PORT, API_USER, API_PROTOCOL
-from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_PATH, WAZUH_API_CONF, WAZUH_SECURITY_CONF
+from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_API_CONF, WAZUH_SECURITY_CONF
 from wazuh_testing.tools.configuration import get_api_conf, write_api_conf, write_security_conf
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
 
 
 @pytest.fixture(scope='module')
@@ -73,17 +73,21 @@ def configure_api_environment(get_configuration, request):
 
     if hasattr(request.module, 'force_restart_after_restoring'):
         if getattr(request.module, 'force_restart_after_restoring'):
-            subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'ossec-control'), 'restart'])
+            control_service('restart')
 
 
 @pytest.fixture(scope='module')
 def restart_api(get_configuration, request):
+    # Stop Wazuh and Wazuh API
+    control_service('stop')
+
     # Reset api.log and start a new monitor
-    subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'ossec-control'), 'stop'])
     truncate_file(API_LOG_FILE_PATH)
     file_monitor = FileMonitor(API_LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    subprocess.call([os.path.join(WAZUH_PATH, 'bin', 'ossec-control'), 'start'])
+
+    # Start Wazuh and Wazuh API
+    control_service('start')
 
 
 @pytest.fixture(scope='module')

--- a/tests/system/test_jwt_invalidation/conftest.py
+++ b/tests/system/test_jwt_invalidation/conftest.py
@@ -16,7 +16,7 @@ def set_default_api_conf(request):
         api_conf_backup[host] = yaml.safe_load(hm.get_file_content(host, WAZUH_API_CONF))
 
     with open(api_tmp_backup, 'w') as f:
-        f.write(yaml.safe_dump(api_conf_backup))
+        f.write(yaml.dump(api_conf_backup))
 
     hm.apply_api_config(api_config=new_api_conf, host_list=test_hosts, clear_log=True)
 


### PR DESCRIPTION
Hello team,

This PR is related to [#5824](https://github.com/wazuh/wazuh/pull/5868). The wazuh-api service has been merged together with wazuh-manager service here. This PR adds the changes needed to ensure integration and System QA tests works as expected without the Wazuh-api service.

## Service QA tests results

**test_jwt_invalidation**
```
test_change_rbac_mode.py ....          [ 21%]
test_change_security_resources.py .... [ 42%]
test_disconnected_nodes.py .           [ 47%]
test_revoke_endpoint.py ......         [ 78%]
test_update_password.py ....           [100%]
```

## Integration QA tests results
```
test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss.              [  5%]
test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py .s.ss.s.          [ 17%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss [ 21%]
.                                                                                           [ 22%]
test_api/test_config/test_cache/test_cache.py .ss.                                          [ 28%]
test_api/test_config/test_cors/test_cors.py x.                                              [ 31%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.                      [ 37%]
test_api/test_config/test_experimental_features/test_experimental_features.py .ssF          [ 42%]
test_api/test_config/test_host_port/test_host_port.py .s.ss.s.                              [ 54%]
test_api/test_config/test_https/test_https.py .ss.                                          [ 60%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.          [ 65%]
test_api/test_config/test_logs/test_logs.py .ss.                                            [ 71%]
test_api/test_config/test_rbac/test_rbac_mode.py EEEE                                       [ 77%]
test_api/test_config/test_use_only_authd/test_use_only_authd.py FsFsFs.ss.s.s.s.            [100%]
```