### PR TITLE
Automatic tests for unlimited agents

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -21,7 +21,8 @@ setup(name='wazuh_testing',
                                       'data/analysis_alert_windows.json',
                                       'data/state_integrity_analysis_schema.json',
                                       'data/gcp_event.json',
-                                      'data/keepalives.txt'
+                                      'data/keepalives.txt',
+                                      'data/rootcheck.txt'
                                       ]
                     },
       include_package_data=True,

--- a/deps/wazuh_testing/wazuh_testing/data/rootcheck.txt
+++ b/deps/wazuh_testing/wazuh_testing/data/rootcheck.txt
@@ -1,0 +1,33 @@
+#Example rootcheck scan results
+Starting rootcheck scan.
+File '/var/lib/file' is owned by root and has written permissions
+File '/var/lib/linkfile' is owned by root and has written permissions to anyone.
+File '/dev/file' present on /dev. Possible hidden file.
+File '/dev/linkfile' present on /dev. Possible hidden file.
+Rootkit 'malware1' detected by the presence of file '/tmp/malware1'.
+Rootkit 'malware2' detected by the presence of file '/tmp/malware2'.
+Anomaly detected in file '/tmp/hidden1'. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.
+Anomaly detected in file '/tmp/hidden2'. Hidden from stats, but showing up on readdir. Possible kernel level rootkit.
+Anomaly detected in file '/etc/suspicious1'. File size doesn't match what we found. Possible kernel level rootkit.
+Anomaly detected in file '/etc/suspicious2'. File size doesn't match what we found. Possible kernel level rootkit.
+Files hidden inside directory '/var/lib'. Link count does not match number of files (7,5).
+Files hidden inside directory '/bin'. Link count does not match number of files (7,5).
+Trojaned version of file 'trojan1' detected. Signature used: 'abcdef' (Generic).
+Trojaned version of file 'trojan2' detected. Signature used: 'abcdef' (Generic).
+Interface 'eth5' in promiscuous mode.
+Interface 'eth8' in promiscuous mode.
+Interface 'eth5' in promiscuous mode, but ifconfig is not showing it(probably trojaned).
+Interface 'eth8' in promiscuous mode, but ifconfig is not showing it(probably trojaned).
+Excessive number of 'tcp' ports hidden. It maybe a false-positive or something really bad is going on.
+Excessive number of 'udp' ports hidden. It maybe a false-positive or something really bad is going on.
+Port '5555'(tcp) hidden. Kernel-level rootkit or trojaned version of netstat.
+Port '6666'(udp) hidden. Kernel-level rootkit or trojaned version of netstat.
+Process 'malicious1' hidden from kill (9) or getsid (5). Possible kernel-level rootkit.
+Process 'malicious2' hidden from kill (9) or getsid (5). Possible kernel-level rootkit.
+Process 'malicious3' hidden from kill (8), getsid (7) or getpgid. Possible kernel-level rootkit.
+Process 'malicious4' hidden from kill (8), getsid (7) or getpgid. Possible kernel-level rootkit.
+Process 'malicious5' hidden from /proc. Possible kernel level rootkit.
+Process 'malicious6' hidden from /proc. Possible kernel level rootkit.
+Process 'malicious7' hidden from ps. Possible trojaned version installed.
+Process 'malicious8' hidden from ps. Possible trojaned version installed.
+Ending rootcheck scan.

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -38,8 +38,9 @@ agent_count = 1
 
 class Agent:
     def __init__(self, manager_address, cypher="aes", os=None,
-                 inventory_sample=None, id=None, name=None, key=None,
-                 version="3.12", fim_eps=None, fim_integrity_eps=None,
+                 inventory_sample=None, rootcheck_sample= None,
+                 id=None, name=None, key=None, version="3.12",
+                 fim_eps=None, fim_integrity_eps=None,
                  authd_password=None):
         self.id = id
         self.name = name
@@ -57,14 +58,16 @@ class Agent:
         self.authd_password = authd_password
         self.inventory_sample = inventory_sample
         self.inventory = None
