### PR TITLE
[API] Update system tests to support the new API response format

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -52,6 +52,6 @@ def get_token_login_api(protocol, host, port, user, password, login_endpoint, ti
     response = requests.get(login_url, headers=get_login_headers(user, password), verify=False, timeout=timeout)
 
     if response.status_code == 200:
-        return json.loads(response.content.decode())['token']
+        return json.loads(response.content.decode())['data']['token']
     else:
         raise Exception(f"Error obtaining login token: {response.json()}")

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -242,7 +242,7 @@ class HostManager:
                                                          f'user={user} password={password} method={login_method} '
                                                          f'{login_body} validate_certs=no force_basic_auth=yes',
                                                          check=check)
-            return token_response['json']['token']
+            return token_response['json']['data']['token']
         except KeyError:
             raise KeyError(f'Failed to get token: {token_response}')
 

--- a/tests/system/test_jwt_invalidation/test_change_rbac_mode.py
+++ b/tests/system/test_jwt_invalidation/test_change_rbac_mode.py
@@ -41,7 +41,7 @@ def test_change_rbac_mode_with_endpoint(login_endpoint, set_default_api_conf, re
     # Get current RBAC mode
     response = host_manager.make_api_call(test_hosts[0], endpoint='/security/config', token=tokens[test_hosts[0]])
     assert response['status'] == 200, f'Failed to get security settings: {response}'
-    new_rbac_mode = opposite_rbac_mode[response['json']['rbac_mode']]
+    new_rbac_mode = opposite_rbac_mode[response['json']['data']['rbac_mode']]
 
     # Change RBAC mode using endpoint
     response = host_manager.make_api_call(test_hosts[0], method='PUT', endpoint='/security/config',
@@ -68,11 +68,14 @@ def test_change_rbac_mode_manually(login_endpoint, set_default_api_conf, restore
     # Get current RBAC mode
     response = host_manager.make_api_call(test_hosts[0], endpoint='/security/config', token=tokens[test_hosts[0]])
     assert response['status'] == 200, f'Failed to get security settings: {response}'
-    new_rbac_mode = opposite_rbac_mode[response['json']['rbac_mode']]
+    new_rbac_mode = opposite_rbac_mode[response['json']['data']['rbac_mode']]
 
     # Change RBAC mode manually
     host_manager.modify_file_content(test_hosts[0], path=WAZUH_SECURITY_CONF,
                                      content=yaml.safe_dump({'rbac_mode': new_rbac_mode}))
+
+    # Restart the wazuh-manager service
+    host_manager.get_host(test_hosts[0]).ansible('command', f'service wazuh-manager restart', check=False)
 
     # Assert every token is revoked
     for host in test_hosts:


### PR DESCRIPTION
Hello team,

This PR adapts QA System and Integration tests to support the new response format for `/security/user/authenticate` and the other updated endpoints.

## System tests results
```
======================================================================= test session starts =======================================================================
platform linux -- Python 3.8.2, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/vagrant_shared/wazuh-qa/tests/system/test_jwt_invalidation
plugins: tavern-1.0.0, testinfra-5.0.0
collected 19 items                                                                                                                                                

test_change_rbac_mode.py ....                                                                                                                               [ 21%]
test_change_security_resources.py ....                                                                                                                      [ 42%]
test_disconnected_nodes.py .                                                                                                                                [ 47%]
test_revoke_endpoint.py ......                                                                                                                              [ 78%]
test_update_password.py ....                                                                                                                                [100%]

================================================================== 19 passed in 1117.37 seconds ===================================================================
```

```
======================================================================= test session starts =======================================================================
platform linux -- Python 3.8.2, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/vagrant_shared/wazuh-qa/tests/system/test_cluster/test_agent_enrollment
plugins: tavern-1.0.0, testinfra-5.0.0
collected 1 item                                                                                                                                                  

test_agent_enrollment.py .                                                                                                                                  [100%]

=================================================================== 1 passed in 123.17 seconds ====================================================================
```

```
======================================================================= test session starts =======================================================================
platform linux -- Python 3.8.2, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/vagrant_shared/wazuh-qa/tests/system/test_cluster/test_agent_info_sync
plugins: tavern-1.0.0, testinfra-5.0.0
collected 2 items                                                                                                                                                 

test_agent_info_sync.py ..                                                                                                                                  [100%]

=================================================================== 2 passed in 220.95 seconds ====================================================================
```

