### PR TITLE
Migration agent-info data to wazuhdb epic integration tests

### DIFF
--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -183,30 +183,12 @@ def check_agent_timestamp(id, name, ip, expected):
     else:
         return False
 
-def check_agent_info(name, ip, expected):
-    agent_info_file = name+'-'+ip
-    agent_info_path = os.path.join(WAZUH_PATH, 'queue', 'agent-info', agent_info_file)
-    if expected == os.path.exists(agent_info_path):
-        return True
-    else:
-        return False
-
 def check_rids(id, expected):
     agent_info_path = os.path.join(WAZUH_PATH, 'queue', 'rids', id)
     if expected == os.path.exists(agent_info_path):
         return True
     else:
         return False
-
-def create_agent_info(name, ip):
-    agent_info_file = name+'-'+ip
-    agent_info_path = os.path.join(WAZUH_PATH, 'queue', 'agent-info', agent_info_file)
-    try:
-        file = open(agent_info_path, 'w')
-        file.close()
-        os.chmod(agent_info_path, 0o777)
-    except IOError:
-        raise
 
 def create_rids(id):
     rids_path = os.path.join(WAZUH_PATH, 'queue', 'rids', id)
@@ -295,16 +277,14 @@ def duplicate_ip_agent_delete_test(server):
     #Register first agent
     response = register_agent('userA', 'TestGroup','192.0.0.0') 
     create_rids('001') #Simulate rids was created
-    create_agent_info('userA','192.0.0.0') #Simulate agent_info was created
     create_diff('userA') #Simulate diff folder was created
     assert response[:len(SUCCESS_RESPONSE)] == SUCCESS_RESPONSE, 'Wrong response received' 
     assert check_client_keys('001', True), 'Agent key was never created' 
     assert check_agent_groups('001', True), 'Agent group was never created'
     assert check_agent_timestamp('001', 'userA', '192.0.0.0', True), 'Agent_timestamp was never created'
     assert check_rids('001', True), 'Rids file was never created'
-    assert check_agent_info('userA', '192.0.0.0', True), 'Agent_info was never created'
     assert check_diff('userA', True), 'Agent diff folder was never created'
-   
+
     #Register agent with duplicate IP
     response = register_agent('userC', 'TestGroup', '192.0.0.0')
     assert response[:len(SUCCESS_RESPONSE)] == SUCCESS_RESPONSE, 'Wrong response received'
@@ -315,7 +295,6 @@ def duplicate_ip_agent_delete_test(server):
     assert check_agent_timestamp('002', 'userC', '192.0.0.0', True), 'Agent_timestamp was never created'
     assert check_agent_timestamp('001', 'userA', '192.0.0.0', False), 'Agent_timestamp was not removed'
     assert check_rids('001', False), 'Rids file was was not removed'
-    assert check_agent_info('userA', '192.0.0.0', False), 'Agent_info was not removed'
     assert check_diff('userA', False), 'Agent diff folder was not removed'
           
 
@@ -340,14 +319,12 @@ def duplicate_name_agent_delete_test(server):
     #Register first agents
     response = register_agent('userB', 'TestGroup')   
     create_rids('003') #Simulate rids was created 
-    create_agent_info('userB','any') #Simulate agent_info was created
     create_diff('userB') #Simulate diff folder was created
     assert response[:len(SUCCESS_RESPONSE)] == SUCCESS_RESPONSE, 'Wrong response received' 
     assert check_client_keys('003', True), 'Agent key was never created'
     assert check_agent_groups('003', True), 'Agent group was never created'
     assert check_agent_timestamp('003', 'userB', 'any', True), 'Agent_timestamp was never created'
     assert check_rids('003', True), 'Rids file was never created'
-    assert check_agent_info('userB', 'any', True), 'Agent_info was never created'
     assert check_diff('userB', True), 'Agent diff folder was never created'  
     
     #Register agent with duplicate Name
@@ -360,7 +337,6 @@ def duplicate_name_agent_delete_test(server):
     assert check_agent_timestamp('004', 'userB', 'any', True), 'Agent_timestamp was never created'
     assert check_agent_timestamp('003', 'userB', 'any', False), 'Agent_timestamp was not removed'
     assert check_rids('003', False), 'Rids file was was not removed'
-    assert check_agent_info('userB', 'any', False), 'Agent_info was not removed'
     assert check_diff('userB', False), 'Agent diff folder was not removed'
 
 

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -4,21 +4,49 @@
   description: "Check success use cases for each global command"
   test_case:
   -
+    input: 'global delete-group TestGroup1'
+    output: "ok"
+    stage: "global delete-group previous insert"
+  -
+    input: 'global find-group TestGroup1'
+    output: "ok []"
+    stage: "global find-group previous insert"    
+  -
+    input: 'global insert-agent-group TestGroup1'
+    output: 'ok'
+    stage: "global insert-agent-group success"
+  -
+    input: 'global find-group default'
+    output: 'ok [{"id":1}]'
+    stage: "global find-group after insert"
+  -
+    input: 'global find-group TestGroup1'
+    output: 'ok [{"id":2}]'
+    stage: "global find-group after insert" 
+  -
+    input: 'global select-groups'
+    output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
+    stage: "global select-groups success"
+  -  
     input: 'global delete-agent 1'
     output: "ok"
