### PR TITLE
Fix FIM integration tests failing in 4.0 in Ubuntu and Windows

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -826,13 +826,6 @@ def callback_num_inotify_watches(line):
         return match.group(1)
 
 
-def callback_realtime_engine_started(line):
-    match = re.match(r'.*Real-time file integrity monitoring started.*', line)
-
-    if match:
-        return True
-
-
 def callback_file_size_limit_reached(line):
     match = re.match(r'.*File \'(.*)\' is too big for configured maximum size to perform diff operation\.', line)
 
@@ -1313,8 +1306,8 @@ def detect_realtime_start(file_monitor):
     file_monitor : FileMonitor
         File log monitor to detect events
     """
-    file_monitor.start(timeout=60, callback=callback_realtime_engine_started,
-                       error_message='Did not receive expected "Real-time file integrity monitoring started" event')
+    file_monitor.start(timeout=60, callback=callback_num_inotify_watches,
+                       error_message='Did not receive expected "Folders monitored with real-time engine..." event')
 
 
 def detect_whodata_start(file_monitor):

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -854,6 +854,13 @@ def callback_diff_size_limit_value(line):
         return match.group(1)
 
 
+def callback_deleted_diff_folder(line):
+    match = re.match(r'.*Folder \'(.*)\' has been deleted.*', line)
+
+    if match:
+        return match.group(1)
+
+
 def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None):
     """
     Change date and time of the system depending on a boolean condition. Optionally, a monitor may be used to check

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -826,6 +826,13 @@ def callback_num_inotify_watches(line):
         return match.group(1)
 
 
+def callback_realtime_engine_started(line):
+    match = re.match(r'.*Real-time file integrity monitoring started.*', line)
+
+    if match:
+        return True
+
+
 def callback_file_size_limit_reached(line):
     match = re.match(r'.*File \'(.*)\' is too big for configured maximum size to perform diff operation\.', line)
 
@@ -1295,6 +1302,34 @@ def detect_initial_scan(file_monitor):
     """
     file_monitor.start(timeout=60, callback=callback_detect_end_scan,
                        error_message='Did not receive expected "File integrity monitoring scan ended" event')
+
+
+def detect_realtime_start(file_monitor):
+    """
+    Detect realtime engine start when restarting Wazuh.
+
+    Parameters
+    ----------
+    file_monitor : FileMonitor
+        File log monitor to detect events
+    """
+    file_monitor.start(timeout=60, callback=callback_realtime_engine_started,
+                       error_message='Did not receive expected "Real-time file integrity monitoring started" event')
+
+
+def detect_whodata_start(file_monitor):
+    """
+    Detect whodata engine start when restarting Wazuh.
+
+    Parameters
+    ----------
+    file_monitor : FileMonitor
+        File log monitor to detect events
+    """
+    file_monitor.start(timeout=60, callback=callback_real_time_whodata_started,
+                       error_message='Did not receive expected'
+                                     '"File integrity monitoring real-time Whodata engine started" event')
+
 
 
 def generate_params(extra_params: dict = None, apply_to_all: Union[Sequence[Any], Generator[dict, None, None]] = None,

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -366,7 +366,7 @@ python3 -m pytest [options] [file_or_dir] [file_or_dir] [...]
 - `--default-timeout`: overwrites the default timeout (in seconds). This value is used to make a test fail if a condition
 is not met before the given time lapse. Some tests make use of this value and other has other fixed timeout that cannot be
 modified.
-- `--fim_mode`: Specify the mode of execution of the FIM tests. (ex. --fim_mode="scheduled"). To run the test in realtime and whodata the option must be specified twice: --fim_mode="realtime" -- fim_mode="whodata". If the option is not specified, the test will run using scheduled, whodata and realtime.
+- `--fim_mode`: Specify the mode of execution of the FIM tests. (ex. --fim_mode="scheduled"). To run the test in realtime and whodata the option must be specified twice: --fim_mode="realtime" --fim_mode="whodata". If the option is not specified, the test will run using scheduled, whodata and realtime.
 
 _Use `-h` to see the rest or check its [documentation](https://docs.pytest.org/en/latest/usage.html)._
 

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan
+from wazuh_testing.fim import LOG_FILE_PATH, detect_initial_scan, detect_realtime_start, detect_whodata_start
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
@@ -12,7 +12,9 @@ from wazuh_testing.tools.services import control_service
 
 @pytest.fixture(scope='module')
 def restart_syscheckd(get_configuration, request):
-    # Reset ossec.log and start a new monitor
+    """
+    Reset ossec.log and start a new monitor.
+    """
     control_service('stop', daemon='ossec-syscheckd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
@@ -21,7 +23,14 @@ def restart_syscheckd(get_configuration, request):
 
 
 @pytest.fixture(scope='module')
-def wait_for_initial_scan(get_configuration, request):
-    # Wait for initial FIM scan to end
+def wait_for_syscheck_start(get_configuration, request):
+    """
+    Wait for initial FIM scan to end. If realtime or whodata are enabled, it will wait for their start too.
+    """
     file_monitor = getattr(request.module, 'wazuh_log_monitor')
     detect_initial_scan(file_monitor)
+
+    if get_configuration['metadata']['fim_mode'] == 'realtime':
+        detect_realtime_start(file_monitor)
+    elif get_configuration['metadata']['fim_mode'] == 'whodata':
+        detect_whodata_start(file_monitor)

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -25,12 +25,17 @@ def restart_syscheckd(get_configuration, request):
 @pytest.fixture(scope='module')
 def wait_for_syscheck_start(get_configuration, request):
     """
-    Wait for initial FIM scan to end. If realtime or whodata are enabled, it will wait for their start too.
+    Wait for realtime start, whodata start or end of initial FIM scan.
     """
     file_monitor = getattr(request.module, 'wazuh_log_monitor')
-    detect_initial_scan(file_monitor)
+    mode_key = 'fim_mode' if 'fim_mode2' not in get_configuration['metadata'] else 'fim_mode2'
 
-    if get_configuration['metadata']['fim_mode'] == 'realtime':
-        detect_realtime_start(file_monitor)
-    elif get_configuration['metadata']['fim_mode'] == 'whodata':
-        detect_whodata_start(file_monitor)
+    try:
+        if get_configuration['metadata'][mode_key] == 'realtime':
+            detect_realtime_start(file_monitor)
+        elif get_configuration['metadata'][mode_key] == 'whodata':
+            detect_whodata_start(file_monitor)
+        else:   # scheduled
+            detect_initial_scan(file_monitor)
+    except KeyError:
+        detect_initial_scan(file_monitor)

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -23,7 +23,7 @@ def restart_syscheckd(get_configuration, request):
 
 
 @pytest.fixture(scope='module')
-def wait_for_syscheck_start(get_configuration, request):
+def wait_for_fim_start(get_configuration, request):
     """
     Wait for realtime start, whodata start or end of initial FIM scan.
     """

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
@@ -202,7 +202,7 @@ def get_checkers(check_list):
 ])
 def test_ambiguous_complex(tags_to_apply,
                            get_configuration, configure_environment,
-                           restart_syscheckd, wait_for_syscheck_start):
+                           restart_syscheckd, wait_for_fim_start):
     """Automatic test for each configuration given in the yaml.
 
     The main purpose of this test is to check that syscheck will apply different configurations between subdirectories

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_complex.py
@@ -202,7 +202,7 @@ def get_checkers(check_list):
 ])
 def test_ambiguous_complex(tags_to_apply,
                            get_configuration, configure_environment,
-                           restart_syscheckd, wait_for_initial_scan):
+                           restart_syscheckd, wait_for_syscheck_start):
     """Automatic test for each configuration given in the yaml.
 
     The main purpose of this test is to check that syscheck will apply different configurations between subdirectories

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
@@ -123,7 +123,7 @@ def _test_recursion_cud(ini, fin, path, recursion_subdir, scheduled,
     ([testdir, subdir], {'ambiguous_restrict'})
 ])
 def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                            wait_for_syscheck_start):
+                            wait_for_fim_start):
     """Check restrict configuration events.
 
     Check if syscheck detects regular file changes (add, modify, delete) depending on its restrict configuration.
@@ -159,7 +159,7 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
     ([testdir, subdir], {'ambiguous_report_changes'})
 ])
 def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_syscheck_start):
+                          wait_for_fim_start):
     """Check content_changes field for each event
 
     Check if syscheck detects or not the content_changes field for each event depending on its report_changes
@@ -220,7 +220,7 @@ def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_e
     ([testdir, subdir], {'ambiguous_tags'})
 ])
 def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                        wait_for_syscheck_start):
+                        wait_for_fim_start):
     """Check if syscheck detects the event property 'tags' for each event.
 
     This test validates both situations, making sure that if tags='no', there won't be a
@@ -252,7 +252,7 @@ def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_env
     (testdir_recursion, 4, {'ambiguous_recursion'})
 ])
 def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_configuration, configure_environment,
-                             restart_syscheckd, wait_for_syscheck_start):
+                             restart_syscheckd, wait_for_fim_start):
     """Check alerts for each level defined in recursion_level
 
     Check if syscheck detects alerts for each level defined in the recursion_level attribute.
@@ -295,7 +295,7 @@ def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_config
     ([testdir_recursion_tag, testdir_recursion_no_tag], 2, False, {'ambiguous_no_recursion_tag'})
 ])
 def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags_to_apply, get_configuration,
-                                 configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                 configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check alerts for each level defined in recursion_level with tags
 
     Check if syscheck detects alerts for each level defined in the recursion_level attribute and
@@ -335,7 +335,7 @@ def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags
 ])
 @pytest.mark.parametrize('dirname, checkers', parametrize_list)
 def test_ambiguous_check(dirname, checkers, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                         wait_for_syscheck_start):
+                         wait_for_fim_start):
     """Check if syscheck detects every check set in the configuration.
 
     Check are read from left to right, overwriting any ambiguous configuration.

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ambiguous_simple.py
@@ -123,7 +123,7 @@ def _test_recursion_cud(ini, fin, path, recursion_subdir, scheduled,
     ([testdir, subdir], {'ambiguous_restrict'})
 ])
 def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                            wait_for_initial_scan):
+                            wait_for_syscheck_start):
     """Check restrict configuration events.
 
     Check if syscheck detects regular file changes (add, modify, delete) depending on its restrict configuration.
@@ -159,7 +159,7 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
     ([testdir, subdir], {'ambiguous_report_changes'})
 ])
 def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_initial_scan):
+                          wait_for_syscheck_start):
     """Check content_changes field for each event
 
     Check if syscheck detects or not the content_changes field for each event depending on its report_changes
@@ -220,7 +220,7 @@ def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_e
     ([testdir, subdir], {'ambiguous_tags'})
 ])
 def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                        wait_for_initial_scan):
+                        wait_for_syscheck_start):
     """Check if syscheck detects the event property 'tags' for each event.
 
     This test validates both situations, making sure that if tags='no', there won't be a
@@ -252,7 +252,7 @@ def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_env
     (testdir_recursion, 4, {'ambiguous_recursion'})
 ])
 def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_configuration, configure_environment,
-                             restart_syscheckd, wait_for_initial_scan):
+                             restart_syscheckd, wait_for_syscheck_start):
     """Check alerts for each level defined in recursion_level
 
     Check if syscheck detects alerts for each level defined in the recursion_level attribute.
@@ -295,7 +295,7 @@ def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_config
     ([testdir_recursion_tag, testdir_recursion_no_tag], 2, False, {'ambiguous_no_recursion_tag'})
 ])
 def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags_to_apply, get_configuration,
-                                 configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                 configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check alerts for each level defined in recursion_level with tags
 
     Check if syscheck detects alerts for each level defined in the recursion_level attribute and
@@ -335,7 +335,7 @@ def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags
 ])
 @pytest.mark.parametrize('dirname, checkers', parametrize_list)
 def test_ambiguous_check(dirname, checkers, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                         wait_for_initial_scan):
+                         wait_for_syscheck_start):
     """Check if syscheck detects every check set in the configuration.
 
     Check are read from left to right, overwriting any ambiguous configuration.

--- a/tests/integration/test_fim/test_ambiguous_confs/test_duplicate_entries.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_duplicate_entries.py
@@ -210,7 +210,8 @@ def test_duplicate_entries_report(get_configuration, configure_environment, rest
         'Error: Diff file created'
 
 
-def test_duplicate_entries_complex(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_duplicate_entries_complex(get_configuration, configure_environment, restart_syscheckd,
+                                   wait_for_syscheck_start):
     """Check if syscheckd ignores duplicate entries, complex entries.
        For instance:
            - The second entry should prevail over the first one.

