### PR TITLE
Test cases for rules and decoders invalid syntax

### DIFF
--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_0.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_0.xml
@@ -1,0 +1,2 @@
+<!-- Test: garbage file -->
+<This is not even a XML file>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_1.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_1.xml
@@ -1,0 +1,2 @@
+<!-- Test: no closing decoder XML tag -->
+<decoder name="name">

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_10.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_10.xml
@@ -1,0 +1,4 @@
+<!-- Test: invalid offset-->
+<decoder name="name">
+    <prematch offset="after_prematch">^example</prematch>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_2.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_2.xml
@@ -1,0 +1,8 @@
+<!-- Test: decoder with no existing parent -->
+<decoder name="name-0">
+  <program_name>^test</program_name>
+</decoder>
+
+<decoder name="name-1">
+  <parent>test-parent</parent>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_3.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_3.xml
@@ -1,0 +1,4 @@
+<!-- Test: no existing attribute -->
+<decoder name="name">
+    <invalid_field>some value</invalid_field>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_4.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_4.xml
@@ -1,0 +1,4 @@
+<!-- Test: decoder with no name-->
+<decoder>
+  <program_name>^test</program_name>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_5.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_5.xml
@@ -1,0 +1,5 @@
+<!-- Test: regex attribute without order attribute -->
+<decoder name="test">
+  <prematch>\s</prematch>
+  <regex>^\s*(\S+)\s*:</regex>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_6.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_6.xml
@@ -1,0 +1,4 @@
+<!-- Test: regex attribute without prematch/program_name/parent attribute -->
+<decoder name="test">
+  <regex>^\s*(\S+)\s*:</regex>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_7.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_7.xml
@@ -1,0 +1,5 @@
+<!-- Test: order attribute without regex attribute -->
+<decoder name="test">
+  <prematch>\s</prematch>
+  <order>srcuser</order>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_8.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_8.xml
@@ -1,0 +1,12 @@
+<!-- Test: two-level order parenting -->
+<decoder name="name0">
+  <program_name>^test</program_name>
+</decoder>
+
+<decoder name="name1">
+  <parent>name0</parent>
+</decoder>
+
+<decoder name="name2">
+  <parent>name1</parent>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_9.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_9.xml
@@ -1,0 +1,5 @@
+<!-- Test: invalid plugin_decoder -->
+<decoder name="name">
+  <prematch>^{\s*"</prematch>
+  <plugin_decoder>INVALID_Decoder</plugin_decoder>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_0.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_0.xml
@@ -1,0 +1,2 @@
+<!-- Test: garbage file-->
+<This is not even a XML file>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_1.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_1.xml
@@ -1,0 +1,10 @@
+<!-- Test: No closing XML tag -->
+<!--2020/09/21 14:23:36 ossec-testrule: ERROR: (1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: End of file and some elements were not closed. (line 11). -->
+<group name="testing">
+
+  <rule id="100001" level="0">
+    <program_name>example</program_name>
+    <description>example_description</description>
+  </rule>
+
+</group

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_10.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_10.xml
@@ -1,0 +1,8 @@
+<!-- Test: invalid rule label -->
+<group name="testing">
+
+    <rule id="100001" level="3" invalid_label="value" >
+    <description>example_description</description>
+    </rule>
+    
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_11.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_11.xml
@@ -1,0 +1,9 @@
+<!-- Test: non existing group in if_group -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <if_group>non_existing_group</if_group>
+    <description>Non existing group description</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_12.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_12.xml
@@ -1,0 +1,10 @@
+<!-- Test: invalid values on option attribute -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <program_name>example</program_name>
+    <description>example_description</description>
+    <options>invalid_option</options>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_13.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_13.xml
@@ -1,0 +1,15 @@
+<!-- Test: different_* attribute without frequency and timeframe -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <program_name>example</program_name>
+    <description>example_description</description>
+    </rule>
+
+    <rule id="100002" level="5">
+    <if_sid>100001</if_sid>
+    <different_srcip />
+    <description>example different_ip without frequency</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_14.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_14.xml
@@ -1,0 +1,10 @@
+<!-- Test: non existing decoder -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <decoded_as>non_existing_decoder</decoded_as>
+    <description>example_description</description>
+    </rule>
+
+</group>
+

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_2.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_2.xml
@@ -1,0 +1,6 @@
+<!-- Test: no group -->
+
+    <rule id="100001" level="0">
+    <program_name>example</program_name>
+    <description>example_description</description>
+    </rule>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_3.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_3.xml
@@ -1,0 +1,9 @@
+<!-- Test: invalid level -->
+<group name="testing">
+
+    <rule id="100001" level="20">
+    <program_name>example</program_name>
+    <description>example_description</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_4.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_4.xml
@@ -1,0 +1,9 @@
+<!-- Test: invalid rule overwrite -->
+<group name="testing">
+
+  <rule id="123123" level="3" overwrite="yes" >
+    <program_name>example</program_name>
+    <description>example_description</description>
+  </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_5.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_5.xml
@@ -1,0 +1,21 @@
+<!-- Test: same_* attribute without frequency and timeframe -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <program_name>example</program_name>
+    <description>example_description</description>
+    </rule>
+
+    <rule id="100002" level="5">
+    <if_sid>100001</if_sid>
+    <same_srcip />
+    <description>example same_ip without frequency</description>
+    </rule>
+
+    <rule id="100003" level="5">
+    <if_sid>100001</if_sid>
+    <different_srcip />
+    <description>example different_ip without frequency</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_6.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_6.xml
@@ -1,0 +1,10 @@
+<!-- Test: invalid weekday -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <program_name>example</program_name>
+    <weekday>osvaldo</weekday>
+    <description>example_description</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_7.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_7.xml
@@ -1,0 +1,10 @@
+<!-- Test:  no existing if_sid rule number -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <if_sid>123123</if_sid>
+    <program_name>example</program_name>
+    <description>example_description</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_8.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_8.xml
@@ -1,0 +1,14 @@
+<!-- Test:  if_matched_sid attribute without frequency and timeframe -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <program_name>example</program_name>
+    <description>example_description</description>
+    </rule>
+
+    <rule id="100002" level="5">
+    <if_matched_sid>100005</if_matched_sid>
+    <description>example if_matched_sid without existig rule and frequency/timeframe</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_9.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_9.xml
@@ -1,0 +1,10 @@
+<!-- Test:  non existing/invalid attribute -->
+<group name="testing">
+
+    <rule id="100001" level="3">
+    <program_name>example</program_name>
+    <madeup_attr>example</madeup_attr>
+    <description>example_description</description>
+    </rule>
+
+</group>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_decoder_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_decoder_syntax.yaml
@@ -1,0 +1,78 @@
+---
+-
+  name: "Invalid decoder syntax: garbage file"
+  decoder: "custom_decoder_0.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/decoders/local_decoder.xml': XMLERR: Attribute 'is' has no value. (line 2)."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: no closing XML tag"
+  decoder: "custom_decoder_1.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/decoders/local_decoder.xml': XMLERR: End of file and some elements were not closed. (line 3)."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: no existing parent"
+  decoder: "custom_decoder_2.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2101): Parent decoder name invalid: 'test-parent'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: no existing attribute"
+  decoder: "custom_decoder_3.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: Invalid element 'invalid_field' for decoder 'decoder'"
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: decoder with no name"
+  decoder: "custom_decoder_4.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1230): Invalid element in the configuration: 'decoder'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: regex attribute without order attribute"
+  decoder: "custom_decoder_5.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2107): Decoder configuration error: 'test'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: regex attribute without prematch/program_name/parent attribute"
+  decoder: "custom_decoder_6.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2108): No 'prematch' found in decoder: 'test'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: order attribute without regex attribute"
+  decoder: "custom_decoder_7.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2107): Decoder configuration error: 'test'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: two-level order parenting"
+  decoder: "custom_decoder_8.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2101): Parent decoder name invalid: 'name1'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: invalid plugin_decoder"
+  decoder: "custom_decoder_9.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2110): Invalid decoder argument for plugin_decoder: 'INVALID_Decoder'."
+  output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: invalid offset"
+  decoder: "custom_decoder_10.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2107): Decoder configuration error: 'name'."
+  output_data_codemsg: -1

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_decoder_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_decoder_syntax.yaml
@@ -4,75 +4,75 @@
   decoder: "custom_decoder_0.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/decoders/local_decoder.xml': XMLERR: Attribute 'is' has no value. (line 2)."
+  output_data_msg: "(1226): Error reading XML file 'etc/decoders/local_decoder.xml': XMLERR: Attribute 'is' has no value. (line 2)."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: no closing XML tag"
   decoder: "custom_decoder_1.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/decoders/local_decoder.xml': XMLERR: End of file and some elements were not closed. (line 3)."
+  output_data_msg: "(1226): Error reading XML file 'etc/decoders/local_decoder.xml': XMLERR: End of file and some elements were not closed. (line 3)."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: no existing parent"
   decoder: "custom_decoder_2.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2101): Parent decoder name invalid: 'test-parent'."
+  output_data_msg: "(2101): Parent decoder name invalid: 'test-parent'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: no existing attribute"
   decoder: "custom_decoder_3.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: Invalid element 'invalid_field' for decoder 'decoder'"
+  output_data_msg: "Invalid element 'invalid_field' for decoder 'decoder'"
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: decoder with no name"
   decoder: "custom_decoder_4.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1230): Invalid element in the configuration: 'decoder'."
+  output_data_msg: "(1230): Invalid element in the configuration: 'decoder'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: regex attribute without order attribute"
   decoder: "custom_decoder_5.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2107): Decoder configuration error: 'test'."
+  output_data_msg: "(2107): Decoder configuration error: 'test'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: regex attribute without prematch/program_name/parent attribute"
   decoder: "custom_decoder_6.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2108): No 'prematch' found in decoder: 'test'."
+  output_data_msg: "(2108): No 'prematch' found in decoder: 'test'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: order attribute without regex attribute"
   decoder: "custom_decoder_7.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2107): Decoder configuration error: 'test'."
+  output_data_msg: "(2107): Decoder configuration error: 'test'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: two-level order parenting"
   decoder: "custom_decoder_8.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2101): Parent decoder name invalid: 'name1'."
+  output_data_msg: "(2101): Parent decoder name invalid: 'name1'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: invalid plugin_decoder"
   decoder: "custom_decoder_9.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2110): Invalid decoder argument for plugin_decoder: 'INVALID_Decoder'."
+  output_data_msg: "(2110): Invalid decoder argument for plugin_decoder: 'INVALID_Decoder'."
   output_data_codemsg: -1
 -
   name: "Invalid decoder syntax: invalid offset"
   decoder: "custom_decoder_10.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (2107): Decoder configuration error: 'name'."
+  output_data_msg: "(2107): Decoder configuration error: 'name'."
   output_data_codemsg: -1

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
@@ -4,103 +4,103 @@
   rules: "custom_rule_0.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: Attribute 'is' has no value. (line 2)."
+  output_data_msg: "(1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: Attribute 'is' has no value. (line 2)."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: no closing XML tag"
   rules: "custom_rule_1.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: End of file and some elements were not closed. (line 11)."
+  output_data_msg: "(1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: End of file and some elements were not closed. (line 11)."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: no group"
   rules: "custom_rule_2.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: 'ERROR: rules_op: Invalid root element "rule".Only "group" is allowed'
+  output_data_msg: 'rules_op: Invalid root element "rule".Only "group" is allowed'
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: invalid level"
   rules: "custom_rule_3.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: 'ERROR: rules_op: Invalid level: 20. Must be an integer between 0 and 16.'
+  output_data_msg: 'rules_op: Invalid level: 20. Must be an integer between 0 and 16.'
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: invalid rule overwrite"
   rules: "custom_rule_4.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: Overwrite rule '123123' not found."
+  output_data_msg: "Overwrite rule '123123' not found."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: same_* attribute without frequency and timeframe"
   rules: "custom_rule_5.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: Invalid use of frequency/context options. Missing if_matched on rule '100002'."
+  output_data_msg: "Invalid use of frequency/context options. Missing if_matched on rule '100002'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: invalid weekday"
   rules: "custom_rule_6.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1241): Invalid day format: 'osvaldo'."
+  output_data_msg: "(1241): Invalid day format: 'osvaldo'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: no existing if_sid rule number"
   rules: "custom_rule_7.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: rules_list: Signature ID '123123' not found. Invalid 'if_sid'."
+  output_data_msg: "rules_list: Signature ID '123123' not found. Invalid 'if_sid'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: no existing if_matched_sid rule number attribute without frequency and timeframe"
   rules: "custom_rule_8.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: rules_list: Signature ID '100005' not found. Invalid 'if_sid'."
+  output_data_msg: "rules_list: Signature ID '100005' not found. Invalid 'if_sid'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: non existing/invalid attribute"
   rules: "custom_rule_9.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: Invalid option 'madeup_attr' for rule '100001'."
+  output_data_msg: "Invalid option 'madeup_attr' for rule '100001'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: no invalid rule label"
   rules: "custom_rule_10.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: 'ERROR: rules_op: Invalid attribute "invalid_label". Only id, level, maxsize, accuracy, noalert, ignore, frequency and timeframe are allowed.'
+  output_data_msg: 'rules_op: Invalid attribute "invalid_label". Only id, level, maxsize, accuracy, noalert, ignore, frequency and timeframe are allowed.'
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: non existing group in if_group"
   rules: "custom_rule_11.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: rules_list: Group 'non_existing_group' not found. Invalid 'if_group'."
+  output_data_msg: "rules_list: Group 'non_existing_group' not found. Invalid 'if_group'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: invalid values on option attribute"
   rules: "custom_rule_12.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: (1235): Invalid value for element 'options': invalid_option."
+  output_data_msg: "(1235): Invalid value for element 'options': invalid_option."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: different_* attribute without frequency and timeframe"
   rules: "custom_rule_13.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: Invalid use of frequency/context options. Missing if_matched on rule '100002'."
+  output_data_msg: "Invalid use of frequency/context options. Missing if_matched on rule '100002'."
   output_data_codemsg: -1
 -
   name: "Invalid rules syntax: non existing decoder"
   rules: "custom_rule_14.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "ERROR: Invalid decoder name: 'non_existing_decoder'."
+  output_data_msg: "Invalid decoder name: 'non_existing_decoder'."
   output_data_codemsg: -1

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
@@ -1,0 +1,106 @@
+---
+-
+  name: "Invalid rules syntax: garbage file"
+  rules: "custom_rule_0.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: Attribute 'is' has no value. (line 2)."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: no closing XML tag"
+  rules: "custom_rule_1.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1226): Error reading XML file 'etc/rules/local_rules.xml': XMLERR: End of file and some elements were not closed. (line 11)."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: no group"
+  rules: "custom_rule_2.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: 'ERROR: rules_op: Invalid root element "rule".Only "group" is allowed'
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: invalid level"
+  rules: "custom_rule_3.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: 'ERROR: rules_op: Invalid level: 20. Must be an integer between 0 and 16.'
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: invalid rule overwrite"
+  rules: "custom_rule_4.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: Overwrite rule '123123' not found."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: same_* attribute without frequency and timeframe"
+  rules: "custom_rule_5.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: Invalid use of frequency/context options. Missing if_matched on rule '100002'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: invalid weekday"
+  rules: "custom_rule_6.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1241): Invalid day format: 'osvaldo'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: no existing if_sid rule number"
+  rules: "custom_rule_7.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: rules_list: Signature ID '123123' not found. Invalid 'if_sid'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: no existing if_matched_sid rule number attribute without frequency and timeframe"
+  rules: "custom_rule_8.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: rules_list: Signature ID '100005' not found. Invalid 'if_sid'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: non existing/invalid attribute"
+  rules: "custom_rule_9.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: Invalid option 'madeup_attr' for rule '100001'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: no invalid rule label"
+  rules: "custom_rule_10.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: 'ERROR: rules_op: Invalid attribute "invalid_label". Only id, level, maxsize, accuracy, noalert, ignore, frequency and timeframe are allowed.'
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: non existing group in if_group"
+  rules: "custom_rule_11.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: rules_list: Group 'non_existing_group' not found. Invalid 'if_group'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: invalid values on option attribute"
+  rules: "custom_rule_12.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (1235): Invalid value for element 'options': invalid_option."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: different_* attribute without frequency and timeframe"
+  rules: "custom_rule_13.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: Invalid use of frequency/context options. Missing if_matched on rule '100002'."
+  output_data_codemsg: -1
+-
+  name: "Invalid rules syntax: non existing decoder"
+  rules: "custom_rule_14.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: Invalid decoder name: 'non_existing_decoder'."
+  output_data_codemsg: -1

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import yaml
+import shutil
+import json
+
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations    
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+messages_path = os.path.join(test_data_path, 'invalid_decoder_syntax.yaml')
+with open(messages_path) as f:
+    test_cases = yaml.safe_load(f)
+
+# Variables
+
+log_monitor_paths = [LOG_FILE_PATH]
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
+
+# Fixtures
+
+@pytest.fixture(scope='function')
+def configure_local_decoders(get_configuration, request):
+    """Configure a custom decoder in local_decoder.xml for testing. Restart Wazuh is needed for applying the configuration is optional."""
+
+    # save current configuration
+    shutil.copy('/var/ossec/etc/decoders/local_decoder.xml', '/var/ossec/etc/decoders/local_decoder.xml.cpy')
+
+    # configuration for testing
+    file_test = os.path.join(test_data_path, get_configuration['decoder'])
+    shutil.copy(file_test, '/var/ossec/etc/decoders/local_decoder.xml')
+
+    yield
+
+    # restore previous configuration
+    shutil.copy('/var/ossec/etc/decoders/local_decoder.xml.cpy','/var/ossec/etc/decoders/local_decoder.xml')
+
+@pytest.fixture(scope='module', params=test_cases,ids=[test_case['name'] for test_case in test_cases])
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Tests
+
+def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,connect_to_sockets_function):
+    """Check that every input message in logtest socket generates the adequate output """
+
+    # send the logtest request
+    receiver_sockets[0].send(get_configuration['input'], size=True)
+
+    # receive logtest reply and parse it
+    response = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
+    result = json.loads(response)
+
+    # error list to enable multi-assert per test-case
+    errors = []
+    
+    if 'output_error' in  get_configuration and \
+            get_configuration['output_error'] != result["error"]:
+        errors.append( "output_error" )
+
+    if 'output_data_msg' in  get_configuration and \
+            get_configuration['output_data_msg'] != result["data"]["messages"][0]:
+        errors.append( "output_data_msg" )
+
+    if 'output_data_codemsg' in  get_configuration and \
+            get_configuration['output_data_codemsg'] != result["data"]["codemsg"]:
+        errors.append( "output_data_codemsg" )
+
+    # error if any check fails
+    assert not errors , "Failed stage(s) :{}".format("\n".join(errors))

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -15,7 +15,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
-# Configurations    
+# Configurations
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(test_data_path, 'invalid_decoder_syntax.yaml')
@@ -47,9 +47,10 @@ def configure_local_decoders(get_configuration, request):
     yield
 
     # restore previous configuration
-    shutil.copy('/var/ossec/etc/decoders/local_decoder.xml.cpy','/var/ossec/etc/decoders/local_decoder.xml')
+    shutil.copy('/var/ossec/etc/decoders/local_decoder.xml.cpy', '/var/ossec/etc/decoders/local_decoder.xml')
 
-@pytest.fixture(scope='module', params=test_cases,ids=[test_case['name'] for test_case in test_cases])
+
+@pytest.fixture(scope='module', params=test_cases, ids=[test_case['name'] for test_case in test_cases])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -57,7 +58,7 @@ def get_configuration(request):
 
 # Tests
 
-def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,connect_to_sockets_function):
+def test_invalid_decoder_syntax(get_configuration, configure_local_decoders, connect_to_sockets_function):
     """Check that every input message in logtest socket generates the adequate output """
 
     # send the logtest request
