### PR TITLE
[API] Add security resources integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -70,6 +70,7 @@ def get_api_details_dict(protocol=API_PROTOCOL, host=API_HOST, port=API_PORT, us
 
 
 def get_security_resource_information(**kwargs):
+    """Get all information about a security resource."""
     assert len(kwargs) == 1, f'This function only admits one argument'
     endpoint = {
         'user_ids': '/users?user_ids=',

--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -42,7 +42,7 @@ def get_base_url(protocol, host, port):
 def get_login_headers(user, password):
     basic_auth = f"{user}:{password}".encode()
     return {'Content-Type': 'application/json',
-                     'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
+            'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
 
 
 def get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout):
@@ -55,3 +55,38 @@ def get_token_login_api(protocol, host, port, user, password, login_endpoint, ti
         return json.loads(response.content.decode())['data']['token']
     else:
         raise Exception(f"Error obtaining login token: {response.json()}")
+
+
+def get_api_details_dict(protocol=API_PROTOCOL, host=API_HOST, port=API_PORT, user=API_USER, password=API_PASS,
+                         login_endpoint=API_LOGIN_ENDPOINT, timeout=10):
+    """Get API details"""
+    return {
+        'base_url': get_base_url(protocol, host, port),
+        'auth_headers': {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout)}'
+        }
+    }
+
+
+def get_security_resource_information(**kwargs):
+    assert len(kwargs) == 1, f'This function only admits one argument'
+    endpoint = {
+        'user_ids': '/users?user_ids=',
+        'role_ids': '/roles?role_ids=',
+        'policy_ids': '/policies?policy_ids=',
+        'rule_ids': '/rules?rule_ids=',
+    }
+
+    api_details = get_api_details_dict()
+    resource = next(iter(kwargs.keys()))
+    value = kwargs[resource]
+    value = ','.join(value) if isinstance(value, list) else value
+    get_endpoint = api_details['base_url'] + '/security' + endpoint[resource] + str(value)
+
+    response = requests.get(get_endpoint, headers=api_details['auth_headers'], verify=False)
+
+    if response.json()['error'] == 0:
+        return response.json()['data']['affected_items'][0]
+    else:
+        return {}

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -7,8 +7,7 @@ import shutil
 
 import pytest
 
-from wazuh_testing.api import callback_detect_api_start, get_base_url, get_token_login_api, API_HOST, \
-    API_LOGIN_ENDPOINT, API_PASS, API_PORT, API_USER, API_PROTOCOL
+from wazuh_testing.api import callback_detect_api_start, get_api_details_dict
 from wazuh_testing.tools import API_LOG_FILE_PATH, WAZUH_API_CONF, WAZUH_SECURITY_CONF
 from wazuh_testing.tools.configuration import get_api_conf, write_api_conf, write_security_conf
 from wazuh_testing.tools.file import truncate_file
@@ -100,14 +99,4 @@ def wait_for_start(get_configuration, request):
 
 @pytest.fixture(scope='module')
 def get_api_details():
-    def _get_api_details(protocol=API_PROTOCOL, host=API_HOST, port=API_PORT, user=API_USER,
-                         password=API_PASS, login_endpoint=API_LOGIN_ENDPOINT, timeout=10):
-        return {
-            'base_url': get_base_url(protocol, host, port),
-            'auth_headers': {
-                'Content-Type': 'application/json',
-                'Authorization': f'Bearer {get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout)}'
-            }
-        }
-
-    return _get_api_details
+    return get_api_details_dict

--- a/tests/integration/test_api/test_rbac/conftest.py
+++ b/tests/integration/test_api/test_rbac/conftest.py
@@ -4,7 +4,7 @@ import requests
 from wazuh_testing.api import get_api_details_dict
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def set_security_resources(request):
     def remove_test_security_resources(endpoint):
         parameter = {
@@ -23,76 +23,73 @@ def set_security_resources(request):
     policies_endpoint = api_details['base_url'] + '/security/policies'
     rules_endpoint = api_details['base_url'] + '/security/rules'
 
-    user_ids, role_ids, policy_ids, rule_ids = list(), list(), list(), list()
+    # Create new user
+    response = requests.post(users_endpoint,
+                             json={'username': f'test_user',
+                                   'password': 'Password1!',
+                                   'allow_run_as': False},
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
+    user_id = response.json()['data']['affected_items'][0]['id']
 
-    for i in range(5):
-        # Create new user
-        response = requests.post(users_endpoint,
-                                 json={'username': f'user_{i}',
-                                       'password': 'Password1!',
-                                       'allow_run_as': False},
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
-        user_ids.append(response.json()['data']['affected_items'][0]['id'])
+    # Create new role
+    response = requests.post(roles_endpoint,
+                             json={'name': f'test_role'},
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
+    role_id = response.json()['data']['affected_items'][0]['id']
 
-        # Create new role
-        response = requests.post(roles_endpoint,
-                                 json={'name': f'role_{i}'},
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
-        role_ids.append(response.json()['data']['affected_items'][0]['id'])
+    # Create new policy
+    response = requests.post(policies_endpoint,
+                             json={'name': f'test_policy',
+                                   'policy': {
+                                       'actions': ['agent:read'],
+                                       'resources': [f'agent:id:999'],
+                                       'effect': 'allow'
+                                   }},
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
+    policy_id = response.json()['data']['affected_items'][0]['id']
 
-        # Create new policy
-        response = requests.post(policies_endpoint,
-                                 json={'name': f'policy_{i}',
-                                       'policy': {
-                                           'actions': ['agent:read'],
-                                           'resources': [f'agent:id:{i}'],
-                                           'effect': 'allow'
-                                       }},
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
-        policy_ids.append(response.json()['data']['affected_items'][0]['id'])
+    # Create new rule
+    response = requests.post(rules_endpoint,
+                             json={'name': f'test_rule',
+                                   'rule': {
+                                       'FIND$': {
+                                           'definition': 'test'
+                                       }
+                                   }},
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
+    rule_id = response.json()['data']['affected_items'][0]['id']
 
-        # Create new rule
-        response = requests.post(rules_endpoint,
-                                 json={'name': f'rule_{i}',
-                                       'rule': {
-                                           'FIND$': {
-                                               'definition': i
-                                           }
-                                       }},
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
-        rule_ids.append(response.json()['data']['affected_items'][0]['id'])
+    # Create relationships between them
+    # User-Role
+    response = requests.post(f"{users_endpoint}/{user_id}/roles?role_ids={role_id}",
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
 
-        # Create relationships between them
-        # User-Role
-        response = requests.post(f"{users_endpoint}/{user_ids[-1]}/roles?role_ids={role_ids[-1]}",
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
+    # Role-Policy
+    response = requests.post(f"{roles_endpoint}/{role_id}/policies?policy_ids={policy_id}",
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
 
-        # Role-Policy
-        response = requests.post(f"{roles_endpoint}/{role_ids[-1]}/policies?policy_ids={policy_ids[-1]}",
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
+    # Role-Rule
+    response = requests.post(f"{roles_endpoint}/{role_id}/rules?rule_ids={rule_id}",
+                             headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
 
-        # Role-Rule
-        response = requests.post(f"{roles_endpoint}/{role_ids[-1]}/rules?rule_ids={rule_ids[-1]}",
-                                 headers=api_details['auth_headers'], verify=False)
-        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
-                                            f'{response.text}'
-
-    setattr(request.module, 'user_ids', user_ids)
-    setattr(request.module, 'role_ids', role_ids)
-    setattr(request.module, 'policy_ids', policy_ids)
-    setattr(request.module, 'rule_ids', rule_ids)
+    setattr(request.module, 'user_id', user_id)
+    setattr(request.module, 'role_id', role_id)
+    setattr(request.module, 'policy_id', policy_id)
+    setattr(request.module, 'rule_id', rule_id)
 
     yield
 

--- a/tests/integration/test_api/test_rbac/conftest.py
+++ b/tests/integration/test_api/test_rbac/conftest.py
@@ -1,0 +1,102 @@
+import pytest
+import requests
+
+from wazuh_testing.api import get_api_details_dict
+
+
+@pytest.fixture(scope='module')
+def set_security_resources(request):
+    def remove_test_security_resources(endpoint):
+        parameter = {
+            users_endpoint: 'user_ids',
+            roles_endpoint: 'role_ids',
+            policies_endpoint: 'policy_ids',
+            rules_endpoint: 'rule_ids'
+        }
+        remove = requests.delete(f'{endpoint}?{parameter[endpoint]}=all', headers=api_details['auth_headers'],
+                                 verify=False)
+        assert remove.status_code == 200, f'Could not clean security resources. Response: {remove.text}'
+
+    api_details = get_api_details_dict()
+    users_endpoint = api_details['base_url'] + '/security/users'
+    roles_endpoint = api_details['base_url'] + '/security/roles'
+    policies_endpoint = api_details['base_url'] + '/security/policies'
+    rules_endpoint = api_details['base_url'] + '/security/rules'
+
+    user_ids, role_ids, policy_ids, rule_ids = list(), list(), list(), list()
+
+    for i in range(5):
+        # Create new user
+        response = requests.post(users_endpoint,
+                                 json={'username': f'user_{i}',
+                                       'password': 'Password1!',
+                                       'allow_run_as': False},
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+        user_ids.append(response.json()['data']['affected_items'][0]['id'])
+
+        # Create new role
+        response = requests.post(roles_endpoint,
+                                 json={'name': f'role_{i}'},
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+        role_ids.append(response.json()['data']['affected_items'][0]['id'])
+
+        # Create new policy
+        response = requests.post(policies_endpoint,
+                                 json={'name': f'policy_{i}',
+                                       'policy': {
+                                           'actions': ['agent:read'],
+                                           'resources': [f'agent:id:{i}'],
+                                           'effect': 'allow'
+                                       }},
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+        policy_ids.append(response.json()['data']['affected_items'][0]['id'])
+
+        # Create new rule
+        response = requests.post(rules_endpoint,
+                                 json={'name': f'rule_{i}',
+                                       'rule': {
+                                           'FIND$': {
+                                               'definition': i
+                                           }
+                                       }},
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+        rule_ids.append(response.json()['data']['affected_items'][0]['id'])
+
+        # Create relationships between them
+        # User-Role
+        response = requests.post(f"{users_endpoint}/{user_ids[-1]}/roles?role_ids={role_ids[-1]}",
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+
+        # Role-Policy
+        response = requests.post(f"{roles_endpoint}/{role_ids[-1]}/policies?policy_ids={policy_ids[-1]}",
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+
+        # Role-Rule
+        response = requests.post(f"{roles_endpoint}/{role_ids[-1]}/rules?rule_ids={rule_ids[-1]}",
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+
+    setattr(request.module, 'user_ids', user_ids)
+    setattr(request.module, 'role_ids', role_ids)
+    setattr(request.module, 'policy_ids', policy_ids)
+    setattr(request.module, 'rule_ids', rule_ids)
+
+    yield
+
+    remove_test_security_resources(users_endpoint)
+    remove_test_security_resources(roles_endpoint)
+    remove_test_security_resources(policies_endpoint)
+    remove_test_security_resources(rules_endpoint)

--- a/tests/integration/test_api/test_rbac/test_add_old_resource.py
+++ b/tests/integration/test_api/test_rbac/test_add_old_resource.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import requests
+from wazuh_testing.api import get_security_resource_information
+
+# Variables
+user_id, role_id, policy_id, rule_id = None, None, None, None
+
+
+# Tests
+def test_add_old_user(set_security_resources, get_api_details):
+    api_details = get_api_details()
+    old_user_info = get_security_resource_information(user_ids=user_id)
+    assert old_user_info, f'There is not information about this role: {user_id}'
+
+    delete_endpoint = api_details['base_url'] + f'/security/users?user_ids={user_id}'
+    response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+
+    add_endpoint = api_details['base_url'] + f'/security/users'
+    response = requests.post(add_endpoint, json={'username': old_user_info['username'],
+                                                 'password': 'Password1!'}, headers=api_details['auth_headers'],
+                             verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+    relationships = response.json()['data']['affected_items'][0]
+    for key, value in relationships.items():
+        if key not in ['id', 'username', 'password', 'allow_run_as']:
+            assert not value, f'Relationships are not empty: {key}->{value}'
+
+
+def test_add_old_role(set_security_resources, get_api_details):
+    api_details = get_api_details()
+    old_role_info = get_security_resource_information(role_ids=role_id)
+    assert old_role_info, f'There is not information about this role: {role_id}'
+
+    delete_endpoint = api_details['base_url'] + f'/security/roles?role_ids={role_id}'
+    response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+
+    add_endpoint = api_details['base_url'] + f'/security/roles'
+    response = requests.post(add_endpoint, json={'name': old_role_info['name']}, headers=api_details['auth_headers'],
+                             verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+    relationships = response.json()['data']['affected_items'][0]
+    for key, value in relationships.items():
+        if key not in ['id', 'name']:
+            assert not value, f'Relationships are not empty: {key}->{value}'
+
+
+def test_add_old_policy(set_security_resources, get_api_details):
+    api_details = get_api_details()
+    old_policy_info = get_security_resource_information(policy_ids=policy_id)
+    assert old_policy_info, f'There is not information about this policy: {policy_id}'
+
+    delete_endpoint = api_details['base_url'] + f'/security/policies?policy_ids={policy_id}'
+    response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+
+    add_endpoint = api_details['base_url'] + f'/security/policies'
+    response = requests.post(add_endpoint,
+                             json={'name': old_policy_info['name'],
+                                   'policy': old_policy_info['policy']},
+                             headers=api_details['auth_headers'],
+                             verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+    relationships = response.json()['data']['affected_items'][0]
+    for key, value in relationships.items():
+        if key not in ['id', 'name', 'policy']:
+            assert not value, f'Relationships are not empty: {key}->{value}'
+
+
+def test_add_old_rule(set_security_resources, get_api_details):
+    api_details = get_api_details()
+    old_rule_info = get_security_resource_information(rule_ids=rule_id)
+    assert old_rule_info, f'There is not information about this policy: {rule_id}'
+
+    delete_endpoint = api_details['base_url'] + f'/security/rules?rule_ids={rule_id}'
+    response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+
+    add_endpoint = api_details['base_url'] + f'/security/rules'
+    response = requests.post(add_endpoint,
+                             json={'name': old_rule_info['name'],
+                                   'rule': old_rule_info['rule']},
+                             headers=api_details['auth_headers'],
+                             verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+    relationships = response.json()['data']['affected_items'][0]
+    for key, value in relationships.items():
+        if key not in ['id', 'name', 'rule']:
+            assert not value, f'Relationships are not empty: {key}->{value}'

--- a/tests/integration/test_api/test_rbac/test_add_old_resource.py
+++ b/tests/integration/test_api/test_rbac/test_add_old_resource.py
@@ -10,6 +10,7 @@ user_id, role_id, policy_id, rule_id = None, None, None, None
 
 # Tests
 def test_add_old_user(set_security_resources, get_api_details):
+    """Remove a user with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
     old_user_info = get_security_resource_information(user_ids=user_id)
     assert old_user_info, f'There is not information about this role: {user_id}'
@@ -30,6 +31,7 @@ def test_add_old_user(set_security_resources, get_api_details):
 
 
 def test_add_old_role(set_security_resources, get_api_details):
+    """Remove a role with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
     old_role_info = get_security_resource_information(role_ids=role_id)
     assert old_role_info, f'There is not information about this role: {role_id}'
@@ -49,6 +51,7 @@ def test_add_old_role(set_security_resources, get_api_details):
 
 
 def test_add_old_policy(set_security_resources, get_api_details):
+    """Remove a policy with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
     old_policy_info = get_security_resource_information(policy_ids=policy_id)
     assert old_policy_info, f'There is not information about this policy: {policy_id}'
@@ -71,6 +74,7 @@ def test_add_old_policy(set_security_resources, get_api_details):
 
 
 def test_add_old_rule(set_security_resources, get_api_details):
+    """Remove a rule with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
     old_rule_info = get_security_resource_information(rule_ids=rule_id)
     assert old_rule_info, f'There is not information about this policy: {rule_id}'

--- a/tests/integration/test_api/test_rbac/test_admin_resources.py
+++ b/tests/integration/test_api/test_rbac/test_admin_resources.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import pytest
+import requests
+
+
+@pytest.fixture(scope='module')
+def get_configuration():
+    # Needed to restart the API
+    pass
+
+
+# Functions
+def get_admin_resources(api_details, endpoint):
+    response = requests.get(f"{api_details['base_url']}{endpoint}", headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
+
+    admin_ids = [item['id'] for item in response.json()['data']['affected_items'] if item['id'] < 100]
+
+    return admin_ids
+
+
+def remove_admin_resources(api_details, admin_ids, endpoint, resource):
+    """Try to remove all admin security resources and expect the proper exception.
+
+    Parameters
+    ----------
+    api_details : dict
+        API details.
+    admin_ids : list
+        List of admin IDs.
+    endpoint : str
+        Security endpoint.
+    resource : str
+        Name of the resources.
+    """
+    response = requests.delete(
+        f"{api_details['base_url']}{endpoint}?{resource}={','.join([str(id) for id in admin_ids])}",
+        headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
+    data = response.json()['data']
+    assert not data['affected_items'], f"Admin resources could be deleted: {data['affected_items']}"
+    assert data['failed_items'], f'Expected failed items but there were not'
+    assert data['failed_items'][0]['error']['code'] == 4008, 'Error code was different from expected: ' \
+                                                             f"{data['failed_items'][0]['error']['code']}"
+    assert admin_ids == data['failed_items'][0]['id'], f"IDs do not match: {data['failed_items'][0]['id']}"
+
+
+def modify_admin_resources(api_details, admin_ids, endpoint, body):
+    """Try to remove all admin security resources and expect the proper exception.
+
+    Parameters
+    ----------
+    api_details : dict
+        API details.
+    admin_ids : list
+        List of admin IDs.
+    endpoint : str
+        Security endpoint.
+    body : dict
+        Dictionary with the security resource information to be changed.
+    """
+    for resource_id in admin_ids:
+        response = requests.put(f"{api_details['base_url']}{endpoint}/{resource_id}", json=body,
+                                headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
+        data = response.json()['data']
+        assert not data['affected_items'], f"Admin resources could be modified: {data['affected_items']}"
+        assert data['failed_items'], f'Expected failed items but there were not'
+        assert data['failed_items'][0]['error']['code'] == 4008, 'Error code was different from expected: ' \
+                                                                 f"{data['failed_items'][0]['error']['code']}"
+        assert [resource_id] == data['failed_items'][0]['id'], f"ID does not match: {data['failed_items'][0]['id']}"
+
+
+# Tests
+def test_admin_users(restart_api, get_api_details):
+    """Test if admin security users can be removed."""
+    api_details = get_api_details()
+
+    endpoint = '/security/users'
+    resource = 'user_ids'
+    admin_ids = get_admin_resources(api_details, endpoint)
+    remove_admin_resources(api_details, admin_ids, endpoint, resource)
+
+
+def test_admin_roles(restart_api, get_api_details):
+    """Test if admin security roles can be removed."""
+    api_details = get_api_details()
+
+    endpoint = '/security/roles'
+    resource = 'role_ids'
+    body = {'name': 'random_role_name_test'}
+
+    admin_ids = get_admin_resources(api_details, endpoint)
+    remove_admin_resources(api_details, admin_ids, endpoint, resource)
+    modify_admin_resources(api_details, admin_ids, endpoint, body)
+
+
+def test_admin_policies(restart_api, get_api_details):
+    """Test if admin security policies can be removed."""
+    api_details = get_api_details()
+
+    endpoint = '/security/policies'
+    resource = 'policy_ids'
+    body = {'name': 'random_policy_name_test',
+            'policy': {'actions': ['test_action'], 'resources': ['test_resources'], 'effect': 'allow'}}
+
+    admin_ids = get_admin_resources(api_details, endpoint)
+    remove_admin_resources(api_details, admin_ids, endpoint, resource)
+    modify_admin_resources(api_details, admin_ids, endpoint, body)
+
+
+def test_admin_rules(restart_api, get_api_details):
+    """Test if admin security rules can be removed."""
+    api_details = get_api_details()
+
+    endpoint = '/security/rules'
+    resource = 'rule_ids'
+    body = {'name': 'random_rule_name_test', 'rule': {'rule_key': 'rule_value'}}
+
+    admin_ids = get_admin_resources(api_details, endpoint)
+    remove_admin_resources(api_details, admin_ids, endpoint, resource)
+    modify_admin_resources(api_details, admin_ids, endpoint, body)

--- a/tests/integration/test_api/test_rbac/test_policy_position.py
+++ b/tests/integration/test_api/test_rbac/test_policy_position.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import pytest
+import requests
+from wazuh_testing.api import get_security_resource_information
+
+# Variables
+user_id, role_id, policy_id, rule_id = None, None, None, None
+policy_positions = list()
+
+
+@pytest.fixture(scope='function')
+def add_new_policies(get_api_details):
+    api_details = get_api_details()
+    # Add first policy to list
+    policy_positions.append(policy_id)
+    for position in range(1, 4):
+        # Create new policy
+        response = requests.post(api_details['base_url'] + '/security/policies',
+                                 json={'name': f'test_policy_position_{position}',
+                                       'policy': {
+                                           'actions': ['agent:read'],
+                                           'resources': [f'agent:id:{position}'],
+                                           'effect': 'allow'
+                                       }},
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, 'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+        p_id = response.json()['data']['affected_items'][0]['id']
+
+        # Create Role-Policy
+        response = requests.post(f"{api_details['base_url']}/security/roles/{role_id}/policies?policy_ids={p_id}"
+                                 f"&position={position}",
+                                 headers=api_details['auth_headers'], verify=False)
+        assert response.status_code == 200, 'Expected status code was 200. Full response: ' \
+                                            f'{response.text}'
+        policy_positions.insert(position, p_id)
+
+
+# Functions
+def remove_role_policy(api_details, p_id):
+    response = requests.delete(f"{api_details['base_url']}/security/roles/{role_id}/policies?policy_ids={p_id}",
+                               headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
+    policy_positions.remove(p_id)
+    assert get_security_resource_information(role_ids=role_id)['policies'] == policy_positions, 'Positions do not match'
+
+
+def add_role_policy(api_details, p_id, position):
+    response = requests.post(f"{api_details['base_url']}/security/roles/{role_id}/policies?policy_ids={p_id}"
+                             f"&position={position}", headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
+    policy_positions.insert(position, p_id)
+    assert get_security_resource_information(role_ids=role_id)['policies'] == policy_positions, 'Positions do not match'
+
+
+# Tests
+def test_policy_position(set_security_resources, add_new_policies, get_api_details):
+    api_details = get_api_details()
+
+    # Remove and add in the same position
+    pol_id = policy_positions[2]
+    remove_role_policy(api_details, pol_id)
+    add_role_policy(api_details, pol_id, 2)
+
+    # Remove and add in different positions
+    pol_id = policy_positions[3]
+    remove_role_policy(api_details, pol_id)
+    add_role_policy(api_details, pol_id, 0)
+
+    # Remove and add in the same position after changing the initial state
+    pol_id = policy_positions[1]
+    remove_role_policy(api_details, pol_id)
+    add_role_policy(api_details, pol_id, 1)

--- a/tests/integration/test_api/test_rbac/test_policy_position.py
+++ b/tests/integration/test_api/test_rbac/test_policy_position.py
@@ -12,6 +12,7 @@ policy_positions = list()
 
 @pytest.fixture(scope='function')
 def add_new_policies(get_api_details):
+    """Create new policies and relationships between them and the testing role."""
     api_details = get_api_details()
     # Add first policy to list
     policy_positions.append(policy_id)
@@ -40,6 +41,13 @@ def add_new_policies(get_api_details):
 
 # Functions
 def remove_role_policy(api_details, p_id):
+    """Remove a role-policy relationship and update the relationships reference list.
+
+    Parameters
+    ----------
+    p_id : int
+        Policy ID.
+    """
     response = requests.delete(f"{api_details['base_url']}/security/roles/{role_id}/policies?policy_ids={p_id}",
                                headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
@@ -48,6 +56,15 @@ def remove_role_policy(api_details, p_id):
 
 
 def add_role_policy(api_details, p_id, position):
+    """Add a role-policy relationship and update the relationships reference list.
+
+    Parameters
+    ----------
+    p_id : int
+        Policy ID.
+    position : int
+        Relationship position.
+    """
     response = requests.post(f"{api_details['base_url']}/security/roles/{role_id}/policies?policy_ids={p_id}"
                              f"&position={position}", headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Expected status code was 200. Full response: {response.text}'
@@ -57,6 +74,8 @@ def add_role_policy(api_details, p_id, position):
 
 # Tests
 def test_policy_position(set_security_resources, add_new_policies, get_api_details):
+    """Test if the correct order between role-policy relationships remain after removing some of them and adding others
+    using the `position` parameter."""
     api_details = get_api_details()
 
     # Remove and add in the same position

--- a/tests/integration/test_api/test_rbac/test_remove_relationship.py
+++ b/tests/integration/test_api/test_rbac/test_remove_relationship.py
@@ -6,7 +6,7 @@ import requests
 from wazuh_testing.api import get_security_resource_information
 
 # Variables
-user_ids, role_ids, policy_ids, rule_ids = list(), list(), list(), list()
+user_id, role_id, policy_id, rule_id = None, None, None, None
 
 
 # Functions
@@ -45,9 +45,9 @@ def remove_relationship(api_details, endpoint, resource, related_resource, relat
 def test_remove_user_role_relationship(set_security_resources, get_api_details):
     """Test if the user and role still exist after removing their relationship."""
     api_details = get_api_details()
-    endpoint = api_details['base_url'] + f'/security/users/{user_ids[0]}/roles?role_ids={role_ids[0]}'
-    resource = role_ids[0]
-    related_resource = {'user_ids': user_ids[0]}
+    endpoint = api_details['base_url'] + f'/security/users/{user_id}/roles?role_ids={role_id}'
+    resource = role_id
+    related_resource = {'user_ids': user_id}
     relation = 'users'
 
     remove_relationship(api_details, endpoint, resource, related_resource, relation)
@@ -56,9 +56,9 @@ def test_remove_user_role_relationship(set_security_resources, get_api_details):
 def test_remove_role_policy_relationship(set_security_resources, get_api_details):
     """Test if the role and policy still exist after removing their relationship."""
     api_details = get_api_details()
-    endpoint = api_details['base_url'] + f'/security/roles/{role_ids[1]}/policies?policy_ids={policy_ids[1]}'
-    resource = role_ids[1]
-    related_resource = {'policy_ids': policy_ids[1]}
+    endpoint = api_details['base_url'] + f'/security/roles/{role_id}/policies?policy_ids={policy_id}'
+    resource = role_id
+    related_resource = {'policy_ids': policy_id}
     relation = 'policies'
 
     remove_relationship(api_details, endpoint, resource, related_resource, relation)
@@ -67,9 +67,9 @@ def test_remove_role_policy_relationship(set_security_resources, get_api_details
 def test_remove_role_rule_relationship(set_security_resources, get_api_details):
     """Test if the role and rule still exist after removing their relationship."""
     api_details = get_api_details()
-    endpoint = api_details['base_url'] + f'/security/roles/{role_ids[2]}/rules?rule_ids={rule_ids[2]}'
-    resource = role_ids[2]
-    related_resource = {'rule_ids': rule_ids[2]}
+    endpoint = api_details['base_url'] + f'/security/roles/{role_id}/rules?rule_ids={rule_id}'
+    resource = role_id
+    related_resource = {'rule_ids': rule_id}
     relation = 'rules'
 
     remove_relationship(api_details, endpoint, resource, related_resource, relation)

--- a/tests/integration/test_api/test_rbac/test_remove_relationship.py
+++ b/tests/integration/test_api/test_rbac/test_remove_relationship.py
@@ -3,28 +3,73 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import requests
-
-# Variables
 from wazuh_testing.api import get_security_resource_information
 
+# Variables
 user_ids, role_ids, policy_ids, rule_ids = list(), list(), list(), list()
 
 
-# Configurations
+# Functions
+def remove_relationship(api_details, endpoint, resource, related_resource, relation):
+    """Remove a relationship between two security resources and check if the resources were deleted.
 
-def test_remove_user_role_relationship(set_security_resources, get_api_details):
-    api_details = get_api_details()
-
-    remove_endpoint = api_details['base_url'] + f'/security/users/{user_ids[0]}/roles?role_ids={role_ids[0]}'
-    assert get_security_resource_information(role_ids=role_ids[0])['users'], f'Role {role_ids[0]} does not belong to ' \
-                                                                             f'any user'
+    Parameters
+    ----------
+    api_details : dict
+        API details such as the headers.
+    endpoint : str
+        Request endpoint.
+    resource : int
+        Resource ID.
+    related_resource : dict
+        Dict with resource information (parameter and ID).
+    relation : str
+        Role entry of the related resource.
+    """
+    # Assert the relationship exists
+    assert get_security_resource_information(role_ids=resource)[relation], f'Resource {resource} does not belong to ' \
+                                                                           f'any {relation}'
 
     # Remove relationship between
-    response = requests.delete(remove_endpoint, headers=api_details['auth_headers'], verify=False)
+    response = requests.delete(endpoint, headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
-    role = get_security_resource_information(role_ids=role_ids[0])
+    res = get_security_resource_information(role_ids=resource)
 
     # Assert resources still exist but the relationship does not
-    assert role, 'Role was removed as well'
-    assert not role['users'], f'Relationship still exists'
-    assert get_security_resource_information(user_ids=user_ids[0]), 'Related user was removed as well'
+    assert res, 'Resource was removed as well'
+    assert not res[relation], f'Relationship still exists'
+    assert get_security_resource_information(**related_resource), 'Related user was removed as well'
+
+
+# Tests
+def test_remove_user_role_relationship(set_security_resources, get_api_details):
+    """Test if the user and role still exist after removing their relationship."""
+    api_details = get_api_details()
+    endpoint = api_details['base_url'] + f'/security/users/{user_ids[0]}/roles?role_ids={role_ids[0]}'
+    resource = role_ids[0]
+    related_resource = {'user_ids': user_ids[0]}
+    relation = 'users'
+
+    remove_relationship(api_details, endpoint, resource, related_resource, relation)
+
+
+def test_remove_role_policy_relationship(set_security_resources, get_api_details):
+    """Test if the role and policy still exist after removing their relationship."""
+    api_details = get_api_details()
+    endpoint = api_details['base_url'] + f'/security/roles/{role_ids[1]}/policies?policy_ids={policy_ids[1]}'
+    resource = role_ids[1]
+    related_resource = {'policy_ids': policy_ids[1]}
+    relation = 'policies'
+
+    remove_relationship(api_details, endpoint, resource, related_resource, relation)
+
+
+def test_remove_role_rule_relationship(set_security_resources, get_api_details):
+    """Test if the role and rule still exist after removing their relationship."""
+    api_details = get_api_details()
+    endpoint = api_details['base_url'] + f'/security/roles/{role_ids[2]}/rules?rule_ids={rule_ids[2]}'
+    resource = role_ids[2]
+    related_resource = {'rule_ids': rule_ids[2]}
+    relation = 'rules'
+
+    remove_relationship(api_details, endpoint, resource, related_resource, relation)

--- a/tests/integration/test_api/test_rbac/test_remove_relationship.py
+++ b/tests/integration/test_api/test_rbac/test_remove_relationship.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import requests
+
+# Variables
+from wazuh_testing.api import get_security_resource_information
+
+user_ids, role_ids, policy_ids, rule_ids = list(), list(), list(), list()
+
+
+# Configurations
+
+def test_remove_user_role_relationship(set_security_resources, get_api_details):
+    api_details = get_api_details()
+
+    remove_endpoint = api_details['base_url'] + f'/security/users/{user_ids[0]}/roles?role_ids={role_ids[0]}'
+    assert get_security_resource_information(role_ids=role_ids[0])['users'], f'Role {role_ids[0]} does not belong to ' \
+                                                                             f'any user'
+
+    # Remove relationship between
+    response = requests.delete(remove_endpoint, headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
+    role = get_security_resource_information(role_ids=role_ids[0])
+
+    # Assert resources still exist but the relationship does not
+    assert role, 'Role was removed as well'
+    assert not role['users'], f'Relationship still exists'
+    assert get_security_resource_information(user_ids=user_ids[0]), 'Related user was removed as well'

--- a/tests/integration/test_api/test_rbac/test_remove_resource.py
+++ b/tests/integration/test_api/test_rbac/test_remove_resource.py
@@ -11,6 +11,17 @@ user_id, role_id, policy_id, rule_id = None, None, None, None
 
 # Functions
 def check_relationships(original_relationships, new_relationships, deleted_relationship):
+    """Check if the relationships stay the same after removing security resources.
+
+    Parameters
+    ----------
+    original_relationships : dict
+        Original relationships.
+    new_relationships : dict
+        Relationships after removing a security resource.
+    deleted_relationship : str
+        Security resource that was deleted.
+    """
     original_relationships[deleted_relationship] = []
     assert original_relationships == new_relationships, f'Some relationships were deleted. ' \
                                                         f'\nOriginal: {original_relationships}\n' \
@@ -18,6 +29,15 @@ def check_relationships(original_relationships, new_relationships, deleted_relat
 
 
 def check_resources(deleted_resource, resource_id):
+    """Check if the security resources stay the same.
+
+    Parameters
+    ----------
+    deleted_resource : str
+        Name of the deleted resource.
+    resource_id : int
+        ID of the resource.
+    """
     resources = {
         'users': 'user_ids',
         'roles': 'role_ids',
@@ -32,6 +52,7 @@ def check_resources(deleted_resource, resource_id):
 
 # Tests
 def test_remove_rule(set_security_resources, get_api_details):
+    """Test if relationships between security resources stay the same after removing the linked rule."""
     api_details = get_api_details()
     relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
@@ -48,6 +69,7 @@ def test_remove_rule(set_security_resources, get_api_details):
 
 
 def test_remove_policy(set_security_resources, get_api_details):
+    """Test if relationships between security resources stay the same after removing the linked policy."""
     api_details = get_api_details()
     relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
@@ -64,6 +86,7 @@ def test_remove_policy(set_security_resources, get_api_details):
 
 
 def test_remove_user(set_security_resources, get_api_details):
+    """Test if relationships between security resources stay the same after removing the linked user."""
     api_details = get_api_details()
     relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
@@ -80,6 +103,7 @@ def test_remove_user(set_security_resources, get_api_details):
 
 
 def test_remove_role(set_security_resources, get_api_details):
+    """Test if relationships between security resources stay the same after removing the linked role."""
     api_details = get_api_details()
     relationships = get_security_resource_information(user_ids=user_id)
     assert relationships, 'There are not relationships'

--- a/tests/integration/test_api/test_rbac/test_remove_resource.py
+++ b/tests/integration/test_api/test_rbac/test_remove_resource.py
@@ -6,7 +6,7 @@ import requests
 from wazuh_testing.api import get_security_resource_information
 
 # Variables
-user_ids, role_ids, policy_ids, rule_ids = list(), list(), list(), list()
+user_id, role_id, policy_id, rule_id = None, None, None, None
 
 
 # Functions
@@ -32,68 +32,64 @@ def check_resources(deleted_resource, resource_id):
 
 # Tests
 def test_remove_rule(set_security_resources, get_api_details):
-    id_index = 0
     api_details = get_api_details()
-    relationships = get_security_resource_information(role_ids=role_ids[id_index])
+    relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
 
-    delete_endpoint = api_details['base_url'] + f'/security/rules?rule_ids={rule_ids[id_index]}'
+    delete_endpoint = api_details['base_url'] + f'/security/rules?rule_ids={rule_id}'
     response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
 
-    new_relationships = get_security_resource_information(role_ids=role_ids[id_index])
+    new_relationships = get_security_resource_information(role_ids=role_id)
     assert new_relationships, 'There are not relationships'
 
-    check_resources('rules', rule_ids[id_index])
+    check_resources('rules', rule_id)
     check_relationships(relationships, new_relationships, 'rules')
 
 
 def test_remove_policy(set_security_resources, get_api_details):
-    id_index = 1
     api_details = get_api_details()
-    relationships = get_security_resource_information(role_ids=role_ids[id_index])
+    relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
 
-    delete_endpoint = api_details['base_url'] + f'/security/policies?policy_ids={policy_ids[id_index]}'
+    delete_endpoint = api_details['base_url'] + f'/security/policies?policy_ids={policy_id}'
     response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
 
-    new_relationships = get_security_resource_information(role_ids=role_ids[id_index])
+    new_relationships = get_security_resource_information(role_ids=role_id)
     assert new_relationships, 'There are not relationships'
 
-    check_resources('policies', policy_ids[id_index])
+    check_resources('policies', policy_id)
     check_relationships(relationships, new_relationships, 'policies')
 
 
 def test_remove_user(set_security_resources, get_api_details):
-    id_index = 2
     api_details = get_api_details()
-    relationships = get_security_resource_information(role_ids=role_ids[id_index])
+    relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
 
-    delete_endpoint = api_details['base_url'] + f'/security/users?user_ids={user_ids[id_index]}'
+    delete_endpoint = api_details['base_url'] + f'/security/users?user_ids={user_id}'
     response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
 
-    new_relationships = get_security_resource_information(role_ids=role_ids[id_index])
+    new_relationships = get_security_resource_information(role_ids=role_id)
     assert new_relationships, 'There are not relationships'
 
-    check_resources('users', user_ids[id_index])
+    check_resources('users', user_id)
     check_relationships(relationships, new_relationships, 'users')
 
 
 def test_remove_role(set_security_resources, get_api_details):
-    id_index = 3
     api_details = get_api_details()
-    relationships = get_security_resource_information(user_ids=user_ids[id_index])
+    relationships = get_security_resource_information(user_ids=user_id)
     assert relationships, 'There are not relationships'
 
-    delete_endpoint = api_details['base_url'] + f'/security/roles?role_ids={role_ids[id_index]}'
+    delete_endpoint = api_details['base_url'] + f'/security/roles?role_ids={role_id}'
     response = requests.delete(delete_endpoint, headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Status code was not 200. Response: {response.text}'
 
-    new_relationships = get_security_resource_information(user_ids=user_ids[id_index])
+    new_relationships = get_security_resource_information(user_ids=user_id)
     assert new_relationships, 'There are not relationships'
 
-    check_resources('roles', role_ids[id_index])
+    check_resources('roles', role_id)
     check_relationships(relationships, new_relationships, 'roles')


### PR DESCRIPTION
Hello team,
this closes #905 .

This PR adds new integration tests for the RBAC resources relationships.
A refactor in the `api.py` module was needed as these tests could benefit from some of the functions that were already implemented. These changes did not break any other test.

# Tests performed
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.6.8, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.0.1, testinfra-5.0.0
collected 16 items                                                                                                                                                                          

test_api/test_rbac/test_add_old_resource.py ....                                                                                                                                      [ 25%]
test_api/test_rbac/test_admin_resources.py F...                                                                                                                                       [ 50%]
test_api/test_rbac/test_policy_position.py .                                                                                                                                          [ 56%]
test_api/test_rbac/test_remove_relationship.py ...                                                                                                                                    [ 75%]
test_api/test_rbac/test_remove_resource.py ....                                                                                                                                       [100%]

======================================================================== 1 failed, 15 passed, 16 warnings in 56.76s =========================================================================

```
This one fail is correct. We need to change the exception code when trying to remove an admin user.


Regards,
Víctor.