-    stage: "global delete-agent previous insert success"
+    stage: "global delete-agent previous insert"
   -
     input: 'global get-agent-info 1'
     output: 'ok []'
-    stage: "global get-agent-info previous insert success"
+    stage: "global get-agent-info previous insert"
   -
     input: 'global insert-agent {"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","group":"TestGroup1","date_add":1599223378}'
     output: "ok"
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":0}]'
-    stage: "global get-agent-info after insert success"
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":1}]'
+    stage: "global get-agent-info after insert"
+  -
+    input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
+    output: 'ok [{"id":1}]'
+    stage: "global find-agent success"
   -
     input: 'global update-agent-name {"id":1,"name":"TestName2"}'
     output: "ok"
@@ -51,7 +79,6 @@
     input: 'global get-agent-info 1'
     output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup","sync_status":1}]'
     stage: "global get-agent-info success after updates"
-    ignore: "yes"
   -
     input: 'global set-labels 1 TestKey:TestLabel'
     output: 'ok'
@@ -61,6 +88,85 @@
     output: 'ok [{"id":1,"key":"#\"_agent_ip\"","value":"0.0.0.1"},{"id":1,"key":"#\"_manager_hostname\"","value":"TestManagerHost"},{"id":1,"key":"#\"_node_name\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]'
     stage: "global get-agent-info success after updates"
   -
+    input: 'global select-agent-name 1'
+    output: 'ok [{"name":"TestName2"}]'
+    stage: "global select-agent-name success"
+  -
+    input: 'global select-agent-group  1'
+    output: 'ok [{"group":"TestGroup2"}]'
+    stage: "global select-agent-group success"
+  -
+    input: 'global select-agent-status 1'
+    output: 'ok [{"status":"updated"}]'
+    stage: "global select-agent-status success"
+  -
+    input: 'global select-fim-offset 1'
+    output: 'ok [{"fim_offset":100}]'
+    stage: "global select-fim-offset success"
+  -
+    input: 'global select-reg-offset 1'
+    output: 'ok [{"reg_offset":100}]'
+    stage: "global select-reg-offset success"
+  -
+    input: 'global select-keepalive TestName1 0.0.0.1'
+    output: 'ok [{"last_keepalive":*}]'
+    stage: "global select-keepalive success"
+    use_regex: "yes" 
+  -
+    input: 'global select-groups'
+    output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
+    stage: "global select-groups success"
+
+  -
+    input: 'global get-all-agents start_id -1'
+    output: 'ok 0,1'
+    stage: "global get-all-agents success"
+  -
+    input: 'global get-agents-by-keepalive condition > 100 start_id 0'
+    output: 'ok 1'
+    stage: "global get-agents-by-keepalive success"
+  -
+    input: 'global get-agents-by-keepalive condition < 100 start_id 0'
+    output: 'ok '
+    stage: "global get-agents-by-keepalive success"
+
+  -
+    input: 'global sync-agent-info-get start_id 0'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    stage: "global sync-agent-info-get"
+    use_regex: 'yes'
+  -
+    input: 'global sync-agent-info-get'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    stage: "global sync-agent-info-get"
+    use_regex: 'yes'
+  -
+    input: 'global sync-agent-info-set'
+    output: 'ok'
+    stage: "global sync-agent-info-set"
+    
+
+  -
+    input: 'global insert-agent-belong {"id_group":1,"id_agent":1}'
+    output: 'ok'
+    stage: "global insert-agent-belong success"
+  -
+    input: 'global delete-agent-belong 1'
+    output: 'ok'
+    stage: "global delete-agent-belong success"
+  -
+    input: 'global insert-agent-belong {"id_group":1,"id_agent":1}'
+    output: 'ok'
+    stage: "global insert-agent-belong success"
+  -
+    input: 'global delete-group-belong TestGroup1'
+    output: 'ok'
+    stage: "global delete-group-belong"
+  -
+    input: 'global delete-group TestGroup1'
+    output: "ok"
+    stage: "global delete-group after insert"   
+  -
     input: 'global delete-agent 1'
     output: "ok"
-    stage: "global delete-agent post insert success"
+    stage: "global delete-agent after insert"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -74,9 +74,9 @@
     output: "ok"
     stage: "global update-agent-name success"
   -
-    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq"}'
+    input: 'global update-agent-data {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq","labels":"TestKey1:TestLabel1"}'
     output: "ok"
-    stage: "global update-agent-version success"
+    stage: "global update-agent-data success"
   -
     input: 'global update-agent-status {"id":1,"status":"updated"}'
     output: "ok"
@@ -107,12 +107,16 @@
   description: "Check success use cases for labels table commands on global DB"
   test_case:
   -
-    input: 'global set-labels 1 TestKey:TestLabel'
+    input: 'global get-labels 1'
+    output: 'ok [{"id":1,"key":"TestKey1","value":"TestLabel1"}]'
+    stage: "global get-labels success"
+  -
+    input: 'global set-labels 1 TestKey2:TestLabel2'
     output: 'ok'
     stage: "global set-labels success"
   -
     input: 'global get-labels 1'
