### PR TITLE
 Wazuh-logtest: Adapt new protocol Invalid input log_processing

### DIFF
--- a/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
+++ b/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
@@ -5,61 +5,61 @@
   test_case:
   -
     input: '{"token": kTy234Sdvtp7","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format": "syslog","location": "master->/var/log/syslog"}'
-    output: "{\"messages\":[\"ERROR: (7306): Error parsing JSON\",\"ERROR: (7307): Error in position 10, ... {\\\"token\\\": kTy234Sdvt ...\"],\"codemsg\":-2}"
+    output: '{"error":7306,"data":{},"message":"Error parsing JSON"}'
     stage: 'Json malformed (Missing ")'
 -
   name: "Missing event"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4","log_format": "syslog","location": "master->/var/log/syslog"}'
-    output: "{\"messages\":[\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","log_format":"syslog","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
     stage: 'Missing event'
 -
   name: "Missing log_format"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location": "master->/var/log/syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'log_format' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
     stage: 'Missing log_format'
 -
   name: "Missing location"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format": "syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
     stage: 'Missing location'
 -
   name: "Missing event/log_format"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4","location": "master->/var/log/syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
     stage: 'Missing event/log_format'
 -
   name: "Missing event/location"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4","log_format": "syslog"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","log_format":"syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
     stage: 'Missing event/location'
 -
   name: "Missing log_format/location"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756."}'
-    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'log_format' JSON field is required and must be a string\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756."}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
     stage: 'Missing log_format/location'
 -
   name: "Missing event/log_format/location"
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": "4885bbf4"}'
-    output: "{\"messages\":[\"ERROR: (7308): 'location' JSON field is required and must be a string\",\"ERROR: (7308): 'log_format' JSON field is required and must be a string\",\"ERROR: (7313): 'event' JSON field not found or is empty\"],\"codemsg\":-2}"
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
     stage: 'Missing event/log_format/location'

--- a/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
+++ b/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
@@ -16,6 +16,38 @@
     output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
     stage: 'Missing event'
 -
+  name: "Bad type num - event"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": 123456,"log_format":"syslog","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    stage: 'Bad type num - event'
+-
+  name: "Bad type array - event"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": ["test"],"log_format":"syslog","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    stage: 'Bad type array - event'
+-
+  name: "Bad type bool - event"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": true,"log_format":"syslog","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    stage: 'Bad type bool - event'
+-
+  name: "Null event"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": null,"log_format":"syslog","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    stage: 'Null event'
+-
   name: "Missing log_format"
   description: "Check invalid input for client request"
   test_case:
@@ -24,6 +56,38 @@
     output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
     stage: 'Missing log_format'
 -
+  name: "Bad type num - log_format"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : 123456,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    stage: 'Bad type num - log_format'
+-
+  name: "Bad type array - log_format"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : ["test"] ,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    stage: 'Bad type array - log_format'
+-
+  name: "Bad type bool - log_format"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : false,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    stage: 'Bad type bool - log_format'
+-
+  name: "Null log_format"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : null,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    stage: 'Null log_format'
+-
   name: "Missing location"
   description: "Check invalid input for client request"
   test_case:
@@ -31,6 +95,38 @@
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
     output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
     stage: 'Missing location'
+-
+  name: "Bad type num - location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : 123456,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    stage: 'Bad type num - location'
+-
+  name: "Bad type array - location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : ["test"] ,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    stage: 'Bad type array - location'
+-
+  name: "Bad type bool - location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : false,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    stage: 'Bad type bool - location'
+-
+  name: "Null location"
+  description: "Check invalid input for client request"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : null,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    stage: 'Null location'
 -
   name: "Missing event/log_format"
   description: "Check invalid input for client request"

--- a/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
+++ b/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
@@ -4,8 +4,8 @@
   description: "Check invalid input for client request"
   test_case:
   -
-    input: '{"token": kTy234Sdvtp7","event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format": "syslog","location": "master->/var/log/syslog"}'
-    output: '{"error":7306,"data":{},"message":"Error parsing JSON"}'
+    input: '{"version":1,origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","log_format":"syslog","location":"master->/var/log/syslog"}}'
+    output: '{"message":"(7307): Error parsing JSON in position 14, ... rsion\":1,origin\":{\"n ...","error":1,"data":{}}'
     stage: 'Json malformed (Missing ")'
 -
   name: "Missing event"
@@ -13,7 +13,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","log_format":"syslog","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    output: "{\"message\":\"(7313): 'event' JSON field not found\",\"error\":2,\"data\":{}}"
     stage: 'Missing event'
 -
   name: "Bad type num - event"
@@ -21,7 +21,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": 123456,"log_format":"syslog","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    output: "{\"message\":\"(7317): 'event' JSON field value is not valid\",\"error\":2,\"data\":{}}"
     stage: 'Bad type num - event'
 -
   name: "Bad type array - event"