+        self.rootcheck_sample = rootcheck_sample
+        self.rootcheck = None
         self.fim = None
+        self.fim_integrity = None
         self.modules = {
             "keepalive": {"status": "enabled", "frequency": 60.0},
-            "fim": {"status": "enabled", "eps": self.fim_eps},
-            "fim_integrity": {"status": "disabled",
-                              "eps": self.fim_integrity_eps},
-            "syscollector": {"status": "disabled", "frequency": 60.0,
-                             "eps": 200},           
+            "fim": {"status": "disabled", "eps": self.fim_eps},
+            "fim_integrity": {"status": "disabled", "eps": self.fim_integrity_eps},
+            "syscollector": {"status": "disabled", "frequency": 60.0, "eps": 200},
+            "rootcheck": {"status": "enabled", "frequency": 60.0, "eps": 200},
             "receive_messages": {"status": "enabled"},
         }
         self.sha_key = None
@@ -74,7 +77,6 @@ class Agent:
         self.stop_receive = 0
         self.disconnect = None
         self.counter_disconnect = None
-        self.fim_integrity = None
         self.setup()
 
     # Set up agent: Keep alive, encryption key and start up msg.
@@ -324,6 +326,8 @@ class Agent:
     def initializeModules(self):
         if self.modules["syscollector"]["status"] == "enabled":
             self.inventory = Inventory(self.os, self.inventory_sample)
+        if self.modules["rootcheck"]["status"] == "enabled":
+            self.rootcheck = Rootcheck(self.rootcheck_sample)
         if self.modules["fim"]["status"] == "enabled":
             self.fim = GeneratorFIM(self.id, self.name, self.version)
         if self.modules["fim_integrity"]["status"] == "enabled":
@@ -357,6 +361,32 @@ class Inventory:
                                                self.SYSCOLLECTOR,
                                                line.strip("\n"))
                     self.inventory.append(msg)
+                line = fp.readline()
+
+
+class Rootcheck:
+    def __init__(self, os, rootcheck_sample=None):
+        self.os = os
+        self.ROOTCHECK = 'rootcheck'
+        self.ROOTCHECK_MQ = '9'
+        self.rootcheck = []
+        self.rootcheck_path = ""
+        self.rootcheck_sample = rootcheck_sample
+        self.setup()
+
+    def setup(self):
+        if self.rootcheck_sample is None:
+            self.rootcheck_path = os.path.join(_data_path, 'rootcheck.txt')
+        else:
+            self.rootcheck_path = os.path.join(_data_path, self.rootcheck_sample)
+        with open(self.rootcheck_path) as fp:
+            line = fp.readline()
+            while line:
+                if not line.startswith("#"):
+                    msg = "{0}:{1}:{2}".format(self.ROOTCHECK_MQ,
+                                               self.ROOTCHECK,
+                                               line.strip("\n"))
+                    self.rootcheck.append(msg)
                 line = fp.readline()
 
 
@@ -760,6 +790,32 @@ class InjectorThread (threading.Thread):
                   - ((time() - starttime)
                      % self.agent.modules["syscollector"]["frequency"]))
 
+    def rootcheck(self):
+        sleep(10)
+        starttime = time()
+        while self.stop_thread == 0:
+            # Send agent rootcheck scan
+            print("Scan started - {}({}) - {}({})"
+                  .format(self.agent.name,
+                          self.agent.id,
+                          "rootcheck",
+                          self.agent.rootcheck.rootcheck_path))
+            for item in self.agent.rootcheck.rootcheck:
+                self.sender.sendEvent(self.agent.createEvent(item))
+                self.totalMessages += 1
+                if self.totalMessages % \
+                   self.agent.modules["rootcheck"]["eps"] == 0:
+                    self.totalMessages = 0
+                    sleep(1.0 - ((time() - starttime) % 1.0))
+            print("Scan ended - {}({}) - {}({})"
+                  .format(self.agent.name,
+                          self.agent.id,
+                          "rootcheck",
+                          self.agent.rootcheck.rootcheck_path))
+            sleep(self.agent.modules["rootcheck"]["frequency"]
+                  - ((time() - starttime)
+                     % self.agent.modules["rootcheck"]["frequency"]))
+
     def run(self):
         # message = "1:/var/log/syslog:Jan 29 10:03:41 master sshd[19635]:
         #   pam_unix(sshd:session): session opened for user vagrant by (uid=0)
