### PR TITLE
Registry integration test: No diff

### DIFF
--- a/tests/integration/test_fim/test_registry/test_nodiff/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_nodiff/data/wazuh_conf.yaml
@@ -1,0 +1,63 @@
+---
+# No diff str configuration
+- tags:
+  - no_diff_str
+  apply_to_modules:
+  - test_no_diff
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: 'both'
+            - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+      - diff:
+          elements:
+            - registry_nodiff:
+                value: VALUE_1
+                attributes:
+                  - arch: 'both'
+            - registry_nodiff:
+                value: VALUE_2
+                attributes:
+                    - arch: '64bit'
+# No diff regex configuration
+- tags:
+  - no_diff_regex
+  apply_to_modules:
+  - test_no_diff
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: 'both'
+            - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+      - diff:
+          elements:
+            - registry_nodiff:
+                value: SREGEX_1
+                attributes:
+                    - type: 'sregex'
+                    - arch: 'both'
+            - registry_nodiff:
+                value: SREGEX_2
+                attributes:
+                    - type: 'sregex'
+                    - arch: '64bit'

--- a/tests/integration/test_fim/test_registry/test_nodiff/test_no_diff.py
+++ b/tests/integration/test_fim/test_registry/test_nodiff/test_no_diff.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+import sys
+import pytest
+from hashlib import sha1
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, create_registry, registry_parser, KEY_WOW64_32KEY, \
+    KEY_WOW64_64KEY, generate_params, callback_detect_event, check_time_travel
+from wazuh_testing.tools import PREFIX, WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from win32con import REG_SZ
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
+
+# Variables
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+no_diff_value = "nodiff_value"
+value_sregex = "nodiff_value$"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+conf_params = {'WINDOWS_REGISTRY_1':reg1, 'WINDOWS_REGISTRY_2':reg2,
+               'VALUE_1': os.path.join(reg1, no_diff_value), 'VALUE_2' : os.path.join(reg2, no_diff_value),
+               'SREGEX_1': value_sregex, 'SREGEX_2': value_sregex}
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, content, truncated, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_str'}),
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_str'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, no_diff_value, "test_content", True, {'no_diff_str'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", "test_content", False, {'no_diff_str'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_str'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_str'})
+
+])
+def test_no_diff_str(key, subkey, arch, value_name, content, truncated, tags_to_apply,
+                  get_configuration, configure_environment, restart_syscheckd,
+                  wait_for_fim_start):
+    """
+    Check the only files detected are those matching the restrict regex
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    truncated : bool
+        True if an event must be generated, False otherwise.
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    values = {value_name: content}
+
+    def report_changes_validator(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]", sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str, sha1(value.encode()).hexdigest())
+            assert os.path.exists(diff_file), f'{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
+
+
+    def no_diff_validator(event):
+        """Validate content_changes value is truncated if the file is set to no_diff"""
+        if truncated:
+            assert '<Diff truncated because nodiff option>' in event['data'].get('content_changes'), \
+                f'content_changes is not truncated'
+        else:
+            assert '<Diff truncated because nodiff option>' not in event['data'].get('content_changes'), \
+                f'content_changes is truncated'
+
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                     min_timeout=global_parameters.default_timeout, triggers_event=True,
+                     validators_after_update=[report_changes_validator, no_diff_validator])
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, content, truncated, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_regex'}),
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_regex'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, no_diff_value, "test_content", True, {'no_diff_regex'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", "test_content", False, {'no_diff_regex'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_regex'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_regex'})
+])
+def test_no_diff_regex(key, subkey, arch, value_name, content, truncated, tags_to_apply,
+                  get_configuration, configure_environment, restart_syscheckd,
+                  wait_for_fim_start):
+    """
+    Check the only files detected are those matching the restrict regex
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    truncated : bool
+        True if an event must be generated, False otherwise.
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    values = {value_name: content}
+
+    def report_changes_validator(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]", sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str, sha1(value.encode()).hexdigest())
+            assert os.path.exists(diff_file), f'{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
+
+
+    def no_diff_validator(event):
+        """Validate content_changes value is truncated if the file is set to no_diff"""
+        if truncated:
+            assert '<Diff truncated because nodiff option>' in event['data'].get('content_changes'), \
+                f'content_changes is not truncated'
+        else:
+            assert '<Diff truncated because nodiff option>' not in event['data'].get('content_changes'), \
+                f'content_changes is truncated'
+
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                     min_timeout=global_parameters.default_timeout, triggers_event=True,
+                     validators_after_update=[report_changes_validator, no_diff_validator])

--- a/tests/integration/test_fim/test_registry/test_nodiff/test_no_diff.py
+++ b/tests/integration/test_fim/test_registry/test_nodiff/test_no_diff.py
@@ -1,20 +1,24 @@
 # Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 import os
-import sys
 import pytest
 from hashlib import sha1
+from time import sleep
+
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, create_registry, registry_parser, KEY_WOW64_32KEY, \
-    KEY_WOW64_64KEY, generate_params, callback_detect_event, check_time_travel
-from wazuh_testing.tools import PREFIX, WAZUH_PATH
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
+from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from win32con import REG_SZ
+
+# Marks
+
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
 
 # Variables
+
 key = "HKEY_LOCAL_MACHINE"
 sub_key_1 = "SOFTWARE\\test_key"
 sub_key_2 = "SOFTWARE\\Classes\\test_key"
@@ -30,9 +34,14 @@ reg1, reg2 = test_regs
 
 
 # Configurations
-conf_params = {'WINDOWS_REGISTRY_1':reg1, 'WINDOWS_REGISTRY_2':reg2,
-               'VALUE_1': os.path.join(reg1, no_diff_value), 'VALUE_2' : os.path.join(reg2, no_diff_value),
-               'SREGEX_1': value_sregex, 'SREGEX_2': value_sregex}
+
+conf_params = {'WINDOWS_REGISTRY_1': reg1,
+               'WINDOWS_REGISTRY_2': reg2,
+               'VALUE_1': os.path.join(reg1, no_diff_value),
+               'VALUE_2': os.path.join(reg2, no_diff_value),
+               'SREGEX_1': value_sregex,
+               'SREGEX_2': value_sregex}
+
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
 
@@ -40,26 +49,27 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 # Fixtures
 
+
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-@pytest.mark.parametrize('key, subkey, arch, value_name, content, truncated, tags_to_apply', [
-    (key, sub_key_1, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_str'}),
-    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_str'}),
-    (key, sub_key_1, KEY_WOW64_32KEY, no_diff_value, "test_content", True, {'no_diff_str'}),
-    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", "test_content", False, {'no_diff_str'}),
-    (key, sub_key_2, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_str'}),
-    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_str'})
+@pytest.mark.parametrize('key, subkey, arch, value_name, truncated, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, no_diff_value, True, {'no_diff_str'}),
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", False, {'no_diff_str'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, no_diff_value, True, {'no_diff_str'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", False, {'no_diff_str'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, no_diff_value, True, {'no_diff_str'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", False, {'no_diff_str'})
 
 ])
-def test_no_diff_str(key, subkey, arch, value_name, content, truncated, tags_to_apply,
-                  get_configuration, configure_environment, restart_syscheckd,
-                  wait_for_fim_start):
+def test_no_diff_str(key, subkey, arch, value_name, truncated, tags_to_apply,
+                     get_configuration, configure_environment, restart_syscheckd,
+                     wait_for_fim_start):
     """
-    Check the only files detected are those matching the restrict regex
+    Check the only values detected are those matching the restrict using the value path.
 
     Parameters
     ----------
@@ -77,46 +87,48 @@ def test_no_diff_str(key, subkey, arch, value_name, content, truncated, tags_to_
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    values = {value_name: content}
+    values = {value_name: "some content"}
 
     def report_changes_validator(event):
         """Validate content_changes attribute exists in the event"""
         for value in values:
-            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]", sha1(os.path.join(key, subkey).encode()).hexdigest())
-            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str, sha1(value.encode()).hexdigest())
-            assert os.path.exists(diff_file), f'{diff_file} does not exist'
-            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
+            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str,
+                                     sha1(value.encode()).hexdigest())
 
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
 
     def no_diff_validator(event):
         """Validate content_changes value is truncated if the file is set to no_diff"""
         if truncated:
             assert '<Diff truncated because nodiff option>' in event['data'].get('content_changes'), \
-                f'content_changes is not truncated'
+                'content_changes is not truncated'
         else:
             assert '<Diff truncated because nodiff option>' not in event['data'].get('content_changes'), \
-                f'content_changes is truncated'
-
+                'content_changes is truncated'
 
     registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
-                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                     min_timeout=global_parameters.default_timeout, triggers_event=True,
-                     validators_after_update=[report_changes_validator, no_diff_validator])
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator, no_diff_validator])
+    sleep(0.5)
 
 
-@pytest.mark.parametrize('key, subkey, arch, value_name, content, truncated, tags_to_apply', [
-    (key, sub_key_1, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_regex'}),
-    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_regex'}),
-    (key, sub_key_1, KEY_WOW64_32KEY, no_diff_value, "test_content", True, {'no_diff_regex'}),
-    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", "test_content", False, {'no_diff_regex'}),
-    (key, sub_key_2, KEY_WOW64_64KEY, no_diff_value, "test_content", True, {'no_diff_regex'}),
-    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", "test_content", False, {'no_diff_regex'})
+@pytest.mark.parametrize('key, subkey, arch, value_name, truncated, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, no_diff_value, True, {'no_diff_regex'}),
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", False, {'no_diff_regex'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, no_diff_value, True, {'no_diff_regex'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", False, {'no_diff_regex'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, no_diff_value, True, {'no_diff_regex'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", False, {'no_diff_regex'})
 ])
-def test_no_diff_regex(key, subkey, arch, value_name, content, truncated, tags_to_apply,
-                  get_configuration, configure_environment, restart_syscheckd,
-                  wait_for_fim_start):
+def test_no_diff_regex(key, subkey, arch, value_name, truncated, tags_to_apply,
+                       get_configuration, configure_environment, restart_syscheckd,
+                       wait_for_fim_start):
     """
-    Check the only files detected are those matching the restrict regex
+    Check the only files detected are those matching the restrict regex.
 
     Parameters
     ----------
@@ -134,28 +146,31 @@ def test_no_diff_regex(key, subkey, arch, value_name, content, truncated, tags_t
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    values = {value_name: content}
+    values = {value_name: "some content"}
 
     def report_changes_validator(event):
         """Validate content_changes attribute exists in the event"""
         for value in values:
-            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]", sha1(os.path.join(key, subkey).encode()).hexdigest())
-            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str, sha1(value.encode()).hexdigest())
-            assert os.path.exists(diff_file), f'{diff_file} does not exist'
-            assert event['data'].get('content_changes') is not None, f'content_changes is empty'
+            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
 
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str,
+                                     sha1(value.encode()).hexdigest())
+
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
 
     def no_diff_validator(event):
         """Validate content_changes value is truncated if the file is set to no_diff"""
         if truncated:
             assert '<Diff truncated because nodiff option>' in event['data'].get('content_changes'), \
-                f'content_changes is not truncated'
+                'content_changes is not truncated'
         else:
             assert '<Diff truncated because nodiff option>' not in event['data'].get('content_changes'), \
-                f'content_changes is truncated'
-
-
+                'content_changes is truncated'
     registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
-                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                     min_timeout=global_parameters.default_timeout, triggers_event=True,
-                     validators_after_update=[report_changes_validator, no_diff_validator])
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator, no_diff_validator])
+    # Avoid overlapping of events
+    sleep(0.5)