-    output: 'ok [{"id":1,"key":"#\"_agent_ip\"","value":"0.0.0.1"},{"id":1,"key":"#\"_manager_hostname\"","value":"TestManagerHost"},{"id":1,"key":"#\"_node_name\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]'
+    output: 'ok [{"id":1,"key":"TestKey2","value":"TestLabel2"}]'
     stage: "global get-labels success"
 -
   name: "Select commands"
@@ -173,7 +177,7 @@
   test_case:
   -
     input: 'global sync-agent-info-get last_id 0'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"TestKey2","value":"TestLabel2"}]}]'
     stage: "global sync-agent-info-get success"
     use_regex: 'yes'
   -
@@ -186,7 +190,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global sync-agent-info-get'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"TestKey2","value":"TestLabel2"}]}]'
     stage: "global sync-agent-info-get no arg success"
     use_regex: 'yes'
 -

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -257,3 +257,30 @@
     input: 'global delete-agent 3'
     output: "ok"
     stage: "global delete-agent after insert"
+-
+  name: "Manager keepalive"
+  description: "Check success use cases for manager keepalive."
+  test_case:
+  -
+    input: 'global get-agent-info 0'
+    output: 'ok [{"id":0,"name":"*","ip":"*","register_ip":"*","os_name":"*","os_version":"*","os_major":"*","os_minor":"*","os_codename":"*","os_platform":"*","os_uname":"*","os_arch":"*","version":"*","manager_host":"*","node_name":"*","date_add":*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    stage: "global manager get-agent-info success pre update"
+    use_regex: "yes"
+  -
+    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"127.0.0.1","sync_status":"synced"}'
+    output: "ok"
+    stage: "global manager update-agent-data success"
+  -
+    input: 'global get-agent-info 0'
+    output: 'ok [{"id":0,"name":"*","ip":"*","register_ip":"*","os_name":"*","os_version":"*","os_major":"*","os_minor":"*","os_codename":"*","os_platform":"*","os_uname":"*","os_arch":"*","version":"*","manager_host":"*","node_name":"*","date_add":*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    stage: "global manager get-agent-info success post update with IP"
+    use_regex: "yes" 
+  -
+    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced"}'
+    output: "ok"
+    stage: "global manager update-agent-data success"
+  -
+    input: 'global get-agent-info 0'
+    output: 'ok [{"id":0,"name":"*","ip":"*","register_ip":"*","os_name":"*","os_version":"*","os_major":"*","os_minor":"*","os_codename":"*","os_platform":"*","os_uname":"*","os_arch":"*","version":"*","manager_host":"*","node_name":"*","date_add":*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    stage: "global manager get-agent-info success post update without IP"
+    use_regex: "yes"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -4,27 +4,35 @@
   description: "Check success use cases for each global command"
   test_case:
   -
-    input: 'global insert-agent {"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","group":"TestGroup","date_add":1599223378}'
+    input: 'global delete-agent 1'
+    output: "ok"
+    stage: "global delete-agent previous insert success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok []'
+    stage: "global get-agent-info previous insert success"
+  -
+    input: 'global insert-agent {"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","group":"TestGroup1","date_add":1599223378}'
     output: "ok"
     stage: "global insert-agent success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":0}]'
+    stage: "global get-agent-info after insert success"
   -
     input: 'global update-agent-name {"id":1,"name":"TestName2"}'
     output: "ok"
     stage: "global update-agent-name success"
   -
-    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManageHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":1}'
+    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":1}'
     output: "ok"
     stage: "global update-agent-version success"
-  -
-    input: 'global update-keepalive {"id":1,"sync_status":1}'
-    output: "ok"
-    stage: "global update-keepalive success"
   -
     input: 'global update-agent-status {"id":1,"status":"updated"}'
     output: "ok"
     stage: "global update-agent-status success"
   -
-    input: 'global update-agent-group {"id":1,"group":"TestGroup"}'
+    input: 'global update-agent-group {"id":1,"group":"TestGroup2"}'
     output: "ok"
     stage: "global update-agent-group success"
   -
@@ -36,26 +44,23 @@
     output: "ok"
     stage: "global update-reg-offset success"
   -
-    input: 'global set-labels 1 TestLabel'
+    input: 'global update-keepalive {"id":1,"sync_status":1}'
     output: "ok"
-    stage: "global set-labels success"
-  -
-    input: 'global get-all-agents start_id 0'
-    output: "ok 1"
-    stage: "global get-all-agents success"
-  -
-    input: 'global get-agents-by-keepalive condition > 0 start_id 0'
-    output: "ok 1"
-    stage: "global get-agents-by-keepalive success"
-  -
-    input: 'global get-agents-by-keepalive condition < 0 start_id 0'
-    output: "ok "
-    stage: "global get-agents-by-keepalive success"
-  -
-    input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
-    output: 'ok [{"id":1}]'
-    stage: "global find-agent success"
+    stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManageHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":1599251694,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup","sync_status":1}]'
-    stage: "global get-agent-info success"
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup","sync_status":1}]'
+    stage: "global get-agent-info success after updates"
+    ignore: "yes"
+  -
+    input: 'global set-labels 1 TestKey:TestLabel'
+    output: 'ok'
+    stage: "global get-agent-info success after updates"
+  -
+    input: 'global get-labels 1'
+    output: 'ok [{"id":1,"key":"#\"_agent_ip\"","value":"0.0.0.1"},{"id":1,"key":"#\"_manager_hostname\"","value":"TestManagerHost"},{"id":1,"key":"#\"_node_name\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]'
+    stage: "global get-agent-info success after updates"
+  -
+    input: 'global delete-agent 1'
+    output: "ok"
+    stage: "global delete-agent post insert success"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -1,7 +1,7 @@
 ---
 -