@@ -773,6 +829,8 @@ class InjectorThread (threading.Thread):
             self.fim()
         elif self.module == "syscollector":
             self.inventory()
+        elif self.module == "rootcheck":
+            self.rootcheck()
         elif self.module == "fim_integrity":
             self.fim_integrity()
         elif self.module == "receive_messages":

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -312,7 +312,8 @@ class SocketController:
         return output
 
     def receive(self, size=False):
-        """Receive a message from the socket.
+        """
+        Receive a message from the socket.
 
         Parameters
         ----------

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -312,8 +312,7 @@ class SocketController:
         return output
 
     def receive(self, size=False):
-        """
-        Receive a message from the socket.
+        """Receive a message from the socket.
 
         Parameters
         ----------
@@ -337,7 +336,7 @@ class SocketController:
                         output += self.sock.recv(4096, socket.MSG_DONTWAIT)
                     except:
                         break
-        
+
         return output
 
     def set_ssl_configuration(self, ciphers="HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH",
@@ -517,11 +516,11 @@ class StreamServerPort(socketserver.ThreadingTCPServer):
 
 
 class SSLStreamServerPort(socketserver.ThreadingTCPServer):
-    
+
     ciphers = "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH"
     ssl_version = ssl.PROTOCOL_TLSv1_2
-    certfile = None 
-    keyfile = None 
+    certfile = None
+    keyfile = None
     ca_cert = None
     cert_reqs = ssl.CERT_NONE
     options = None
@@ -563,7 +562,7 @@ class SSLStreamServerPort(socketserver.ThreadingTCPServer):
             self.options = options
 
         return
-    
+
 
     def get_request(self):
         """
@@ -573,7 +572,7 @@ class SSLStreamServerPort(socketserver.ThreadingTCPServer):
 
         if not self.certfile or not self.keyfile or not self.ssl_version:
             raise Exception('SSL configuration needs to be set in SSLStreamServer')
-        
+
         try:
             if self.options:
                 context = ssl.SSLContext(self.ssl_version)
@@ -593,7 +592,7 @@ class SSLStreamServerPort(socketserver.ThreadingTCPServer):
                                         certfile = self.certfile,
                                         keyfile = self.keyfile,
                                         ssl_version = self.ssl_version,
-                                        ciphers= self.ciphers, 
+                                        ciphers= self.ciphers,
                                         cert_reqs=self.cert_reqs,
                                         ca_certs=self.ca_cert)
         except OSError as err:

--- a/tests/integration/test_rids/data/wazuh_manager_conf.yaml
+++ b/tests/integration/test_rids/data/wazuh_manager_conf.yaml
@@ -1,0 +1,18 @@
+---
+    - tags:
+      - all
+      apply_to_modules:
+      - test_rids
+      sections:
+      - section: remote
+        elements:
+        - connection:
+            value: 'secure'
+        - port:
+            value: 1514
+        - protocol:
+            value: 'tcp'
+        - queue_size:
+            value: 131072
+        - rids_closing_time:
+            value: 60

--- a/tests/integration/test_rids/data/wazuh_manager_conf.yaml
+++ b/tests/integration/test_rids/data/wazuh_manager_conf.yaml
@@ -3,6 +3,7 @@
       - all
       apply_to_modules:
       - test_rids
+      - test_rids_conf
       sections:
       - section: remote
         elements:

--- a/tests/integration/test_rids/test_rids.py
+++ b/tests/integration/test_rids/test_rids.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import json
+import os
+import pytest
+import sqlite3
+import time
+import psutil
+
+
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.agent_simulator import Sender, Injector, Agent, \
+                    create_agents
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import SocketController
+from wazuh_testing.tools.services import control_service
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+RIDS_DIR = os.path.join(WAZUH_PATH, 'queue', 'rids')
+
+SERVER_ADDRESS = 'localhost'
+CRYPTO = 'aes'
+PROTOCOL = 'tcp'
+
+
+metadata = [
+    {
+        'agents_number': 1,
+        'check_close': [False]
+    },
+    {
+        'agents_number': 1,
+        'check_close': [True]
+    },
+    {
+        'agents_number': 3,
+        'check_close': [True, True, True]
+    },
+    {
+        'agents_number': 3,
+        'check_close': [False, False, False]
+    },
+    {
+        'agents_number': 3,
+        'check_close': [True, False, True]
+    }
+]
+params = [{} for x in range(0, len(metadata))]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_manager_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=params, metadata=metadata)
+
+
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module"""
+    yield request.param
+
+
+@pytest.fixture(scope="function")
+def restart_service():
+    set_recv_counter_flush(10)
+    control_service('restart')
+
+    yield
+
+
+def create_injectors(agents):
+    injectors = []
+    sender = Sender(SERVER_ADDRESS, protocol=PROTOCOL)
+    for index, agent in enumerate(agents):
+        injector = Injector(sender, agent)
+        injectors.append(injector)
+        injector.run()
+        if PROTOCOL == "tcp":
+            sender = Sender(manager_address=SERVER_ADDRESS, protocol=PROTOCOL)
+    return injectors
+
+
+def get_remoted_pid():
+    for process in psutil.process_iter():
+        if process.name() == 'ossec-remoted':
+            return process.pid
+    return None
+
+
+def set_recv_counter_flush(new_recv_counter):
+    new_content = ''
+
+    internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
+
+    with open(internal_options, 'r') as f:
+        lines = f.readlines()
+
+        for line in lines:
+            new_line = line
+            if 'remoted.recv_counter_flush' in line:
+                new_line = f'remoted.recv_counter_flush={new_recv_counter}\n'
+            new_content += new_line
+
+    with open(internal_options, 'w') as f:
+        f.write(new_content)
+
+
+def test_rids(get_configuration, configure_environment, restart_service):
+    metadata = get_configuration.get('metadata')
+    agents_number = metadata['agents_number']
+    check_close = metadata['check_close']
+
+    agents = create_agents(agents_number, SERVER_ADDRESS, CRYPTO)
+
+    injectors = create_injectors(agents)
+
+    # Let time to remoted store counters for agents
+    time.sleep(20)
+
+    process = psutil.Process(get_remoted_pid())
+    opened = process.open_files()
+
+    # Check that rids is open
+    for agent in agents:
+        agent_rids_path = os.path.join(RIDS_DIR, agent.id)
+        rids_for_agent_open = False
+        for path in opened:
+            if agent_rids_path in path:
+                rids_for_agent_open = True
+                break
+
+        assert rids_for_agent_open, f"Agent fd should be open {agent.id}"
+
+    for index, injector in enumerate(injectors):
+        if check_close[index]:
+            injector.stop_receive()
+
+    if True in check_close:
+        # Wait that the thread close the rids
+        time.sleep(120)
+
+        opened = process.open_files()
+
+        # Check that rids is close
+        for agent_index, agent in enumerate(agents):
+            agent_rids_path = os.path.join(RIDS_DIR, agents[agent_index].id)
+            rids_for_agent_open = False
+
+            for path in opened:
+                if agent_rids_path in path:
+                    rids_for_agent_open = True
+                    break
+
+            if check_close[agent_index]:
+                assert not rids_for_agent_open, f"Agent fd should be close {agents[agent_index].id}"
+            else:
+                assert rids_for_agent_open, f"Agent fd should be open {agents[agent_index].id}"
+                injectors[agent_index].stop_receive()

--- a/tests/integration/test_rids/test_rids_conf.py
+++ b/tests/integration/test_rids/test_rids_conf.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import time
+
+
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.services import control_service
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+
+metadata = [
+    {
+        'remoted.verify_msg_id': 1,
+        'remoted.worker_pool': 4,
+        'expected_start': False
+    },
+    {
+        'remoted.verify_msg_id': 1,
+        'remoted.worker_pool': 1,
+        'expected_start': True
+    },
+    {
+        'remoted.verify_msg_id': 0,
+        'remoted.worker_pool': 4,
+        'expected_start': True
+    }
+]
+params = [{} for x in range(0, len(metadata))]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_manager_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=params, metadata=metadata)
+
+
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module"""
+    yield request.param
+
+
+def restart_service():
+    control_service('restart')
+
+
+def set_internal_options_conf(param, value):
+    new_content = ''
+
+    internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
+
+    with open(internal_options, 'r') as f:
+        lines = f.readlines()
+
+        for line in lines:
+            new_line = line
+            if param in line:
+                new_line = f'{param}={value}\n'
+            new_content += new_line
+
+    with open(internal_options, 'w') as f:
+        f.write(new_content)
+
+
+def test_rids_conf(get_configuration, configure_environment):
+    metadata = get_configuration.get('metadata')
+    expected_start = metadata['expected_start']
+
+    set_internal_options_conf('remoted.verify_msg_id', metadata['remoted.verify_msg_id'])
+    set_internal_options_conf('remoted.worker_pool', metadata['remoted.worker_pool'])
+
+    try:
+        restart_service()
+        assert expected_start, 'Expected configuration error'
+    except ValueError:
+        assert not expected_start, 'Start error was not expected'
+
+    # Set default config again
+    set_internal_options_conf('remoted.verify_msg_id', 0)
+    set_internal_options_conf('remoted.worker_pool', 4)

--- a/tests/integration/test_rootcheck/data/wazuh_manager_conf.yaml
+++ b/tests/integration/test_rootcheck/data/wazuh_manager_conf.yaml
@@ -1,0 +1,10 @@
+---
+    - tags:
+      - all
+      apply_to_modules:
+      - test_rootcheck
+      sections:
+      - section: rootcheck
+        elements:
+        - disabled:
+            value: 'no'

--- a/tests/integration/test_rootcheck/test_rootcheck.py
+++ b/tests/integration/test_rootcheck/test_rootcheck.py
@@ -1,0 +1,182 @@
+
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import json
+import os
+import pytest
+import sqlite3
+import time
+
+
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.agent_simulator import Sender, Injector, Agent, \
+                    create_agents
+from wazuh_testing.tools.monitoring import SocketController
+from wazuh_testing.tools.services import control_service
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+WAZUH_DB_DIR = os.path.join(WAZUH_PATH, 'queue', 'db')
+WDB_PATH = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
+
+SERVER_ADDRESS = 'localhost'
+CRYPTO = 'aes'
+PROTOCOL = 'tcp'
+
+
+metadata = [
+    {
+        'agents_number': 1,
+        'check_updates': False,
+        'check_delete': False
+    },
+    {
+        'agents_number': 3,
+        'check_updates': False,
+        'check_delete': False
+    },
+    {
+        'agents_number': 1,
+        'check_updates': True,
+        'check_delete': False
+    },
+    {
+        'agents_number': 3,
+        'check_updates': True,
+        'check_delete': False
+    },
+    {
+        'agents_number': 1,
+        'check_updates': False,
+        'check_delete': True
+    },
+    {
+        'agents_number': 3,
+        'check_updates': False,
+        'check_delete': True
+    },
+]
+params = [{} for x in range(0, len(metadata))]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_manager_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__,
+                                           params=params, metadata=metadata)
+
+
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module"""
+    yield request.param
+
+
+@pytest.fixture(scope="function")
+def restart_service():
+    control_service('restart')
+
+    yield
+
+
+def retrieve_rootcheck_rows(agent_id):
+    agent_db_path = os.path.join(WAZUH_DB_DIR, f'{agent_id}.db')
+    conn = sqlite3.connect(agent_db_path)
+    cursor = conn.cursor()
+    cursor.execute("select * from pm_event")
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return rows
+
+
+def create_injectors(agents):
+    injectors = []
+    sender = Sender(SERVER_ADDRESS, protocol=PROTOCOL)
+    for index, agent in enumerate(agents):
+        injector = Injector(sender, agent)
+        injectors.append(injector)
+        injector.run()
+        if PROTOCOL == "tcp":
+            sender = Sender(manager_address=SERVER_ADDRESS, protocol=PROTOCOL)
+    return injectors
+
+
+def send_delete_table_request(agent_id):
+    controller = SocketController(WDB_PATH)
+    controller.send(f'agent {agent_id} rootcheck delete', size=True)
+    response = controller.receive(size=True)
+    return response
+
+
+def test_rootcheck(get_configuration, configure_environment, restart_service):
+    metadata = get_configuration.get('metadata')
+    agents_number = metadata['agents_number']
+    check_updates = metadata['check_updates']
+    check_delete = metadata['check_delete']
+
+    agents = create_agents(agents_number, SERVER_ADDRESS, CRYPTO)
+
+    injectors = create_injectors(agents)
+
+    # Let rootcheck events to be sent for 60 seconds
+    time.sleep(60)
+
+    for injector in injectors:
+        injector.stop_receive()
+
+    # Service needs to be stopped otherwise db lock will be held by Wazuh db
+    control_service('stop')
+
+    # Check that logs have been added to the sql database
+    for agent in agents:
+        rows = retrieve_rootcheck_rows(agent.id)
+        db_string = [row[3] for row in rows]
+
+        logs_string = [':'.join(x.split(':')[2:]) for x in
+                       agent.rootcheck.rootcheck]
+        for log in logs_string:
+            assert log in db_string, f"Log: \"{log}\" not found in Database"
+
+    if check_updates:
+        # Service needs to be stopped otherwise db lock will be held by
+        # Wazuh db
+        control_service('start')
+
+        update_threshold = time.time()
+
+        injectors = create_injectors(agents)
+
+        # Let rootcheck events to be sent for 60 seconds
+        time.sleep(60)
+
+        # Check that logs have been updated
+        for agent in agents:
+            rows = retrieve_rootcheck_rows(agent.id)
+
+            db_string = [row[3] for row in rows]
+
+            logs_string = [':'.join(x.split(':')[2:]) for x in
+                           agent.rootcheck.rootcheck]
+            for row in rows:
+                assert row[1] < update_threshold, \
+                    f'First time in log was updated after insertion'
+                assert row[2] > update_threshold, \
+                    f'Updated time in log was not updated'
+                assert row[3] in logs_string, \
+                    f"Log: \"{log}\" not found in Database"
+
+    if check_delete:
+        # Service needs to be stopped otherwise db lock will be held by
+        # Wazuh db
+        control_service('start')
+
+        for agent in agents:
+            response = send_delete_table_request(agent.id)
+            assert response.startswith(b'ok'), "Wazuh DB returned an error " \
+                "trying to delete the agent"
+
+            rows = retrieve_rootcheck_rows(agent.id)
+            assert len(rows) == 0, 'Rootcheck events were not deleted'

