### PR TITLE
Wazuh-logtest: Adapt new protocol to check-remove-session

### DIFF
--- a/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
+++ b/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
@@ -5,15 +5,15 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":6}}'
-    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
+    output: '{"message":"(7316): Failure to remove session. token JSON field must be a string","error":4,"data":{}}'
     stage: 'Remove invalid numeric token'
 -
   name: "Remove invalid json"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session": asd}'
-    output: '{"error":7306,"data":{},"message":"Error parsing JSON"}'
+    input: '{"version:1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":6}}'
+    output: '{"message":"(7307): Error parsing JSON in position 13, ... ersion:1,\"origin\":{\" ...","error":1,"data":{}}'
     stage: 'Remove invalid json'
 -
   name: "Remove invalid empty json object token"
@@ -21,15 +21,15 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":{}}}}'
-    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
+    output: '{"message":"(7316): Failure to remove session. token JSON field must be a string","error":4,"data":{}}'
     stage: 'Remove invalid empty json object token'
 -
   name: "Remove invalid array token"
   description: "Check remove session"
   test_case:
   -
-    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":["12345678","asd"]]}}'
-    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":["12345678","asd"]}}'
+    output: '{"message":"(7316): Failure to remove session. token JSON field must be a string","error":4,"data":{}}'
     stage: 'Remove invalid array token'
 -
   name: "Remove invalid token null"
@@ -37,7 +37,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":null}}'
-    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
+    output: '{"message":"(7316): Failure to remove session. token JSON field must be a string","error":4,"data":{}}'
     stage: 'Remove invalid token null'
 -
   name: "Remove invalid boolean token "
@@ -45,7 +45,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":true}}'
-    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
+    output: '{"message":"(7316): Failure to remove session. token JSON field must be a string","error":4,"data":{}}'
     stage: 'Remove invalid boolean token'
 -
   name: "Remove invalid token len"
@@ -53,7 +53,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":"asd"}}'
-    output: "{\"error\":7309,\"data\":{},\"message\":\"'asd' is not a valid token\"}"
+    output: "{\"message\":\"(7309): 'asd' is not a valid token\",\"error\":4,\"data\":{}}"
     stage: 'Remove invalid token len'
 -
   name: "Remove non-exist session"
@@ -68,6 +68,6 @@
   description: "Check remove session"
   test_case:
   -
-    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":"{}"}}'
-    output: "{\"error\":0,\"data\":{\"messages\":[\"INFO: (7206): The session '{}' was closed successfully\"],\"codemsg\":0}}"
+    input: '{{"version": 1,"origin": {{"name": "Integration Test","module": "api"}},"command": "remove_session", "parameters": {{"token": "{}"}}}}'
+    output: "{{\"error\":0,\"data\":{{\"messages\":[\"INFO: (7206): The session '{}' was closed successfully\"],\"codemsg\":0}}}}"
     stage: 'Remove session OK'

--- a/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
+++ b/tests/integration/test_logtest/test_remove_session/data/remove_session.yaml
@@ -4,8 +4,8 @@
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session": 6}'
-    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":6}}'
+    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
     stage: 'Remove invalid numeric token'
 -
   name: "Remove invalid json"
@@ -13,61 +13,61 @@
   test_case:
   -
     input: '{"remove_session": asd}'
-    output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 19, ... session\\\": asd} ...\"],\"codemsg\":-2}"
+    output: '{"error":7306,"data":{},"message":"Error parsing JSON"}'
     stage: 'Remove invalid json'
 -
   name: "Remove invalid empty json object token"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session": {}}'
-    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":{}}}}'
+    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
     stage: 'Remove invalid empty json object token'
 -
   name: "Remove invalid array token"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session":["asdasd",123123]}'
-    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":["12345678","asd"]]}}'
+    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
     stage: 'Remove invalid array token'
 -
   name: "Remove invalid token null"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session":null}'
-    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":null}}'
+    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
     stage: 'Remove invalid token null'
 -
   name: "Remove invalid boolean token "
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session":true}'
-    output: "{\"messages\":[\"ERROR: (7316): Failure to remove session. remove_session JSON field must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":true}}'
+    output: '{"error":7316,"data":{},"message":"Failure to remove session. remove_session JSON field must be a string"}'
     stage: 'Remove invalid boolean token'
 -
   name: "Remove invalid token len"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session": "asd"}'
-    output: "{\"messages\":[\"ERROR: (7309): 'asd' is not a valid token\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":"asd"}}'
+    output: "{\"error\":7309,\"data\":{},\"message\":\"'asd' is not a valid token\"}"
     stage: 'Remove invalid token len'
 -
   name: "Remove non-exist session"
   description: "Check remove session"
   test_case:
   -
-    input: '{"remove_session": "12345678"}'
-    output: "{\"messages\":[\"ERROR: (7004): No session found for token '12345678'\"],\"codemsg\":-1}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":"12345678"}}'
+    output: "{\"error\":0,\"data\":{\"messages\":[\"ERROR: (7004): No session found for token '12345678'\"],\"codemsg\":-1}}"
     stage: 'Remove non-exist session'
 -
   name: "Remove session OK"
   description: "Check remove session"
   test_case:
   -
-    input: '{{"remove_session": "{}"}}'
-    output: "{{\"messages\":[\"INFO: (7206): The session '{}' was closed successfully\"],\"codemsg\":0}}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"remove_session","parameters":{"token":"{}"}}'
+    output: "{\"error\":0,\"data\":{\"messages\":[\"INFO: (7206): The session '{}' was closed successfully\"],\"codemsg\":0}}"
     stage: 'Remove session OK'

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -34,10 +34,10 @@ receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in t
 
 
 def create_session():
-    receiver_sockets[0].send(
-        '{"event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process'
-        ' 17756.","log_format": "syslog","location": "master->/var/log/syslog"}',
-        size=True)
+    receiver_sockets[0].send('{"version":1,"origin":{"name":"Integration Test","module":"api"},\
+        "command":"log_processing","parameters":{"event":"Jun 24 11:54:19 Master systemd[2099]: \
+        Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog",\
+        "location":"master->/var/log/syslog"}}', size=True)
     token = json.loads(receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode())['data']['token']
 
     # Close socket

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -38,7 +38,7 @@ def create_session():
         '{"event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process'
         ' 17756.","log_format": "syslog","location": "master->/var/log/syslog"}',
         size=True)
-    token = json.loads(receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode())['token']
+    token = json.loads(receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode())['data']['token']
 
     # Close socket
     close_sockets(receiver_sockets)


### PR DESCRIPTION
Hi Team,

This PR adapts the integration tests of check-remove-section in wazuh logtest.


# Examples

## Protocol error example (invalid token field)

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "remove_session",
    "parameters": {
        "token": 6
    }
}
```

Expected output
```
{
    "error": 7316,
    "data": {},
    "message": "Failure to remove session. remove_session JSON field must be a string"
}
```

## Internal wazuh-log test error (Session not found)

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "remove_session",
    "parameters": {
        "token": "12345678"
    }
}
```

Expected
```
{
    "error": 0,
    "data": {
        "messages": [
            "ERROR: (7004): No session found for token '12345678'"
        ],
        "codemsg": -1
    }
}
```

## Successful 
 
Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "remove_session",
    "parameters": {
        "token": "15915911"
    }
}
```

Expected output
```
{
    "error": 0,
    "data": {
        "messages": [
            "INFO: (7206): The session '{}' was closed successfully"
        ],
        "codemsg": 0
    }
}
```