### PR TITLE
Remove import pdb and set_trace

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import uuid
 from datetime import datetime
-import pdb
 
 import pytest
 from numpydoc.docscrape import FunctionDoc
@@ -55,7 +54,6 @@ def pytest_runtest_setup(item):
 @pytest.fixture(scope='module')
 def restart_wazuh(get_configuration, request):
     # Stop Wazuh
-    pdb.set_trace()
     control_service('stop')
 
     # Reset ossec.log and start a new monitor

--- a/tests/integration/test_agentd/conftest.py
+++ b/tests/integration/test_agentd/conftest.py
@@ -2,7 +2,6 @@ import os
 import pytest
 import socket
 import ssl
-import pdb
 import platform
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 from wazuh_testing.tools.monitoring import FileMonitor


### PR DESCRIPTION
Hello team,


This PR removes the unnecessary **import.pdb** and **set_trace**, which was left from my development on enrollment






Best regards.