@@ -70,16 +71,16 @@ def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,conn
     # error list to enable multi-assert per test-case
     errors = []
 
-    if 'output_error' in  get_configuration and get_configuration['output_error'] != result["error"]:
+    if 'output_error' in get_configuration and get_configuration['output_error'] != result["error"]:
         errors.append("output_error")
 
-    if ('output_data_msg' in  get_configuration and
+    if ('output_data_msg' in get_configuration and
             get_configuration['output_data_msg'] not in result["data"]["messages"][0]):
         errors.append("output_data_msg")
 
-    if ('output_data_codemsg' in  get_configuration and
+    if ('output_data_codemsg' in get_configuration and
             get_configuration['output_data_codemsg'] != result["data"]["codemsg"]):
         errors.append("output_data_codemsg")
 
     # error if any check fails
-    assert not errors , "Failed stage(s) :{}".format("\n".join(errors))
+    assert not errors, "Failed stage(s) :{}".format("\n".join(errors))

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -8,8 +8,8 @@ import yaml
 import shutil
 import json
 
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
-from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools import WAZUH_PATH
+
 
 # Marks
 
@@ -24,15 +24,18 @@ with open(messages_path) as f:
 
 # Variables
 
-log_monitor_paths = [LOG_FILE_PATH]
 logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
+
 
 # Fixtures
 
 @pytest.fixture(scope='function')
 def configure_local_decoders(get_configuration, request):
-    """Configure a custom decoder in local_decoder.xml for testing. Restart Wazuh is needed for applying the configuration is optional."""
+    """
+    Configure a custom decoder in local_decoder.xml for testing.
+    Restart Wazuh is needed for applying the configuration is optional.
+    """
 
     # save current configuration
     shutil.copy('/var/ossec/etc/decoders/local_decoder.xml', '/var/ossec/etc/decoders/local_decoder.xml.cpy')
@@ -51,6 +54,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # Tests
 
 def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,connect_to_sockets_function):
@@ -65,18 +69,17 @@ def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,conn
 
     # error list to enable multi-assert per test-case
     errors = []
-    
-    if 'output_error' in  get_configuration and \
-            get_configuration['output_error'] != result["error"]:
-        errors.append( "output_error" )
 
-    if 'output_data_msg' in  get_configuration and \
-            get_configuration['output_data_msg'] != result["data"]["messages"][0]:
-        errors.append( "output_data_msg" )
+    if 'output_error' in  get_configuration and get_configuration['output_error'] != result["error"]:
+        errors.append("output_error")
 
-    if 'output_data_codemsg' in  get_configuration and \
-            get_configuration['output_data_codemsg'] != result["data"]["codemsg"]:
-        errors.append( "output_data_codemsg" )
+    if ('output_data_msg' in  get_configuration and
+            get_configuration['output_data_msg'] not in result["data"]["messages"][0]):
+        errors.append("output_data_msg")
+
+    if ('output_data_codemsg' in  get_configuration and
+            get_configuration['output_data_codemsg'] != result["data"]["codemsg"]):
+        errors.append("output_data_codemsg")
 
     # error if any check fails
     assert not errors , "Failed stage(s) :{}".format("\n".join(errors))

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import yaml
+import shutil
+import json
+
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations    
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+messages_path = os.path.join(test_data_path, 'invalid_rules_syntax.yaml')
+with open(messages_path) as f:
+    test_cases = yaml.safe_load(f)
+
+# Variables
+
+log_monitor_paths = [LOG_FILE_PATH]
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
+
+# Fixtures
+
+@pytest.fixture(scope='function')
+def configure_local_rules(get_configuration, request):
+    """Configure a custom rule in local_rules.xml for testing"""
+
+    # save current configuration
+    shutil.copy('/var/ossec/etc/rules/local_rules.xml', '/var/ossec/etc/rules/local_rules.xml.cpy')
+
+    # configuration for testing
+    file_test = os.path.join(test_data_path, get_configuration['rules'])
+    shutil.copy(file_test, '/var/ossec/etc/rules/local_rules.xml')
+
+    yield
+
+    # restore previous configuration
+    shutil.copy('/var/ossec/etc/rules/local_rules.xml.cpy','/var/ossec/etc/rules/local_rules.xml')
+
+
+@pytest.fixture(scope='module', params=test_cases, ids=[test_case['name'] for test_case in test_cases])
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Tests
+
+def test_invalid_rule_syntax(get_configuration, configure_local_rules,connect_to_sockets_function):
+    """Check that every input message in logtest socket generates the adequate output """
+
+    # send the logtest request
+    receiver_sockets[0].send(get_configuration['input'], size=True)
+
+    # receive logtest reply and parse it
+    response = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
+    result = json.loads(response)
+
+    # error list to enable multi-assert per test-case
+    errors = []
+
+    if 'output_error' in  get_configuration and \
+            get_configuration['output_error'] != result["error"]:
+        errors.append( "output_error" )
+
+    if 'output_data_msg' in  get_configuration and \
+            get_configuration['output_data_msg'] != result["data"]["messages"][0]:
+        errors.append( "output_data_msg" )
+
+    if 'output_data_codemsg' in  get_configuration and \
+            get_configuration['output_data_codemsg'] != result["data"]["codemsg"]:
+        errors.append( "output_data_codemsg" )
+    
+    # error if any check fails
+    assert not errors , "Failed stage(s) :{}".format("\n".join(errors))

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -15,7 +15,7 @@ from wazuh_testing.tools import WAZUH_PATH
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
-# Configurations    
+# Configurations
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(test_data_path, 'invalid_rules_syntax.yaml')
@@ -52,9 +52,10 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # Tests
 
-def test_invalid_rule_syntax(get_configuration, configure_local_rules,connect_to_sockets_function):
+def test_invalid_rule_syntax(get_configuration, configure_local_rules, connect_to_sockets_function):
     """Check that every input message in logtest socket generates the adequate output """
 
     # send the logtest request
@@ -67,16 +68,16 @@ def test_invalid_rule_syntax(get_configuration, configure_local_rules,connect_to
     # error list to enable multi-assert per test-case
     errors = []
 
-    if 'output_error' in  get_configuration and get_configuration['output_error'] != result["error"]:
+    if 'output_error' in get_configuration and get_configuration['output_error'] != result["error"]:
         errors.append("output_error")
 
-    if ('output_data_msg' in  get_configuration and
+    if ('output_data_msg' in get_configuration and
             get_configuration['output_data_msg'] not in result["data"]["messages"][0]):
         errors.append("output_data_msg")
 
-    if ('output_data_codemsg' in  get_configuration and
+    if ('output_data_codemsg' in get_configuration and
             get_configuration['output_data_codemsg'] != result["data"]["codemsg"]):
         errors.append("output_data_codemsg")
 
     # error if any check fails
-    assert not errors , "Failed stage(s) :{}".format("\n".join(errors))
+    assert not errors, "Failed stage(s) :{}".format("\n".join(errors))

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -8,8 +8,8 @@ import yaml
 import shutil
 import json
 
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
-from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools import WAZUH_PATH
+
 
 # Marks
 
@@ -24,9 +24,9 @@ with open(messages_path) as f:
 
 # Variables
 
-log_monitor_paths = [LOG_FILE_PATH]
 logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
+
 
 # Fixtures
 
@@ -67,17 +67,16 @@ def test_invalid_rule_syntax(get_configuration, configure_local_rules,connect_to
     # error list to enable multi-assert per test-case
     errors = []
 
-    if 'output_error' in  get_configuration and \
-            get_configuration['output_error'] != result["error"]:
-        errors.append( "output_error" )
+    if 'output_error' in  get_configuration and get_configuration['output_error'] != result["error"]:
+        errors.append("output_error")
 
-    if 'output_data_msg' in  get_configuration and \
-            get_configuration['output_data_msg'] != result["data"]["messages"][0]:
-        errors.append( "output_data_msg" )
+    if ('output_data_msg' in  get_configuration and
+            get_configuration['output_data_msg'] not in result["data"]["messages"][0]):
+        errors.append("output_data_msg")
 
-    if 'output_data_codemsg' in  get_configuration and \
-            get_configuration['output_data_codemsg'] != result["data"]["codemsg"]:
-        errors.append( "output_data_codemsg" )
-    
+    if ('output_data_codemsg' in  get_configuration and
+            get_configuration['output_data_codemsg'] != result["data"]["codemsg"]):
+        errors.append("output_data_codemsg")
+
     # error if any check fails
     assert not errors , "Failed stage(s) :{}".format("\n".join(errors))


### PR DESCRIPTION
Hello team,

This tests cases checks invalid syntax of rules and decoders, showing the correct messages and error code to user
Closes #831 

# Tests logic

Copy different wrong formated/incomplete custom rules and decoders file (`/var/ossec/etc/rules/local_rules.xml` and `/var/ossec/etc/decoders/local_decoders.xml`)
Is important to copy this files after `ossec-analysisd` is running, otherwise it will return error when initializing.

# Tests checks
## Invalid decoders
- [x] Decoder - Garbage file
- [x] Decoder - No closing XML tag
- [x] Decoder - No existing parent
- [x] Decoder - No existing attribute
- [x] Decoder - Decoder with no name
- [x] Decoder - Regex attribute without order attribute
- [x] Decoder - Regex attribute without prematch/program_name/parent attribute
- [x] Decoder - Order attribute without regex attribute
- [x] Decoder - Two-level order parenting
- [x] Decoder - Invalid plugin_decoder
- [x] Decoder - Invalid offset

## Invalid rules
- [x] Rule - Garbage file
- [x] Rule - No closing XML tag
- [x] Rule - No group
- [x] Rule - Invalid level
- [x] Rule - Invalid rule overwrite
- [x] Rule - Same_* attribute without frequency and timeframe
- [x] Rule - Invalid weekday
- [x] Rule - No existing if_sid rule number
- [x] Rule - No existing if_matched_sid rule number attribute without frequency and timeframe
- [x] Rule - Non existing/invalid attribute
- [x] Rule - No invalid rule label
- [x] Rule - Non existing group in if_group
- [x] Rule - Invalid values on option attribute
- [x] Rule - Different_* attribute without frequency and timeframe
- [x] Rule - Non existing decoder








Best regards.