--- a/tests/integration/test_fim/test_ambiguous_confs/test_duplicate_entries.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_duplicate_entries.py
@@ -102,7 +102,7 @@ def check_event(previous_mode: str, previous_event: dict, file: str):
 # tests
 
 
-def test_duplicate_entries(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_duplicate_entries(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd ignores duplicate entries.
        For instance:
            - The second entry should prevail over the first one.
@@ -138,7 +138,7 @@ def test_duplicate_entries(get_configuration, configure_environment, restart_sys
 
 
 def test_duplicate_entries_sregex(get_configuration, configure_environment,
-                                  restart_syscheckd, wait_for_initial_scan):
+                                  restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd ignores duplicate entries, sregex patterns of restrict.
        For instance:
            - The second entry should prevail over the first one.
@@ -175,7 +175,7 @@ def test_duplicate_entries_sregex(get_configuration, configure_environment,
         raise AttributeError(f'Unexpected event {event}')
 
 
-def test_duplicate_entries_report(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_duplicate_entries_report(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd ignores duplicate entries, report changes.
        For instance:
            - The second entry should prevail over the first one.
@@ -210,7 +210,7 @@ def test_duplicate_entries_report(get_configuration, configure_environment, rest
         'Error: Diff file created'
 
 
-def test_duplicate_entries_complex(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_duplicate_entries_complex(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd ignores duplicate entries, complex entries.
        For instance:
            - The second entry should prevail over the first one.

--- a/tests/integration/test_fim/test_ambiguous_confs/test_duplicate_entries.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_duplicate_entries.py
@@ -102,7 +102,7 @@ def check_event(previous_mode: str, previous_event: dict, file: str):
 # tests
 
 
-def test_duplicate_entries(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_duplicate_entries(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd ignores duplicate entries.
        For instance:
            - The second entry should prevail over the first one.
@@ -138,7 +138,7 @@ def test_duplicate_entries(get_configuration, configure_environment, restart_sys
 
 
 def test_duplicate_entries_sregex(get_configuration, configure_environment,
-                                  restart_syscheckd, wait_for_syscheck_start):
+                                  restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd ignores duplicate entries, sregex patterns of restrict.
        For instance:
            - The second entry should prevail over the first one.
@@ -175,7 +175,7 @@ def test_duplicate_entries_sregex(get_configuration, configure_environment,
         raise AttributeError(f'Unexpected event {event}')
 
 
-def test_duplicate_entries_report(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_duplicate_entries_report(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd ignores duplicate entries, report changes.
        For instance:
            - The second entry should prevail over the first one.
@@ -211,7 +211,7 @@ def test_duplicate_entries_report(get_configuration, configure_environment, rest
 
 
 def test_duplicate_entries_complex(get_configuration, configure_environment, restart_syscheckd,
-                                   wait_for_syscheck_start):
+                                   wait_for_fim_start):
     """Check if syscheckd ignores duplicate entries, complex entries.
        For instance:
            - The second entry should prevail over the first one.

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -54,7 +54,7 @@ def get_configuration(request):
     (testdir2, 'not_ignored_sregex', True, {'valid_regex'})
 ])
 def test_ignore_works_over_restrict(folder, filename, triggers_event, tags_to_apply, get_configuration,
-                                    configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                    configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if the ignore tag prevails over the restrict one when using both in the same directory.
 
     This test is intended to be used with valid configurations files. Each execution of this test will configure

--- a/tests/integration/test_fim/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -54,7 +54,7 @@ def get_configuration(request):
     (testdir2, 'not_ignored_sregex', True, {'valid_regex'})
 ])
 def test_ignore_works_over_restrict(folder, filename, triggers_event, tags_to_apply, get_configuration,
-                                    configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                    configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if the ignore tag prevails over the restrict one when using both in the same directory.
 
     This test is intended to be used with valid configurations files. Each execution of this test will configure

--- a/tests/integration/test_fim/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     dir2,
 ])
 def test_whodata_prevails_over_realtime(directory, get_configuration, put_env_variables, configure_environment,
-                                        restart_syscheckd, wait_for_syscheck_start):
+                                        restart_syscheckd, wait_for_fim_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
+++ b/tests/integration/test_fim/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     dir2,
 ])
 def test_whodata_prevails_over_realtime(directory, get_configuration, put_env_variables, configure_environment,
-                                        restart_syscheckd, wait_for_initial_scan):
+                                        restart_syscheckd, wait_for_syscheck_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_audit/test_audit_after_initial_scan.py
+++ b/tests/integration/test_fim/test_audit/test_audit_after_initial_scan.py
@@ -52,7 +52,7 @@ def get_configuration(request):
 ])
 def test_remove_and_read_folder(tags_to_apply, folder, get_configuration,
                                 configure_environment, restart_syscheckd,
-                                wait_for_initial_scan):
+                                wait_for_syscheck_start):
     """Remove folder which is monitored with auditd and then create it again.
 
     Parameters
@@ -79,7 +79,7 @@ def test_remove_and_read_folder(tags_to_apply, folder, get_configuration,
     {'config1'}
 ])
 def test_reconnect_to_audit(tags_to_apply, get_configuration, configure_environment,
-                            restart_syscheckd, wait_for_initial_scan):
+                            restart_syscheckd, wait_for_syscheck_start):
     """Restart auditd and check Wazuh reconnect to auditd
 
     Parameters

--- a/tests/integration/test_fim/test_audit/test_audit_after_initial_scan.py
+++ b/tests/integration/test_fim/test_audit/test_audit_after_initial_scan.py
@@ -52,7 +52,7 @@ def get_configuration(request):
 ])
 def test_remove_and_read_folder(tags_to_apply, folder, get_configuration,
                                 configure_environment, restart_syscheckd,
-                                wait_for_syscheck_start):
+                                wait_for_fim_start):
     """Remove folder which is monitored with auditd and then create it again.
 
     Parameters
@@ -79,7 +79,7 @@ def test_remove_and_read_folder(tags_to_apply, folder, get_configuration,
     {'config1'}
 ])
 def test_reconnect_to_audit(tags_to_apply, get_configuration, configure_environment,
-                            restart_syscheckd, wait_for_syscheck_start):
+                            restart_syscheckd, wait_for_fim_start):
     """Restart auditd and check Wazuh reconnect to auditd
 
     Parameters

--- a/tests/integration/test_fim/test_audit/test_remove_rule_five_times.py
+++ b/tests/integration/test_fim/test_audit/test_remove_rule_five_times.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     ({'config1'}, '/testdir2', 'wazuh_fim')
 ])
 def test_remove_rule_five_times(tags_to_apply, folder, audit_key,
-                                get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Remove auditd rule using auditctl five times and check Wazuh ignores folder.
 
     Parameters

--- a/tests/integration/test_fim/test_audit/test_remove_rule_five_times.py
+++ b/tests/integration/test_fim/test_audit/test_remove_rule_five_times.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     ({'config1'}, '/testdir2', 'wazuh_fim')
 ])
 def test_remove_rule_five_times(tags_to_apply, folder, audit_key,
-                                get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Remove auditd rule using auditctl five times and check Wazuh ignores folder.
 
     Parameters

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
@@ -78,6 +79,7 @@ def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,
         Syscheck checkers (check_all).
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
+    mult = 1 if sys.platform == 'win32' else 2
 
     if encoding is not None:
         name = name.encode(encoding)
@@ -85,5 +87,5 @@ def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=[name],
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                     min_timeout=global_parameters.default_timeout, options=checkers, encoding=encoding,
+                     min_timeout=global_parameters.default_timeout * mult, options=checkers, encoding=encoding,
                      triggers_event=True)

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
@@ -67,7 +67,7 @@ def get_configuration(request):
 ])
 def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,
                               get_configuration, configure_environment,
-                              restart_syscheckd, wait_for_syscheck_start):
+                              restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheckd detects regular file changes (add, modify, delete)
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_changes.py
@@ -67,7 +67,7 @@ def get_configuration(request):
 ])
 def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,
                               get_configuration, configure_environment,
-                              restart_syscheckd, wait_for_initial_scan):
+                              restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheckd detects regular file changes (add, modify, delete)
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_after_delete_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_after_delete_dir.py
@@ -50,7 +50,7 @@ def get_configuration(request):
     {'ossec_conf'}
 ])
 def test_create_after_delete(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                             wait_for_syscheck_start):
+                             wait_for_fim_start):
     """
     Check that a monitored directory keeps reporting events after deleting and creating it again. It tests
     that under Windows systems the directory watcher is refreshed after directory re-creation 1 second after.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_after_delete_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_after_delete_dir.py
@@ -50,7 +50,7 @@ def get_configuration(request):
     {'ossec_conf'}
 ])
 def test_create_after_delete(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                             wait_for_initial_scan):
+                             wait_for_syscheck_start):
     """
     Check that a monitored directory keeps reporting events after deleting and creating it again. It tests
     that under Windows systems the directory watcher is refreshed after directory re-creation 1 second after.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
@@ -79,7 +79,7 @@ def get_configuration(request):
 ])
 def test_create_file_realtime_whodata(folder, name, filetype, content, checkers, tags_to_apply, encoding,
                                       get_configuration,
-                                      configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                      configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check if a special or regular file creation is detected by syscheck using realtime and whodata monitoring
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_rt_wd.py
@@ -79,7 +79,7 @@ def get_configuration(request):
 ])
 def test_create_file_realtime_whodata(folder, name, filetype, content, checkers, tags_to_apply, encoding,
                                       get_configuration,
-                                      configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                      configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check if a special or regular file creation is detected by syscheck using realtime and whodata monitoring
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
@@ -79,7 +79,7 @@ def get_configuration(request):
                         pytest.mark.xfail(reason='Xfail due to issue: https://github.com/wazuh/wazuh/issues/4612')))
 ])
 def test_create_file_scheduled(folder, name, filetype, content, checkers, tags_to_apply, encoding, get_configuration,
-                               configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                               configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check if a special or regular file creation is detected by syscheck using scheduled monitoring
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_create_scheduled.py
@@ -79,7 +79,7 @@ def get_configuration(request):
                         pytest.mark.xfail(reason='Xfail due to issue: https://github.com/wazuh/wazuh/issues/4612')))
 ])
 def test_create_file_scheduled(folder, name, filetype, content, checkers, tags_to_apply, encoding, get_configuration,
-                               configure_environment, restart_syscheckd, wait_for_initial_scan):
+                               configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check if a special or regular file creation is detected by syscheck using scheduled monitoring
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
@@ -53,7 +53,7 @@ def get_configuration(request):
 ])
 def test_delete_folder(folder, file_list, filetype, tags_to_apply,
                        get_configuration, configure_environment,
-                       restart_syscheckd, wait_for_initial_scan):
+                       restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheckd detects 'deleted' events from the files contained
     in a folder that is being deleted.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_delete_folder.py
@@ -53,7 +53,7 @@ def get_configuration(request):
 ])
 def test_delete_folder(folder, file_list, filetype, tags_to_apply,
                        get_configuration, configure_environment,
-                       restart_syscheckd, wait_for_syscheck_start):
+                       restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheckd detects 'deleted' events from the files contained
     in a folder that is being deleted.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_dir_with_commas.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_dir_with_commas.py
@@ -48,7 +48,7 @@ def get_configuration(request):
     dir2,
 ])
 def test_directories_with_commas(directory, get_configuration, put_env_variables, configure_environment,
-                                 restart_syscheckd, wait_for_syscheck_start):
+                                 restart_syscheckd, wait_for_fim_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_dir_with_commas.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_dir_with_commas.py
@@ -48,7 +48,7 @@ def get_configuration(request):
     dir2,
 ])
 def test_directories_with_commas(directory, get_configuration, put_env_variables, configure_environment,
-                                 restart_syscheckd, wait_for_initial_scan):
+                                 restart_syscheckd, wait_for_syscheck_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -51,7 +51,7 @@ def extra_configuration_before_yield():
     create_file(HARDLINK, testdir1, 'hardlink', target=os.path.join(testdir1, 'test_2'))
 
 
-def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check if FIM entries match the path count
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_entries_match_path_count.py
@@ -51,7 +51,7 @@ def extra_configuration_before_yield():
     create_file(HARDLINK, testdir1, 'hardlink', target=os.path.join(testdir1, 'test_2'))
 
 
-def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_entries_match_path_count(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check if FIM entries match the path count
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -70,7 +70,7 @@ def extra_configuration_after_yield():
     (testdir3, testdir2, f'subdir3{os.path.sep}', {'ossec_conf'}, True, True)
 ])
 def test_move_dir(source_folder, target_folder, subdir, tags_to_apply, triggers_delete_event, triggers_add_event,
-                  get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+                  get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheckd detects 'added' or 'deleted' events when moving a
     subfolder from a folder to another one.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -70,7 +70,7 @@ def extra_configuration_after_yield():
     (testdir3, testdir2, f'subdir3{os.path.sep}', {'ossec_conf'}, True, True)
 ])
 def test_move_dir(source_folder, target_folder, subdir, tags_to_apply, triggers_delete_event, triggers_add_event,
-                  get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                  get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheckd detects 'added' or 'deleted' events when moving a
     subfolder from a folder to another one.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_dir.py
@@ -69,10 +69,8 @@ def extra_configuration_after_yield():
     (testdir3, testdir2, 'subdir2', {'ossec_conf'}, True, True),
     (testdir3, testdir2, f'subdir3{os.path.sep}', {'ossec_conf'}, True, True)
 ])
-def test_move_dir(source_folder, target_folder, subdir, tags_to_apply,
-                   triggers_delete_event, triggers_add_event,
-                   get_configuration, configure_environment,
-                   restart_syscheckd, wait_for_initial_scan):
+def test_move_dir(source_folder, target_folder, subdir, tags_to_apply, triggers_delete_event, triggers_add_event,
+                  get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
     """
     Check if syscheckd detects 'added' or 'deleted' events when moving a
     subfolder from a folder to another one.
@@ -97,6 +95,8 @@ def test_move_dir(source_folder, target_folder, subdir, tags_to_apply,
 
     if mode == 'whodata' and subdir[-1] == os.path.sep and sys.platform == 'linux':
         pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/4720')
+    elif mode == 'whodata' and subdir[-1] == os.path.sep and sys.platform == 'win32':
+        pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/6089')
 
     # Move folder to target directory
     os.rename(os.path.join(source_folder, subdir), os.path.join(target_folder, subdir))

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_file.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_file.py
@@ -58,7 +58,7 @@ def get_configuration(request):
 def test_move_file(file, file_content, tags_to_apply, source_folder, target_folder,
                    triggers_delete_event, triggers_add_event,
                    get_configuration, configure_environment,
-                   restart_syscheckd, wait_for_syscheck_start):
+                   restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheckd detects 'added' or 'deleted' events when moving a file.
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_file.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_move_file.py
@@ -58,7 +58,7 @@ def get_configuration(request):
 def test_move_file(file, file_content, tags_to_apply, source_folder, target_folder,
                    triggers_delete_event, triggers_add_event,
                    get_configuration, configure_environment,
-                   restart_syscheckd, wait_for_initial_scan):
+                   restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheckd detects 'added' or 'deleted' events when moving a file.
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
@@ -81,6 +81,8 @@ def test_new_directory(tags_to_apply, get_configuration, configure_environment, 
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     if sys.platform != 'win32':
+        detect_initial_scan(wazuh_log_monitor)
+
         # Create the monitored directory with files and check that events are not raised
         regular_file_cud(directory_str, wazuh_log_monitor, file_list=['file1', 'file2', 'file3'],
                          min_timeout=global_parameters.default_timeout, triggers_event=False)

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
@@ -63,8 +63,7 @@ def extra_configuration_after_yield():
 @pytest.mark.parametrize('tags_to_apply', [
     {'ossec_conf'}
 ])
-def test_new_directory(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                       wait_for_syscheck_start):
+def test_new_directory(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
     """
     Check that a new monitored directory generates events after the next scheduled scan.
 
@@ -88,6 +87,8 @@ def test_new_directory(tags_to_apply, get_configuration, configure_environment, 
 
         detect_initial_scan(wazuh_log_monitor)
     else:
+        detect_initial_scan(wazuh_log_monitor)
+
         # Wait for syscheck to realize the directories don't exist
         wazuh_log_monitor.start(timeout=10, callback=callback_non_existing_monitored_dir,
                                 error_message='Monitoring discarded message not found')

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_new_dirs.py
@@ -64,7 +64,7 @@ def extra_configuration_after_yield():
     {'ossec_conf'}
 ])
 def test_new_directory(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                       wait_for_initial_scan):
+                       wait_for_syscheck_start):
     """
     Check that a new monitored directory generates events after the next scheduled scan.
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
@@ -55,7 +55,7 @@ def get_configuration(request):
     (2, {'ossec_conf'})
 ])
 def test_regular_file_changes(sleep, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                              wait_for_syscheck_start):
+                              wait_for_fim_start):
     """
     Check if syscheckd detects regular file changes (add, modify, delete) with a very specific delay between every
     action.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_quick_changes.py
@@ -55,7 +55,7 @@ def get_configuration(request):
     (2, {'ossec_conf'})
 ])
 def test_regular_file_changes(sleep, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                              wait_for_initial_scan):
+                              wait_for_syscheck_start):
     """
     Check if syscheckd detects regular file changes (add, modify, delete) with a very specific delay between every
     action.

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_rename.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_rename.py
@@ -4,7 +4,6 @@
 
 import os
 import shutil
-from datetime import timedelta
 
 import pytest
 
@@ -14,7 +13,6 @@ from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGUL
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.time import TimeMachine
 
 # Marks
 
@@ -134,6 +132,4 @@ def test_rename(folder, tags_to_apply,
         os.rename(folder, os.path.join(os.path.dirname(folder), new_name))
         check_time_travel(scheduled, monitor=wazuh_log_monitor)
         expect_events(new_name)
-        # Travel in time to force delete event in realtime/whodata
-        check_time_travel(not scheduled, monitor=wazuh_log_monitor)
         expect_events(folder)

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_rename.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_rename.py
@@ -66,7 +66,7 @@ def clean_directories(request):
 ])
 def test_rename(folder, tags_to_apply,
                 get_configuration, clean_directories, configure_environment,
-                restart_syscheckd, wait_for_syscheck_start):
+                restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheckd detects events when renaming directories or files.
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_rename.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_rename.py
@@ -68,7 +68,7 @@ def clean_directories(request):
 ])
 def test_rename(folder, tags_to_apply,
                 get_configuration, clean_directories, configure_environment,
-                restart_syscheckd, wait_for_initial_scan):
+                restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheckd detects events when renaming directories or files.
 

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
@@ -65,7 +65,7 @@ def get_configuration(request):
     {'ossec_conf'}
 ])
 def test_events_from_existing_files(filename, tags_to_apply, get_configuration,
-                                    configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                    configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheck generates modified alerts for files that exists when starting the agent"""
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'

--- a/tests/integration/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
+++ b/tests/integration/test_fim/test_basic_usage/test_basic_usage_starting_agent.py
@@ -65,7 +65,7 @@ def get_configuration(request):
     {'ossec_conf'}
 ])
 def test_events_from_existing_files(filename, tags_to_apply, get_configuration,
-                                    configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                    configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheck generates modified alerts for files that exists when starting the agent"""
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'

--- a/tests/integration/test_fim/test_benchmark/test_benchmark.py
+++ b/tests/integration/test_fim/test_benchmark/test_benchmark.py
@@ -60,7 +60,7 @@ def get_configuration(request):
 ])
 def test_benchmark_regular_files(files, folder, tags_to_apply, get_configuration,
                                  configure_environment, restart_syscheckd,
-                                 wait_for_initial_scan):
+                                 wait_for_syscheck_start):
     """
     Check syscheckd detects a certain volume of file changes (add, modify, delete)
 

--- a/tests/integration/test_fim/test_benchmark/test_benchmark.py
+++ b/tests/integration/test_fim/test_benchmark/test_benchmark.py
@@ -60,7 +60,7 @@ def get_configuration(request):
 ])
 def test_benchmark_regular_files(files, folder, tags_to_apply, get_configuration,
                                  configure_environment, restart_syscheckd,
-                                 wait_for_syscheck_start):
+                                 wait_for_fim_start):
     """
     Check syscheckd detects a certain volume of file changes (add, modify, delete)
 

--- a/tests/integration/test_fim/test_benchmark/test_report_changes_big.py
+++ b/tests/integration/test_fim/test_benchmark/test_report_changes_big.py
@@ -194,7 +194,7 @@ def write_csv(data):
     0, 1024*59
 ])
 def test_report_changes_big(file_size, n_files, tags_to_apply, get_configuration, configure_environment,
-                            restart_syscheckd, wait_for_syscheck_start):
+                            restart_syscheckd, wait_for_fim_start):
     """Verify syscheck when using the report_changes option with large amount of files.
 
     This test creates, in a monitored directory with the report_changes option,

--- a/tests/integration/test_fim/test_benchmark/test_report_changes_big.py
+++ b/tests/integration/test_fim/test_benchmark/test_report_changes_big.py
@@ -194,7 +194,7 @@ def write_csv(data):
     0, 1024*59
 ])
 def test_report_changes_big(file_size, n_files, tags_to_apply, get_configuration, configure_environment,
-                            restart_syscheckd, wait_for_initial_scan):
+                            restart_syscheckd, wait_for_syscheck_start):
     """Verify syscheck when using the report_changes option with large amount of files.
 
     This test creates, in a monitored directory with the report_changes option,

