### PR TITLE
Wazuh DB command to reset the connection status of the agents in global.db - Integration Tests

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -65,6 +65,10 @@
     input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent after insert"
+  -
+    input: 'global insert-agent {"id":2,"name":"TestName2","date_add":1599223378}'
+    output: "ok"
+    stage: "global insert-agent agent 2 again after delete"
 -
   name: "Update commands"
   description: "Check success use cases for update commands on global DB"
@@ -157,7 +161,7 @@
   test_case:
   -
     input: 'global get-all-agents last_id -1'
-    output: 'ok 0,1'
+    output: 'ok 0,1,2'
     stage: "global get-all-agents success"
 -
   name: "get-agents-by-keepalive command"
@@ -238,6 +242,35 @@
     output: 'ok'
     stage: "global insert-agent-belong success"
 -
+  name: "Reset connection status"
+  description: "Check success use cases for reset connection status command."
+  test_case:
+  -
+    input: 'global reset-agents-connection'
+    output: 'ok'
+    stage: "global reset-agents-connection success"
+    test: 'yes'
+  -
+    input: 'global get-agent-info 0'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    stage: "global manager get-agent-info success post reset connection status"
+    use_regex: "yes"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
+    stage: "global agent get-agent-info success post reset connection status"
+    use_regex: "yes"
+  -
+    input: 'global get-agent-info 2'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    stage: "global agent get-agent-info success post reset connection status"
+    use_regex: "yes"
+  -
+    input: 'global get-agent-info 3'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"disconnected"}]'
+    stage: "global agent get-agent-info success post reset connection status"
+    use_regex: "yes"
+-
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."
   test_case:
@@ -251,6 +284,10 @@
     stage: "global delete-group after insert"
   -
     input: 'global delete-agent 1'
+    output: "ok"
+    stage: "global delete-agent after insert"
+  -
+    input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent after insert"
   -


### PR DESCRIPTION
Hello team,

# Tests logic

This PR adds IT to new reset-agents-status WazuhDB command.
- It checks the correct parsing and execution of the command.
- It checks that manager and never_connected agents don't change their state.
- It checks that active agents change to disconnected state
At the moment, the tests expect an active status that has to be implemented shortly and will fail until then.

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail

Best regards.