--- a/tests/integration/test_rootcheck/test_rootcheck.py
+++ b/tests/integration/test_rootcheck/test_rootcheck.py
@@ -166,7 +166,7 @@ def test_rootcheck(get_configuration, configure_environment, restart_service,
 
         update_threshold = time.time()
 
-        injectors = create_injectors(agents)
+        create_injectors(agents)
 
         # Let rootcheck events to be sent for 60 seconds
         time.sleep(60)
@@ -174,8 +174,6 @@ def test_rootcheck(get_configuration, configure_environment, restart_service,
         # Check that logs have been updated
         for agent in agents:
             rows = retrieve_rootcheck_rows(agent.id)
-
-            db_string = [row[3] for row in rows]
 
             logs_string = [':'.join(x.split(':')[2:]) for x in
                            agent.rootcheck.rootcheck]

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -141,7 +141,7 @@ elif _agent_version == 'v4.1.0':
             'upgrade_ok': True,
             'result_code': 0,
             'receive_notification': True,
-            'status': 'Failed',   
+            'status': 'Failed',
         }
     }]
 


### PR DESCRIPTION
Hello team,

This pull request add tests to check the new capabilities that allow have unlimited agents registered to a single manager.

Closes #882

# Tests logic

The test are divided in two types:
**Rootcheck:**
- Simulate rootcheck messages from one agent: logs inserted in the agent's database.
- Simulate rootcheck messages from two agents: logs inserted in the agents' databases.
- Simulate repeated rootcheck messages from one agent: last time updated in the agent's database.
- Simulate delete messages from one agent: logs deleted from agent's database.
- Simulate delete messages from two agents: logs deleted from agents' databases.