-  name: "Basics success"
-  description: "Check success use cases for each global command"
+  name: "Basics Insert"
+  description: "Check success use cases for insert commands on global DB"
   test_case:
   -
     input: 'global delete-group TestGroup1'
@@ -41,12 +41,32 @@
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":1}]'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":0}]'
     stage: "global get-agent-info after insert"
   -
     input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
     output: 'ok [{"id":1}]'
-    stage: "global find-agent success"
+    stage: "global find-agent success"   
+  -  
+    input: 'global delete-agent 2'
+    output: "ok"
+    stage: "global delete-agent previous insert"
+  -
+    input: 'global insert-agent {"id":2,"name":"TestName2","date_add":1599223378}'
+    output: "ok"
+    stage: "global insert-agent minimal fields success"
+  -
+    input: 'global get-agent-info 2'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
+    stage: "global get-agent-info after minimal fields insert"
+  -  
+    input: 'global delete-agent 2'
+    output: "ok"
+    stage: "global delete-agent after insert"
+-
+  name: "Basics Update"
+  description: "Check success use cases for update commands on global DB"
+  test_case:
   -
     input: 'global update-agent-name {"id":1,"name":"TestName2"}'
     output: "ok"
@@ -77,16 +97,25 @@
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup","sync_status":1}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":1}]'
     stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+-
+  name: "Basics labels"
+  description: "Check success use cases for labels table commands on global DB"
+  test_case:
   -
     input: 'global set-labels 1 TestKey:TestLabel'
     output: 'ok'
-    stage: "global get-agent-info success after updates"
+    stage: "global set-labels success"
   -
     input: 'global get-labels 1'
     output: 'ok [{"id":1,"key":"#\"_agent_ip\"","value":"0.0.0.1"},{"id":1,"key":"#\"_manager_hostname\"","value":"TestManagerHost"},{"id":1,"key":"#\"_node_name\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]'
-    stage: "global get-agent-info success after updates"
+    stage: "global get-labels success"
+-
+  name: "Basics Select"
+  description: "Check success use cases for select commands on global DB"
+  test_case:
   -
     input: 'global select-agent-name 1'
     output: 'ok [{"name":"TestName2"}]'
@@ -108,7 +137,7 @@
     output: 'ok [{"reg_offset":100}]'
     stage: "global select-reg-offset success"
   -
-    input: 'global select-keepalive TestName1 0.0.0.1'
+    input: 'global select-keepalive TestName2 0.0.0.1'
     output: 'ok [{"last_keepalive":*}]'
     stage: "global select-keepalive success"
     use_regex: "yes" 
@@ -116,11 +145,18 @@
     input: 'global select-groups'
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
     stage: "global select-groups success"
-
+-
+  name: "Basics get-all-agents"
+  description: "Check success use cases for get-all-agents command on global DB. Chunks command"
+  test_case:
   -
     input: 'global get-all-agents start_id -1'
     output: 'ok 0,1'
     stage: "global get-all-agents success"
+-
+  name: "Basics get-agents-by-keepalive"
+  description: "Check success use cases for get-agents-by-keepalive command on global DB. Chunks command"
+  test_case:
   -
     input: 'global get-agents-by-keepalive condition > 100 start_id 0'
     output: 'ok 1'
@@ -129,23 +165,60 @@
     input: 'global get-agents-by-keepalive condition < 100 start_id 0'
     output: 'ok '
     stage: "global get-agents-by-keepalive success"
-
+-
+  name: "Basics sync-agent-info-get"
+  description: "Check success use cases for sync-agent-info-get command on global DB. Chunks command"
+  test_case:
   -
     input: 'global sync-agent-info-get start_id 0'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
-    stage: "global sync-agent-info-get"
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    stage: "global sync-agent-info-get success"
     use_regex: 'yes'
+  -
+    input: 'global sync-agent-info-get start_id 0'
+    output: 'ok []'
+    stage: "global sync-agent-info-get after first get success"
+  -
+    input: 'global update-keepalive {"id":1,"sync_status":1}'
+    output: "ok"
+    stage: "global update-keepalive success"
   -
     input: 'global sync-agent-info-get'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
-    stage: "global sync-agent-info-get"
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    stage: "global sync-agent-info-get no arg success"
     use_regex: 'yes'
+-
+  name: "Basics sync-agent-info-set"
+  description: "Check success use cases for sync-agent-info-get command on global DB."
+  test_case:
   -
-    input: 'global sync-agent-info-set'
+    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
     output: 'ok'