@@ -29,7 +29,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": ["test"],"log_format":"syslog","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    output: "{\"message\":\"(7317): 'event' JSON field value is not valid\",\"error\":2,\"data\":{}}"
     stage: 'Bad type array - event'
 -
   name: "Bad type bool - event"
@@ -37,7 +37,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": true,"log_format":"syslog","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    output: "{\"message\":\"(7317): 'event' JSON field value is not valid\",\"error\":2,\"data\":{}}"
     stage: 'Bad type bool - event'
 -
   name: "Null event"
@@ -45,7 +45,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": null,"log_format":"syslog","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7313,\"data\":{},\"messages\":\"'event' JSON field not found or is empty\"}"
+    output: "{\"message\":\"(7317): 'event' JSON field value is not valid\",\"error\":2,\"data\":{}}"
     stage: 'Null event'
 -
   name: "Missing log_format"
@@ -53,7 +53,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'log_format' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Missing log_format'
 -
   name: "Bad type num - log_format"
@@ -61,7 +61,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : 123456,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'log_format' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Bad type num - log_format'
 -
   name: "Bad type array - log_format"
@@ -69,7 +69,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : ["test"] ,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'log_format' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Bad type array - log_format'
 -
   name: "Bad type bool - log_format"
@@ -77,7 +77,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : false,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'log_format' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Bad type bool - log_format'
 -
   name: "Null log_format"
@@ -85,7 +85,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"log_format" : null,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'log_format' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Null log_format'
 -
   name: "Missing location"
@@ -93,7 +93,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Missing location'
 -
   name: "Bad type num - location"
@@ -101,7 +101,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : 123456,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Bad type num - location'
 -
   name: "Bad type array - location"
@@ -109,7 +109,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : ["test"] ,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Bad type array - location'
 -
   name: "Bad type bool - location"
@@ -117,7 +117,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : false,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Bad type bool - location'
 -
   name: "Null location"
@@ -125,7 +125,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"location" : null,"event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Null location'
 -
   name: "Missing event/log_format"
@@ -133,7 +133,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","location":"master->/var/log/syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'log_format' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'log_format' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Missing event/log_format'
 -
   name: "Missing event/location"
@@ -141,7 +141,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","log_format":"syslog"}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Missing event/location'
 -
   name: "Missing log_format/location"
@@ -149,7 +149,7 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"token":"4885bbf4","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756."}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Missing log_format/location'
 -
   name: "Missing event/log_format/location"
@@ -157,13 +157,53 @@
   test_case:
   -
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{}}'
-    output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
+    output: "{\"message\":\"(7308): 'location' JSON field is required and must be a string\",\"error\":2,\"data\":{}}"
     stage: 'Missing event/log_format/location'
+-
+  name: "Command not found"
+  description: "check invalid command"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"bad_command","parameters":{"location" : "123456","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"message\":\"(7306): Unable to process command\",\"error\":3,\"data\":{}}"
+    stage: 'Command not found'
+-
+  name: "Invalid command type - num"
+  description: "Check invalid command type - num"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":112,"parameters":{"location" : "123456","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"message\":\"(7317): 'command' JSON field value is not valid\",\"error\":2,\"data\":{}}"
+    stage: 'Invalid command type - num'
+-
+  name: "Invalid command type - bool"
+  description: "Check invalid command type - bool"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":false,"parameters":{"location" : "123456","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"message\":\"(7317): 'command' JSON field value is not valid\",\"error\":2,\"data\":{}}"
+    stage: 'Invalid command type - bool'
+-
+  name: "Invalid command type - array"
+  description: "Check invalid command type - array"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":["112"],"parameters":{"location" : "123456","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"message\":\"(7317): 'command' JSON field value is not valid\",\"error\":2,\"data\":{}}"
+    stage: 'Invalid command type - array'
+-
+  name: "Invalid command type - Object"
+  description: "Check invalid command type - Object"
+  test_case:
+  -
+    input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":{"command":"log_processing"},"parameters":{"location" : "123456","event":"Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.","log_format":"syslog"}}'
+    output: "{\"message\":\"(7317): 'command' JSON field value is not valid\",\"error\":2,\"data\":{}}"
+    stage: 'Invalid command type - Object'
 -
   name: "Oversize message"
   description: "Check a message larger than the expected maximum"
   test_case:
   -
     input: '{{"token": kTy234Sdvtp7","event": "{}","log_format": "syslog","location": "master->/var/log/syslog"}}'
-    output: "{\"error\":7315,\"data\":{},\"messages\":\"Failure to receive message: size is bigger than expected\"}"
+    output: "{\"message\":\"(7315): Failure to receive message: size is bigger than expected\",\"error\":5}"
     stage: 'Oversize message'

--- a/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
+++ b/tests/integration/test_logtest/test_invalid_socket_input/data/invalid_socket_input.yaml
@@ -63,3 +63,11 @@
     input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{}}'
     output: "{\"error\":7308,\"data\":{},\"messages\":\"'location' JSON field is required and must be a string\"}"
     stage: 'Missing event/log_format/location'
