### PR TITLE
Updating global.db IT with the new connection_status column

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -10,7 +10,7 @@
   -
     input: 'global find-group TestGroup1'
     output: "ok []"
-    stage: "global find-group previous insert"    
+    stage: "global find-group previous insert"
   -
     input: 'global insert-agent-group TestGroup1'
     output: 'ok'
@@ -23,13 +23,13 @@
   -
     input: 'global find-group TestGroup1'
     output: 'ok [{"id":*}]'
-    stage: "global find-group after insert" 
+    stage: "global find-group after insert"
     use_regex: "yes"
   -
     input: 'global select-groups'
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
     stage: "global select-groups success"
-  -  
+  -
     input: 'global delete-agent 1'
     output: "ok"
     stage: "global delete-agent previous insert"
@@ -43,13 +43,13 @@
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced"}]'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after insert"
   -
     input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
     output: 'ok [{"id":1}]'
-    stage: "global find-agent success"   
-  -  
+    stage: "global find-agent success"
+  -
     input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent previous insert"
@@ -59,9 +59,9 @@
     stage: "global insert-agent minimal fields success"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after minimal fields insert"
-  -  
+  -
     input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent after insert"
@@ -99,7 +99,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -146,7 +146,7 @@
     input: 'global select-keepalive TestName2 0.0.0.1'
     output: 'ok [{"last_keepalive":*}]'
     stage: "global select-keepalive success"
-    use_regex: "yes" 
+    use_regex: "yes"
   -
     input: 'global select-groups'
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
@@ -205,7 +205,7 @@
     input: 'global get-agent-info 3'
     output: 'ok []'
     stage: "global get-agent-info success after non-existent sync-agent-info-set"
-  -  
+  -
     input: 'global delete-agent 3'
     output: "ok"
     stage: "global delete-agent previous insert"
@@ -219,12 +219,12 @@
     stage: "global sync-agent-info-set success"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
   name: "Belongs commands"
   description: "Check success use cases for belongs table commands on global DB"
-  test_case:  
+  test_case:
   -
     input: 'global insert-agent-belong {"id_group":1,"id_agent":1}'
     output: 'ok'
@@ -248,7 +248,7 @@
   -
     input: 'global delete-group TestGroup1'
     output: "ok"
-    stage: "global delete-group after insert"   
+    stage: "global delete-group after insert"
   -
     input: 'global delete-agent 1'
     output: "ok"
@@ -263,7 +263,7 @@
   test_case:
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
@@ -272,15 +272,15 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update with IP"
-    use_regex: "yes" 
+    use_regex: "yes"
   -
     input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced"}'
     output: "ok"
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update without IP"
     use_regex: "yes"


### PR DESCRIPTION
Hello team,

The Epic [5887](https://github.com/wazuh/wazuh/issues/5887) improves the way that Wazuh manages the status of the agents.

When the issue [6302](https://github.com/wazuh/wazuh/issues/6302) created the new **connection_status** column, it was necessary to update the _test_wazuh_db.py::test_wazuh_db_messages_ test for each **get-agent-info** call to **global.db**.

# Tests logic

When the information of the agent is returned, **active** is expected for the manager and **never_connected** for the rest of the agents.

# Tests checks

- [x] Proven that tests **pass** when they have to pass


## Test results

![qa](https://user-images.githubusercontent.com/65046601/96614164-2d76e500-12d6-11eb-8c20-935652dc7fe4.png)


Best regards.