-    stage: "global sync-agent-info-set"
-    
-
+    stage: "global sync-agent-info-set non-existent agent"
+  -
+    input: 'global get-agent-info 3'
+    output: 'ok []'
+    stage: "global get-agent-info success after non-existent sync-agent-info-set"
+  -  
+    input: 'global delete-agent 3'
+    output: "ok"
+    stage: "global delete-agent previous insert"
+  -
+    input: 'global insert-agent {"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","date_add":1599223378}'
+    output: "ok"
+    stage: "global insert-agent success"
+  -
+    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
+    output: 'ok'
+    stage: "global sync-agent-info-set success"
+  -
+    input: 'global get-agent-info 3'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
+    stage: "global get-agent-info success after sync-agent-info-set success"
+-
+  name: "Basics Belongs"
+  description: "Check success use cases for belongs table commands on global DB"
+  test_case:  
   -
     input: 'global insert-agent-belong {"id_group":1,"id_agent":1}'
     output: 'ok'
@@ -158,6 +231,10 @@
     input: 'global insert-agent-belong {"id_group":1,"id_agent":1}'
     output: 'ok'
     stage: "global insert-agent-belong success"
+-
+  name: "Basics Delete"
+  description: "Check success use cases for delete commands on global DB."
+  test_case:
   -
     input: 'global delete-group-belong TestGroup1'
     output: 'ok'
@@ -168,5 +245,9 @@
     stage: "global delete-group after insert"   
   -
     input: 'global delete-agent 1'
+    output: "ok"
+    stage: "global delete-agent after insert"
+  -
+    input: 'global delete-agent 3'
     output: "ok"
     stage: "global delete-agent after insert"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -43,7 +43,7 @@
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":0}]'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced"}]'
     stage: "global get-agent-info after insert"
   -
     input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
@@ -59,7 +59,7 @@
     stage: "global insert-agent minimal fields success"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
     stage: "global get-agent-info after minimal fields insert"
   -  
     input: 'global delete-agent 2'
@@ -74,7 +74,7 @@
     output: "ok"
     stage: "global update-agent-name success"
   -
-    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":1}'
+    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-agent-version success"
   -
@@ -94,12 +94,12 @@
     output: "ok"
     stage: "global update-reg-offset success"
   -
-    input: 'global update-keepalive {"id":1,"sync_status":1}'
+    input: 'global update-keepalive {"id":1,"sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":1}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -181,7 +181,7 @@
     output: 'ok []'
     stage: "global sync-agent-info-get after first get success"
   -
-    input: 'global update-keepalive {"id":1,"sync_status":1}'
+    input: 'global update-keepalive {"id":1,"sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-keepalive success"
   -
@@ -215,7 +215,7 @@
     stage: "global sync-agent-info-set success"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
   name: "Belongs commands"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -1,6 +1,6 @@
 ---
 -
-  name: "Basics Insert"
+  name: "Insert commands"
   description: "Check success use cases for insert commands on global DB"
   test_case:
   -
@@ -66,7 +66,7 @@
     output: "ok"
     stage: "global delete-agent after insert"
 -
-  name: "Basics Update"
+  name: "Update commands"
   description: "Check success use cases for update commands on global DB"
   test_case:
   -
@@ -103,7 +103,7 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
-  name: "Basics labels"
+  name: "Labels commands"
   description: "Check success use cases for labels table commands on global DB"
   test_case:
   -
@@ -115,7 +115,7 @@
     output: 'ok [{"id":1,"key":"#\"_agent_ip\"","value":"0.0.0.1"},{"id":1,"key":"#\"_manager_hostname\"","value":"TestManagerHost"},{"id":1,"key":"#\"_node_name\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]'
     stage: "global get-labels success"
 -
-  name: "Basics Select"
+  name: "Select commands"
   description: "Check success use cases for select commands on global DB"
   test_case:
   -
@@ -148,7 +148,7 @@
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
     stage: "global select-groups success"
 -
-  name: "Basics get-all-agents"
+  name: "get-all-agents command"
   description: "Check success use cases for get-all-agents command on global DB. Chunks command"
   test_case:
   -
@@ -156,7 +156,7 @@
     output: 'ok 0,1'
     stage: "global get-all-agents success"
 -
-  name: "Basics get-agents-by-keepalive"
+  name: "get-agents-by-keepalive command"
   description: "Check success use cases for get-agents-by-keepalive command on global DB. Chunks command"
   test_case:
   -
@@ -168,7 +168,7 @@
     output: 'ok '
     stage: "global get-agents-by-keepalive success"
 -
-  name: "Basics sync-agent-info-get"
+  name: "sync-agent-info-get command"
   description: "Check success use cases for sync-agent-info-get command on global DB. Chunks command"
   test_case:
   -
@@ -190,7 +190,7 @@
     stage: "global sync-agent-info-get no arg success"
     use_regex: 'yes'
 -
-  name: "Basics sync-agent-info-set"
+  name: "sync-agent-info-set command"
   description: "Check success use cases for sync-agent-info-get command on global DB."
   test_case:
   -
@@ -218,7 +218,7 @@
     output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
-  name: "Basics Belongs"
+  name: "Belongs commands"
   description: "Check success use cases for belongs table commands on global DB"
   test_case:  
   -
@@ -234,7 +234,7 @@
     output: 'ok'
     stage: "global insert-agent-belong success"
 -
-  name: "Basics Delete"
+  name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."
   test_case:
   -

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -17,12 +17,14 @@
     stage: "global insert-agent-group success"
   -
     input: 'global find-group default'
-    output: 'ok [{"id":1}]'
+    output: 'ok [{"id":*}]'
     stage: "global find-group after insert"
