### PR TITLE
Wazuh DB command to get a list of agents by connection status from global.db - Integration Tests

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -293,7 +293,6 @@
     input: 'global reset-agents-connection'
     output: 'ok'
     stage: "global reset-agents-connection success"
-    test: 'yes'
   -
     input: 'global get-agent-info 0'
     output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
@@ -314,6 +313,42 @@
     output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
+-
+  name: "get-agents-by-connection-status command"
+  description: "Check success use cases for get-agents-by-connection-status command on global DB."
+  test_case:
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"never_connected"}'
+    output: "ok"
+    stage: "global update-connection-status never_connected"
+  -
+    input: 'global update-connection-status {"id":2,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status pending"
+  -
+    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status active"
+  -
+    input: 'global get-agents-by-connection-status never_connected'
+    output: 'ok [{"id":1}]'
+    stage: "global get-agents-by-connection-status never_connected success"
+  -
+    input: 'global get-agents-by-connection-status pending'
+    output: 'ok [{"id":2}]'
+    stage: "global get-agents-by-connection-status pending success"
+  -
+    input: 'global get-agents-by-connection-status active'
+    output: 'ok [{"id":3}]'
+    stage: "global get-agents-by-connection-status active success"
+  -
+    input: 'global reset-agents-connection'
+    output: 'ok'
+    stage: "global reset-agents-connection"
+  -
+    input: 'global get-agents-by-connection-status disconnected'
+    output: 'ok [{"id":2},{"id":3}]'
+    stage: "global get-agents-by-connection-status disconnected success"
 -
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."


### PR DESCRIPTION
Hello team,

# Tests logic

This PR adds IT to new get-agents-by-keepalive WazuhDB command.
- It checks the correct parsing and execution of the command.

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail

Best regards.