--- a/tests/integration/test_fim/test_checks/test_check_all.py
+++ b/tests/integration/test_fim/test_checks/test_check_all.py
@@ -72,7 +72,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_all_single(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_syscheck_start):
+                          wait_for_fim_start):
     """
     Test the functionality of `check_all` option when used in conjunction with another check on the same directory,
     having "check_all" to "yes" and the other check to "no".
@@ -117,7 +117,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                   wait_for_syscheck_start):
+                   wait_for_fim_start):
     """
     Test the functionality of `check_all` option when used in conjunction with more than one check on the same directory,
     having "check_all" to "yes" and the other ones to "no".
@@ -142,7 +142,7 @@ def test_check_all(path, checkers, get_configuration, configure_environment, res
 
 @pytest.mark.parametrize('path, checkers', [(testdir1, {})])
 def test_check_all_no(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                      wait_for_syscheck_start):
+                      wait_for_fim_start):
     """
     Test the functionality of `check_all` option when set to no.
 

--- a/tests/integration/test_fim/test_checks/test_check_all.py
+++ b/tests/integration/test_fim/test_checks/test_check_all.py
@@ -116,7 +116,8 @@ else:
 
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
-def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd,
+                   wait_for_syscheck_start):
     """
     Test the functionality of `check_all` option when used in conjunction with more than one check on the same directory,
     having "check_all" to "yes" and the other ones to "no".

--- a/tests/integration/test_fim/test_checks/test_check_all.py
+++ b/tests/integration/test_fim/test_checks/test_check_all.py
@@ -72,7 +72,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_all_single(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_initial_scan):
+                          wait_for_syscheck_start):
     """
     Test the functionality of `check_all` option when used in conjunction with another check on the same directory,
     having "check_all" to "yes" and the other check to "no".
@@ -116,7 +116,7 @@ else:
 
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
-def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Test the functionality of `check_all` option when used in conjunction with more than one check on the same directory,
     having "check_all" to "yes" and the other ones to "no".
@@ -141,7 +141,7 @@ def test_check_all(path, checkers, get_configuration, configure_environment, res
 
 @pytest.mark.parametrize('path, checkers', [(testdir1, {})])
 def test_check_all_no(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                      wait_for_initial_scan):
+                      wait_for_syscheck_start):
     """
     Test the functionality of `check_all` option when set to no.
 

