### PR TITLE
[Agent-info][Cluster] Add system test for agent-info synchronization

### DIFF
--- a/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
@@ -11,6 +11,7 @@
       - automake
       - autoconf
       - libtool
+      - sqlite3
     force_apt_get: True
     state: present
 
@@ -69,6 +70,13 @@
   file:
     path: /var/ossec/etc/client.keys
     state: absent
+
+- name: enable authd and clusterd debug mode
+  blockinfile:
+    path: /var/ossec/etc/local_internal_options.conf
+    block: |
+      authd.debug=2
+      wazuh_clusterd.debug=2
 
 - name: Register agents
   blockinfile:

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
@@ -12,6 +12,7 @@
       - autoconf
       - libtool
       - python3-pytest
+      - sqlite3
     force_apt_get: True
     state: present
 
@@ -69,6 +70,13 @@
     regexp: '<node>(.*)</node>'
     line: "<node>{{ master_hostname }}</node>"
     backrefs: yes
+
+- name: enable authd and clusterd debug mode
+  blockinfile:
+    path: /var/ossec/etc/local_internal_options.conf
+    block: |
+      authd.debug=2
+      wazuh_clusterd.debug=2
 
 - name: Restart Wazuh
   command: /var/ossec/bin/ossec-control restart

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
@@ -3,7 +3,12 @@ wazuh-master:
   - regex: '.*Received request:.*{"daemon_name": "wazuh-db", "message": "global sync-agent-info-set.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
-
+  - regex: '.*wazuh-worker1.*Finished integrity synchronization.'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: '.*wazuh-worker2.*Finished integrity synchronization.'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
 
 wazuh-worker1:
   - regex: ".*Starting agent-info sync process."
@@ -21,6 +26,27 @@ wazuh-worker1:
   - regex: ".*Master's wazuh-db response: ok."
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
-  - regex: ".*Finished sending process to wazuh-db."
+  - regex: ".*Finished sending information to wazuh-db.*"
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+
+
+wazuh-worker2:
+  - regex: ".*Starting agent-info sync process."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Obtaining data to be sent to master's wazuh-db."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Obtained .* chunks of data to be sent."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Starting sending information to wazuh-db."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Master's wazuh-db response: ok."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Finished sending information to wazuh-db.*"
     path: "/var/ossec/logs/cluster.log"
     timeout: 60

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
@@ -1,0 +1,26 @@
+---
+wazuh-master:
+  - regex: '.*Received request:.*{"daemon_name": "wazuh-db", "message": "global sync-agent-info-set.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+
+
+wazuh-worker1:
+  - regex: ".*Starting agent-info sync process."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Obtaining data to be sent to master's wazuh-db."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Obtained .* chunks of data to be sent."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Starting sending information to wazuh-db."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Master's wazuh-db response: ok."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+  - regex: ".*Finished sending process to wazuh-db."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
@@ -5,10 +5,11 @@ wazuh-master:
     timeout: 60
   - regex: '.*wazuh-worker1.*Finished integrity synchronization.'
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: '.*wazuh-worker2.*Finished integrity synchronization.'
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
+
 
 wazuh-worker1:
   - regex: ".*Starting agent-info sync process."
@@ -16,19 +17,19 @@ wazuh-worker1:
     timeout: 60
   - regex: ".*Obtaining data to be sent to master's wazuh-db."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Obtained .* chunks of data to be sent."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Starting sending information to wazuh-db."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Master's wazuh-db response: ok."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Finished sending information to wazuh-db.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 30
 
 
 wazuh-worker2:
@@ -37,16 +38,16 @@ wazuh-worker2:
     timeout: 60
   - regex: ".*Obtaining data to be sent to master's wazuh-db."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Obtained .* chunks of data to be sent."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Starting sending information to wazuh-db."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Master's wazuh-db response: ok."
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 15
   - regex: ".*Finished sending information to wazuh-db.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 30

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages_remove_agent.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages_remove_agent.yml
@@ -1,0 +1,15 @@
+---
+wazuh-worker2:
+  - regex: "*Agents to remove.*"
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 20
+  - regex: ".*Agent files removed"
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 10
+  - regex: ".*Updating files: End"
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 10
+  - regex: ".*The master has verified that the integrity is right."
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
+

--- a/tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.py
+++ b/tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.py
@@ -14,29 +14,79 @@ from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH
 testinfra_hosts = ["wazuh-master", "wazuh-worker1", "wazuh-agent1"]
 
 inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-                              'provisioning', 'enrollment_cluster', 'inventory.yml')
+                              'provisioning', 'basic_cluster', 'inventory.yml')
+
 host_manager = HostManager(inventory_path)
 local_path = os.path.dirname(os.path.abspath(__file__))
 messages_path = os.path.join(local_path, 'data/messages.yml')
 tmp_path = os.path.join(local_path, 'tmp')
 
+label = "test_label"
+
+
 @pytest.fixture(scope='module')
 def configure_environment():
     host_manager.get_host('wazuh-master').ansible('command', f'service wazuh-manager stop', check=False)
     host_manager.get_host('wazuh-worker1').ansible('command', f'service wazuh-manager stop', check=False)