+    use_regex: "yes"
   -
     input: 'global find-group TestGroup1'
-    output: 'ok [{"id":2}]'
+    output: 'ok [{"id":*}]'
     stage: "global find-group after insert" 
+    use_regex: "yes"
   -
     input: 'global select-groups'
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
@@ -72,7 +74,7 @@
     output: "ok"
     stage: "global update-agent-name success"
   -
-    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":1}'
+    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":1}'
     output: "ok"
     stage: "global update-agent-version success"
   -
@@ -97,7 +99,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":1}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":1}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -150,7 +152,7 @@
   description: "Check success use cases for get-all-agents command on global DB. Chunks command"
   test_case:
   -
-    input: 'global get-all-agents start_id -1'
+    input: 'global get-all-agents last_id -1'
     output: 'ok 0,1'
     stage: "global get-all-agents success"
 -
@@ -158,11 +160,11 @@
   description: "Check success use cases for get-agents-by-keepalive command on global DB. Chunks command"
   test_case:
   -
-    input: 'global get-agents-by-keepalive condition > 100 start_id 0'
+    input: 'global get-agents-by-keepalive condition > 100 last_id 0'
     output: 'ok 1'
     stage: "global get-agents-by-keepalive success"
   -
-    input: 'global get-agents-by-keepalive condition < 100 start_id 0'
+    input: 'global get-agents-by-keepalive condition < 100 last_id 0'
     output: 'ok '
     stage: "global get-agents-by-keepalive success"
 -
@@ -170,12 +172,12 @@
   description: "Check success use cases for sync-agent-info-get command on global DB. Chunks command"
   test_case:
   -
-    input: 'global sync-agent-info-get start_id 0'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    input: 'global sync-agent-info-get last_id 0'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
     stage: "global sync-agent-info-get success"
     use_regex: 'yes'
   -
-    input: 'global sync-agent-info-get start_id 0'
+    input: 'global sync-agent-info-get last_id 0'
     output: 'ok []'
     stage: "global sync-agent-info-get after first get success"
   -
@@ -184,7 +186,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global sync-agent-info-get'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"0.0.0.1"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"TestManagerHost"},{"id":1,"key":"#\\"_node_name\\"","value":"TestNodeName"},{"id":1,"key":"TestKey","value":"TestLabel"}]}]'
     stage: "global sync-agent-info-get no arg success"
     use_regex: 'yes'
 -
@@ -192,7 +194,7 @@
   description: "Check success use cases for sync-agent-info-get command on global DB."
   test_case:
   -
-    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
+    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
     output: 'ok'
     stage: "global sync-agent-info-set non-existent agent"
   -
@@ -208,12 +210,12 @@
     output: "ok"
     stage: "global insert-agent success"
   -
-    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
+    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
     output: 'ok'
     stage: "global sync-agent-info-set success"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestOsVersion","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":0}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
   name: "Basics Belongs"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -263,7 +263,7 @@
   test_case:
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,"name":"*","ip":"*","register_ip":"*","os_name":"*","os_version":"*","os_major":"*","os_minor":"*","os_codename":"*","os_platform":"*","os_uname":"*","os_arch":"*","version":"*","manager_host":"*","node_name":"*","date_add":*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
@@ -272,7 +272,7 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,"name":"*","ip":"*","register_ip":"*","os_name":"*","os_version":"*","os_major":"*","os_minor":"*","os_codename":"*","os_platform":"*","os_uname":"*","os_arch":"*","version":"*","manager_host":"*","node_name":"*","date_add":*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
     stage: "global manager get-agent-info success post update with IP"
     use_regex: "yes" 
   -
@@ -281,6 +281,6 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,"name":"*","ip":"*","register_ip":"*","os_name":"*","os_version":"*","os_major":"*","os_minor":"*","os_codename":"*","os_platform":"*","os_uname":"*","os_arch":"*","version":"*","manager_host":"*","node_name":"*","date_add":*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
     stage: "global manager get-agent-info success post update without IP"
     use_regex: "yes"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -1,0 +1,61 @@
+---
+-
+  name: "Basics success"
+  description: "Check success use cases for each global command"
+  test_case:
+  -
+    input: 'global insert-agent {"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","group":"TestGroup","date_add":1599223378}'
+    output: "ok"
+    stage: "global insert-agent success"
+  -
+    input: 'global update-agent-name {"id":1,"name":"TestName2"}'
+    output: "ok"
+    stage: "global update-agent-name success"
+  -
+    input: 'global update-agent-version {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManageHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":1}'
+    output: "ok"
+    stage: "global update-agent-version success"
+  -
+    input: 'global update-keepalive {"id":1,"sync_status":1}'
+    output: "ok"
+    stage: "global update-keepalive success"
+  -
+    input: 'global update-agent-status {"id":1,"status":"updated"}'
+    output: "ok"
+    stage: "global update-agent-status success"
+  -
+    input: 'global update-agent-group {"id":1,"group":"TestGroup"}'
+    output: "ok"
+    stage: "global update-agent-group success"
+  -
+    input: 'global update-fim-offset {"id":1,"offset":100}'
+    output: "ok"
+    stage: "global update-fim-offset success"
+  -
+    input: 'global update-reg-offset {"id":1,"offset":100}'
+    output: "ok"
+    stage: "global update-reg-offset success"
+  -
+    input: 'global set-labels 1 TestLabel'
+    output: "ok"
+    stage: "global set-labels success"
+  -
+    input: 'global get-all-agents start_id 0'
+    output: "ok 1"
+    stage: "global get-all-agents success"
+  -
+    input: 'global get-agents-by-keepalive condition > 0 start_id 0'
+    output: "ok 1"
+    stage: "global get-agents-by-keepalive success"
+  -
+    input: 'global get-agents-by-keepalive condition < 0 start_id 0'
+    output: "ok "
+    stage: "global get-agents-by-keepalive success"
+  -
+    input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
+    output: 'ok [{"id":1}]'
+    stage: "global find-agent success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestOsVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManageHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":1599251694,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup","sync_status":1}]'
+    stage: "global get-agent-info success"

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -7,6 +7,10 @@ import os
 import pytest
 import yaml
 import re