--- a/tests/integration/test_fim/test_checks/test_check_others.py
+++ b/tests/integration/test_fim/test_checks/test_check_others.py
@@ -71,7 +71,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_others_individually(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                                   wait_for_initial_scan):
+                                   wait_for_syscheck_start):
     """
     Test the behaviour of every Check option individually without using the Check_all option. Check_all option will
     be set to "no" in order to avoid using the default check_all configuration.
@@ -117,7 +117,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_others(path, checkers, get_configuration, configure_environment,
-                      restart_syscheckd, wait_for_initial_scan):
+                      restart_syscheckd, wait_for_syscheck_start):
     """
     Test the behaviour of several combinations of Check options over the same directory with Check_all disabled to
     avoid using the default check_all configuration. The order of the checks (including check_all="no") will be

--- a/tests/integration/test_fim/test_checks/test_check_others.py
+++ b/tests/integration/test_fim/test_checks/test_check_others.py
@@ -71,7 +71,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_others_individually(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                                   wait_for_syscheck_start):
+                                   wait_for_fim_start):
     """
     Test the behaviour of every Check option individually without using the Check_all option. Check_all option will
     be set to "no" in order to avoid using the default check_all configuration.
@@ -117,7 +117,7 @@ else:
 
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_others(path, checkers, get_configuration, configure_environment,
-                      restart_syscheckd, wait_for_syscheck_start):
+                      restart_syscheckd, wait_for_fim_start):
     """
     Test the behaviour of several combinations of Check options over the same directory with Check_all disabled to
     avoid using the default check_all configuration. The order of the checks (including check_all="no") will be

--- a/tests/integration/test_fim/test_checks/test_checksums.py
+++ b/tests/integration/test_fim/test_checks/test_checksums.py
@@ -67,7 +67,7 @@ def get_configuration(request):
     (testdir9, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_MD5SUM} - {CHECK_SHA256SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
 ])
 def test_checksums_checkall(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                            wait_for_syscheck_start):
+                            wait_for_fim_start):
     """
     Test the behaviour of check_all="yes" when using it with one or more check_sum options (checksum, sha1sum,
     sha256sum and md5sum) set to "no".
@@ -105,7 +105,7 @@ def test_checksums_checkall(path, checkers, get_configuration, configure_environ
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_SHA256SUM} - {CHECK_MD5SUM})
 ])
 def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                   wait_for_syscheck_start):
+                   wait_for_fim_start):
     """
     Test the checksum options (checksum, sha1sum, sha256sum and md5sum)
     behaviour when is used alone or in conjunction.

--- a/tests/integration/test_fim/test_checks/test_checksums.py
+++ b/tests/integration/test_fim/test_checks/test_checksums.py
@@ -104,7 +104,8 @@ def test_checksums_checkall(path, checkers, get_configuration, configure_environ
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA256SUM}),
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_SHA256SUM} - {CHECK_MD5SUM})
 ])
-def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd,
+                   wait_for_syscheck_start):
     """
     Test the checksum options (checksum, sha1sum, sha256sum and md5sum)
     behaviour when is used alone or in conjunction.

--- a/tests/integration/test_fim/test_checks/test_checksums.py
+++ b/tests/integration/test_fim/test_checks/test_checksums.py
@@ -67,7 +67,7 @@ def get_configuration(request):
     (testdir9, REQUIRED_ATTRIBUTES[CHECK_ALL] - {CHECK_MD5SUM} - {CHECK_SHA256SUM} - REQUIRED_ATTRIBUTES[CHECK_SUM]),
 ])
 def test_checksums_checkall(path, checkers, get_configuration, configure_environment, restart_syscheckd,
-                            wait_for_initial_scan):
+                            wait_for_syscheck_start):
     """
     Test the behaviour of check_all="yes" when using it with one or more check_sum options (checksum, sha1sum,
     sha256sum and md5sum) set to "no".
@@ -104,7 +104,7 @@ def test_checksums_checkall(path, checkers, get_configuration, configure_environ
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_MD5SUM} - {CHECK_SHA256SUM}),
     (testdir8, REQUIRED_ATTRIBUTES[CHECK_SUM] - {CHECK_SHA256SUM} - {CHECK_MD5SUM})
 ])
-def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Test the checksum options (checksum, sha1sum, sha256sum and md5sum)
     behaviour when is used alone or in conjunction.

--- a/tests/integration/test_fim/test_checks/test_hard_link.py
+++ b/tests/integration/test_fim/test_checks/test_hard_link.py
@@ -54,7 +54,7 @@ def get_configuration(request):
     (testdir1, "regular2", testdir1, "hardlink", 2)
 ])
 def test_hard_link(path_file, file_name, path_link, link_name, num_links, get_configuration,
-                   configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                   configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Test the check_inode option when used with Hard links by creating a hard link file inside and outside the
     monitored directory.

--- a/tests/integration/test_fim/test_checks/test_hard_link.py
+++ b/tests/integration/test_fim/test_checks/test_hard_link.py
@@ -54,7 +54,7 @@ def get_configuration(request):
     (testdir1, "regular2", testdir1, "hardlink", 2)
 ])
 def test_hard_link(path_file, file_name, path_link, link_name, num_links, get_configuration,
-                   configure_environment, restart_syscheckd, wait_for_initial_scan):
+                   configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Test the check_inode option when used with Hard links by creating a hard link file inside and outside the
     monitored directory.

--- a/tests/integration/test_fim/test_env_variables/test_dir.py
+++ b/tests/integration/test_fim/test_env_variables/test_dir.py
@@ -58,7 +58,7 @@ def get_configuration(request):
     dir4
 ])
 def test_tag_directories(directory, get_configuration, put_env_variables, configure_environment,
-                         restart_syscheckd, wait_for_initial_scan):
+                         restart_syscheckd, wait_for_syscheck_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_env_variables/test_dir.py
+++ b/tests/integration/test_fim/test_env_variables/test_dir.py
@@ -58,7 +58,7 @@ def get_configuration(request):
     dir4
 ])
 def test_tag_directories(directory, get_configuration, put_env_variables, configure_environment,
-                         restart_syscheckd, wait_for_syscheck_start):
+                         restart_syscheckd, wait_for_fim_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_env_variables/test_dir_win32.py
+++ b/tests/integration/test_fim/test_env_variables/test_dir_win32.py
@@ -43,7 +43,7 @@ def get_configuration(request):
 # Test
 @pytest.mark.parametrize('directory', [subdir1])
 def test_tag_directories(directory, get_configuration, put_env_variables, configure_environment,
-                         restart_syscheckd, wait_for_syscheck_start):
+                         restart_syscheckd, wait_for_fim_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_env_variables/test_dir_win32.py
+++ b/tests/integration/test_fim/test_env_variables/test_dir_win32.py
@@ -43,7 +43,7 @@ def get_configuration(request):
 # Test
 @pytest.mark.parametrize('directory', [subdir1])
 def test_tag_directories(directory, get_configuration, put_env_variables, configure_environment,
-                         restart_syscheckd, wait_for_initial_scan):
+                         restart_syscheckd, wait_for_syscheck_start):
     """
     Test alerts are generated when monitor environment variables
     """

--- a/tests/integration/test_fim/test_env_variables/test_ignore.py
+++ b/tests/integration/test_fim/test_env_variables/test_ignore.py
@@ -60,7 +60,7 @@ def get_configuration(request):
     (dir4, True),
 ])
 def test_tag_ignore(directory, event_generated, get_configuration, configure_environment, put_env_variables,
-                    restart_syscheckd, wait_for_syscheck_start):
+                    restart_syscheckd, wait_for_fim_start):
     """
     Test environment variables are ignored
     """

--- a/tests/integration/test_fim/test_env_variables/test_ignore.py
+++ b/tests/integration/test_fim/test_env_variables/test_ignore.py
@@ -60,7 +60,7 @@ def get_configuration(request):
     (dir4, True),
 ])
 def test_tag_ignore(directory, event_generated, get_configuration, configure_environment, put_env_variables,
-                    restart_syscheckd, wait_for_initial_scan):
+                    restart_syscheckd, wait_for_syscheck_start):
     """
     Test environment variables are ignored
     """

--- a/tests/integration/test_fim/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_env_variables/test_nodiff.py
@@ -58,7 +58,7 @@ def get_configuration(request):
     (dir4, "testing.txt", False),
 ])
 def test_tag_nodiff(directory, filename, hidden_content, get_configuration, put_env_variables, configure_environment,
-                    restart_syscheckd, wait_for_initial_scan):
+                    restart_syscheckd, wait_for_syscheck_start):
     """
     Test nodiff option works with environment variables
 

--- a/tests/integration/test_fim/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_env_variables/test_nodiff.py
@@ -58,7 +58,7 @@ def get_configuration(request):
     (dir4, "testing.txt", False),
 ])
 def test_tag_nodiff(directory, filename, hidden_content, get_configuration, put_env_variables, configure_environment,
-                    restart_syscheckd, wait_for_syscheck_start):
+                    restart_syscheckd, wait_for_fim_start):
     """
     Test nodiff option works with environment variables
 

--- a/tests/integration/test_fim/test_file_limit/test_file_limit_capacity_alerts.py
+++ b/tests/integration/test_fim/test_file_limit/test_file_limit_capacity_alerts.py
@@ -57,7 +57,7 @@ def get_configuration(request):
     (0, {'file_limit_conf'})
 ])
 def test_file_limit_capacity_alert(percentage, tags_to_apply, get_configuration, configure_environment,
-                                   restart_syscheckd, wait_for_syscheck_start):
+                                   restart_syscheckd, wait_for_fim_start):
     """
     Checks that the corresponding alerts appear in schedule mode for different capacity thresholds.
 

--- a/tests/integration/test_fim/test_file_limit/test_file_limit_capacity_alerts.py
+++ b/tests/integration/test_fim/test_file_limit/test_file_limit_capacity_alerts.py
@@ -57,7 +57,7 @@ def get_configuration(request):
     (0, {'file_limit_conf'})
 ])
 def test_file_limit_capacity_alert(percentage, tags_to_apply, get_configuration, configure_environment,
-                                   restart_syscheckd, wait_for_initial_scan):
+                                   restart_syscheckd, wait_for_syscheck_start):
     """
     Checks that the corresponding alerts appear in schedule mode for different capacity thresholds.
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_change_target.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_change_target.py
@@ -44,7 +44,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_change_target(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                restart_wazuh, wait_for_syscheck_start):
+                                restart_wazuh, wait_for_fim_start):
     """
     Check if syscheck updates the symlink target properly
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_change_target.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_change_target.py
@@ -44,7 +44,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_change_target(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                restart_wazuh, wait_for_initial_scan):
+                                restart_wazuh, wait_for_syscheck_start):
     """
     Check if syscheck updates the symlink target properly
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir2)
 ])
 def test_symbolic_change_target_inside_folder(tags_to_apply, previous_target, new_target, get_configuration,
-                                              configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                              configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheck stops detecting events from previous target when pointing to a new folder
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_change_target_inside_folder.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir2)
 ])
 def test_symbolic_change_target_inside_folder(tags_to_apply, previous_target, new_target, get_configuration,
-                                              configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                              configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheck stops detecting events from previous target when pointing to a new folder
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_delete_symlink.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_delete_symlink.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_delete_symlink(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                 restart_syscheckd, wait_for_initial_scan):
+                                 restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheck stops detecting events when deleting the monitored symlink.
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_delete_symlink.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_delete_symlink.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_delete_symlink(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                 restart_syscheckd, wait_for_syscheck_start):
+                                 restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheck stops detecting events when deleting the monitored symlink.
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_delete_target.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_delete_target.py
@@ -48,7 +48,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_delete_target(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                restart_syscheckd, wait_for_syscheck_start):
+                                restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheck detects events properly when removing a target, have the symlink updated and
     then recreating the target

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_delete_target.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_delete_target.py
@@ -48,7 +48,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_delete_target(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                restart_syscheckd, wait_for_initial_scan):
+                                restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheck detects events properly when removing a target, have the symlink updated and
     then recreating the target

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_follow_symbolic_disabled.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_follow_symbolic_disabled.py
@@ -49,7 +49,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target)
 ])
 def test_follow_symbolic_disabled(path, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                  wait_for_syscheck_start):
