### PR TITLE
Adapt API tests to hot-changes removal.

### DIFF
--- a/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
@@ -7,7 +7,9 @@ import time
 
 import pytest
 import requests
+
 from wazuh_testing.tools.configuration import check_apply_test, get_api_conf
+from wazuh_testing.tools.services import control_service
 
 # Marks
 
@@ -55,6 +57,8 @@ def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_env
                                 headers=api_details['auth_headers'], verify=False)
     assert put_response.status_code == 200, f'Expected status code was 200, ' \
                                             f'but {put_response.status_code} was returned. \nFull response: {put_response.text}'
+
+    control_service('restart')
 
     # Provoke an api block (default: 300 requests)
     api_details['base_url'] += '/agents'

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/data/conf.yaml
@@ -2,14 +2,10 @@
 - tags:
   - config1
   conf:
-    host: 0.0.0.0
-    port: 55000
     block_time: 10
     max_login_attempts: 10
 - tags:
   - config2
   conf:
-    host: 0.0.0.0
-    port: 55000
     block_time: 6
     max_login_attempts: 3


### PR DESCRIPTION
Hello team,

## Description

This PR fixes the API configuration integration tests to remove the hot-changes feature, which involves an extra Wazuh restart in certain tests:
- test_DOS_blocking_system.py
- test_bruteforce_blocking_system.py

During testing, a couple of bugs were found in recent changes to the brute force protection mechanism. Therefore, these tests work correctly once the PRs associated with this issue are merged: https://github.com/wazuh/wazuh/issues/6039

This PR is related to https://github.com/wazuh/wazuh/issues/5993

## Tests performed (manager, ubuntu)

```
/var/ossec/framework/python/bin/python3 -m pytest test_api/test_config
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, html-2.1.1, tavern-1.6.0, cov-2.10.1
collected 70 items                                                                                                                                                                                           

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss.                                                                                                                         [  5%]
test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py .s.ss.s.                                                                                                                     [ 17%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss.                                                                                                           [ 22%]
test_api/test_config/test_cache/test_cache.py .ss.                                                                                                                                                     [ 28%]
test_api/test_config/test_cors/test_cors.py x.                                                                                                                                                         [ 31%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.                                                                                                                                 [ 37%]
test_api/test_config/test_experimental_features/test_experimental_features.py .ss.                                                                                                                     [ 42%]
test_api/test_config/test_host_port/test_host_port.py .s.ss.s.                                                                                                                                         [ 54%]
test_api/test_config/test_https/test_https.py .ss.                                                                                                                                                     [ 60%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                                                                     [ 65%]
test_api/test_config/test_logs/test_logs.py .ss.                                                                                                                                                       [ 71%]
test_api/test_config/test_rbac/test_rbac_mode.py .ss.                                                                                                                                                  [ 77%]
test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.s.ss.s.s.s.                                                                                                                       [100%]

============================================================================================== warnings summary ==============================================================================================
/var/ossec/framework/python/lib/python3.8/site-packages/jsonschema/compat.py:6
/var/ossec/framework/python/lib/python3.8/site-packages/jsonschema/compat.py:6
  /var/ossec/framework/python/lib/python3.8/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py: 72 warnings
test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py: 20 warnings
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py: 23 warnings
test_api/test_config/test_cache/test_cache.py: 7 warnings
test_api/test_config/test_cors/test_cors.py: 4 warnings
test_api/test_config/test_experimental_features/test_experimental_features.py: 4 warnings
test_api/test_config/test_https/test_https.py: 2 warnings
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py: 6 warnings
test_api/test_config/test_rbac/test_rbac_mode.py: 4 warnings
test_api/test_config/test_use_only_authd/test_use_only_authd.py: 22 warnings
  /var/ossec/framework/python/lib/python3.8/site-packages/urllib3/connectionpool.py:979: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration0-False-tags_to_apply0]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration0-False-tags_to_apply0]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration1-False-tags_to_apply0]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration1-False-tags_to_apply0]
  /var/ossec/framework/python/lib/python3.8/site-packages/urllib3/connectionpool.py:979: InsecureRequestWarning: Unverified HTTPS request is being made to host '0.0.0.0'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================================== 35 passed, 34 skipped, 1 xfailed, 170 warnings in 877.53s (0:14:37) =====================================================================
```


Best regards.