+import json
+import socket
+import struct
+import sqlite3
 
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.monitoring import ManInTheMiddle
@@ -42,6 +46,7 @@ receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
 monitored_sockets_params = [('wazuh-db', None, True)]
 
 receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
+   
 
 def regex_match(regex, string):
     regex = regex.replace("*", ".*")
@@ -54,6 +59,54 @@ def regex_match(regex, string):
     string = string.replace("(", "")
     string = string.replace(")", "")
     return bool(re.match(regex, string))
+
+
+def insert_agents(id_offset, amount): 
+    for id in range(id_offset,id_offset+amount):
+        command = f'global insert-agent {{"id":{id},"name":"TestName{id}","date_add":1599223378}}'
+        receiver_sockets[0].send(command, size=True)
+        response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
+                                          callback=callback_wazuhdb_response).result()
+        data = response.split(" ", 1)
+        if data[0]!='ok':
+            raise AssertionError('Unable to add agent {id}')
+
+"""
+def insert_agents(id_offset, amount):
+    ADDR = '/var/ossec/queue/db/wdb'
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(ADDR)
+
+    for id in range(id_offset,id_offset+amount):
+        command = f'global insert-agent {{"id":{id},"name":"TestName{id}","date_add":1599223378}}'
+        command = struct.pack('<I', len(command)) + command.encode()
+        sock.send(command)
+        data = sock.recv(4)
+        data_size = struct.unpack('<I', data[0:4])[0]
+        data = sock.recv(data_size).decode(encoding='utf-8', errors='ignore').split(" ", 1)
+        if data[0]!='ok':
+            raise AssertionError('Unable to add agent {id}')
+"""
+"""
+def insert_agents(id_offset, amount):
+    try:
+        sqliteConnection = sqlite3.connect('/var/ossec/queue/db/global.db')
+        cursor = sqliteConnection.cursor()       
+
+        for id_ in range(id_offset,id_offset+amount):
+            query = f"INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_major, os_minor, os_codename, os_platform, date_add, last_keepalive, sync_status) VALUES ({id_},'wazuh-agent{id_}','any','b7efaafcde1bb0f3d3cbbf5b32e6335878305f4e6a19bec2d065f5e53e134e65','Ubuntu','18.04.4 LTS','18','04','Bionic Beaver','ubuntu', 0,0,1)"
+            count = cursor.execute(query)
+
+        sqliteConnection.commit()        
+        cursor.close()
+
+    except sqlite3.Error as error:
+        print("Failed to insert data into sqlite table", error)
+    finally:
+        if (sqliteConnection):
+            sqliteConnection.close()
+            print("The SQLite connection is closed")
+"""
 
 # Tests
 
@@ -70,7 +123,7 @@ def test_wazuh_db_messages(configure_sockets_environment, connect_to_sockets_mod
     ----------
     test_case : list
         List of test_case stages (dicts with input, output and stage keys).
-    """
+    """    
     for stage in test_case:
         if 'ignore' in stage and stage['ignore'] == "yes":
             continue
@@ -98,3 +151,45 @@ def test_wazuh_db_create_agent(configure_sockets_environment, connect_to_sockets
                            "stage": "Syscheck - Agent does not exits yet"}]}
     test_wazuh_db_messages(configure_sockets_environment, connect_to_sockets_module, test['test_case'])
     assert os.path.exists(os.path.join(WAZUH_PATH, 'queue', 'db', "999.db"))