+                                  wait_for_fim_start):
     """Check what happens when follow_symbolic_link option is set to "no".
 
     Ensure that the monitored symbolic link is considered a regular file and it will not follow its target path. It will

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_follow_symbolic_disabled.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_follow_symbolic_disabled.py
@@ -49,7 +49,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target)
 ])
 def test_follow_symbolic_disabled(path, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                  wait_for_initial_scan):
+                                  wait_for_syscheck_start):
     """Check what happens when follow_symbolic_link option is set to "no".
 
     Ensure that the monitored symbolic link is considered a regular file and it will not follow its target path. It will

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
@@ -44,7 +44,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target)
 ])
 def test_symbolic_monitor_symlink(tags_to_apply, main_folder, get_configuration, configure_environment,
-                                  restart_syscheckd, wait_for_initial_scan):
+                                  restart_syscheckd, wait_for_syscheck_start):
     """
     Check what happens with a symlink and its target when syscheck monitors it.
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_monitor_symlink.py
@@ -44,7 +44,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target)
 ])
 def test_symbolic_monitor_symlink(tags_to_apply, main_folder, get_configuration, configure_environment,
-                                  restart_syscheckd, wait_for_syscheck_start):
+                                  restart_syscheckd, wait_for_fim_start):
     """
     Check what happens with a symlink and its target when syscheck monitors it.
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -54,7 +54,7 @@ def get_configuration(request):
 ])
 def test_symbolic_monitor_directory_with_symlink(monitored_dir, non_monitored_dir1, non_monitored_dir2,
                                                  sym_target, tags_to_apply, get_configuration, configure_environment,
-                                                 restart_syscheckd, wait_for_syscheck_start):
+                                                 restart_syscheckd, wait_for_fim_start):
     """
     Check what happens with a symlink and its target when syscheck monitors a directory with a symlink
     and not the symlink itself.

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -54,7 +54,7 @@ def get_configuration(request):
 ])
 def test_symbolic_monitor_directory_with_symlink(monitored_dir, non_monitored_dir1, non_monitored_dir2,
                                                  sym_target, tags_to_apply, get_configuration, configure_environment,
-                                                 restart_syscheckd, wait_for_initial_scan):
+                                                 restart_syscheckd, wait_for_syscheck_start):
     """
     Check what happens with a symlink and its target when syscheck monitors a directory with a symlink
     and not the symlink itself.

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_revert_symlink.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_revert_symlink.py
@@ -45,7 +45,7 @@ def get_configuration(request):
     {'monitored_file'}
 ])
 def test_symbolic_revert_symlink(tags_to_apply, get_configuration, configure_environment,
-                                 restart_syscheckd, wait_for_initial_scan):
+                                 restart_syscheckd, wait_for_syscheck_start):
     """
     Check if syscheck detects new targets properly
 

--- a/tests/integration/test_fim/test_follow_symbolic_link/test_revert_symlink.py
+++ b/tests/integration/test_fim/test_follow_symbolic_link/test_revert_symlink.py
@@ -45,7 +45,7 @@ def get_configuration(request):
     {'monitored_file'}
 ])
 def test_symbolic_revert_symlink(tags_to_apply, get_configuration, configure_environment,
-                                 restart_syscheckd, wait_for_syscheck_start):
+                                 restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheck detects new targets properly
 

--- a/tests/integration/test_fim/test_ignore/test_ignore_registry.py
+++ b/tests/integration/test_fim/test_ignore/test_ignore_registry.py
@@ -84,7 +84,7 @@ def get_configuration(request):
     (keys_strings, keys_objects, {'ignore_registry'})
 ])
 def test_ignore_registry(key_string, key_object, tags_to_apply, get_configuration,
-                         configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                         configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check registries are ignored according to configuration.
 

--- a/tests/integration/test_fim/test_ignore/test_ignore_registry.py
+++ b/tests/integration/test_fim/test_ignore/test_ignore_registry.py
@@ -84,7 +84,7 @@ def get_configuration(request):
     (keys_strings, keys_objects, {'ignore_registry'})
 ])
 def test_ignore_registry(key_string, key_object, tags_to_apply, get_configuration,
-                         configure_environment, restart_syscheckd, wait_for_initial_scan):
+                         configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check registries are ignored according to configuration.
 

--- a/tests/integration/test_fim/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_ignore/test_ignore_valid.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 
+from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, callback_ignore, create_file, REGULAR, \
     generate_params, check_time_travel
 from wazuh_testing.tools import PREFIX
@@ -81,7 +82,7 @@ def get_configuration(request):
 def test_ignore_subdirectory(folder, filename, content, triggers_event,
                              tags_to_apply, get_configuration,
                              configure_environment, restart_syscheckd,
-                             wait_for_initial_scan):
+                             wait_for_syscheck_start):
     """
     Check files are ignored in subdirectory according to configuration. It also ensures that events for files that
     are not being ignored are still detected when using the ignore option.
@@ -109,7 +110,7 @@ def test_ignore_subdirectory(folder, filename, content, triggers_event,
     check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
     if triggers_event:
-        event = wazuh_log_monitor.start(timeout=10,
+        event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 2,
                                         callback=callback_detect_event,
                                         error_message='Did not receive expected '
                                                       '"Sending FIM event: ..." event').result()
@@ -117,7 +118,7 @@ def test_ignore_subdirectory(folder, filename, content, triggers_event,
         assert event['data']['path'] == os.path.join(folder, filename), f'Event path not equal'
     else:
         while True:
-            ignored_file = wazuh_log_monitor.start(timeout=10,
+            ignored_file = wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 2,
                                                    callback=callback_ignore).result()
             if ignored_file == os.path.join(folder, filename):
                 break

--- a/tests/integration/test_fim/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_ignore/test_ignore_valid.py
@@ -82,7 +82,7 @@ def get_configuration(request):
 def test_ignore_subdirectory(folder, filename, content, triggers_event,
                              tags_to_apply, get_configuration,
                              configure_environment, restart_syscheckd,
-                             wait_for_syscheck_start):
+                             wait_for_fim_start):
     """
     Check files are ignored in subdirectory according to configuration. It also ensures that events for files that
     are not being ignored are still detected when using the ignore option.

--- a/tests/integration/test_fim/test_max_eps/data/wazuh_conf_synchro.yaml
+++ b/tests/integration/test_fim/test_max_eps/data/wazuh_conf_synchro.yaml
@@ -15,7 +15,5 @@
         - FIM_MODE
     - synchronization:
         elements:
-        - interval:
-            value: 60
         - max_eps:
             value: MAX_EPS

--- a/tests/integration/test_fim/test_max_eps/data/wazuh_conf_synchro.yaml
+++ b/tests/integration/test_fim/test_max_eps/data/wazuh_conf_synchro.yaml
@@ -15,5 +15,7 @@
         - FIM_MODE
     - synchronization:
         elements:
+        - interval:
+            value: 60
         - max_eps:
             value: MAX_EPS

--- a/tests/integration/test_fim/test_max_eps/test_max_eps.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps.py
@@ -33,7 +33,8 @@ conf_params = {'TEST_DIRECTORIES': directory_str,
 
 eps_values = ['50', '10']
 
-p, m = generate_params(extra_params=conf_params, apply_to_all=({'MAX_EPS': eps_value} for eps_value in eps_values))
+p, m = generate_params(extra_params=conf_params, apply_to_all=({'MAX_EPS': eps_value} for eps_value in eps_values),
+                       modes=['scheduled'])
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
 
@@ -62,7 +63,7 @@ def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wa
         create_file(REGULAR, testdir1, f'test{i}_{mode}_{max_eps}', content='')
 
     check_time_travel(mode == "scheduled")
-    n_results = max_eps * 4
+    n_results = max_eps * 5
 
     result = wazuh_log_monitor.start(timeout=(n_results/max_eps)*6,
                                      accum_results=n_results,

--- a/tests/integration/test_fim/test_max_eps/test_max_eps.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps.py
@@ -64,20 +64,14 @@ def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wa
     check_time_travel(mode == "scheduled")
     n_results = max_eps * 4
 
-    try:
-        result = wazuh_log_monitor.start(timeout=(n_results/max_eps)*6,
-                                         accum_results=n_results,
-                                         callback=callback_event_message,
-                                         error_message=f'Received less results than expected ({n_results})').result()
+    result = wazuh_log_monitor.start(timeout=(n_results/max_eps)*6,
+                                     accum_results=n_results,
+                                     callback=callback_event_message,
+                                     error_message=f'Received less results than expected ({n_results})').result()
 
-        counter = Counter([date_time for date_time, _ in result])
-        error_margin = (max_eps * 0.1)
+    counter = Counter([date_time for date_time, _ in result])
+    error_margin = (max_eps * 0.1)
 
-        for date_time, n_occurrences in counter.items():
-            assert n_occurrences <= round(
-                max_eps + error_margin), f'Sent {n_occurrences} but a maximum of {max_eps} was set'
-    except TimeoutError as e:
-        if mode == 'whodata':
-            pytest.xfail(reason='Xfailing due to issue: https://github.com/wazuh/wazuh/issues/4660')
-        else:
-            raise e
+    for _, n_occurrences in counter.items():
+        assert n_occurrences <= round(
+            max_eps + error_margin), f'Sent {n_occurrences} but a maximum of {max_eps} was set'

--- a/tests/integration/test_fim/test_max_eps/test_max_eps.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps.py
@@ -45,7 +45,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check that max_eps is respected when a big quantity of syscheck events are generated.
 

--- a/tests/integration/test_fim/test_max_eps/test_max_eps.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps.py
@@ -45,7 +45,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check that max_eps is respected when a big quantity of syscheck events are generated.
 

--- a/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
@@ -57,7 +57,7 @@ def create_files(get_configuration):
         create_file(REGULAR, testdir1, f'test{i}_{mode}_{max_eps}', content='')
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def delete_files():
     yield
     for test_dir in test_directories_no_delete:

--- a/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
@@ -93,6 +93,6 @@ def test_max_eps_on_start(get_configuration, create_files, configure_environment
     counter = Counter([date_time for date_time, _ in result])
     error_margin = (max_eps * 0.1)
 
-    for date_time, n_occurrences in counter.items():
+    for _, n_occurrences in counter.items():
         assert n_occurrences <= round(
             max_eps + error_margin), f'Sent {n_occurrences} but a maximum of {max_eps} was set'

--- a/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
+++ b/tests/integration/test_fim/test_max_eps/test_max_eps_synchronization.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 import shutil
 from collections import Counter
 
@@ -33,8 +34,10 @@ conf_params = {'TEST_DIRECTORIES': directory_str,
                'MODULE_NAME': __name__}
 
 eps_values = ['50', '10']
+test_modes = ['realtime'] if sys.platform == 'linux' or sys.platform == 'win32' else ['scheduled']
 
-p, m = generate_params(extra_params=conf_params, apply_to_all=({'MAX_EPS': eps_value} for eps_value in eps_values))
+p, m = generate_params(extra_params=conf_params, apply_to_all=({'MAX_EPS': eps_value} for eps_value in eps_values),
+                       modes=test_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
 

--- a/tests/integration/test_fim/test_moving_files/test_moving_files.py
+++ b/tests/integration/test_fim/test_moving_files/test_moving_files.py
@@ -93,7 +93,7 @@ def get_configuration(request):
     (testdir2, testdir1, testfile2, realtime, whodata)
 ])
 def test_moving_file_to_whodata(dirsrc, dirdst, filename, mod_del_event, mod_add_event, get_configuration,
-                                configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                                configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Test Syscheck's behaviors when moving files from a directory monitored by whodata to another
     monitored by realtime and vice versa.

--- a/tests/integration/test_fim/test_moving_files/test_moving_files.py
+++ b/tests/integration/test_fim/test_moving_files/test_moving_files.py
@@ -93,7 +93,7 @@ def get_configuration(request):
     (testdir2, testdir1, testfile2, realtime, whodata)
 ])
 def test_moving_file_to_whodata(dirsrc, dirdst, filename, mod_del_event, mod_add_event, get_configuration,
-                                configure_environment, restart_syscheckd, wait_for_initial_scan):
+                                configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Test Syscheck's behaviors when moving files from a directory monitored by whodata to another
     monitored by realtime and vice versa.

--- a/tests/integration/test_fim/test_multiple_dirs/common.py
+++ b/tests/integration/test_fim/test_multiple_dirs/common.py
@@ -40,20 +40,15 @@ def multiple_dirs_test(mode=None, dir_list=None, file=None, scheduled=None, whod
                 time.sleep(0.05)  # This sleep is to let whodata fetching all events
 
         check_time_travel(time_travel=scheduled)
-        try:
-            events = log_monitor.start(timeout=timeout,
-                                       callback=callback_detect_event,
-                                       accum_results=n_results,
-                                       error_message='Did not receive expected "Sending FIM event: ..." event').result()
-            time.sleep(1)
 
-            for ev in events:
-                validate_event(ev)
-        except TimeoutError as e:
-            if len(log_monitor.result()) != n_results:
-                pytest.fail(reason=f'Expected {n_results} events, not {len(log_monitor.result())}')
-            else:
-                raise e
+        events = log_monitor.start(timeout=timeout,
+                                   callback=callback_detect_event,
+                                   accum_results=n_results,
+                                   error_message='Did not receive expected "Sending FIM event: ..." event').result()
+        time.sleep(1)
+
+        for ev in events:
+            validate_event(ev)
 
     try:
         perform_and_validate_events(create_file, {'content': ''})

--- a/tests/integration/test_fim/test_multiple_dirs/test_multiple_dirs.py
+++ b/tests/integration/test_fim/test_multiple_dirs/test_multiple_dirs.py
@@ -9,7 +9,7 @@ from wazuh_testing import global_parameters
 
 from test_fim.test_multiple_dirs.common import multiple_dirs_test
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, callback_warn_max_dir_monitored, \
-                               detect_initial_scan
+                               detect_initial_scan, detect_realtime_start, detect_whodata_start
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import PREFIX
@@ -75,11 +75,19 @@ def test_multiple_dirs(dir_list, tags_to_apply, get_configuration, configure_env
         List with all the directories to be monitored.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
+
     discarded = wait_for_event()
     assert discarded == expected_discarded, f'Directories discarded expected to be: {discarded}'
 
-    detect_initial_scan(wazuh_log_monitor)
+    if get_configuration['metadata']['fim_mode'] == 'realtime':
+        detect_realtime_start(wazuh_log_monitor)
+    elif get_configuration['metadata']['fim_mode'] == 'whodata':
+        detect_whodata_start(wazuh_log_monitor)
+    else:   # scheduled
+        detect_initial_scan(wazuh_log_monitor)
+
     file = 'regular'
+
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     whodata = get_configuration['metadata']['fim_mode'] == 'whodata'
 

--- a/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
+++ b/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
@@ -81,7 +81,7 @@ def get_configuration(request):
     (test_directories, {'multiple_dir_entries'})
 ])
 def test_cud_multiple_dir_entries(dir_list, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                  wait_for_initial_scan):
+                                  wait_for_syscheck_start):
     """
     Check if syscheck can detect every event when adding, modifying and deleting a file within multiple monitored
     directories.

--- a/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
+++ b/tests/integration/test_fim/test_multiple_dirs/test_multiple_entries.py
@@ -81,7 +81,7 @@ def get_configuration(request):
     (test_directories, {'multiple_dir_entries'})
 ])
 def test_cud_multiple_dir_entries(dir_list, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                  wait_for_syscheck_start):
