### PR TITLE
Tests remove session

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -314,6 +314,21 @@ class SocketController:
         self.close()
 
 
+def close_sockets(receiver_sockets):
+    """Close the sockets connection gracefully."""
+    for socket in receiver_sockets:
+        try:
+            # We flush the buffer before closing connection if connection is TCP
+            if socket.protocol == 1:
+                socket.sock.settimeout(5)
+                socket.receive()  # Flush buffer before closing connection
+            socket.close()
+        except OSError as e:
+            if e.errno == 9:
+                # Do not try to close the socket again if it was reused or closed already
+                pass
+
+
 class QueueMonitor:
     def __init__(self, queue_item, time_step=0.5):
         """Create a new instance to monitor any given queue.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_CONF, WAZUH_SERVICE
 from wazuh_testing.tools.configuration import get_wazuh_conf, set_section_wazuh_conf, write_wazuh_conf
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController
+from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController, close_sockets
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs
 from wazuh_testing.tools.time import TimeMachine
 
@@ -286,21 +286,6 @@ def connect_to_sockets(request):
     setattr(request.module, 'receiver_sockets', receiver_sockets)
 
     return receiver_sockets
-
-
-def close_sockets(receiver_sockets):
-    """Close the sockets connection gracefully."""
-    for socket in receiver_sockets:
-        try:
-            # We flush the buffer before closing connection if connection is TCP
-            if socket.protocol == 1:
-                socket.sock.settimeout(5)
-                socket.receive()  # Flush buffer before closing connection
-            socket.close()
-        except OSError as e:
-            if e.errno == 9:
-                # Do not try to close the socket again if it was reused or closed already
-                pass
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
+++ b/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
@@ -13,7 +13,7 @@
   test_case:
   -
     input: '{"remove_session": asd}'
-    output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 20, ... ession\\\":asd}\\n ...\"],\"codemsg\":-2}"
+    output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 19, ... session\\\": asd} ...\"],\"codemsg\":-2}"
     stage: 'Remove invalid json'
 -
   name: "Remove null token"

--- a/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
+++ b/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
@@ -1,12 +1,12 @@
 ---
 -
-  name: "Remove invalid token type"
+  name: "Remove invalid numeric token"
   description: "Check remove session"
   test_case:
   -
     input: '{"remove_session": 6}'
     output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
-    stage: 'Remove invalid token type'
+    stage: 'Remove invalid numeric token'
 -
   name: "Remove invalid json"
   description: "Check remove session"
@@ -16,21 +16,45 @@
     output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 19, ... session\\\": asd} ...\"],\"codemsg\":-2}"
     stage: 'Remove invalid json'
 -
-  name: "Remove null token"
+  name: "Remove invalid empty json object token"
   description: "Check remove session"
   test_case:
   -
     input: '{"remove_session": {}}'
     output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
-    stage: 'Remove null token'
+    stage: 'Remove invalid empty json object token'
 -
-  name: "Remove invalid token"
+  name: "Remove invalid array token"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session": "{asd}"}'
-    output: "{\"messages\":[\"ERROR: (7309): '{asd}' is not a valid token\"],\"codemsg\":-2}"
-    stage: 'Remove invalid token'
+    input: '{"remove_session":["asdasd",123123]}'
+    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    stage: 'Remove invalid array token'
+-
+  name: "Remove invalid token null"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session":null}'
+    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    stage: 'Remove invalid token null'
+-
+  name: "Remove invalid boolean token "
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session":true}'
+    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    stage: 'Remove invalid boolean token'
+-
+  name: "Remove invalid token len"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session": "asd"}'
+    output: "{\"messages\":[\"ERROR: (7309): 'asd' is not a valid token\"],\"codemsg\":-2}"
+    stage: 'Remove invalid token len'
 -
   name: "Remove non-exist session"
   description: "Check remove session"

--- a/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
+++ b/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
@@ -1,0 +1,49 @@
+---
+-
+  name: "Remove invalid token type"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session": 6}'
+    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    stage: 'Remove invalid token type'
+-
+  name: "Remove invalid json"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session": asd}'
+    output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 20, ... ession\\\":asd}\\n ...\"],\"codemsg\":-2}"
+    stage: 'Remove invalid json'
+-
+  name: "Remove null token"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session": {}}'
+    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    stage: 'Remove null token'
+-
+  name: "Remove invalid token"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session": "{asd}"}'
+    output: "{\"messages\":[\"ERROR: (7309): '{asd}' is not a valid token\"],\"codemsg\":-2}"
+    stage: 'Remove invalid token'
+-
+  name: "Remove non-exist session"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{"remove_session": "12345678"}'
+    output: "{\"messages\":[\"ERROR: (7004): No session found for token '12345678'\"],\"codemsg\":-1}"
+    stage: 'Remove non-exist session'
+-
+  name: "Remove session OK"
+  description: "Check remove session"
+  test_case:
+  -
+    input: '{{"remove_session": "{}"}}'
+    output: "{{\"messages\":[\"INFO: (7206): The session '{}' was closed successfully\"],\"codemsg\":0}}"
+    stage: 'Remove session OK'

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+import yaml
+import json
+
+from wazuh_testing import global_parameters
+from wazuh_testing.analysis import callback_fim_error
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations    
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+messages_path = os.path.join(test_data_path, 'remove_session.yaml')
+with open(messages_path) as f:
+    test_cases = yaml.safe_load(f)
+
+# Variables
+
+log_monitor_paths = [LOG_FILE_PATH]
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+
+receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
+
+receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
+
+def create_session():
+    receiver_sockets[0].send('{"event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format": "syslog","location": "master->/var/log/syslog"}', size=True)
+    result = json.loads(receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode())["token"]
+    return result
+
+
+# Tests
+
+@pytest.mark.parametrize('test_case',
+                         [test_case['test_case'] for test_case in test_cases],
+                         ids=[test_case['name'] for test_case in test_cases])
+def test_remove_session(connect_to_sockets_function, test_case: list):
+    """Check that every input message in logtest socket generates the adequate output
+
+    Parameters
+    ----------
+    test_case : list
+        List of test_case stages (dicts with input, output and stage keys)
+    """
+    stage = test_case[0]
+
+    if stage["stage"] != 'Remove session OK':
+        receiver_sockets[0].send(stage['input'], size=True)
+        result = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
+
+        assert stage['output'] == result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,
+                                                                                stage['stage'])
+    else:
+        session_token = create_session()
+        receiver_sockets[0].send(stage['input'].format(session_token), size=True)
+        result = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
+
+        assert stage['output'].format(session_token) == result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,
+                                                                                stage['stage'])


### PR DESCRIPTION
Hello team,

This PR adds tests for remove session on demand in `Wazuh-logtest`. We implement tests that send remove session messages to logtest (writing the wazuh-logtest unix socket) and check error, warning or success message is expected.

Closes #848 

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Tested and passed in Jenkins.

# Results

- When the expected behavior occurs:
```
======================================= test session starts ========================================
platform linux -- Python 3.6.8, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-1062.4.3.el7.x86_64-x86_64-with-centos-7.7.1908-Core', 'Packages': {'pytest': '6.0.1', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'testinfra': '5.0.0', 'metadata': '1.8.0', 'html': '2.0.1'}}
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-1.8.0, html-2.0.1
collected 9 items                                                                                  

test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid numeric token] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid json] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid empty json object token] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid array token] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid token null] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid boolean token ] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove invalid token len] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove non-exist session] PASSED
test_logtest/test_remove_session/test_remove_session.py::test_remove_session[Remove session OK] PASSED

------------------------- generated html file: file:///vagrant/report.html -------------------------
======================================== 9 passed in 0.47s =========================================
```

Best regards,
Juan Cabrera
