### PR TITLE
Vulnerability Detector: Added local Debian Security Tracker feed support tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -363,13 +363,14 @@ def delete_vulnerability(cveid):
                delete_advisories_info_query_string])
 
 
-def modify_system(os_name="CentOS Linux", os_major="7", name="centos7", agent_id=0, os_minor="1", os_arch="x86_64"):
+def modify_system(os_name="CentOS Linux", os_major="7", name="centos7", agent_id=0, os_minor="1", os_arch="x86_64",
+                  os_version="7.1"):
     """
     Modify the system of the manager.
     Used to select the feed that will be used to search vulnerabilities.
     """
-    query_string = f'update AGENT set OS_NAME="{os_name}", OS_MAJOR="{os_major}", OS_MINOR="{os_minor}",\
-                      OS_ARCH="{os_arch}", NAME="{name}" WHERE id="{agent_id}"'
+    query_string = f'update AGENT set OS_NAME="{os_name}", OS_VERSION="{os_version}", OS_MAJOR="{os_major}",\
+                     OS_MINOR="{os_minor}", OS_ARCH="{os_arch}", NAME="{name}" WHERE id="{agent_id}"'
     make_query(GLOBAL_DB_PATH, [query_string])
 
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -19,7 +19,7 @@ DEBIAN_IMPORT_FEED_TIMEOUT = 50
 
 PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
-GLOBAL_DB_PATH = f"{WAZUH_PATH}/var/db/global.db"
+GLOBAL_DB_PATH = f"{WAZUH_PATH}/queue/db/global.db"
 MSU_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/dictionaries/msu.json.gz"
 CPE_HELPER_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/dictionaries/cpe_helper.json"
 DEFAULT_PACKAGE_NAME = "wazuhintegrationpackage"

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -40,7 +40,7 @@ INVALID_DEBIAN_FEEDS_CONF = 'wazuh_invalid_debian_feed.yaml'
 
 REDHAT_NUM_CUSTOM_VULNERABILITIES = 1
 CANONICAL_NUM_CUSTOM_VULNERABILITIES = 1