+-
+  name: "Oversize message"
+  description: "Check a message larger than the expected maximum"
+  test_case:
+  -
+    input: '{{"token": kTy234Sdvtp7","event": "{}","log_format": "syslog","location": "master->/var/log/syslog"}}'
+    output: "{\"error\":7315,\"data\":{},\"messages\":\"Failure to receive message: size is bigger than expected\"}"
+    stage: 'Oversize message'

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 from string import ascii_uppercase
 import random
+from struct import pack
 
 from wazuh_testing.tools import WAZUH_PATH
 
@@ -44,8 +45,9 @@ def test_invalid_socket_input(connect_to_sockets_function, test_case: list):
     if stage["stage"] != 'Oversize message':
         receiver_sockets[0].send(stage['input'], size=True)
     else:
-        over_size_parameter = ''.join(random.choice(ascii_uppercase) for _ in range(2 ** 16))
-        receiver_sockets[0].send(stage['input'].format(over_size_parameter), size=True)
+        logtest_max_req_size = 2 ** 16
+        oversize_header = pack("<I", logtest_max_req_size)
+        receiver_sockets[0].send(stage['input'].format(oversize_header))
 
     result = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
     assert stage['output'] == result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -17,7 +17,7 @@ from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
-# Configurations    
+# Configurations
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(test_data_path, 'invalid_socket_input.yaml')
@@ -57,4 +57,4 @@ def test_invalid_socket_input(connect_to_sockets_function, test_case: list):
 
     result = receiver_sockets[0].receive(size=True).rstrip(b'\x00').decode()
     assert stage['output'] == result, 'Failed test case stage {}: {}'.format(test_case.index(stage) + 1,
-                                                                                    stage['stage'])
+                                                                             stage['stage'])

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -9,29 +9,21 @@ import yaml
 from string import ascii_uppercase
 import random
 
-from wazuh_testing import global_parameters
-from wazuh_testing.analysis import callback_fim_error
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools import WAZUH_PATH
 
 # Marks
-
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 # Configurations
-
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(test_data_path, 'invalid_socket_input.yaml')
 with open(messages_path) as f:
     test_cases = yaml.safe_load(f)
 
 # Variables
-
-log_monitor_paths = [LOG_FILE_PATH]
 logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
-
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
-
-receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
+receiver_sockets = None  # Set in the fixtures
 
 
 # Tests


### PR DESCRIPTION
Hi Team,

This PR adapts the integration tests of check-remove-section in wazuh logtest.


## Examples log_processing (Invalid inputs)

### Missing field event

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "token": "4885bbf4",
        "log_format": "syslog",
        "location": "master->/var/log/syslog"
    }
}
```

Expected output
```
{
    "error": 7313,
    "data": {},
    "messages": "'event' JSON field not found or is empty"
}
```

### Missing field log_format

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.",
        "location": "master->/var/log/syslog"
    }
}

```

Expected output
```
{
    "error": 7308,
    "data": {},
    "messages": "'log_format' JSON field is required and must be a string"
}
```

### Missing field location

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "token": "4885bbf4",
        "event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756.",
        "log_format": "syslog"
    }
}

```

Expected output
```
{
    "error": 7308,
    "data": {},
    "messages": "'location' JSON field is required and must be a string"
}
```

### Missing event/log_format

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "token": "4885bbf4",
        "location": "master->/var/log/syslog"
    }
}
```

Expected output (Only returns the first error)
```
{
    "error": 7308,
    "data": {},
    "messages": "'log_format' JSON field is required and must be a string"
}
```

### Missing event/location

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "token": "4885bbf4",
        "log_format": "syslog"
    }
}
```

Expected output
```
{
    "error": 7308,
    "data": {},
    "messages": "'location' JSON field is required and must be a string"
}
```

### Missing log_format/location

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "token": "4885bbf4",
        "event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756."
    }
}
```

Expected output
```
{
    "error": 7308,
    "data": {},
    "messages": "'location' JSON field is required and must be a string"
}
```

### Empty data

Input
```
{
    "version": 1,
    "origin": {
        "name": "Integration Test",
        "module": "api"
    },
    "command": "log_processing",
    "parameters": {
        "token": "4885bbf4",
        "event": "Jun 24 11:54:19 Master systemd[2099]: Started VTE child process 20118 launched by terminator process 17756."
    }
}
```

Expected output
```
{
    "error": 7308,
    "data": {},
    "messages": "'location' JSON field is required and must be a string"
}
```