### PR DESCRIPTION
Hello team,

This PR aims to add a new test for the Windows registry integration test


Closes #894 

# Tests logic
 ### First case
- Monitor two keys: One with `arch="64bit` and another with `arch="both"` and using the `nodiff` option for specific values (on both keys).
- It creates values that match the nodiff and other values that don't match the nodiff and check that all the events are generated as expected: in case that the nodiff is applied to that value, the field `content_changes` must be:  `<Diff truncated because nodiff option>`.
### Second case
- Monitor two keys: One with `arch="64bit` and another with `arch="both"` and using the `nodiff` option using regex.
- It creates keys that match the regex and other keys that don't match the regex and check that all the events are generated as expected: in case that the nodiff is applied to that value, the field `content_changes` must be:  `<Diff truncated because nodiff option>`.
# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail

## Windows

- When the expected behavior occurs:

```

python -m pytest -vvx test_no_diff\
=========== test session starts =========== 
platform win32 -- Python 3.7.3, pytest-6.0.2, py-1.9.0, pluggy-0.13.0 -
[  2%] test_no_diff.py:: PASSED
[  4%] test_no_diff.py:: PASSED
[  8%] test_no_diff.py:: PASSED
[ 12%] test_no_diff.py:: PASSED
[ 16%] test_no_diff.py:: PASSED
[ 20%] test_no_diff.py:: PASSED
[ 25%] test_no_diff.py:: SKIPPED
[ 29%] test_no_diff.py:: SKIPPED
[ 33%] test_no_diff.py:: SKIPPED
[ 37%] test_no_diff.py:: SKIPPED
[ 41%] test_no_diff.py:: SKIPPED
[ 45%] test_no_diff.py:: SKIPPED
[ 50%] test_no_diff.py:: SKIPPED
[ 54%] test_no_diff.py:: SKIPPED
[ 58%] test_no_diff.py:: SKIPPED
[ 62%] test_no_diff.py:: SKIPPED
[ 66%] test_no_diff.py:: SKIPPED
[ 70%] test_no_diff.py:: SKIPPED
[ 75%] test_no_diff.py:: PASSED
[ 79%] test_no_diff.py:: PASSED
[ 83%] test_no_diff.py:: PASSED
[ 87%] test_no_diff.py:: PASSED
[ 91%] test_no_diff.py:: PASSED
[ 95%] test_no_diff.py:: PASSED
[100%]

=========================== 12 passed, 12 skipped in 45.05s ===========
```

Best regards.
