### PR TITLE
[Framework][API] Minor fixes for System tests

### DIFF
--- a/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
@@ -77,6 +77,7 @@
     block: |
       authd.debug=2
       wazuh_clusterd.debug=2
+      wazuh_db.debug=2
 
 - name: Register agents
   blockinfile:

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
@@ -77,6 +77,7 @@
     block: |
       authd.debug=2
       wazuh_clusterd.debug=2
+      wazuh_db.debug=2
 
 - name: Restart Wazuh
   command: /var/ossec/bin/ossec-control restart

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
@@ -21,7 +21,7 @@ wazuh-worker1:
   - regex: ".*Obtained .* chunks of data to be sent."
     path: "/var/ossec/logs/cluster.log"
     timeout: 15
-  - regex: ".*Starting sending information to wazuh-db."
+  - regex: ".*Starting to send information to wazuh-db."
     path: "/var/ossec/logs/cluster.log"
     timeout: 15
   - regex: ".*Master's wazuh-db response: ok."
@@ -42,7 +42,7 @@ wazuh-worker2:
   - regex: ".*Obtained .* chunks of data to be sent."
     path: "/var/ossec/logs/cluster.log"
     timeout: 15
-  - regex: ".*Starting sending information to wazuh-db."
+  - regex: ".*Starting to send information to wazuh-db."
     path: "/var/ossec/logs/cluster.log"
     timeout: 15
   - regex: ".*Master's wazuh-db response: ok."

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
@@ -9,6 +9,9 @@ wazuh-master:
   - regex: '.*wazuh-worker2.*Finished integrity synchronization.'
     path: "/var/ossec/logs/cluster.log"
     timeout: 15
+  - regex: '.*Received request: .*test_label.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
 
 
 wazuh-worker1:

--- a/tests/system/test_jwt_invalidation/test_change_rbac_mode.py
+++ b/tests/system/test_jwt_invalidation/test_change_rbac_mode.py
@@ -74,6 +74,9 @@ def test_change_rbac_mode_manually(login_endpoint, set_default_api_conf, restore
     host_manager.modify_file_content(test_hosts[0], path=WAZUH_SECURITY_CONF,
                                      content=yaml.safe_dump({'rbac_mode': new_rbac_mode}))
 
+    # Restart the wazuh-manager service
+    host_manager.get_host(test_hosts[0]).ansible('command', f'service wazuh-manager restart', check=False)
+
     # Assert every token is revoked
     for host in test_hosts:
         response = host_manager.make_api_call(host, endpoint='/agents', token=tokens[host])


### PR DESCRIPTION
Hello team,

This PR applies minor fixes for the ansible system tests. Here are the changes:

* Update Agent-info expected messages for cluster.log as Core changed them.
* The agent info test has been simplified to only check the logs and ignore the database.
* `test_change_rbac_mode` now restarts the manager after changing the rbac mode, as now the change is not applied until the Wazuh API is restarted.