+    host_manager.get_host('wazuh-worker2').ansible('command', f'service wazuh-manager stop', check=False)
+    host_manager.get_host('wazuh-agent1').ansible('command', f'service wazuh-agent stop', check=False)
+    host_manager.get_host('wazuh-agent2').ansible('command', f'service wazuh-agent stop', check=False)
+    host_manager.get_host('wazuh-agent3').ansible('command', f'service wazuh-agent stop', check=False)
     host_manager.clear_file(host='wazuh-master',  file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
     host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
+    host_manager.clear_file(host='wazuh-worker2', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
     yield
+    # Remove the label configuration
+    host_manager.add_block_to_file(host='wazuh-agent2', path=f'{WAZUH_PATH}/etc/ossec.conf', after='</client>',
+                                   before='<client_buffer>', replace='')
+    # Restart agent 2 to apply label removal.
+    host_manager.get_host('wazuh-agent2').ansible('command', f'service wazuh-agent restart', check=False)
+
+    # Restart the removed agent to re-register in the worker to avoid impact over following tests
+    host_manager.get_host('wazuh-agent3').ansible('command', f'service wazuh-agent restart', check=False)
 
 
 def test_agent_info_sync(configure_environment):
-    """Check agent agent-info synchronization works as expected."""
+    """Check agent agent-info synchronization works as expected.
 
+    This test will wait for the expected agent-info messages declared in data/messages.yml. Additionally, it will
+    ensure agent-info synchronization is working by modifying one agent and removing another one."""
     host_manager.control_service(host='wazuh-master', service='wazuh', state="started")
     host_manager.control_service(host='wazuh-worker1', service='wazuh', state="started")
+    host_manager.control_service(host='wazuh-worker2', service='wazuh', state="started")
+
+    # Add a label to one of the agents
+    host_manager.add_block_to_file(host='wazuh-agent2', path=f'{WAZUH_PATH}/etc/ossec.conf', after='</client>',
+                                   before='<client_buffer>',
+                                   replace=f'<labels><label key="{label}">value</label></labels>')
+
+    host_manager.control_service(host='wazuh-agent1', service='wazuh', state="started")
+    host_manager.control_service(host='wazuh-agent2', service='wazuh', state="started")
+    host_manager.control_service(host='wazuh-agent3', service='wazuh', state="started")
 
     # Run the callback checks for the cluster.log
-    HostMonitor(inventory_path=inventory_path,
-                messages_path=messages_path,
-                tmp_path=tmp_path).run()
+    HostMonitor(inventory_path=inventory_path, messages_path=messages_path, tmp_path=tmp_path).run()
 
+    # Check the wazuh-agent2's label is present in the Master node DB
+    master_label = host_manager.run_command('wazuh-master', f'sqlite3 {WAZUH_PATH}/queue/db/global.db '
+                                                            f'"SELECT key FROM labels LIMIT 1;"')
+    assert master_label == f'"{label}"'
+
+    # Check the agent2 is present on the Worker2's client.keys
+    agent_id = host_manager.run_command('wazuh-worker1', f'grep wazuh-agent2 {WAZUH_PATH}/etc/client.keys')
+    assert agent_id, f'wazuh-agent2 was not found in wazuh-worker2\'s client.keys file.'
+
+    # Stop agent2 to avoid agent enrollment
+    host_manager.get_host('wazuh-agent2').ansible('command', f'service wazuh-agent stop', check=False)
+
+    # Remove an agent
+    agent_id = host_manager.run_command('wazuh-master', f'grep wazuh-agent2 {WAZUH_PATH}/etc/client.keys')
+    assert agent_id, f'wazuh-agent2 was not found in Master\'s client.keys file.'
+    host_manager.run_command('wazuh-master', f'{WAZUH_PATH}/bin/manage_agents -r {agent_id[0:3]}')
+
+    # Run again the callback checks for the cluster.log to ensure the info is synchronized
+    HostMonitor(inventory_path=inventory_path, messages_path=messages_path, tmp_path=tmp_path).run()
+
+    # Check the removed agent is not present in wazuh-worker1's client.keys
+    agent_id = host_manager.run_command('wazuh-worker1', f'grep wazuh-agent2 {WAZUH_PATH}/etc/client.keys')
+    assert agent_id is ""

--- a/tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.py
+++ b/tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing.tools.system import HostManager
+from wazuh_testing.tools.monitoring import HostMonitor
+from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH
+
+# Hosts
+testinfra_hosts = ["wazuh-master", "wazuh-worker1", "wazuh-agent1"]
+
+inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                              'provisioning', 'enrollment_cluster', 'inventory.yml')
+host_manager = HostManager(inventory_path)
+local_path = os.path.dirname(os.path.abspath(__file__))
+messages_path = os.path.join(local_path, 'data/messages.yml')
+tmp_path = os.path.join(local_path, 'tmp')
+
+@pytest.fixture(scope='module')
+def configure_environment():
+    host_manager.get_host('wazuh-master').ansible('command', f'service wazuh-manager stop', check=False)
+    host_manager.get_host('wazuh-worker1').ansible('command', f'service wazuh-manager stop', check=False)
+    host_manager.clear_file(host='wazuh-master',  file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
+    host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
+    yield
+
+
+def test_agent_info_sync(configure_environment):
+    """Check agent agent-info synchronization works as expected."""
+
+    host_manager.control_service(host='wazuh-master', service='wazuh', state="started")
+    host_manager.control_service(host='wazuh-worker1', service='wazuh', state="started")
+
+    # Run the callback checks for the cluster.log
+    HostMonitor(inventory_path=inventory_path,
+                messages_path=messages_path,
+                tmp_path=tmp_path).run()
+


### PR DESCRIPTION
Hello tea,

This PR closes #872 and is related to [#5585](https://github.com/wazuh/wazuh/issues/5585). A new System test for agent-info has been added. This test uses the `basic_cluster` ansible environment.

## Test design

The new module contains 2 tests:

- The first one checks cluster.log contains the expected messages after agent-info synchronization process finished and verify the info is shared between nodes by adding a label to a agent and looking for that label in the master's global.db

- The second test removes and agent from the master and ensure the Worker no longer has that agent in its global.db after the synchronization.