+                                  wait_for_fim_start):
     """
     Check if syscheck can detect every event when adding, modifying and deleting a file within multiple monitored
     directories.

--- a/tests/integration/test_fim/test_nodiff/test_no_diff_valid.py
+++ b/tests/integration/test_fim/test_nodiff/test_no_diff_valid.py
@@ -75,7 +75,7 @@ def get_configuration(request):
 def test_no_diff_subdirectory(folder, filename, content, hidden_content,
                               tags_to_apply, get_configuration,
                               configure_environment, restart_syscheckd,
-                              wait_for_syscheck_start):
+                              wait_for_fim_start):
     """
     Check files are ignored in the subdirectory according to configuration
 

--- a/tests/integration/test_fim/test_nodiff/test_no_diff_valid.py
+++ b/tests/integration/test_fim/test_nodiff/test_no_diff_valid.py
@@ -75,7 +75,7 @@ def get_configuration(request):
 def test_no_diff_subdirectory(folder, filename, content, hidden_content,
                               tags_to_apply, get_configuration,
                               configure_environment, restart_syscheckd,
-                              wait_for_initial_scan):
+                              wait_for_syscheck_start):
     """
     Check files are ignored in the subdirectory according to configuration
 

--- a/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -60,7 +60,7 @@ def check_prelink():
     ({'prefilter_cmd'})
 ])
 def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, check_prelink, restart_syscheckd,
-                       wait_for_syscheck_start):
+                       wait_for_fim_start):
     """
     Check if prelink is installed and syscheck works
 

--- a/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/tests/integration/test_fim/test_prefilter_cmd/test_prefilter_cmd.py
@@ -60,7 +60,7 @@ def check_prelink():
     ({'prefilter_cmd'})
 ])
 def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, check_prelink, restart_syscheckd,
-                       wait_for_initial_scan):
+                       wait_for_syscheck_start):
     """
     Check if prelink is installed and syscheck works
 

--- a/tests/integration/test_fim/test_process_priority/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_process_priority/data/wazuh_conf.yaml
@@ -9,5 +9,9 @@
     elements:
     - disabled:
         value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - FIM_MODE
     - process_priority:
         value: PROCESS_PRIORITY

--- a/tests/integration/test_fim/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_process_priority/test_process_priority.py
@@ -39,7 +39,7 @@ def get_configuration(request):
 
 # tests
 
-def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if the ossec-syscheckd service priority is updated correctly using
        <process_priority> tag in ossec.conf.
     """

--- a/tests/integration/test_fim/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_process_priority/test_process_priority.py
@@ -3,10 +3,12 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
 from wazuh_testing.fim import generate_params
+from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.services import get_process
 
@@ -19,13 +21,16 @@ pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 force_restart_after_restoring = True
-test_directories = []
+test_directories = [os.path.join(PREFIX, 'testdir1')]
 
 # configurations
 
 priority_list = ['0', '4', '-5']
+test_modes = ['realtime'] if sys.platform == 'linux' else ['scheduled']
+conf_params = {'TEST_DIRECTORIES': test_directories[0], 'MODULE_NAME': __name__}
 
-p, m = generate_params(apply_to_all=({'PROCESS_PRIORITY': priority_value} for priority_value in priority_list))
+p, m = generate_params(apply_to_all=({'PROCESS_PRIORITY': priority_value} for priority_value in priority_list),
+                       extra_params=conf_params, modes=test_modes)
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 

--- a/tests/integration/test_fim/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_process_priority/test_process_priority.py
@@ -44,7 +44,7 @@ def get_configuration(request):
 
 # tests
 
-def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if the ossec-syscheckd service priority is updated correctly using
        <process_priority> tag in ossec.conf.
     """

--- a/tests/integration/test_fim/test_recursion_level/test_recursion_level.py
+++ b/tests/integration/test_fim/test_recursion_level/test_recursion_level.py
@@ -157,7 +157,7 @@ def get_configuration(request):
     (dir_recursion_320_space, subdir_space, 320)
 ])
 def test_recursion_level(dirname, subdirname, recursion_level, get_configuration, configure_environment,
-                         restart_syscheckd, wait_for_syscheck_start):
+                         restart_syscheckd, wait_for_fim_start):
     """
     Check if files are correctly detected by syscheck with recursion level using scheduled, realtime and whodata
     monitoring.

--- a/tests/integration/test_fim/test_recursion_level/test_recursion_level.py
+++ b/tests/integration/test_fim/test_recursion_level/test_recursion_level.py
@@ -157,7 +157,7 @@ def get_configuration(request):
     (dir_recursion_320_space, subdir_space, 320)
 ])
 def test_recursion_level(dirname, subdirname, recursion_level, get_configuration, configure_environment,
-                         restart_syscheckd, wait_for_initial_scan):
+                         restart_syscheckd, wait_for_syscheck_start):
     """
     Check if files are correctly detected by syscheck with recursion level using scheduled, realtime and whodata
     monitoring.

--- a/tests/integration/test_fim/test_report_changes/common.py
+++ b/tests/integration/test_fim/test_report_changes/common.py
@@ -65,7 +65,7 @@ def translate_size(configured_size='1KB'):
 
 def disable_file_max_size():
     """
-    Disable the syscheck.max_file_size option from the internal_options.conf file.
+    Disable the syscheck.file_max_size option from the internal_options.conf file.
     """
     new_content = ''
 
@@ -87,7 +87,7 @@ def disable_file_max_size():
 
 def restore_file_max_size():
     """
-    Restore the syscheck.max_file_size option from the internal_options.conf file.
+    Restore the syscheck.file_max_size option from the internal_options.conf file.
     """
     new_content = ''
 
@@ -101,6 +101,50 @@ def restore_file_max_size():
 
         for line in lines:
             new_line = line.replace('syscheck.file_max_size=0', 'syscheck.file_max_size=1024')
+            new_content += new_line
+
+    with open(internal_options, 'w') as f:
+        f.write(new_content)
+
+
+def disable_rt_delay():
+    """
+    Disable the syscheck.rt_delay option from the internal_options.conf file.
+    """
+    new_content = ''
+
+    if sys.platform == 'win32':
+        internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
+    else:
+        internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
+
+    with open(internal_options, 'r') as f:
+        lines = f.readlines()
+
+        for line in lines:
+            new_line = line.replace('syscheck.rt_delay=5', 'syscheck.rt_delay=1000')
+            new_content += new_line
+
+    with open(internal_options, 'w') as f:
+        f.write(new_content)
+
+
+def restore_rt_delay():
+    """
+    Restore the syscheck.rt_delay option from the internal_options.conf file.
+    """
+    new_content = ''
+
+    if sys.platform == 'win32':
+        internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
+    else:
+        internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
+
+    with open(internal_options, 'r') as f:
+        lines = f.readlines()
+
+        for line in lines:
+            new_line = line.replace('syscheck.rt_delay=1000', 'syscheck.rt_delay=5')
             new_content += new_line
 
     with open(internal_options, 'w') as f:

--- a/tests/integration/test_fim/test_report_changes/test_disk_quota_disabled.py
+++ b/tests/integration/test_fim/test_report_changes/test_disk_quota_disabled.py
@@ -60,7 +60,7 @@ def get_configuration(request):
     ('regular_0', testdir1, 10000000),
 ])
 def test_disk_quota_disabled(tags_to_apply, filename, folder, size, get_configuration, configure_environment,
-                             restart_syscheckd, wait_for_initial_scan):
+                             restart_syscheckd, wait_for_syscheck_start):
     """
     Check that the disk_quota option is disabled correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_disk_quota_disabled.py
+++ b/tests/integration/test_fim/test_report_changes/test_disk_quota_disabled.py
@@ -60,7 +60,7 @@ def get_configuration(request):
     ('regular_0', testdir1, 10000000),
 ])
 def test_disk_quota_disabled(tags_to_apply, filename, folder, size, get_configuration, configure_environment,
-                             restart_syscheckd, wait_for_syscheck_start):
+                             restart_syscheckd, wait_for_fim_start):
     """
     Check that the disk_quota option is disabled correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_default.py
@@ -79,7 +79,7 @@ def test_file_size_default(tags_to_apply, filename, folder, get_configuration, c
     diff_file_path = make_diff_file_path(folder=folder, filename=filename)
 
     # Create file with a smaller size than the configured value
-    to_write = generate_string(int(size_limit / 2), '0')
+    to_write = generate_string(int(size_limit / 10), '0')
     create_file(REGULAR, folder, filename, content=to_write)
 
     check_time_travel(scheduled)

--- a/tests/integration/test_fim/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_default.py
@@ -90,6 +90,7 @@ def test_file_size_default(tags_to_apply, filename, folder, get_configuration, c
         pytest.raises(FileNotFoundError(f"{diff_file_path} not found. It should exist before increasing the size."))
 
     # Increase the size of the file over the configured value
+    to_write = generate_string(size_limit, '0')
     modify_file_content(folder, filename, new_content=to_write*3)
 
     check_time_travel(scheduled)

--- a/tests/integration/test_fim/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_default.py
@@ -56,7 +56,7 @@ def get_configuration(request):
     ('regular_0', testdir1),
 ])
 def test_file_size_default(tags_to_apply, filename, folder, get_configuration, configure_environment, restart_syscheckd,
-                           wait_for_syscheck_start):
+                           wait_for_fim_start):
     """
     Check that the file_size option with a default value for report_changes is working correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_default.py
