### PR TITLE
Add IT to check Wazuh-logtest remove old sessions correctly

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logtest.py
+++ b/deps/wazuh_testing/wazuh_testing/logtest.py
@@ -35,6 +35,13 @@ def callback_session_initialized(line):
     return None
 
 
+def callback_remove_session(line):
+    match = re.match(r".*\(7206\): The session '(\S+)' was closed successfully", line)
+    if match:
+        return match.group(1)
+    return None
+
+
 def callback_invalid_token(line):
     match = re.match(r".*\(7309\): '(\S+)' is not a valid token", line)
     if match:

--- a/deps/wazuh_testing/wazuh_testing/logtest.py
+++ b/deps/wazuh_testing/wazuh_testing/logtest.py
@@ -29,21 +29,21 @@ def callback_configuration_error(line):
 
 
 def callback_session_initialized(line):
-    match = re.match(r".*\(7202\): Session initialized with token '(\S+)'", line)
+    match = re.match(r".*\(7202\): Session initialized with token '(\w{8})'", line)
     if match:
         return match.group(1)
     return None
 
 
 def callback_remove_session(line):
-    match = re.match(r".*\(7206\): The session '(\S+)' was closed successfully", line)
+    match = re.match(r".*\(7206\): The session '(\w{8})' was closed successfully", line)
     if match:
         return match.group(1)
     return None
 
 
 def callback_invalid_token(line):
-    match = re.match(r".*\(7309\): '(\S+)' is not a valid token", line)
+    match = re.match(r".*\(7309\): '(\w{8})' is not a valid token", line)
     if match:
         return match.group(1)
     return None

--- a/tests/integration/test_logtest/test_remove_old_sessions/data/wazuh_conf.yaml
+++ b/tests/integration/test_logtest/test_remove_old_sessions/data/wazuh_conf.yaml
@@ -1,0 +1,32 @@
+# conf 1
+- tags:
+  - conf
+  apply_to_modules:
+  - test_remove_old_sessions
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '1'
+    - max_sessions:
+        value: '3'
+    - session_timeout:
+        value: '300'
+# conf 2
+- tags:
+  - conf
+  apply_to_modules:
+  - test_remove_old_session_for_inactivity
+  sections:
+  - section: rule_test
+    elements:
+    - enabled:
+        value: 'yes'
+    - threads:
+        value: '1'
+    - max_sessions:
+        value: '3'
+    - session_timeout:
+        value: '5'

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import time
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.logtest import (callback_logtest_started,
+                                   callback_remove_session,
+                                   callback_session_initialized)
+
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+# Variables
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+receiver_sockets_params = [(logtest_sock, 'AF_UNIX', 'TCP')]
+receiver_sockets = None
+
+msg_create_session = """{"version":1, "command":"log_processing", "parameters":{
+"event": "Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928",
+"log_format": "syslog", "location": "master->/var/log/syslog"}}"""
+
+
+# Fixture
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Test
+def test_remove_old_session_for_inactivity(get_configuration, configure_environment,
+                                           restart_wazuh, connect_to_sockets_function):
+    """
+    Create more sessions than allowed and wait session_timeout seconds,
+    then check Wazuh-logtest has removed session for inactivity.
+    """
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callback_logtest_started,
+                            error_message="Event 'logtest started' not found")
+
+    session_timeout = int(get_configuration['sections'][0]['elements'][3]['session_timeout']['value'])
+
+    receiver_sockets[0].send(msg_create_session, True)
+    msg_recived = receiver_sockets[0].receive().decode()
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callback_session_initialized,
+                            error_message="Event 'session initialized' not found")
+
+    time.sleep(session_timeout)
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callback_remove_session,
+                            error_message="Event 'session removed' not found")

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.monitoring import FileMonitor, SocketController
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.logtest import (callback_logtest_started,
+                                   callback_remove_session,
+                                   callback_session_initialized)
+
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+# Variables
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+
+msg_create_session = """{"version":1, "command":"log_processing", "parameters":{
+"event": "Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928",
+"log_format": "syslog", "location": "master->/var/log/syslog"}}"""
+
+
+# Function to manage the comunication with Wazuh-logtest
+def create_connection():
+    return SocketController(address=logtest_sock, family='AF_UNIX', connection_protocol='TCP')
+
+def remove_connection(connection):
+    connection.close()
+    del connection
+
+
+# Fixture
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Test
+def test_remove_old_session(get_configuration, configure_environment, restart_wazuh):
+    """
+    Create more sessions than allowed and wait for the message which
+    informs that Wazuh-logtest has removed the oldest session.
+    """
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callback_logtest_started,
+                            error_message='Event not found')
+
+    max_sessions = int(get_configuration['sections'][0]['elements'][2]['max_sessions']['value'])
+
+    for i in range(0, max_sessions):
+
+        receiver_socket = create_connection()
+        receiver_socket.send(msg_create_session, True)
+        msg_recived = receiver_socket.receive().decode()
+        remove_connection(receiver_socket)
+
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_session_initialized,
+                                error_message='Event not found')
+
+    # This session should do Wazuh-logtest to remove the oldest session
+    receiver_socket = create_connection()
+    receiver_socket.send(msg_create_session, True)
+    msg_recived = receiver_socket.receive().decode()
+    remove_connection(receiver_socket)
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callback_remove_session,
+                            error_message='Event not found')
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callback_session_initialized,
+                            error_message='Event not found')

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
@@ -35,6 +35,7 @@ msg_create_session = """{"version":1, "command":"log_processing", "parameters":{
 def create_connection():
     return SocketController(address=logtest_sock, family='AF_UNIX', connection_protocol='TCP')
 
+
 def remove_connection(connection):
     connection.close()
     del connection


### PR DESCRIPTION
Hello team,

This IT check that Wazuh-Logtest remove old sessions correctly

Regards,
Eva

***
```
test_logtest$ sudo python3 -m pytest .
========================================== test session starts ===========================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/eva/wazuh/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: testinfra-5.0.0, metadata-1.10.0, html-2.1.1
collected 85 items                                                                                       

test_configuration/test_configuration_file.py .....                                                [  5%]
test_configuration/test_get_configuration_sock.py .....                                            [ 11%]
test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py ...........                       [ 24%]
test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py ...............                     [ 42%]
test_invalid_socket_input/test_invalid_socket_input.py ..........................                  [ 72%]
test_invalid_token/test_invalid_session_token.py ......                                            [ 80%]
test_remove_old_sessions/test_remove_old_session_for_inactivity.py .                               [ 81%]
test_remove_old_sessions/test_remove_old_sessions.py .                                             [ 82%]
test_remove_session/test_remove_session.py .........                                               [ 92%]
test_rules_decoders_load/test_load_rules_decoders.py ......                                        [100%]

===================================== 85 passed in 331.05s (0:05:31) =====================================
```