### PR TITLE
Wazuh DB command to set the connection status of an agent in global.db - Integration Tests

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -106,6 +106,42 @@
     output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status pending success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"pending"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status active success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"disconnected"}'
+    output: "ok"
+    stage: "global update-connection-status disconnected success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"dummy_status"}'
+    output: "err Cannot execute Global database query; CHECK constraint failed: agent"
+    stage: "global update-connection-status dummy_status error"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
 -
   name: "Labels commands"
   description: "Check success use cases for labels table commands on global DB"
@@ -245,6 +281,14 @@
   name: "Reset connection status"
   description: "Check success use cases for reset connection status command."
   test_case:
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status pending success"
+  -
+    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status active success"
   -
     input: 'global reset-agents-connection'
     output: 'ok'


### PR DESCRIPTION
Hello team,

This PR includes new test cases to validate the right behavior of the new Wazuh DB command `update-connection-status`. This new command allows a client to update the new `connection_status` column of an agent in `global.db` included as part of the development of the [Epic 5887](https://github.com/wazuh/wazuh/issues/5887).

For more details about the command, see the **Requirements** section of the [Issue 6304](https://github.com/wazuh/wazuh/issues/6304).

Closes [#6304](https://github.com/wazuh/wazuh/issues/6304)

# Tests logic

- It checks the correct parsing and execution of the command.
- It checks that the statuses `never_connected`, `pending`, `active`, and `disconnected` can be properly set.
- It checks that a status different than the mentioned in the previous item can't be assigned.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

![image](https://user-images.githubusercontent.com/5703274/96808767-dcf3aa80-13ef-11eb-9254-fbcdb851cd2f.png)
