### PR TITLE
Update tests with agents_list parameter

### DIFF
--- a/tests/integration/test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py
+++ b/tests/integration/test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py
@@ -7,7 +7,6 @@ import time
 from secrets import token_hex
 import random
 from ipaddress import IPv4Address
-from requests.packages.urllib3.util.retry import Retry
 
 import pytest
 import requests
@@ -80,8 +79,9 @@ def test_behind_proxy_server(insert_agent, tags_to_apply, get_configuration, con
     api_details['base_url'] += '/agents'
 
     # Delete previous agents to avoid duplicate data error.
-    delete_url = api_details['base_url'] + f"?purge=true&status=&older_than=0s"
-    requests.delete(delete_url, headers=api_details['auth_headers'], verify=False)
+    delete_url = api_details['base_url'] + f"?agents_list=all&purge=true&status=&older_than=0s"
+    delete_response = requests.delete(delete_url, headers=api_details['auth_headers'], verify=False)
+    assert delete_response.status_code == 200, f'Delete response was not 200. Response: {delete_response.text}'
 
     # Add agent
     post_url = api_details['base_url'] + '/insert' if insert_agent else api_details['base_url']
@@ -91,7 +91,7 @@ def test_behind_proxy_server(insert_agent, tags_to_apply, get_configuration, con
         agent_id = post_response.json()['data']['id']
 
         # Get the agent to check its IP
-        api_details['base_url'] += f"?list_agents={agent_id}"
+        api_details['base_url'] += f"?agents_list={agent_id}"
 
         # It is necessary to wait a bit after adding the agent before querying it.
         retries = 0

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -86,8 +86,9 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
 
         # Delete the agent created
         agent_id = post_response.json()['data']['id']
-        api_details['base_url'] += f"?list_agents={agent_id}&purge=true&status=&older_than=0s"
-        requests.delete(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
+        api_details['base_url'] += f"?agents_list={agent_id}&purge=true&status=&older_than=0s"
+        delete_response = requests.delete(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
+        assert delete_response.status_code == 200, f'Delete response was not 200. Response: {delete_response.text}'
 
 
 @pytest.mark.parametrize('tags_to_apply', [
@@ -131,7 +132,7 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']
-        api_details['base_url'] += f"?list_agents={agent_id}&purge=true&status=&older_than=0s"
+        api_details['base_url'] += f"?agents_list={agent_id}&purge=true&status=&older_than=0s"
         requests.delete(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
 
 
@@ -172,7 +173,7 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']
-        api_details['base_url'] += f"?list_agents={agent_id}&purge=true&status=&older_than=0s"
+        api_details['base_url'] += f"?agents_list={agent_id}&purge=true&status=&older_than=0s"
         requests.delete(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
 
 
@@ -215,7 +216,7 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
     # It is necessary to wait a bit after adding the agent before deleting or querying it.
     time.sleep(1)
     delete_url = api_details['base_url'] + \
-                 f"?list_agents={post_response.json()['data']['id']}&purge=true&status=&older_than=0s"
+                 f"?agents_list={post_response.json()['data']['id']}&purge=true&status=&older_than=0s"
     delete_response = requests.delete(delete_url, headers=api_details['auth_headers'], verify=False).json()
 
     # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.


### PR DESCRIPTION
Hello team, this PR is part of #888 .

There were some integration tests that were not updated after the parameters changes in the code. We had to change `list_agents` for `agents_list`.

## Modified tests
### test_use_only_authd
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.6.8, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.0.1, testinfra-5.0.0
collected 16 items                                                                                                                                                                          

test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.s.ss.s.s.s.                                                                                                      [100%]

========================================================================= 8 passed, 8 skipped, 8 warnings in 55.56s =========================================================================

```

### test_behind_proxy_server
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.6.8, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.0.1, testinfra-5.0.0
collected 8 items                                                                                                                                                                           

test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py .s.ss.s.                                                                                                    [100%]

=================================================================== 4 passed, 4 skipped, 4 warnings in 111.12s (0:01:51) ====================================================================

```

Regards,
Víctor.