### PR TITLE
Add a Wazuh DB command to disconnect the agents that didn't send a keepalive - Integration Tests

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -78,7 +78,7 @@
     output: "ok"
     stage: "global update-agent-name success"
   -
-    input: 'global update-agent-data {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq","labels":"TestKey1:TestLabel1"}'
+    input: 'global update-agent-data {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq","connection_status":"never_connected","labels":"TestKey1:TestLabel1"}'
     output: "ok"
     stage: "global update-agent-data success"
   -
@@ -97,10 +97,6 @@
     input: 'global update-reg-offset {"id":1,"offset":100}'
     output: "ok"
     stage: "global update-reg-offset success"
-  -
-    input: 'global update-keepalive {"id":1,"sync_status":"syncreq"}'
-    output: "ok"
-    stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
     output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
@@ -140,6 +136,15 @@
   -
     input: 'global get-agent-info 1'
     output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-keepalive {"id":1,"sync_status":"syncreq","connection_status":"active"}'
+    output: "ok"
+    stage: "global update-keepalive success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -225,7 +230,7 @@
     output: 'ok []'
     stage: "global sync-agent-info-get after first get success"
   -
-    input: 'global update-keepalive {"id":1,"sync_status":"syncreq"}'
+    input: 'global update-keepalive {"id":1,"sync_status":"syncreq","connection_status":"active"}'
     output: "ok"
     stage: "global update-keepalive success"
   -
@@ -350,6 +355,46 @@
     output: 'ok [{"id":2},{"id":3}]'
     stage: "global get-agents-by-connection-status disconnected success"
 -
+  name: "disconnect-agents command"
+  description: "Check the right behavior of disconnect-agents command on global DB."
+  test_case:
+  -
+    input: 'global sql UPDATE agent SET last_keepalive = 100 WHERE id = 1;'
+    output: "ok []"
+    stage: "global updating agent's 1 keepalive to 100"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status as active for agent 1 success"
+  -
+    input: 'global sql UPDATE agent SET last_keepalive = 150 WHERE id = 2;'
+    output: "ok []"
+    stage: "global updating agent's 2 keepalive to 150"
+  -
+    input: 'global update-connection-status {"id":2,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status as pending for agent 2 success"
+  -
+    input: 'global sql UPDATE agent SET last_keepalive = 200 WHERE id = 3;'
+    output: "ok []"
+    stage: "global updating agent's 3 keepalive to 200"
+  -
+    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status as active for agent 3 success"
+  -
+    input: 'global get-agents-by-connection-status disconnected'
+    output: 'ok []'
+    stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
+  -
+    input: 'global disconnect-agents 175'
+    output: 'ok [{"id":1}]'
+    stage: "global disconnect-agents success"
+  -
+    input: 'global get-agents-by-connection-status disconnected'
+    output: 'ok [{"id":1}]'
+    stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
+-
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."
   test_case:
@@ -383,7 +428,7 @@
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
-    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"127.0.0.1","sync_status":"synced"}'
+    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"127.0.0.1","sync_status":"synced","connection_status":"active"}'
     output: "ok"
     stage: "global manager update-agent-data success"
   -
@@ -392,7 +437,7 @@
     stage: "global manager get-agent-info success post update with IP"
     use_regex: "yes"
   -
-    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced"}'
+    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced","connection_status":"active"}'
     output: "ok"
     stage: "global manager update-agent-data success"
   -


### PR DESCRIPTION
Hello team,

This PR includes new test cases to validate the right behavior of the new Wazuh DB command `disconnect_agents`. This new command allows a client to set agents that didn't send a keepalive for a while as disconnected.

For more details about the command, see the **Requirements** section of the [Issue 6345](https://github.com/wazuh/wazuh/issues/6345).

Closes [#6345](https://github.com/wazuh/wazuh/issues/6345)

# Tests logic

- It checks the correct parsing and execution of the command.
- It checks that only agents in `active` state are set as `disconnected`.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail