### PR TITLE
[4.0] Update enrollment and keypolling tests

### DIFF
--- a/tests/integration/test_cluster/test_key_polling/test_key_polling_master.py
+++ b/tests/integration/test_cluster/test_key_polling/test_key_polling_master.py
@@ -85,6 +85,7 @@ def test_key_polling_master(cmd, counter, payload, expected, configure_environme
     expected : str
         Expected message in krequest socket
     """
+    pytest.xfail("Development in progress: https://github.com/wazuh/wazuh/issues/4387")
     # Build message and send it to the master
     message = cluster_msg_build(cmd=cmd, counter=counter, payload=payload, encrypt=True)
     receiver_sockets[0].send(message)

--- a/tests/integration/test_cluster/test_key_polling/test_key_polling_worker.py
+++ b/tests/integration/test_cluster/test_key_polling/test_key_polling_worker.py
@@ -78,6 +78,7 @@ def test_key_polling_worker(cmd, counter, payload, configure_environment, config
     payload : bytes
         Cluster message payload data
     """
+    pytest.xfail("Development in progress: https://github.com/wazuh/wazuh/issues/4387")
     # Build message to send to c-internal.sock in the worker and send it
     message = cluster_msg_build(cmd=cmd, counter=counter, payload=payload, encrypt=False)
     receiver_sockets[0].send(message)

--- a/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
@@ -30,7 +30,7 @@ wazuh-worker1:
 
 
 wazuh-agent1:
-  - regex: ".*Requesting a key to server:.*"
+  - regex: ".*Requesting a key from server:.*"
     path: "/var/ossec/logs/ossec.log"
     timeout: 60
   - regex: ".*Registering agent to unverified manager"
@@ -39,12 +39,12 @@ wazuh-agent1:
   - regex: ".*Using agent name as:*"
     path: "/var/ossec/logs/ossec.log"
     timeout: 60
-  - regex: ".*Waiting for manager reply"
+  - regex: ".*Waiting for server reply"
     path: "/var/ossec/logs/ossec.log"
     timeout: 60
   - regex: ".*Valid key received"
     path: "/var/ossec/logs/ossec.log"
     timeout: 60
-  - regex: ".*Sleeping .* seconds to allow manager key file updates"
+  - regex: ".*Waiting .* seconds before server connection"
     path: "/var/ossec/logs/ossec.log"
     timeout: 60

--- a/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
+++ b/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import pytest
 
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.tools.monitoring import HostMonitor
@@ -41,6 +42,7 @@ def test_agent_key_polling(inventory_path):
     inventory_path : str
         Path to the Ansible hosts inventory
     """
+    pytest.xfail("Development in progress: https://github.com/wazuh/wazuh/issues/4387")
     actual_path = os.path.dirname(os.path.abspath(__file__))
     host_manager = HostManager(inventory_path=inventory_path)
     configure_environment(host_manager)


### PR DESCRIPTION
Hello team,

This PR updates the expected messages for the agent enrollment system test as Core changed those messages related to this process. It also marks the keypolling integration and system tests as `xfail` until [issue 4387](https://github.com/wazuh/wazuh/issues/4387) is ready.