-DEBIAN_NUM_CUSTOM_VULNERABILITIES = 2
+DEBIAN_NUM_CUSTOM_VULNERABILITIES = 3
 NVD_NUM_CUSTOM_VULNERABILITIES = 5
 
 SYSTEM_DATA = {
@@ -560,7 +560,7 @@ def check_failure_when_importing_feed(wazuh_log_monitor, expected_vulnerabilitie
             wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
             log_event=r"ERROR: \(\d+\): The .* feed couldn't be parsed from .* file"
         )
-    if 
+
     check_log_event(
         wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
         log_event=r"ERROR: \(\d+\): CVE database could not be updated."

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -114,12 +114,6 @@ def callback_detect_vulnerability_detector_enabled(line):
     return match1 is not None and match2 is None
 
 
-def callback_detect_os_parameter_warning(line):
-    msg = r'.*wazuh-modulesd.*wmodules-vuln-detector.*WARNING.*\'os\'.*single-provider.*'
-    match = re.match(msg, line)
-    return match is not None
-
-
 def make_vuln_callback(pattern, prefix=VULNERABILITY_DETECTOR_PREFIX):
     """
     Creates a callback function from a text pattern.

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -31,6 +31,7 @@ CUSTOM_REDHAT_JSON_FEED = 'custom_redhat_json_feed.json'
 CUSTOM_REDHAT_OVAL_FEED = 'custom_redhat_oval_feed.xml'
 CUSTOM_CANONICAL_OVAL_FEED = 'custom_canonical_oval_feed.xml'
 CUSTOM_DEBIAN_OVAL_FEED = 'custom_debian_oval_feed.xml'
+CUSTOM_DEBIAN_JSON_FEED = 'custom_debian_json_feed.json'
 CUSTOM_NVD_VULNERABILITIES_1 = 'nvd_vulnerabilities_1.json'
 CUSTOM_NVD_VULNERABILITIES_2 = 'nvd_vulnerabilities_2.json'
 INVALID_RHEL_FEEDS_CONF = 'wazuh_invalid_redhat_feed.yaml'
@@ -559,7 +560,7 @@ def check_failure_when_importing_feed(wazuh_log_monitor, expected_vulnerabilitie
             wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
             log_event=r"ERROR: \(\d+\): The .* feed couldn't be parsed from .* file"
         )
-
+    if 
     check_log_event(
         wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,
         log_event=r"ERROR: \(\d+\): CVE database could not be updated."

--- a/tests/integration/test_vulnerability_detector/data/configuration/test_feeds/wazuh_invalid_debian_feed.yaml
+++ b/tests/integration/test_vulnerability_detector/data/configuration/test_feeds/wazuh_invalid_debian_feed.yaml
@@ -27,3 +27,5 @@
             attributes:
             - path: DEBIAN_CUSTOM_FEED
             value: 'buster'
+        - path:
+            value: DEBIAN_JSON_FEED

--- a/tests/integration/test_vulnerability_detector/data/configuration/test_feeds/wazuh_invalid_type_custom_feed.yaml
+++ b/tests/integration/test_vulnerability_detector/data/configuration/test_feeds/wazuh_invalid_type_custom_feed.yaml
@@ -43,6 +43,8 @@
             attributes:
             - path: DEBIAN_CUSTOM_FEED
             value: 'buster'
+        - path:
+            value: DEBIAN_CUSTOM_JSON_FEED
     - provider:
         attributes:
         - name: 'nvd'
@@ -95,6 +97,8 @@
             attributes:
             - url: DEBIAN_URL_FEED
             value: 'buster'
+        - url:
+            value: DEBIAN_JSON_FEED
     - provider:
         attributes:
         - name: 'nvd'

--- a/tests/integration/test_vulnerability_detector/data/feeds/custom_debian_json_feed.json
+++ b/tests/integration/test_vulnerability_detector/data/feeds/custom_debian_json_feed.json
@@ -1,0 +1,110 @@
+{
+    "test": {
+        "CVE-2012-0833": {
+            "description": "The acllas__handle_group_entry function in servers/plugins/acl/acllas.c in 389 Directory Server before 1.2.10 does not properly handled access control instructions (ACIs) that use certificate groups, which allows remote authenticated LDAP users with a certificate group to cause a denial of service (infinite loop and CPU consumption) by binding to the server.",
+            "scope": "local",
+            "releases": {
+                "bullseye": {
+                    "status": "resolved",
+                    "repositories": {
+                        "bullseye": "1.4.4.3-1"
+                    },
+                    "fixed_version": "0",
+                    "urgency": "unimportant"
+                },
+                "buster": {
+                    "status": "resolved",
+                    "repositories": {
+                        "buster": "1.4.0.21-1"
+                    },
+                    "fixed_version": "0",
+                    "urgency": "unimportant"
+                },
+                "sid": {
+                    "status": "resolved",
+                    "repositories": {
+                        "sid": "1.4.4.3-1"
+                    },
+                    "fixed_version": "0",
+                    "urgency": "unimportant"
+                },
+                "stretch": {
+                    "status": "resolved",
+                    "repositories": {
+                        "stretch": "1.3.5.17-2"
+                    },
+                    "fixed_version": "0",
+                    "urgency": "unimportant"
+                }
+            }
+        },
+        "CVE-2012-2678": {
+            "description": "389 Directory Server before 1.2.11.6 (aka Red Hat Directory Server before 8.2.10-3), after the password for a LDAP user has been changed and before the server has been reset, allows remote attackers to read the plaintext password via the unhashed#user#password attribute.",
+            "scope": "local"
+        },
+        "CVE-2019-13659": {
+            "description": "IDN spoofing in Omnibox in Google Chrome prior to 77.0.3865.75 allowed a remote attacker to perform domain spoofing via IDN homographs via a crafted domain name.",
+            "scope": "local",
+            "releases": {
+                "bullseye": {
+                    "status": "resolved",
+                    "repositories": {
+                        "bullseye": "83.0.4103.116-3"
+                    },
+                    "fixed_version": "78.0.3904.87-1",
+                    "urgency": "not yet assigned"
+                },
+                "buster": {
+                    "status": "resolved",
+                    "repositories": {
+                        "buster": "83.0.4103.116-1~deb10u3",
+                        "buster-security": "83.0.4103.116-1~deb10u3"
+                    },
+                    "fixed_version": "78.0.3904.97-1~deb10u1",
+                    "urgency": "not yet assigned"
+                },
+                "sid": {
+                    "status": "resolved",
+                    "repositories": {
+                        "sid": "83.0.4103.116-3"
+                    },
+                    "fixed_version": "78.0.3904.87-1",
+                    "urgency": "not yet assigned"
+                },
+                "stretch": {
+                    "status": "open",
+                    "repositories": {
+                        "stretch": "73.0.3683.75-1~deb9u1",
+                        "stretch-security": "73.0.3683.75-1~deb9u1"
+                    },
+                    "urgency": "end-of-life"
+                }
+            }
+        },
+        "CVE-2015-8559": {
+            "description": "The knife bootstrap command in chef leaks the validator.pem private RSA key to /var/log/messages.",
+            "debianbug": 809670,
+            "scope": "local",
+            "releases": {
+                "buster": {
+                    "status": "open",
+                    "repositories": {
+                        "buster": "13.8.7-4"
+                    },
+                    "urgency": "low",
+                    "nodsa": "Minor issue; workaround using validatorless bootstrapping",
+                    "nodsa_reason": "ignored"
+                },
+                "stretch": {
+                    "status": "open",
+                    "repositories": {
+                        "stretch": "12.14.60-2"
+                    },
+                    "urgency": "low",
+                    "nodsa": "Minor issue; workaround using validatorless bootstrapping",
+                    "nodsa_reason": "ignored"
+                }
+            }
+        }
+    }
+}

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
@@ -22,11 +22,13 @@ current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, '..', '..', 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', 'test_feeds', vd.INVALID_DEBIAN_FEEDS_CONF)
 custom_debian_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path}]
+parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
+               'DEBIAN_JSON_FEED': custom_debian_json_feed_path}]
 ids = ['DEBIAN_configuration']
 
 # Insert extra tags before <generator> tag

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
@@ -21,11 +21,13 @@ current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, '..', '..', 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', 'test_feeds', vd.INVALID_DEBIAN_FEEDS_CONF)
 custom_debian_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path}]
+parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
+               'DEBIAN_JSON_FEED': custom_debian_json_feed_path}]
 ids = ['DEBIAN_configuration']
 
 test_data = [

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.py
@@ -22,11 +22,13 @@ current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, '..', '..', 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', 'test_feeds', vd.INVALID_DEBIAN_FEEDS_CONF)
 custom_debian_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path}]
+parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
+               'DEBIAN_JSON_FEED': custom_debian_json_feed_path}]
 ids = ['DEBIAN_configuration']
 
 test_data = [

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.py
@@ -21,11 +21,13 @@ current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, '..', '..', 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', 'test_feeds', vd.INVALID_DEBIAN_FEEDS_CONF)
 custom_debian_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path}]
+parameters = [{'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
+               'DEBIAN_JSON_FEED': custom_debian_json_feed_path}]
 ids = ['DEBIAN_configuration']
 
 test_data = [

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -117,6 +117,13 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                                 callback=vd.make_vuln_callback(f"Starting '{callback_system_log}' database update"),
                                 error_message=f"Could not find the provider {callback_system_log} feed download")
 
+        if get_configuration['metadata']['provider_name'] == "debian":
+            # Check Debian Security Tracker feed
+            wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+                                    callback=vd.make_vuln_callback(f"Indexing vulnerabilities from the Debian "
+                                                                   f"Security Tracker."),
+                                    error_message=f"Could not find the Debian Security Tracker feed download")
+
         # Check that the feed is downloaded successfully
         wazuh_log_monitor.start(timeout=download_timeout,
                                 callback=vd.make_vuln_callback(f"The update of the '{callback_system_log}' feed \
@@ -127,7 +134,7 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
         # Travels the time set in the update interval parameter
         check_time_travel(time_travel=True, interval=timedelta(seconds=10))
 
-        # Download again the feed. 
+        # Download again the feed.
         # No updates should be applied since the local copy is up-to-date.
 
         if get_configuration['metadata']['provider_name'] == "nvd" :
@@ -137,7 +144,7 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                 vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=fr"The feed '{callback_system_log} ({year})' is outdated. Fetching the last version.",
                                     update_position=False, timeout=15, prefix=MODULESD_PREFIX)
                 raise AttributeError(f'Unexpected outdated feed message for the provider {callback_system_log}')
-            
+
         else :
             wazuh_log_monitor.start(timeout=download_timeout,
                                 callback=vd.make_vuln_callback(f"The feed '{callback_system_log}' is in its latest version."),

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -4,10 +4,9 @@
 
 import os
 import pytest
-import json
 import wazuh_testing.vulnerability_detector as vd
 from time import sleep
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.fim import check_time_travel
@@ -28,8 +27,8 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 provider_info = {
     'redhat': {
         'aux': {
-            'provider' : 'json_redhat',
-            'system_log':'JSON Red Hat Enterprise Linux',
+            'provider': 'json_redhat',
+            'system_log': 'JSON Red Hat Enterprise Linux',
         },
         'os': ['5', '6', '7', '8'],
         'update_from_year': 1999,
@@ -74,18 +73,20 @@ for provider, values in provider_info.items():
         metadata.append({'provider_name': provider, 'os': '', 'update_from_year': values['update_from_year'],
                          'system_log': values['system_log'], 'download_timeout': values['download_timeout']})
         ids.append(provider)
-    
+
     # Auxiliary/secondary feeds for a provider
     if 'aux' in values:
-        parameters.append({'PROVIDER_NAME': provider, 'OS': values['os'][0], 'UPDATE_FROM_YEAR': values['update_from_year']})
-        metadata.append({'provider_name': provider, 'os': values['os'][0], 'update_from_year': values['update_from_year'],
-                         'system_log': values['aux']['system_log'], 'download_timeout': values['download_timeout']})
+        parameters.append(
+            {'PROVIDER_NAME': provider, 'OS': values['os'][0], 'UPDATE_FROM_YEAR': values['update_from_year']})
+        metadata.append(
+            {'provider_name': provider, 'os': values['os'][0], 'update_from_year': values['update_from_year'],
+             'system_log': values['aux']['system_log'], 'download_timeout': values['download_timeout']})
         ids.append(values['aux']['provider'])
-
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 MODULESD_PREFIX = r'.*wazuh-modulesd.*'
+
 
 # Fixtures
 @pytest.fixture(scope='module', params=configurations, ids=ids)
@@ -129,7 +130,7 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                                 callback=vd.make_vuln_callback(f"The update of the '{callback_system_log}' feed \
                                                                  finished successfully"),
                                 error_message=f"The provider {callback_system_log} download has taken more than \
-                                                {download_timeout/60} minutes")
+                                                {download_timeout / 60} minutes")
 
         # Travels the time set in the update interval parameter
         check_time_travel(time_travel=True, interval=timedelta(seconds=10))
@@ -137,18 +138,20 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
         # Download again the feed.
         # No updates should be applied since the local copy is up-to-date.
 
-        if get_configuration['metadata']['provider_name'] == "nvd" :
+        if get_configuration['metadata']['provider_name'] == "nvd":
             # There's no "already up-to-date" message for the nvd.
             year = get_configuration['metadata']['update_from_year']
             with pytest.raises(TimeoutError):
-                vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=fr"The feed '{callback_system_log} ({year})' is outdated. Fetching the last version.",
-                                    update_position=False, timeout=15, prefix=MODULESD_PREFIX)
+                vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor,
+                                   log_event=fr"The feed '{callback_system_log} ({year})' is outdated. Fetching the last version.",
+                                   update_position=False, timeout=15, prefix=MODULESD_PREFIX)
                 raise AttributeError(f'Unexpected outdated feed message for the provider {callback_system_log}')
 
-        else :
+        else:
             wazuh_log_monitor.start(timeout=download_timeout,
-                                callback=vd.make_vuln_callback(f"The feed '{callback_system_log}' is in its latest version."),
-                                error_message=f"Could not find the provider {callback_system_log} updated feed log after \
+                                    callback=vd.make_vuln_callback(
+                                        f"The feed '{callback_system_log}' is in its latest version."),
+                                    error_message=f"Could not find the provider {callback_system_log} updated feed log after \
                                                 the interval update")
 
     finally:

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -24,14 +24,15 @@ files_path = tempfile.gettempdir()
 custom_redhat_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)
 custom_canonical_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
 custom_debian_oval_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 custom_nvd_json_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 custom_redhat_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_JSON_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 correctly_feeds = [custom_redhat_oval_feed_path, custom_canonical_oval_feed_path, custom_debian_oval_feed_path,
-                   custom_nvd_json_path, custom_redhat_json_feed_path]
-correctly_imported_feeds = []
+                   custom_nvd_json_path, custom_redhat_json_feed_path, custom_debian_json_feed_path]
+correctly_imported_feeds = [custom_debian_json_feed_path]
 for feeds in correctly_feeds:
     if feeds == custom_redhat_json_feed_path:
         correctly_imported_feeds.append(feeds + "$")
@@ -90,12 +91,24 @@ canonical_ids = [f"Canonical_{custom_file}" for custom_file in canonical_custom_
 debian_custom_files = custom_files + [custom_debian_oval_feed_path + f"{extension}"
                                       for extension in custom_correctly_extensions]
 debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
-                          'DEBIAN_CUSTOM_FEED': custom_file, 'NVD_ENABLED': 'no'}
+                          'DEBIAN_CUSTOM_FEED': custom_file, 'DEBIAN_CUSTOM_JSON_FEED': custom_debian_json_feed_path,
+                          'NVD_ENABLED': 'no'}
                          for custom_file in debian_custom_files]
 debian_metadata = [{'feed': 'debian', 'custom_feed': custom_file, 'log_system_name': 'Debian Buster',
                     'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
                    for custom_file in debian_custom_files]
 debian_ids = [f"Debian_{custom_file}" for custom_file in debian_custom_files]
+
+# JSON Debian configurations
+json_debian_custom_files = custom_files + [custom_debian_json_feed_path]
+json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
+                               'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
+                               'DEBIAN_CUSTOM_JSON_FEED': custom_file, 'NVD_ENABLED': 'no'}
+                              for custom_file in json_debian_custom_files]
+json_debian_metadata = [{'feed': 'json debian', 'custom_feed': custom_file, 'log_system_name': 'Debian Buster',
+                         'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
+                        for custom_file in json_debian_custom_files]
+json_debian_ids = [f"JSON_Debian_{custom_file}" for custom_file in json_debian_custom_files]
 
 # NVD configurations
 nvd_custom_files = custom_files + [custom_nvd_json_path + f"{extension}" for extension in custom_correctly_extensions]
@@ -107,9 +120,11 @@ nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_file, 'log_system_name': '
 nvd_ids = [f"NVD_{custom_file}" for custom_file in nvd_custom_files]
 
 # Global configuration
-parameters = redhat_configurations + json_redhat_configurations + canonical_configurations + debian_configurations + nvd_configurations
-metadata = redhat_metadata + json_redhat_metadata + canonical_metadata + debian_metadata + nvd_metadata
-ids = redhat_ids + json_redhat_ids + canonical_ids + debian_ids + nvd_ids
+parameters = redhat_configurations + json_redhat_configurations + canonical_configurations + debian_configurations + \
+             json_debian_configurations + nvd_configurations
+metadata = redhat_metadata + json_redhat_metadata + canonical_metadata + debian_metadata + json_debian_metadata + \
+           nvd_metadata
+ids = redhat_ids + json_redhat_ids + canonical_ids + debian_ids + json_debian_ids + nvd_ids
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -162,12 +177,16 @@ def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configur
 
         vd.clean_vuln_and_sys_programs_tables()
     else:
-        if log_system_name == 'JSON Red Hat Enterprise Linux':
-            expected_vulnerabilities_number = 1
+        expected_vulnerabilities_number = 1 if log_system_name == 'JSON Red Hat Enterprise Linux' else 0
+
+        if get_configuration['metadata']['feed'] != 'json debian':
+            vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor,
+                                                 expected_vulnerabilities_number=expected_vulnerabilities_number
+                                                 )
         else:
-            expected_vulnerabilities_number = 0
-        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor,
-                                             expected_vulnerabilities_number=expected_vulnerabilities_number
-                                             )
+            if custom_feed != '/tmp/dummy.json':
+                vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor,
+                                   log_event=f"Couldn't get the Debian feed .*"
+                                   )
         if expected_vulnerabilities_number > 0:
             vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -24,12 +24,13 @@ custom_redhat_json_feed_url = 'file://' + os.path.join(test_data_path, 'feeds', 
 custom_redhat_oval_feed_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)
 custom_canonical_oval_feed_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUSTOM_CANONICAL_OVAL_FEED)
 custom_debian_oval_feed_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 custom_nvd_json_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUSTOM_NVD_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 url_feeds = [custom_redhat_oval_feed_url, custom_canonical_oval_feed_url, custom_debian_oval_feed_url,
-             custom_nvd_json_url, custom_redhat_json_feed_url]
-correctly_url_feeds = []
+             custom_nvd_json_url, custom_redhat_json_feed_url, custom_debian_json_feed_url]
+correctly_url_feeds = [custom_debian_json_feed_url]
 for feeds in url_feeds:
     correctly_url_feeds.append(feeds + "")
     correctly_url_feeds.append(feeds + ".gz")
@@ -56,9 +57,10 @@ json_redhat_custom_urls = custom_urls + [custom_redhat_json_feed_url + f"{extens
 json_redhat_configurations = [{'REDHAT_ENABLED': 'yes', 'REDHAT_URL_FEED': custom_redhat_oval_feed_url,
                                'REDHAT_JSON_FEED': custom_url, 'CANONICAL_ENABLED': 'no',
                                'DEBIAN_ENABLED': 'no', 'NVD_ENABLED': 'no'} for custom_url in json_redhat_custom_urls]
-json_redhat_metadata = [{'feed': 'redhat', 'custom_feed': custom_url, 'log_system_name': 'JSON Red Hat Enterprise Linux',
-                         'expected_num_vulnerabilities': vd.REDHAT_NUM_CUSTOM_VULNERABILITIES}
-                        for custom_url in json_redhat_custom_urls]
+json_redhat_metadata = [
+    {'feed': 'redhat', 'custom_feed': custom_url, 'log_system_name': 'JSON Red Hat Enterprise Linux',
+     'expected_num_vulnerabilities': vd.REDHAT_NUM_CUSTOM_VULNERABILITIES}
+    for custom_url in json_redhat_custom_urls]
 json_redhat_ids = [f"JSON_RedHat_{custom_url}" for custom_url in json_redhat_custom_urls]
 
 # Canonical configurations
@@ -76,12 +78,24 @@ canonical_ids = [f"Canonical_{custom_url}" for custom_url in canonical_custom_ur
 debian_custom_urls = custom_urls + [custom_debian_oval_feed_url + f"{extension}"
                                     for extension in custom_correctly_extensions]
 debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
-                          'DEBIAN_URL_FEED': custom_url, 'NVD_ENABLED': 'no'}
+                          'DEBIAN_URL_FEED': custom_url, 'DEBIAN_JSON_FEED': custom_debian_json_feed_url,
+                          'NVD_ENABLED': 'no'}
                          for custom_url in debian_custom_urls]
 debian_metadata = [{'feed': 'debian', 'custom_feed': custom_url, 'log_system_name': 'Debian Buster',
                     'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
                    for custom_url in debian_custom_urls]
 debian_ids = [f"Debian_{custom_url}" for custom_url in debian_custom_urls]
+
+# JSON Debian configurations
+json_debian_custom_urls = custom_urls + [custom_debian_json_feed_url]
+json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
+                               'DEBIAN_URL_FEED': custom_debian_oval_feed_url, 'DEBIAN_JSON_FEED': custom_url,
+                               'NVD_ENABLED': 'no'}
+                              for custom_url in json_debian_custom_urls]
+json_debian_metadata = [{'feed': 'json debian', 'custom_feed': custom_url, 'log_system_name': 'Debian Buster',
+                         'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
+                        for custom_url in json_debian_custom_urls]
+json_debian_ids = [f"JSON_Debian_{custom_url}" for custom_url in json_debian_custom_urls]
 
 # NVD configurations
 nvd_custom_urls = custom_urls + [custom_nvd_json_url + f"{extension}"
@@ -94,9 +108,11 @@ nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_url, 'log_system_name': 'N
 nvd_ids = [f"NVD_{custom_url}" for custom_url in nvd_custom_urls]
 
 # Global configuration
-parameters = redhat_configurations + json_redhat_configurations + canonical_configurations + debian_configurations + nvd_configurations
-metadata = redhat_metadata + json_redhat_metadata + canonical_metadata + debian_metadata + nvd_metadata
-ids = redhat_ids + json_redhat_ids + canonical_ids + debian_ids + nvd_ids
+parameters = redhat_configurations + json_redhat_configurations + canonical_configurations + debian_configurations + \
+             json_debian_configurations + nvd_configurations
+metadata = redhat_metadata + json_redhat_metadata + canonical_metadata + debian_metadata + json_debian_metadata + \
+           nvd_metadata
+ids = redhat_ids + json_redhat_ids + canonical_ids + debian_ids + json_debian_ids + nvd_ids
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -134,14 +150,18 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
         vd.clean_vuln_and_sys_programs_tables()
     else:
         timeout = vd.VULN_DETECTOR_GLOBAL_TIMEOUT + 10
-        if log_system_name == 'JSON Red Hat Enterprise Linux':
-            expected_vulnerabilities_number = 1
-        else:
-            expected_vulnerabilities_number = 0
+        expected_vulnerabilities_number = 1 if log_system_name == 'JSON Red Hat Enterprise Linux' else 0
 
-        vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor,
-                                             expected_vulnerabilities_number=expected_vulnerabilities_number,
-                                             timeout=timeout
-                                             )
+        if get_configuration['metadata']['feed'] != 'json debian':
+            vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor,
+                                                 expected_vulnerabilities_number=expected_vulnerabilities_number,
+                                                 timeout=timeout
+                                                 )
+        else:
+            if custom_feed != '/tmp/dummy.json':
+                vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor,
+                                   log_event=f"Couldn't get the Debian feed .*"
+                                   )
+
         if expected_vulnerabilities_number > 0:
             vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -60,8 +60,8 @@ format_feed_data = [
 # NVD
 for year in range(2002, current_year):
     format_feed_data.append({'feed': 'nvd', 'os': year, 'expected_format': 'application/gzip',
-                             'path': f'/tmp/nvdcve-1.0-{year}.json.gz', 'extension': 'gz',
-                             'url': f'https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-{year}.json.gz',
+                             'path': f'/tmp/nvdcve-1.1-{year}.json.gz', 'extension': 'gz',
+                             'url': f'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{year}.json.gz',
                              'decompressed_file': f'/tmp/nvd-{year}.json'})
 
 format_feed_data_ids = [f"{item['feed']}_{item['os']}" for item in format_feed_data]

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -52,7 +52,9 @@ format_feed_data = [
     {'feed': 'debian', 'os': 'jessie', 'expected_format': 'xml',  'path': '/tmp/oval-definitions-jessie.xml',
      'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-jessie.xml'},
     {'feed': 'debian', 'os': 'wheezy', 'expected_format': 'xml',  'path': '/tmp/oval-definitions-wheezy.xml',
-     'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-wheezy.xml'}
+     'extension': 'xml', 'url':  'https://www.debian.org/security/oval/oval-definitions-wheezy.xml'},
+    {'feed': 'debian', 'os': 'generic', 'expected_format': 'json',  'path': '/tmp/debian-security-tracker.json',
+     'extension': 'json', 'url':  'https://security-tracker.debian.org/tracker/data/json'}
 ]
 
 # NVD
@@ -125,7 +127,10 @@ def test_validate_feed_content(feed, manage_file):
         assert file.validate_xml_file(file_path=feed['decompressed_file']), f"{feed_source} file is not XML parseable"
 
     elif feed_source == 'debian':
-        assert file.validate_xml_file(file_path=feed['path']), f"{feed_source} file is not XML parseable"
+        if feed['os'] == 'generic':
+            assert file.validate_json_file(file_path=feed['path']), f"{feed_source} file is not JSON parseable"
+        else:
+            assert file.validate_xml_file(file_path=feed['path']), f"{feed_source} file is not XML parseable"
 
     elif feed_source == 'nvd':
         assert file.get_file_info(file_path=feed['path'], info_type="extension") == feed['extension'],\

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py
@@ -22,18 +22,28 @@ custom_redhat_oval_feed_path = os.path.join(test_data_custom_files, 'feeds', vd.
 custom_redhat_json_feed_path = os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_REDHAT_JSON_FEED)
 custom_redhat_oval_feed_url = 'file://' + os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_REDHAT_OVAL_FEED)
 custom_redhat_json_feed_url = 'file://' + os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_REDHAT_JSON_FEED)
+custom_debian_oval_feed_path = os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_path = os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
+custom_debian_oval_feed_url = 'file://' + os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_DEBIAN_OVAL_FEED)
+custom_debian_json_feed_url = 'file://' + os.path.join(test_data_custom_files, 'feeds', vd.CUSTOM_DEBIAN_JSON_FEED)
 config = ['test_redhat_default', 'test_redhat_path', 'test_redhat_multipath', 'test_redhat_path_multipath',
-          'test_redhat_url', 'test_redhat_multiurl', 'test_redhat_path_multiurl']
+          'test_redhat_url', 'test_redhat_multiurl', 'test_redhat_url_multiurl', 'test_debian_default',
+          'test_debian_path', 'test_debian_multipath', 'test_debian_path_multipath', 'test_debian_url', 
+          'test_debian_multiurl', 'test_debian_url_multiurl']
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 params = [
     {'PROVIDER': 'redhat', 'OS': '8', 'OS_PATH': custom_redhat_oval_feed_path, 'PATH': custom_redhat_json_feed_path,
-     'OS_URL': custom_redhat_oval_feed_url, 'URL': custom_redhat_json_feed_url}
+     'OS_URL': custom_redhat_oval_feed_url, 'URL': custom_redhat_json_feed_url},
+    {'PROVIDER': 'debian', 'OS': 'buster', 'OS_PATH': custom_debian_oval_feed_path, 'PATH': custom_debian_json_feed_path,
+     'OS_URL': custom_debian_oval_feed_url, 'URL': custom_debian_json_feed_url}
 ]
 
 metadata = [
     {'provider': 'redhat', 'os': '8', 'os_path': custom_redhat_oval_feed_path, 'path': custom_redhat_json_feed_path,
-     'os_url': custom_redhat_oval_feed_url, 'url': custom_redhat_json_feed_url}
+     'os_url': custom_redhat_oval_feed_url, 'url': custom_redhat_json_feed_url},
+    {'provider': 'debian', 'os': 'buster', 'os_path': custom_debian_oval_feed_path, 'path': custom_debian_json_feed_path,
+     'os_url': custom_debian_oval_feed_url, 'url': custom_debian_json_feed_url}
 ]
 
 ids = [f"{item}" for item in config]
@@ -62,6 +72,9 @@ def test_multiple_providers(get_configuration, configure_environment, restart_mo
     if provider == 'redhat':
         os_feed = 'https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8-including-unpatched.oval.xml.bz2'
         feed = 'https://access.redhat.com/labs/securitydataapi/cve.json?after=1999-01-01&per_page=1000&page=1'
+    else:
+        os_feed = 'https://www.debian.org/security/oval/oval-definitions-buster.xml'
+        feed = 'https://security-tracker.debian.org/tracker/data/json'
 
     try:
         if get_configuration['sections'][0]['elements'][1]['provider']['elements'][1]['os']['attributes']:
@@ -99,7 +112,8 @@ def test_multiple_providers(get_configuration, configure_environment, restart_mo
                             error_message=f"Event 'Fetching or Downloading {os_feed} was not received")
 
     wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
-                            callback=vd.make_vuln_callback(rf"(Fetching feed from '{feed}'|.*Trying to download).*",
+                            callback=vd.make_vuln_callback(f"((Fetching .* from|Downloading) '{feed}'|.*Trying to "
+                                                           f"download).*",
                                                            prefix='.*wazuh-modulesd.*'),
                             error_message=f"Event 'Trying to download {feed}' was not received")
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.py
@@ -8,8 +8,10 @@ import pytest
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_vuln_callback, callback_detect_os_parameter_warning, \
-    VULN_DETECTOR_GLOBAL_TIMEOUT, check_log_event, clean_vd_tables
+from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_GLOBAL_TIMEOUT, check_log_event, \
+    clean_vd_tables
+from wazuh_testing.tools.services import control_service
+import wazuh_testing.vulnerability_detector as vd
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -28,8 +30,8 @@ params = [
 ]
 
 metadata = [
-    {'provider_name': 'Ubuntu', 'no_warning': 1},
-    {'provider_name': 'Debian', 'no_warning': 1},
+    {'provider_name': 'Ubuntu', 'error': 1},
+    {'provider_name': 'Debian', 'error': 1},
     {'provider_name': 'Red Hat Enterprise Linux', 'os': ['5', '6', '7', '8', '']},
     {'provider_name': 'National Vulnerability Database', 'os': ['']},
 ]
@@ -47,7 +49,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_providers_no_os(get_configuration, configure_environment, restart_modulesd):
+def test_providers_no_os(clean_vuln_tables, get_configuration, configure_environment):
     """
     Check if modulesd downloads the feeds without specifing the os version.
     """
@@ -55,13 +57,17 @@ def test_providers_no_os(get_configuration, configure_environment, restart_modul
     provider_name = get_configuration['metadata']['provider_name']
 
     # Those providers that aren't expected to work without the <os> tag.
-    if 'no_warning' in get_configuration['metadata']:
-        with pytest.raises(TimeoutError):
-            check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=fr".*{provider_name}.*",
-                            update_position=False, timeout=VULN_DETECTOR_GLOBAL_TIMEOUT)
-            # Since the provider is discarded, no message is expected.
-            raise AttributeError(f'Invalid message for provider {provider_name}')
+    try:
+        control_service('restart')
+    except ValueError:
+        assert 'error' in get_configuration['metadata']
 
+    if 'error' in get_configuration['metadata']:
+        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+                            callback=vd.make_vuln_callback(r".* \(\d+\): Configuration error at.*",
+                                                            prefix='.*wazuh-modulesd.*'),
+                            error_message=f"Error log 'Configuration error at '/var/ossec/etc/ossec.conf'.' "
+                                            f"not found")
     else:
         for os in get_configuration['metadata']['os']:
             if os != '':

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py
@@ -4,12 +4,12 @@
 
 import os
 import pytest
+import wazuh_testing.vulnerability_detector as vd
 
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_vuln_callback, callback_detect_os_parameter_warning,\
-                                                 VULN_DETECTOR_GLOBAL_TIMEOUT
+from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_GLOBAL_TIMEOUT, check_log_event
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -44,7 +44,7 @@ metadata = [
     {'provider_name': 'Red Hat Enterprise Linux 7'},
     {'provider_name': 'Red Hat Enterprise Linux 8'},
     {'provider_name': 'National Vulnerability Database', 'os_warning': 1},
-    ]
+]
 
 ids = [f"{item['PROVIDER']}-{item['OS']}" for item in params]
 
@@ -67,11 +67,11 @@ def test_providers(get_configuration, configure_environment, restart_modulesd):
 
     provider_name = get_configuration['metadata']['provider_name']
     if 'os_warning' in get_configuration['metadata']:
-        wazuh_log_monitor.start(
-            timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
-            callback=callback_detect_os_parameter_warning,
-            error_message="Could not find: warning 'os' option can only be used in a single-provider",
-        )
+        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+                                callback=vd.make_vuln_callback(rf".*Invalid option 'os' for .* provider.*",
+                                                               prefix='.*wazuh-modulesd.*'),
+                                error_message=f"Warning log 'Invalid option 'os' for '{provider_name}' "
+                                              f"provider not found")
     wazuh_log_monitor.start(
         timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
         callback=make_vuln_callback(f"Starting '{provider_name}' database update"),

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
@@ -70,7 +70,7 @@ def test_update_from_year(clean_vuln_tables, get_configuration, configure_enviro
         # Check that there is no download from one year before of the update from year value
         with pytest.raises(TimeoutError):
             vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=wrong_year_log_event,
-                               update_position=False, timeout=30, prefix=MODULESD_PREFIX)
+                               update_position=False, timeout=90, prefix=MODULESD_PREFIX)
             raise AttributeError(f'It has been downloaded a feed from an invalid year {update_year} for {provider}')
 
         # Check update from year log event

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_debian_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_debian_inventory.yaml
@@ -15,22 +15,6 @@
         value: '5'
     - provider:
         attributes:
-        - name: 'redhat'
-        elements:
-        - enabled:
-            value: 'no'
-    - provider:
-        attributes:
-        - name: 'debian'
-        elements:
-        - enabled:
-            value: 'yes'
-        - os:
-            value: 'buster'
-        - os:
-            value: 'stretch'
-    - provider:
-        attributes:
         - name: 'nvd'
         elements:
         - enabled:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_different_cves.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_different_cves.yaml
@@ -25,12 +25,6 @@
             value: '10s'
     - provider:
         attributes:
-        - name: 'canonical'
-        elements:
-        - enabled:
-            value: 'yes'
-    - provider:
-        attributes:
         - name: 'debian'
         elements:
         - enabled:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_nvd_configuration.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_nvd_configuration.yaml
@@ -10,11 +10,21 @@
     - enabled:
         value: 'yes'
     - run_on_start:
-        value: 'yes'
+        value: 'no'
     - interval:
         value: '5s'
     - ignore_time:
         value: '5s'
+    - provider:
+        attributes:
+        - name: 'msu'
+        elements:
+        - enabled:
+            value: 'no'
+        - path:
+            value: MSU_JSON_PATH
+        - update_interval:
+            value: '10s'
     - provider:
         attributes:
         - name: 'nvd'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_provider_and_nvd_configuration.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_provider_and_nvd_configuration.yaml
@@ -13,6 +13,8 @@
         value: 'no'
     - interval:
         value: '5s'
+    - ignore_time:
+        value: '5s'
     - provider:
         attributes:
         - name: 'nvd'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_redhat_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_redhat_inventory.yaml
@@ -13,6 +13,8 @@
         value: 'no'
     - interval:
         value: '5s'
+    - ignore_time:
+        value: '5s'
     - provider:
         attributes:
         - name: 'redhat'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_ubuntu_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_ubuntu_inventory.yaml
@@ -13,26 +13,8 @@
         value: 'no'
     - interval:
         value: '5'
-    - provider:
-        attributes:
-        - name: 'canonical'
-        elements:
-        - enabled:
-            value: 'no'
-        - os:
-            value: 'bionic'
-        - os:
-            value: 'xenial'
-        - os:
-            value: 'trusty'
-    - provider:
-        attributes:
-        - name: 'debian'
-        elements:
-        - enabled:
-            value: 'yes'
-        - os:
-            value: 'buster'
+    - ignore_time:
+        value: '5s'
     - provider:
         attributes:
         - name: 'nvd'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -62,7 +62,7 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(5)
+    sleep(3)
 
     # Clean tables
     clean_vd_tables(agent='000')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -59,7 +59,7 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
+    sleep(3)
 
     # Clean tables
     clean_vd_tables(agent='000')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -30,14 +30,13 @@ custom_msu_data_path = os.path.join(test_data_path, vd.CUSTOM_MSU)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 SCAN_TIMEOUT = 40
 
-
-compress_gzip_file(custom_msu_data_path, vd.MSU_PATH)
-
 copy(custom_cpe_helper_data_path, vd.CPE_HELPER_PATH)
 
 # Set configuration
-parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED)}]
-metadata = [{'nvd_json_path': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED)}]
+parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED),
+               'MSU_JSON_PATH': custom_msu_data_path}]
+metadata = [{'nvd_json_path': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED),
+             'msu_json_path': custom_msu_data_path}]
 ids = ['scan_nvd_configuration']
 
 # Read JSON data template
@@ -91,7 +90,7 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(5)
+    sleep(3)
 
     # Mock system
     vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
@@ -91,7 +91,7 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
+    sleep(3)
 
     # Clean tables
     vd.clean_vd_tables(agent='000')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -59,7 +59,7 @@ def mock_vulnerability_scan(request):
     control_service('stop', daemon='wazuh-db')
 
     # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(5)
+    sleep(3)
 
     # Clean tables
     clean_vd_tables(agent='000')


### PR DESCRIPTION
Hello team,

The Debian Security Tracker feed (https://security-tracker.debian.org/tracker/data/json) can be used offline now. For that we use the tag `<path>` or `<url>`. 

Configuration examples:
```xml
<provider name="debian">
    <enabled>yes</enabled>
    <os path="/home/user/oval-definitions-buster.xml">buster</os>
    <os path="/home/user/oval-definitions-stretch.xml">stretch</os>
    <path>/home/user/debian-security-tracker.json</path>
    <update_interval>1h</update_interval>
</provider>
```
or 

```xml
<provider name="debian">
    <enabled>yes</enabled>
    <os url="http://local_repo/oval-definitions-buster.xml">buster</os>
    <os url="http://local_repo/oval-definitions-stretch.xml">stretch</os>
    <url>http://local_repo/debian-security-tracker.json</url>
    <update_interval>1h</update_interval>
</provider>
```

Closes #853 

# Tests logic

- `test_download_feeds.py` Added test in this file to check OVAL and JSON feeds are correctly downloaded and parsed.
- [x] test_download_feeds.py
- `test_validate_feed_content.py` Added Debian Security Tracker feed URL to validate the feed's content.
- [x] test_validate_feed_content.py
- `test_invalid_type_custom_feeds.py` Added custom Debian JSON feed to check error messages when an invalid custom file is used.
- [x] test_invalid_type_custom_feeds.py
- `test_invalid_type_url_feeds.py` Added test that checks invalid URLs to check error messages when VD is trying to download the  Debian Security Tracker feed.
- [x] test_invalid_type_url_feeds.py
- `test_providers_multiple_providers.py` Added test that checks the `<path></path>` and `<os path=''></os>` or `<url></url>` and `<os url=''></os>` for Debian provider. It uses two feeds (OVAL and JSON) to fetch the vulnerabilities and CVEs' metadata.
- [x] test_providers_multiple_providers.py

# Tests checks

- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)
- [x] Tested and passed in Jenkins. Build URL: Centos: https://ci.wazuh.info/job/test_integration_vulnerability_detector/262/
                                                                          Ubuntu: https://ci.wazuh.info/job/test_integration_vulnerability_detector/261/

## RPM manager

### Failed tests:
```
=========================== short test summary info ============================
FAILED test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10]
===== 1 failed, 1411 passed, 2 skipped, 46 xfailed in 14536.92s (4:02:16) ======
```
- This tests was not fixed in this branch but in another. Commit: d5291110756ad6e87cdcb25485105b97694342c6
```
FAILED test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10]

```
- [x] Proven that tests have the expected behavior in **RPM**

## DEB manager
```
=========================== short test summary info ============================
FAILED test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10]
===== 1 failed, 1411 passed, 2 skipped, 46 xfailed in 14812.33s (4:06:52) ======
```
### Failed tests:

- This tests was not fixed in this branch but in another. Commit: d5291110756ad6e87cdcb25485105b97694342c6
```
FAILED test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10]
```

- [x] Proven that tests have the expected behavior in **DEB**
Best regards.