**Rids:**
- Simulate keep-alive messages from one agent: RIDS file blocked.
- Simulate keep-alive messages from one agent and stop the messages for a period of time: RIDS file unblocked.
- Simulate keep-alive messages from three agents and stop the messages from one of them for a period of time: Two RIDS files blocked and one unblocked.
- Test new invalid configuration between verify_msg_id and worker_pool 

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Tested and passed in Jenkins. Build URL: 
`https://ci.wazuh.info/job/test_integration/558/console`
`https://ci.wazuh.info/job/test_integration/560/console`
`https://ci.wazuh.info/job/test_integration/561/console`
`https://ci.wazuh.info/job/test_integration/562/console`

## RPM manager

- RIDS:

```
15:12:12  [0;33m============================= test session starts ==============================[0m
15:12:12  [0;33mplatform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /bin/python3[0m
15:12:12  [0;33mcachedir: .pytest_cache[0m
15:12:12  [0;33mmetadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-centos-7.4.1708-Core', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
15:12:12  [0;33mrootdir: /tmp/test_integration_B558_20201029185728/tests/integration, inifile: pytest.ini[0m
15:12:12  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
15:12:12  [0;33mcollecting ... collected 8 items[0m
15:12:12  [0;33m[0m
15:12:12  [0;33mtest_rids/test_rids.py::test_rids[get_configuration0] PASSED             [ 12%][0m
15:12:12  [0;33mtest_rids/test_rids.py::test_rids[get_configuration1] PASSED             [ 25%][0m
15:12:12  [0;33mtest_rids/test_rids.py::test_rids[get_configuration2] PASSED             [ 37%][0m
15:12:12  [0;33mtest_rids/test_rids.py::test_rids[get_configuration3] PASSED             [ 50%][0m
15:12:12  [0;33mtest_rids/test_rids.py::test_rids[get_configuration4] PASSED             [ 62%][0m
15:12:12  [0;33mtest_rids/test_rids_conf.py::test_rids_conf[get_configuration0] PASSED   [ 75%][0m
15:12:12  [0;33mtest_rids/test_rids_conf.py::test_rids_conf[get_configuration1] PASSED   [ 87%][0m
15:12:12  [0;33mtest_rids/test_rids_conf.py::test_rids_conf[get_configuration2] PASSED   [100%][0m
15:12:12  [0;33m[0m
15:12:12  [0;33m- generated html file: file:///tmp/test_integration_B558_20201029185728/report.html -[0m
15:12:12  [0;33m======================== 8 passed in 667.00s (0:11:07) =========================[0m
```