+
+"""
+def test_wazuh_db_chunks(configure_mitm_environment, connect_to_sockets_module):
+    
+    AGENTS_CANT = 14000
+    AGENTS_OFFSET = 20
+    AGENTS_MAX = AGENTS_OFFSET+AGENTS_CANT
+    
+    #Pre insert agents
+    insert_agents(AGENTS_OFFSET, AGENTS_CANT)
+   
+    #Check get-all-agents chunk limit
+    command = f'global get-all-agents start_id 0'
+    receiver_sockets[0].send(command, size=True)
+    response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
+                                          callback=callback_wazuhdb_response).result()
+    
+    status = response.split(" ",1)[0]
+    assert status == 'due', 'Failed chunks check onget-all-agents. Expected: {}. Response: {}'\
+           .format('due', status)
+    
+    #Check get-agents-by-keepalive chunk limit
+    command = f'global get-agents-by-keepalive condition > -1 start_id 0'
+    receiver_sockets[0].send(command, size=True)
+    response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
+                                          callback=callback_wazuhdb_response).result()
+    
+    status = response.split(" ",1)[0]
+    assert status == 'due', 'Failed chunks check on get-agents-by-keepalive. Expected: {}. Response: {}'\
+           .format('due', status)
+
+    
+    #Check sync-agent-info-get chunk limit
+    command = f'global sync-agent-info-get start_id 0'
+    receiver_sockets[0].send(command, size=True)
+    response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
+                                          callback=callback_wazuhdb_response).result()
+    
+    status = response.split(" ",1)[0]
+    assert status == 'due', 'Failed chunks check on sync-agent-info-get. Expected: {}. Response: {}'\
+           .format('due', status)
+"""

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -121,18 +121,17 @@ def test_wazuh_db_create_agent(configure_sockets_environment, connect_to_sockets
 def test_wazuh_db_chunks(configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
     """Check that commands by chunks work properly when agents amount exceed the response maximum size""" 
 
-    def test_chunk_command(command):
+    def send_chunk_command(command):
         receiver_sockets[0].send(command, size=True)
         response = receiver_sockets[0].receive(size=True).decode()
     
-        status = response.split(" ",1)[0]
+        status = response.split(" ", 1)[0]
         assert status == 'due', 'Failed chunks check on < {} >. Expected: {}. Response: {}'\
                .format(command, 'due', status)
    
-    #Check get-all-agents chunk limit
-    test_chunk_command(f'global get-all-agents last_id 0')
-    #Check get-agents-by-keepalive chunk limit
-    test_chunk_command(f'global get-agents-by-keepalive condition > -1 last_id 0')
-    #Check sync-agent-info-get chunk limit
-    test_chunk_command(f'global sync-agent-info-get last_id 0')
-    
+    # Check get-all-agents chunk limit
+    send_chunk_command(f'global get-all-agents last_id 0')
+    # Check get-agents-by-keepalive chunk limit
+    send_chunk_command(f'global get-agents-by-keepalive condition > -1 last_id 0')
+    # Check sync-agent-info-get chunk limit
+    send_chunk_command(f'global sync-agent-info-get last_id 0')

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -65,12 +65,12 @@ def insert_agents(id_offset, amount):
         if data[0] != 'ok':
             raise AssertionError('Unable to add agent {id}')
 
-        command = f'global update-keepalive {{"id":{id},"sync_status":1}}'
+        command = f'global update-keepalive {{"id":{id},"sync_status":"syncreq"}}'
         receiver_sockets[0].send(command, size=True)
         response = receiver_sockets[0].receive(size=True).decode()
         data = response.split(" ", 1)
         if data[0] != 'ok':
-            raise AssertionError('Unable to add agent {id}')
+            raise AssertionError('Unable to update agent {id}')
 
 
 # Tests
@@ -132,7 +132,7 @@ def test_wazuh_db_chunks(configure_sockets_environment, connect_to_sockets_modul
     response = receiver_sockets[0].receive(size=True).decode()
     
     status = response.split(" ",1)[0]
-    assert status == 'due', 'Failed chunks check onget-all-agents. Expected: {}. Response: {}'\
+    assert status == 'due', 'Failed chunks check on get-all-agents. Expected: {}. Response: {}'\
            .format('due', status)
     
     #Check get-agents-by-keepalive chunk limit

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -163,7 +163,7 @@ def test_wazuh_db_chunks(configure_mitm_environment, connect_to_sockets_module):
     insert_agents(AGENTS_OFFSET, AGENTS_CANT)
    
     #Check get-all-agents chunk limit
-    command = f'global get-all-agents start_id 0'
+    command = f'global get-all-agents last_id 0'
     receiver_sockets[0].send(command, size=True)
     response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
                                           callback=callback_wazuhdb_response).result()
@@ -173,7 +173,7 @@ def test_wazuh_db_chunks(configure_mitm_environment, connect_to_sockets_module):
            .format('due', status)
     
     #Check get-agents-by-keepalive chunk limit
-    command = f'global get-agents-by-keepalive condition > -1 start_id 0'
+    command = f'global get-agents-by-keepalive condition > -1 last_id 0'
     receiver_sockets[0].send(command, size=True)
     response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
                                           callback=callback_wazuhdb_response).result()
@@ -184,7 +184,7 @@ def test_wazuh_db_chunks(configure_mitm_environment, connect_to_sockets_module):
 
     
     #Check sync-agent-info-get chunk limit
-    command = f'global sync-agent-info-get start_id 0'
+    command = f'global sync-agent-info-get last_id 0'
     receiver_sockets[0].send(command, size=True)
     response = monitored_sockets[0].start(timeout=global_parameters.default_timeout,
                                           callback=callback_wazuhdb_response).result()


### PR DESCRIPTION
Hello team,

As part of **Migration agent-info data to wazuhdb** epic, new integration tests were implemented.
This PR add tests cases for every command received by Wazuhdb aimed to global.db
It also modifies old test cases related to agent info folder.

Closes #852

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Tested and passed in Jenkins. Build URL:
                 Ubuntu: https://ci.wazuh.info/job/test_integration/390/
                 Centos: https://ci.wazuh.info/job/test_integration/389/


Best regards.