@@ -56,7 +56,7 @@ def get_configuration(request):
     ('regular_0', testdir1),
 ])
 def test_file_size_default(tags_to_apply, filename, folder, get_configuration, configure_environment, restart_syscheckd,
-                           wait_for_initial_scan):
+                           wait_for_syscheck_start):
     """
     Check that the file_size option with a default value for report_changes is working correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_disabled.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_disabled.py
@@ -60,7 +60,7 @@ def get_configuration(request):
     ('regular_0', testdir1, 1000000),
 ])
 def test_file_size_disabled(tags_to_apply, filename, folder, size, get_configuration, configure_environment,
-                            restart_syscheckd, wait_for_syscheck_start):
+                            restart_syscheckd, wait_for_fim_start):
     """
     Check that the file_size option is disabled correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_disabled.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_disabled.py
@@ -60,7 +60,7 @@ def get_configuration(request):
     ('regular_0', testdir1, 1000000),
 ])
 def test_file_size_disabled(tags_to_apply, filename, folder, size, get_configuration, configure_environment,
-                            restart_syscheckd, wait_for_initial_scan):
+                            restart_syscheckd, wait_for_syscheck_start):
     """
     Check that the file_size option is disabled correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -111,7 +111,7 @@ def test_file_size_values(tags_to_apply, filename, folder, get_configuration, co
     check_time_travel(scheduled)
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
-                            error_message='Did not receive expected "Sending FIM event: ..." event.').result()
+                            error_message='Did not receive expected "Sending FIM event: ..." event.')
 
     if not os.path.exists(diff_file_path):
         raise FileNotFoundError(f"{diff_file_path} not found. It should exist before increasing the size.")

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -8,7 +8,7 @@ import pytest
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_file_size_limit_reached, generate_params, create_file, \
-    check_time_travel, callback_detect_event, modify_file_content
+    check_time_travel, callback_detect_event, modify_file_content, callback_deleted_diff_folder
 from test_fim.test_report_changes.common import generate_string, translate_size, disable_file_max_size, \
     restore_file_max_size, make_diff_file_path, disable_rt_delay, restore_rt_delay
 from wazuh_testing.tools import PREFIX
@@ -125,6 +125,9 @@ def test_file_size_values(tags_to_apply, filename, folder, get_configuration, co
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_file_size_limit_reached,
                             error_message='Did not receive expected '
                             '"File ... is too big for configured maximum size to perform diff operation" event.')
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_deleted_diff_folder,
+                            error_message='Did not receive expected "Folder ... has been deleted." event.')
 
     if os.path.exists(diff_file_path):
         raise FileExistsError(f"{diff_file_path} found. It should not exist after incresing the size.")

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -83,7 +83,7 @@ def extra_configuration_after_yield():
     ('regular_0', testdir1),
 ])
 def test_file_size_values(tags_to_apply, filename, folder, get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_initial_scan):
+                          wait_for_syscheck_start):
     """
     Check that the file_size option for report_changes is working correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -11,7 +11,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_file_size_limit_reached, generate_params, create_file, \
     check_time_travel, callback_detect_event, modify_file_content
 from test_fim.test_report_changes.common import generate_string, translate_size, disable_file_max_size, \
-    restore_file_max_size, make_diff_file_path
+    restore_file_max_size, make_diff_file_path, disable_rt_delay, restore_rt_delay
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -63,6 +63,7 @@ def extra_configuration_before_yield():
     Disable syscheck.file_max_size internal option
     """
     disable_file_max_size()
+    disable_rt_delay()
 
 
 def extra_configuration_after_yield():
@@ -70,6 +71,7 @@ def extra_configuration_after_yield():
     Restore syscheck.file_max_size internal option
     """
     restore_file_max_size()
+    restore_rt_delay()
 
 
 # Tests
@@ -116,11 +118,8 @@ def test_file_size_values(tags_to_apply, filename, folder, get_configuration, co
         raise FileNotFoundError(f"{diff_file_path} not found. It should exist before increasing the size.")
 
     # Increase the size of the file over the configured value
-    if sys.platform == 'linux':
-        os.system('dd if=/dev/zero of=' + os.path.join(folder, filename) + ' bs=1024 count=0 seek=20480')
-    else:
-        to_write = generate_string(size_limit, '0')
-        modify_file_content(folder, filename, new_content=to_write*3)
+    to_write = generate_string(size_limit, '0')
+    modify_file_content(folder, filename, new_content=to_write*3)
 
     check_time_travel(scheduled)
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -3,7 +3,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
 
 import pytest
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
@@ -115,7 +116,11 @@ def test_file_size_values(tags_to_apply, filename, folder, get_configuration, co
         raise FileNotFoundError(f"{diff_file_path} not found. It should exist before increasing the size.")
 
     # Increase the size of the file over the configured value
-    modify_file_content(folder, filename, new_content=to_write*3)
+    if sys.platform == 'linux':
+        os.system('dd if=/dev/zero of=' + os.path.join(folder, filename) + ' bs=1024 count=0 seek=20480')
+    else:
+        to_write = generate_string(size_limit, '0')
+        modify_file_content(folder, filename, new_content=to_write*3)
 
     check_time_travel(scheduled)
 

--- a/tests/integration/test_fim/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_report_changes/test_file_size_values.py
@@ -83,7 +83,7 @@ def extra_configuration_after_yield():
     ('regular_0', testdir1),
 ])
 def test_file_size_values(tags_to_apply, filename, folder, get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_syscheck_start):
+                          wait_for_fim_start):
     """
     Check that the file_size option for report_changes is working correctly.
 

--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -83,7 +83,7 @@ def extra_configuration_after_yield():
     ('regular_6', testdir, 70000, 10),
 ])
 def test_large_changes(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
-                       configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                       configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check content_changes shows the tag 'More changes' when it exceeds the maximum size.
 
     Every change in the content of the file shall produce an alert including

--- a/tests/integration/test_fim/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_report_changes/test_large_changes.py
@@ -83,7 +83,7 @@ def extra_configuration_after_yield():
     ('regular_6', testdir, 70000, 10),
 ])
 def test_large_changes(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
-                       configure_environment, restart_syscheckd, wait_for_initial_scan):
+                       configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check content_changes shows the tag 'More changes' when it exceeds the maximum size.
 
     Every change in the content of the file shall produce an alert including

--- a/tests/integration/test_fim/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_report_changes/test_report_changes_and_diff.py
@@ -64,7 +64,7 @@ def get_configuration(request):
 ])
 def test_reports_file_and_nodiff(folder, checkers, tags_to_apply,
                                  get_configuration, configure_environment,
-                                 restart_syscheckd, wait_for_initial_scan):
+                                 restart_syscheckd, wait_for_syscheck_start):
     """
     Check if report_changes events and diff truncated files are correct
 

--- a/tests/integration/test_fim/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_report_changes/test_report_changes_and_diff.py
@@ -64,7 +64,7 @@ def get_configuration(request):
 ])
 def test_reports_file_and_nodiff(folder, checkers, tags_to_apply,
                                  get_configuration, configure_environment,
-                                 restart_syscheckd, wait_for_syscheck_start):
+                                 restart_syscheckd, wait_for_fim_start):
     """
     Check if report_changes events and diff truncated files are correct
 

--- a/tests/integration/test_fim/test_report_changes/test_report_deleted_diff.py
+++ b/tests/integration/test_fim/test_report_changes/test_report_deleted_diff.py
@@ -136,7 +136,7 @@ def disable_report_changes(fim_mode):
 
 @pytest.mark.parametrize('path', [testdir_nodiff])
 def test_report_when_deleted_directories(path, get_configuration, configure_environment, restart_syscheckd,
-                                         wait_for_syscheck_start):
+                                         wait_for_fim_start):
     """Check if the diff directory is empty when the monitored directory is deleted.
 
     Parameters
@@ -160,7 +160,7 @@ def test_report_when_deleted_directories(path, get_configuration, configure_envi
 
 @pytest.mark.parametrize('path', [testdir_reports])
 def test_no_report_changes(path, get_configuration, configure_environment,
-                           restart_syscheckd, wait_for_syscheck_start):
+                           restart_syscheckd, wait_for_fim_start):
     """Check if duplicated directories in diff are deleted when changing `report_changes` to 'no' or deleting the
     monitored directories.
 
@@ -183,7 +183,7 @@ def test_no_report_changes(path, get_configuration, configure_environment,
 
 
 def test_report_changes_after_restart(get_configuration, configure_environment, restart_syscheckd,
-                                      wait_for_syscheck_start):
+                                      wait_for_fim_start):
     """Check if duplicated directories in diff are deleted when restarting syscheck.
 
     The duplicated directories in diff will be removed after Syscheck restarts but will be created again if the report

--- a/tests/integration/test_fim/test_report_changes/test_report_deleted_diff.py
+++ b/tests/integration/test_fim/test_report_changes/test_report_deleted_diff.py
@@ -136,7 +136,7 @@ def disable_report_changes(fim_mode):
 
 @pytest.mark.parametrize('path', [testdir_nodiff])
 def test_report_when_deleted_directories(path, get_configuration, configure_environment, restart_syscheckd,
-                                         wait_for_initial_scan):
+                                         wait_for_syscheck_start):
     """Check if the diff directory is empty when the monitored directory is deleted.
 
     Parameters
@@ -160,7 +160,7 @@ def test_report_when_deleted_directories(path, get_configuration, configure_envi
 
 @pytest.mark.parametrize('path', [testdir_reports])
 def test_no_report_changes(path, get_configuration, configure_environment,
-                           restart_syscheckd, wait_for_initial_scan):
+                           restart_syscheckd, wait_for_syscheck_start):
     """Check if duplicated directories in diff are deleted when changing `report_changes` to 'no' or deleting the
     monitored directories.
 
@@ -183,7 +183,7 @@ def test_no_report_changes(path, get_configuration, configure_environment,
 
 
 def test_report_changes_after_restart(get_configuration, configure_environment, restart_syscheckd,
-                                      wait_for_initial_scan):
+                                      wait_for_syscheck_start):
     """Check if duplicated directories in diff are deleted when restarting syscheck.
 
     The duplicated directories in diff will be removed after Syscheck restarts but will be created again if the report

--- a/tests/integration/test_fim/test_restrict/test_restrict_valid.py
+++ b/tests/integration/test_fim/test_restrict/test_restrict_valid.py
@@ -71,7 +71,7 @@ def get_configuration(request):
 ])
 def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply,
                   get_configuration, configure_environment, restart_syscheckd,
-                  wait_for_initial_scan):
+                  wait_for_syscheck_start):
     """
     Check the only files detected are those matching the restrict regex
 

--- a/tests/integration/test_fim/test_restrict/test_restrict_valid.py
+++ b/tests/integration/test_fim/test_restrict/test_restrict_valid.py
@@ -71,7 +71,7 @@ def get_configuration(request):
 ])
 def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply,
                   get_configuration, configure_environment, restart_syscheckd,
-                  wait_for_syscheck_start):
+                  wait_for_fim_start):
     """
     Check the only files detected are those matching the restrict regex
 

--- a/tests/integration/test_fim/test_scan/test_scan_day.py
+++ b/tests/integration/test_fim/test_scan/test_scan_day.py
@@ -48,7 +48,7 @@ def get_configuration(request):
 ])
 def test_scan_day(tags_to_apply,
                   get_configuration, configure_environment,
-                  restart_syscheckd, wait_for_syscheck_start):
+                  restart_syscheckd, wait_for_fim_start):
     """Check if there is a scan at a certain day of the week
 
     It will only scan once a week, on the given day.

--- a/tests/integration/test_fim/test_scan/test_scan_day.py
+++ b/tests/integration/test_fim/test_scan/test_scan_day.py
@@ -48,7 +48,7 @@ def get_configuration(request):
 ])
 def test_scan_day(tags_to_apply,
                   get_configuration, configure_environment,
-                  restart_syscheckd, wait_for_initial_scan):
+                  restart_syscheckd, wait_for_syscheck_start):
     """Check if there is a scan at a certain day of the week
 
     It will only scan once a week, on the given day.

--- a/tests/integration/test_fim/test_scan/test_scan_day_and_time.py
+++ b/tests/integration/test_fim/test_scan/test_scan_day_and_time.py
@@ -82,7 +82,7 @@ def get_configuration(request):
 ])
 def test_scan_day_and_time(tags_to_apply,
                            get_configuration, configure_environment,
-                           restart_syscheckd, wait_for_initial_scan):
+                           restart_syscheckd, wait_for_syscheck_start):
     """
     Check if there is a scan in a certain day and time
 