- Rootcheck:

```
15:13:53  [0;33m============================= test session starts ==============================[0m
15:13:53  [0;33mplatform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /bin/python3[0m
15:13:53  [0;33mcachedir: .pytest_cache[0m
15:13:53  [0;33mmetadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-centos-7.4.1708-Core', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
15:13:53  [0;33mrootdir: /tmp/test_integration_B560_20201029185856/tests/integration, inifile: pytest.ini[0m
15:13:53  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
15:13:53  [0;33mcollecting ... collected 6 items[0m
15:13:53  [0;33m[0m
15:13:53  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration0] PASSED [ 16%][0m
15:13:53  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration1] PASSED [ 33%][0m
15:13:53  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration2] PASSED [ 50%][0m
15:13:53  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration3] PASSED [ 66%][0m
15:13:53  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration4] PASSED [ 83%][0m
15:13:53  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration5] PASSED [100%][0m
15:13:53  [0;33m[0m
15:13:53  [0;33m- generated html file: file:///tmp/test_integration_B560_20201029185856/report.html -[0m
15:13:53  [0;33m======================== 6 passed in 716.59s (0:11:56) =========================[0m
```

## DEB manager

- RIDS:

```
15:19:01  [0;33m============================= test session starts ==============================[0m
15:19:01  [0;33mplatform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3[0m
15:19:01  [0;33mcachedir: .pytest_cache[0m
15:19:01  [0;33mmetadata: {'Python': '3.6.9', 'Platform': 'Linux-4.15.0-1060-aws-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
15:19:01  [0;33mrootdir: /tmp/test_integration_B562_20201029190435/tests/integration, inifile: pytest.ini[0m
15:19:01  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
15:19:01  [0;33mcollecting ... collected 8 items[0m
15:19:01  [0;33m[0m
15:19:01  [0;33mtest_rids/test_rids.py::test_rids[get_configuration0] PASSED             [ 12%][0m
15:19:01  [0;33mtest_rids/test_rids.py::test_rids[get_configuration1] PASSED             [ 25%][0m
15:19:01  [0;33mtest_rids/test_rids.py::test_rids[get_configuration2] PASSED             [ 37%][0m
15:19:01  [0;33mtest_rids/test_rids.py::test_rids[get_configuration3] PASSED             [ 50%][0m
15:19:01  [0;33mtest_rids/test_rids.py::test_rids[get_configuration4] PASSED             [ 62%][0m
15:19:01  [0;33mtest_rids/test_rids_conf.py::test_rids_conf[get_configuration0] PASSED   [ 75%][0m
15:19:01  [0;33mtest_rids/test_rids_conf.py::test_rids_conf[get_configuration1] PASSED   [ 87%][0m
15:19:01  [0;33mtest_rids/test_rids_conf.py::test_rids_conf[get_configuration2] PASSED   [100%][0m
15:19:01  [0;33m[0m
15:19:01  [0;33m- generated html file: file:///tmp/test_integration_B562_20201029190435/report.html -[0m
15:19:01  [0;33m======================== 8 passed in 668.46s (0:11:08) =========================[0m
```

- Rootcheck:

```
15:15:21  [0;33m============================= test session starts ==============================[0m
15:15:21  [0;33mplatform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3[0m
15:15:21  [0;33mcachedir: .pytest_cache[0m
15:15:21  [0;33mmetadata: {'Python': '3.6.9', 'Platform': 'Linux-4.15.0-1060-aws-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
15:15:21  [0;33mrootdir: /tmp/test_integration_B561_20201029185929/tests/integration, inifile: pytest.ini[0m
15:15:21  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
15:15:21  [0;33mcollecting ... collected 6 items[0m
15:15:21  [0;33m[0m
15:15:21  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration0] PASSED [ 16%][0m
15:15:21  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration1] PASSED [ 33%][0m
15:15:21  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration2] PASSED [ 50%][0m
15:15:21  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration3] PASSED [ 66%][0m
15:15:21  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration4] PASSED [ 83%][0m
15:15:21  [0;33mtest_rootcheck/test_rootcheck.py::test_rootcheck[get_configuration5] PASSED [100%][0m
15:15:21  [0;33m[0m
15:15:21  [0;33m- generated html file: file:///tmp/test_integration_B561_20201029185929/report.html -[0m
15:15:21  [0;33m======================== 6 passed in 711.60s (0:11:51) =========================[0m
```
