### PR TITLE
Fixed logtest invalid socket input tests

### DIFF
--- a/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
+++ b/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
@@ -13,7 +13,7 @@
   test_case:
   -
     input: '{"token": "4885bbf4","log_format": "syslog","location": "master->/var/log/syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    output: "{\"messages\":[\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
     stage: 'Missing event'
 -
   name: "Missing log_format"
@@ -37,7 +37,7 @@
   test_case:
   -
     input: '{"token": "4885bbf4","location": "master->/var/log/syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    output: "{\"messages\":[\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
     stage: 'Missing event/log_format'
 -
   name: "Missing event/location"
@@ -45,7 +45,7 @@
   test_case:
   -
     input: '{"token": "4885bbf4","log_format": "syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
     stage: 'Missing event/location'
 -
   name: "Missing log_format/location"
@@ -61,5 +61,5 @@
   test_case:
   -
     input: '{"token": "4885bbf4"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7308): 'event' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
     stage: 'Missing event/log_format/location'

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -46,9 +46,8 @@ def test_invalid_socket_input(connect_to_sockets_function, test_case: list):
         List of test_case stages (dicts with input, output and stage keys)
     """
     stage = test_case[0]
-    receiver_sockets[0].send(stage['input'])
-    result = receiver_sockets[0].receive().decode()
+    receiver_sockets[0].send(stage['input'], size=True)
+    result = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
 
-    assert stage['output'] in result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,
-                                                                                 stage['stage'])
-
+    assert stage['output'] == result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,
+                                                                                stage['stage'])


### PR DESCRIPTION
Hello team,

This PR fixes the `logtest-invalid-socket-input` tests after the last changes in `wazuh-logtest`.

Regards,
Juan