### PR TITLE
Updated NVD URLs feed

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -46,8 +46,8 @@ format_feed_data = [
 # NVD
 for year in range(2002, current_year):
     format_feed_data.append({'feed': 'nvd', 'os': year, 'expected_format': 'application/gzip',
-                             'path': f'/tmp/nvdcve-1.0-{year}.json.gz', 'extension': 'gz',
-                             'url': f'https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-{year}.json.gz',
+                             'path': f'/tmp/nvdcve-1.1-{year}.json.gz', 'extension': 'gz',
+                             'url': f'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{year}.json.gz',
                              'decompressed_file': f'/tmp/nvd-{year}.json'})
 
 format_feed_data_ids = [f"{item['feed']}_{item['os']}" for item in format_feed_data]


### PR DESCRIPTION
Hello team,

I have modified `test_validate_feed_content.py` to validate new NVD feeds. I had to change the URL of NVD feed.

Related issue: wazuh/wazuh#6053

# Tests logic

- [x] `test_validate_feed_content.py` 

# Tests checks

- [x] test_validate_feed_content.py tests PASSED:

```
========================================== test session starts ==========================================
platform linux -- Python 3.8.2, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.0.2', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'testinfra': '5.0.0', 'metadata': '1.10.0'}}
rootdir: /home/daniel/Escritorio/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.10.0
collected 27 items                                                                                      

test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[redhat_generic] PASSED [  3%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[canonical_focal] PASSED [  7%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[canonical_bionic] PASSED [ 11%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[canonical_xenial] PASSED [ 14%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[canonical_trusty] PASSED [ 18%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[debian_buster] PASSED [ 22%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[debian_stretch] PASSED [ 25%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[debian_jessie] PASSED [ 29%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[debian_wheezy] PASSED [ 33%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2002] PASSED [ 37%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2003] PASSED [ 40%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2004] PASSED [ 44%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2005] PASSED [ 48%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2006] PASSED [ 51%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2007] PASSED [ 55%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2008] PASSED [ 59%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2009] PASSED [ 62%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2010] PASSED [ 66%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2011] PASSED [ 70%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2012] PASSED [ 74%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2013] PASSED [ 77%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2014] PASSED [ 81%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2015] PASSED [ 85%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2016] PASSED [ 88%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2017] PASSED [ 92%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2018] PASSED [ 96%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_feed_content[nvd_2019] PASSED [100%]
```

- [x] Tier 0 Ubuntu 20: Local
`======================== 53 passed, 1215 skipped in 957.98s (0:15:57) =========================`

- [x] Tier 1 Ubuntu 20: Local:
`============================= 89 passed, 1179 skipped in 2261.18s (0:37:41) =============================`



Best regards.
