### PR TITLE
Fix integrated tests

### DIFF
--- a/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
+++ b/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
@@ -55,5 +55,5 @@ def test_experimental_features(tags_to_apply, get_configuration, configure_api_e
         assert get_response.status_code == 200, f'Expected status code was 200, ' \
             f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
     else:
-        assert get_response.status_code == 400, f'Expected status code was 400, ' \
+        assert get_response.status_code == 404, f'Expected status code was 400, ' \
             f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'

--- a/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
+++ b/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
@@ -55,5 +55,5 @@ def test_experimental_features(tags_to_apply, get_configuration, configure_api_e
         assert get_response.status_code == 200, f'Expected status code was 200, ' \
             f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
     else:
-        assert get_response.status_code == 404, f'Expected status code was 400, ' \
+        assert get_response.status_code == 404, f'Expected status code was 404, ' \
             f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -19,7 +19,6 @@ from wazuh_testing.tools.services import control_service
 
 pytestmark = pytest.mark.server
 
-
 # Configurations
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -72,16 +71,18 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
     data = {'name': token_hex(16),
             'ip': IPv4Address(getrandbits(32)).compressed}
 
+    if use_only_authd:
+        control_service('stop', daemon='ossec-authd')
     # Add agent POST request
     post_response = requests.post(api_details['base_url'], json=data, headers=api_details['auth_headers'], verify=False)
 
     # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
     if use_only_authd:
         assert post_response.status_code == 500, 'Expected status code was 500, ' \
-            f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
     else:
         assert post_response.status_code == 200, 'Expected status code was 200, ' \
-            f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
 
         # Delete the agent created
         agent_id = post_response.json()['data']['id']
@@ -123,10 +124,10 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
     # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
     if use_only_authd:
         assert post_response.status_code == 500, 'Expected status code was 500, ' \
-            f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
     else:
         assert post_response.status_code == 200, 'Expected status code was 200, ' \
-            f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']
@@ -164,10 +165,10 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
     # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
     if use_only_authd:
         assert post_response.status_code == 500, 'Expected status code was 500, ' \
-            f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
     else:
         assert post_response.status_code == 200, 'Expected status code was 200, ' \
-            f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']
@@ -223,7 +224,7 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
                                                                      f'Full response: {delete_response}'
     else:
         assert delete_response['data']['failed_items'][0]['error']['code'] == 1726, 'Expected error code was 1726.' \
-                                                                                  f'Full response: {delete_response}'
+                                                                                    f'Full response: {delete_response}'
         # Delete created agent
         control_service('start', daemon='ossec-authd')
         time.sleep(1)


### PR DESCRIPTION
Hello team,

This PR fixes some bugs found in API integration tests. In particular, these bugs have been detected in test_experimental_features and test_use_only_authd.

### Test results
```bash
root@wazuh-master:/wazuh-qa/tests/integration/test_api/test_config# python -m pytest
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.1.1, metadata-1.10.0, tavern-1.6.0, cov-2.10.1, testinfra-5.0.0
collected 70 items

test_DOS_blocking_system/test_DOS_blocking_system.py .ss.                                                                                                           [  5%]
test_behind_proxy_server/test_behind_proxy_server.py .s.ss.s.                                                                                                       [ 17%]
test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss.                                                                                             [ 22%]
test_cache/test_cache.py .ss.                                                                                                                                       [ 28%]
test_cors/test_cors.py x.                                                                                                                                           [ 31%]
test_drop_privileges/test_drop_privileges.py .ss.                                                                                                                   [ 37%]
test_experimental_features/test_experimental_features.py .ss.                                                                                                       [ 42%]
test_host_port/test_host_port.py .s.ss.s.                                                                                                                           [ 54%]
test_https/test_https.py .ss.                                                                                                                                       [ 60%]
test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                                                       [ 65%]
test_logs/test_logs.py .ss.                                                                                                                                         [ 71%]
test_rbac/test_rbac_mode.py .ss.                                                                                                                                    [ 77%]
test_use_only_authd/test_use_only_authd.py .s.s.s.ss.s.s.s.                                                                                                         [100%]

================================================== 35 passed, 34 skipped, 1 xfailed, 170 warnings in 1109.10s (0:18:29) ===================================================


```

Best regards.
