### PR TITLE
Registry integration test: Recursion level

### DIFF
--- a/tests/integration/test_fim/test_registry/test_recursion_level/data/wazuh_recursion_windows_registry.yaml
+++ b/tests/integration/test_fim/test_registry/test_recursion_level/data/wazuh_recursion_windows_registry.yaml
@@ -11,15 +11,19 @@
         value: REGISTRY_0
         attributes:
         - recursion_level: LEVEL_0
+        - arch: '64bit'
     - windows_registry:
         value: REGISTRY_1
         attributes:
         - recursion_level: LEVEL_1
+        - arch: '64bit'
     - windows_registry:
         value: REGISTRY_2
         attributes:
         - recursion_level: LEVEL_2
+        - arch: '64bit'
     - windows_registry:
         value: REGISTRY_3
         attributes:
         - recursion_level: LEVEL_3
+        - arch: '64bit'

--- a/tests/integration/test_fim/test_registry/test_recursion_level/data/wazuh_recursion_windows_registry.yaml
+++ b/tests/integration/test_fim/test_registry/test_recursion_level/data/wazuh_recursion_windows_registry.yaml
@@ -1,4 +1,5 @@
 ---
+# Configuration for recursion level
 - apply_to_modules:
   - test_recursion_level_registry
   sections:
@@ -7,22 +8,18 @@
     - disabled:
         value: 'no'
     - windows_registry:
-        value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\norecursion"
+        value: REGISTRY_0
         attributes:
-        - recursion_level: "0"
-        - FIM_MODE
+        - recursion_level: LEVEL_0
     - windows_registry:
-        value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\recursion1"
+        value: REGISTRY_1
         attributes:
-        - recursion_level: "1"
-        - FIM_MODE
+        - recursion_level: LEVEL_1
     - windows_registry:
-        value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\recursion5"
+        value: REGISTRY_2
         attributes:
-        - recursion_level: "5"
-        - FIM_MODE
+        - recursion_level: LEVEL_2
     - windows_registry:
-        value: "HKEY_LOCAL_MACHINE\\SOFTWARE\\recursion512"
+        value: REGISTRY_3
         attributes:
-        - recursion_level: "512"
-        - FIM_MODE
+        - recursion_level: LEVEL_3

--- a/tests/integration/test_fim/test_registry/test_recursion_level/test_recursion_level_registry.py
+++ b/tests/integration/test_fim/test_registry/test_recursion_level/test_recursion_level_registry.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 import os
 import pytest
 
@@ -46,7 +47,7 @@ conf_params = {'REGISTRY_0': os.path.join(key, registry_no_recursion),
 
                'REGISTRY_3': os.path.join(key, registry_recursion_29),
                'LEVEL_3': rl_dict[registry_recursion_29]
-}
+               }
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
@@ -72,6 +73,7 @@ def extra_configuration_before_yield():
         create_registry(registry_parser[key], path, KEY_WOW64_64KEY)
 
 # Tests
+
 
 @pytest.mark.parametrize('root_key, registry, arch, edge_limit, ignored_levels', [
     (key, registry_no_recursion, KEY_WOW64_64KEY, 2, 1),
@@ -135,7 +137,7 @@ def test_recursion_level(root_key, registry, arch, edge_limit, ignored_levels,
             path = os.path.join(path, str(level + 1))
             path_list.append(path)
     else:
-        for level in range (recursion_level):
+        for level in range(recursion_level):
             path = os.path.join(path, str(level + 1))
             if level < edge_limit or level > recursion_level - edge_limit:
                 path_list.append(path)


### PR DESCRIPTION
Hello team,

This PR aims to add a new test for the windows registry integration tests
Closes #895

# Tests logic
This test has only one case: 
- The test will monitor some keys with different recursion level. Then it creates values in the lower levels and in the last levels and check that the alerts are generated.
- After that, the test creates keys with a higher recursion level and checks that no events are generated in these keys

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail
- [ ] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`

## Windows

- When the expected behavior occurs:

```
python -m pytest -vvx test_recursion_level\
=================================== test session starts ============
metadata: {'Python': '3.7.3', 'Platform': 'Windows-7-6.1.7601-SP1',
collected 4 items

test_recursion_level_registry.py PASSED [ 25%]
test_recursion_level_registry.py PASSED [ 50%]
test_recursion_level_registry.py PASSED [ 75%]
test_recursion_level_registry.py PASSED [100%]

=========================================== 4 passed in 173.19s (0:02:53) ==============

```
Best regards.