--- a/tests/integration/test_fim/test_scan/test_scan_day_and_time.py
+++ b/tests/integration/test_fim/test_scan/test_scan_day_and_time.py
@@ -82,7 +82,7 @@ def get_configuration(request):
 ])
 def test_scan_day_and_time(tags_to_apply,
                            get_configuration, configure_environment,
-                           restart_syscheckd, wait_for_syscheck_start):
+                           restart_syscheckd, wait_for_fim_start):
     """
     Check if there is a scan in a certain day and time
 

--- a/tests/integration/test_fim/test_scan/test_scan_time.py
+++ b/tests/integration/test_fim/test_scan/test_scan_time.py
@@ -49,7 +49,7 @@ def get_configuration(request):
 ])
 def test_scan_time(tags_to_apply,
                    get_configuration, configure_environment,
-                   restart_syscheckd, wait_for_syscheck_start):
+                   restart_syscheckd, wait_for_fim_start):
     """
     Check if there is a scan at a certain time
 

--- a/tests/integration/test_fim/test_scan/test_scan_time.py
+++ b/tests/integration/test_fim/test_scan/test_scan_time.py
@@ -49,7 +49,7 @@ def get_configuration(request):
 ])
 def test_scan_time(tags_to_apply,
                    get_configuration, configure_environment,
-                   restart_syscheckd, wait_for_initial_scan):
+                   restart_syscheckd, wait_for_syscheck_start):
     """
     Check if there is a scan at a certain time
 

--- a/tests/integration/test_fim/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_skip/test_skip.py
@@ -92,7 +92,7 @@ def extra_configuration_before_yield():
 
 # tests
 
-def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /proc when setting 'skip_proc="yes"'."""
     check_apply_test({'skip_proc'}, get_configuration['tags'])
     trigger = get_configuration['metadata']['skip'] == 'no'
@@ -139,7 +139,7 @@ def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, 
             raise AttributeError(f'Unexpected event {event}')
 
 
-def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /sys when setting 'skip_sys="yes"'."""
     check_apply_test({'skip_sys'}, get_configuration['tags'])
     trigger = get_configuration['metadata']['skip'] == 'no'
@@ -177,7 +177,7 @@ def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, w
 ])
 @patch('wazuh_testing.fim.modify_file_inode')
 def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                  wait_for_syscheck_start):
+                  wait_for_fim_start):
     """Check if syscheckd skips /dev when setting 'skip_dev="yes"'.
 
     /proc, /sys, /dev and nfs directories are special directories. Unless it is specified with skip_*='no', syscheck
@@ -199,7 +199,7 @@ def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration
 ])
 @patch('wazuh_testing.fim.modify_file_inode')
 def test_skip_nfs(modify_inode_mock, directory, tags_to_apply, configure_nfs, get_configuration, configure_environment,
-                  restart_syscheckd, wait_for_syscheck_start):
+                  restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips nfs directories when setting 'skip_nfs="yes"'.
 
     This test assumes you have a nfs directory mounted on '/nfs-mount-point'. If you do not have one, use the fixture

--- a/tests/integration/test_fim/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_skip/test_skip.py
@@ -92,7 +92,7 @@ def extra_configuration_before_yield():
 
 # tests
 
-def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd skips /proc when setting 'skip_proc="yes"'."""
     check_apply_test({'skip_proc'}, get_configuration['tags'])
     trigger = get_configuration['metadata']['skip'] == 'no'
@@ -139,7 +139,7 @@ def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, 
             raise AttributeError(f'Unexpected event {event}')
 
 
-def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd skips /sys when setting 'skip_sys="yes"'."""
     check_apply_test({'skip_sys'}, get_configuration['tags'])
     trigger = get_configuration['metadata']['skip'] == 'no'
@@ -177,7 +177,7 @@ def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, w
 ])
 @patch('wazuh_testing.fim.modify_file_inode')
 def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                  wait_for_initial_scan):
+                  wait_for_syscheck_start):
     """Check if syscheckd skips /dev when setting 'skip_dev="yes"'.
 
     /proc, /sys, /dev and nfs directories are special directories. Unless it is specified with skip_*='no', syscheck
@@ -199,7 +199,7 @@ def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration
 ])
 @patch('wazuh_testing.fim.modify_file_inode')
 def test_skip_nfs(modify_inode_mock, directory, tags_to_apply, configure_nfs, get_configuration, configure_environment,
-                  restart_syscheckd, wait_for_initial_scan):
+                  restart_syscheckd, wait_for_syscheck_start):
     """Check if syscheckd skips nfs directories when setting 'skip_nfs="yes"'.
 
     This test assumes you have a nfs directory mounted on '/nfs-mount-point'. If you do not have one, use the fixture

--- a/tests/integration/test_fim/test_synchronization/test_sync_disabled.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_disabled.py
@@ -39,7 +39,7 @@ def get_configuration(request):
 # Tests
 
 
-def test_sync_disabled(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_sync_disabled(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Verify that synchronization is disabled when enabled is set to no in the configuration.
     """

--- a/tests/integration/test_fim/test_synchronization/test_sync_disabled.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_disabled.py
@@ -39,7 +39,7 @@ def get_configuration(request):
 # Tests
 
 
-def test_sync_disabled(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_sync_disabled(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Verify that synchronization is disabled when enabled is set to no in the configuration.
     """

--- a/tests/integration/test_fim/test_synchronization/test_sync_interval.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_interval.py
@@ -43,7 +43,7 @@ def get_configuration(request):
 
 # Tests
 
-def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Verify that synchronization checks take place at the expected time given SYNC_INTERVAL variable.
     """

--- a/tests/integration/test_fim/test_synchronization/test_sync_interval.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_interval.py
@@ -43,7 +43,7 @@ def get_configuration(request):
 
 # Tests
 
-def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Verify that synchronization checks take place at the expected time given SYNC_INTERVAL variable.
     """

--- a/tests/integration/test_fim/test_synchronization/test_synchronize_integrity_scan.py
+++ b/tests/integration/test_fim/test_synchronization/test_synchronize_integrity_scan.py
@@ -80,21 +80,23 @@ def test_events_while_integrity_scan(tags_to_apply, get_configuration, configure
     # Wait for whodata to start and the synchronization check. Since they are different threads, we cannot expect
     # them to come in order every time
     if get_configuration['metadata']['fim_mode'] == 'whodata':
-        value_1 = wazuh_log_monitor.start(timeout=10, callback=callback_integrity_or_whodata,
+        value_1 = wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 2,
+                                          callback=callback_integrity_or_whodata,
                                           error_message='Did not receive expected "File integrity monitoring '
                                                         'real-time Whodata engine started" or "Initializing '
                                                         'FIM Integrity Synchronization check"').result()
 
-        value_2 = wazuh_log_monitor.start(timeout=10, callback=callback_integrity_or_whodata,
+        value_2 = wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 2,
+                                          callback=callback_integrity_or_whodata,
                                           error_message='Did not receive expected "File integrity monitoring '
                                                         'real-time Whodata engine started" or "Initializing FIM '
                                                         'Integrity Synchronization check"').result()
         assert value_1 != value_2, "callback_integrity_or_whodata detected the same message twice"
 
     else:
-
         # Check the integrity scan has begun
-        wazuh_log_monitor.start(timeout=15, callback=callback_integrity_synchronization_check,
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 3,
+                                callback=callback_integrity_synchronization_check,
                                 error_message='Did not receive expected '
                                               '"Initializing FIM Integrity Synchronization check" event')
 

--- a/tests/integration/test_fim/test_tags/test_tags.py
+++ b/tests/integration/test_fim/test_tags/test_tags.py
@@ -58,7 +58,7 @@ def get_configuration(request):
     ('file2', b'Sample content')
 ])
 def test_tags(folder, name, content,
-              get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+              get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
     Check the tags functionality by applying some tags an ensuring the events raised for the monitored directory has
     the expected tags.

--- a/tests/integration/test_fim/test_tags/test_tags.py
+++ b/tests/integration/test_fim/test_tags/test_tags.py
@@ -58,7 +58,7 @@ def get_configuration(request):
     ('file2', b'Sample content')
 ])
 def test_tags(folder, name, content,
-              get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+              get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """
     Check the tags functionality by applying some tags an ensuring the events raised for the monitored directory has
     the expected tags.

--- a/tests/integration/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
+++ b/tests/integration/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
@@ -80,7 +80,7 @@ def callback_sacl_restored(line):
     {'audit_interval'}
 ])
 def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                   wait_for_syscheck_start):
+                                   wait_for_fim_start):
     """Check that Wazuh detects a SACL change every 'windows_audit_interval' and sets monitoring to real-time if so."""
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
@@ -108,7 +108,7 @@ def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_e
     {'audit_interval'}
 ])
 def test_windows_audit_restore_sacl(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                    wait_for_syscheck_start):
+                                    wait_for_fim_start):
     """Check that Wazuh restores previous SACL rules when the service is stopped."""
     check_apply_test(tags_to_apply, get_configuration['tags'])
 

--- a/tests/integration/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
+++ b/tests/integration/test_fim/test_windows_audit_interval/test_windows_audit_interval.py
@@ -80,7 +80,7 @@ def callback_sacl_restored(line):
     {'audit_interval'}
 ])
 def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                   wait_for_initial_scan):
+                                   wait_for_syscheck_start):
     """Check that Wazuh detects a SACL change every 'windows_audit_interval' and sets monitoring to real-time if so."""
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
@@ -108,7 +108,7 @@ def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_e
     {'audit_interval'}
 ])
 def test_windows_audit_restore_sacl(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
-                                    wait_for_initial_scan):
+                                    wait_for_syscheck_start):
     """Check that Wazuh restores previous SACL rules when the service is stopped."""
     check_apply_test(tags_to_apply, get_configuration['tags'])
 

--- a/tests/integration/test_fim/test_windows_registry/test_windows_registry.py
+++ b/tests/integration/test_fim/test_windows_registry/test_windows_registry.py
@@ -71,7 +71,7 @@ def extra_configuration_before_yield():
     (['32'], "test_tag", {'ossec_conf_2'})
 ])
 def test_windows_registry(arch_list, tag, tags_to_apply,
-                          get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
+                          get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check the correct monitoring of Windows Registries.
 
     This test creates a new registry in windows, adds a value, modifies

--- a/tests/integration/test_fim/test_windows_registry/test_windows_registry.py
+++ b/tests/integration/test_fim/test_windows_registry/test_windows_registry.py
@@ -71,7 +71,7 @@ def extra_configuration_before_yield():
     (['32'], "test_tag", {'ossec_conf_2'})
 ])
 def test_windows_registry(arch_list, tag, tags_to_apply,
-                          get_configuration, configure_environment, restart_syscheckd, wait_for_initial_scan):
+                          get_configuration, configure_environment, restart_syscheckd, wait_for_syscheck_start):
     """Check the correct monitoring of Windows Registries.
 
     This test creates a new registry in windows, adds a value, modifies


### PR DESCRIPTION
## Description

In Wazuh 4.0.0, some tests were failing in Ubuntu and Windows. This pull request fixes these tests. Here is a summary of what has been fixed:

### Ubuntu
#### test_file_size_values

The problem was caused by what is described in wazuh/wazuh#5242. While this is fixed in Wazuh core, I have added a function to increase the value of the rt_delay internal option to 1 second.

### Windows

#### test_basic_usage_changes

The timeout has been increased on Windows.

#### test_move_dir

This test was failing because of this issue: wazuh/wazuh#6089. This case has been set to xfail.

#### test_max_eps_synchronization

This test was failing because the synchronization was not being performed in the 120 seconds the test has as timeout. It has been fixed by setting the synchronization interval to 60 seconds.
This test was also being executed in every FIM mode unnecessarily, now it will run in _realtime_ on Linux and Windows, and in _scheduled_ on macOS and Solaris.

This pull request closes #858.
