### PR TITLE
Agents' status management improvement based on new monitord settings - Epic integration tests

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -43,7 +43,7 @@
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"group":"TestGroup1","sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after insert"
   -
     input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
@@ -59,7 +59,7 @@
     stage: "global insert-agent minimal fields success"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after minimal fields insert"
   -
     input: 'global delete-agent 2'
@@ -82,24 +82,12 @@
     output: "ok"
     stage: "global update-agent-data success"
   -
-    input: 'global update-agent-status {"id":1,"status":"updated"}'
-    output: "ok"
-    stage: "global update-agent-status success"
-  -
     input: 'global update-agent-group {"id":1,"group":"TestGroup2"}'
     output: "ok"
     stage: "global update-agent-group success"
   -
-    input: 'global update-fim-offset {"id":1,"offset":100}'
-    output: "ok"
-    stage: "global update-fim-offset success"
-  -
-    input: 'global update-reg-offset {"id":1,"offset":100}'
-    output: "ok"
-    stage: "global update-reg-offset success"
-  -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -108,7 +96,7 @@
     stage: "global update-connection-status pending success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"pending"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"pending"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -117,7 +105,7 @@
     stage: "global update-connection-status active success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -126,7 +114,7 @@
     stage: "global update-connection-status disconnected success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -135,7 +123,7 @@
     stage: "global update-connection-status dummy_status error"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -144,7 +132,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -175,18 +163,6 @@
     input: 'global select-agent-group  1'
     output: 'ok [{"group":"TestGroup2"}]'
     stage: "global select-agent-group success"
-  -
-    input: 'global select-agent-status 1'
-    output: 'ok [{"status":"updated"}]'
-    stage: "global select-agent-status success"
-  -
-    input: 'global select-fim-offset 1'
-    output: 'ok [{"fim_offset":100}]'
-    stage: "global select-fim-offset success"
-  -
-    input: 'global select-reg-offset 1'
-    output: 'ok [{"reg_offset":100}]'
-    stage: "global select-reg-offset success"
   -
     input: 'global select-keepalive TestName2 0.0.0.1'
     output: 'ok [{"last_keepalive":*}]'
@@ -252,7 +228,7 @@
     stage: "global sync-agent-info-set success"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
   name: "Belongs commands"
@@ -288,22 +264,22 @@
     stage: "global reset-agents-connection success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post reset connection status"
     use_regex: "yes"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"disconnected"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"sync_status":"synced","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
 -
@@ -412,7 +388,7 @@
   test_case:
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
@@ -421,7 +397,7 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update with IP"
     use_regex: "yes"
   -
@@ -430,6 +406,6 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update without IP"
     use_regex: "yes"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -10,7 +10,7 @@
   -
     input: 'global find-group TestGroup1'
     output: "ok []"
-    stage: "global find-group previous insert"    
+    stage: "global find-group previous insert"
   -
     input: 'global insert-agent-group TestGroup1'
     output: 'ok'
@@ -23,13 +23,13 @@
   -
     input: 'global find-group TestGroup1'
     output: 'ok [{"id":*}]'
-    stage: "global find-group after insert" 
+    stage: "global find-group after insert"
     use_regex: "yes"
   -
     input: 'global select-groups'
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
     stage: "global select-groups success"
-  -  
+  -
     input: 'global delete-agent 1'
     output: "ok"
     stage: "global delete-agent previous insert"
@@ -43,13 +43,13 @@
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced"}]'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after insert"
   -
     input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
     output: 'ok [{"id":1}]'
-    stage: "global find-agent success"   
-  -  
+    stage: "global find-agent success"
+  -
     input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent previous insert"
@@ -59,9 +59,9 @@
     stage: "global insert-agent minimal fields success"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after minimal fields insert"
-  -  
+  -
     input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent after insert"
@@ -99,7 +99,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -146,7 +146,7 @@
     input: 'global select-keepalive TestName2 0.0.0.1'
     output: 'ok [{"last_keepalive":*}]'
     stage: "global select-keepalive success"
-    use_regex: "yes" 
+    use_regex: "yes"
   -
     input: 'global select-groups'
     output: 'ok [{"name":"default"},{"name":"TestGroup1"}]'
@@ -205,7 +205,7 @@
     input: 'global get-agent-info 3'
     output: 'ok []'
     stage: "global get-agent-info success after non-existent sync-agent-info-set"
-  -  
+  -
     input: 'global delete-agent 3'
     output: "ok"
     stage: "global delete-agent previous insert"
@@ -219,12 +219,12 @@
     stage: "global sync-agent-info-set success"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
   name: "Belongs commands"
   description: "Check success use cases for belongs table commands on global DB"
-  test_case:  
+  test_case:
   -
     input: 'global insert-agent-belong {"id_group":1,"id_agent":1}'
     output: 'ok'
@@ -248,7 +248,7 @@
   -
     input: 'global delete-group TestGroup1'
     output: "ok"
-    stage: "global delete-group after insert"   
+    stage: "global delete-group after insert"
   -
     input: 'global delete-agent 1'
     output: "ok"
@@ -263,7 +263,7 @@
   test_case:
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
@@ -272,15 +272,15 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update with IP"
-    use_regex: "yes" 
+    use_regex: "yes"
   -
     input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced"}'
     output: "ok"
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update without IP"
     use_regex: "yes"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -205,24 +205,12 @@
     output: 'ok 0,1,2'
     stage: "global get-all-agents success"
 -
-  name: "get-agents-by-keepalive command"
-  description: "Check success use cases for get-agents-by-keepalive command on global DB. Chunks command"
-  test_case:
-  -
-    input: 'global get-agents-by-keepalive condition > 100 last_id 0'
-    output: 'ok 1'
-    stage: "global get-agents-by-keepalive success"
-  -
-    input: 'global get-agents-by-keepalive condition < 100 last_id 0'
-    output: 'ok '
-    stage: "global get-agents-by-keepalive success"
--
   name: "sync-agent-info-get command"
   description: "Check success use cases for sync-agent-info-get command on global DB. Chunks command"
   test_case:
   -
     input: 'global sync-agent-info-get last_id 0'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"TestKey2","value":"TestLabel2"}]}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"connection_status":"active","labels":[{"id":1,"key":"TestKey2","value":"TestLabel2"}]}]'
     stage: "global sync-agent-info-get success"
     use_regex: 'yes'
   -
@@ -235,7 +223,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global sync-agent-info-get'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"labels":[{"id":1,"key":"TestKey2","value":"TestLabel2"}]}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":*,"connection_status":"active","labels":[{"id":1,"key":"TestKey2","value":"TestLabel2"}]}]'
     stage: "global sync-agent-info-get no arg success"
     use_regex: 'yes'
 -
@@ -259,7 +247,7 @@
     output: "ok"
     stage: "global insert-agent success"
   -
-    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200}]'
+    input: 'global sync-agent-info-set [{"id":3,"name":"TestName3","ip":"0.0.0.3","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","last_keepalive":200,"connection_status":"never_connected"}]'
     output: 'ok'
     stage: "global sync-agent-info-set success"
   -

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -106,6 +106,42 @@
     output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status pending success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"pending"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status active success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"disconnected"}'
+    output: "ok"
+    stage: "global update-connection-status disconnected success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"dummy_status"}'
+    output: "err Cannot execute Global database query; CHECK constraint failed: agent"
+    stage: "global update-connection-status dummy_status error"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
 -
   name: "Labels commands"
   description: "Check success use cases for labels table commands on global DB"
@@ -245,6 +281,14 @@
   name: "Reset connection status"
   description: "Check success use cases for reset connection status command."
   test_case:
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status pending success"
+  -
+    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status active success"
   -
     input: 'global reset-agents-connection'
     output: 'ok'

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -293,7 +293,6 @@
     input: 'global reset-agents-connection'
     output: 'ok'
     stage: "global reset-agents-connection success"
-    test: 'yes'
   -
     input: 'global get-agent-info 0'
     output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
@@ -314,6 +313,42 @@
     output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
+-
+  name: "get-agents-by-connection-status command"
+  description: "Check success use cases for get-agents-by-connection-status command on global DB."
+  test_case:
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"never_connected"}'
+    output: "ok"
+    stage: "global update-connection-status never_connected"
+  -
+    input: 'global update-connection-status {"id":2,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status pending"
+  -
+    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status active"
+  -
+    input: 'global get-agents-by-connection-status never_connected'
+    output: 'ok [{"id":1}]'
+    stage: "global get-agents-by-connection-status never_connected success"
+  -
+    input: 'global get-agents-by-connection-status pending'
+    output: 'ok [{"id":2}]'
+    stage: "global get-agents-by-connection-status pending success"
+  -
+    input: 'global get-agents-by-connection-status active'
+    output: 'ok [{"id":3}]'
+    stage: "global get-agents-by-connection-status active success"
+  -
+    input: 'global reset-agents-connection'
+    output: 'ok'
+    stage: "global reset-agents-connection"
+  -
+    input: 'global get-agents-by-connection-status disconnected'
+    output: 'ok [{"id":2},{"id":3}]'
+    stage: "global get-agents-by-connection-status disconnected success"
 -
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -65,6 +65,10 @@
     input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent after insert"
+  -
+    input: 'global insert-agent {"id":2,"name":"TestName2","date_add":1599223378}'
+    output: "ok"
+    stage: "global insert-agent agent 2 again after delete"
 -
   name: "Update commands"
   description: "Check success use cases for update commands on global DB"
@@ -157,7 +161,7 @@
   test_case:
   -
     input: 'global get-all-agents last_id -1'
-    output: 'ok 0,1'
+    output: 'ok 0,1,2'
     stage: "global get-all-agents success"
 -
   name: "get-agents-by-keepalive command"
@@ -238,6 +242,35 @@
     output: 'ok'
     stage: "global insert-agent-belong success"
 -
+  name: "Reset connection status"
+  description: "Check success use cases for reset connection status command."
+  test_case:
+  -
+    input: 'global reset-agents-connection'
+    output: 'ok'
+    stage: "global reset-agents-connection success"
+    test: 'yes'
+  -
+    input: 'global get-agent-info 0'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    stage: "global manager get-agent-info success post reset connection status"
+    use_regex: "yes"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
+    stage: "global agent get-agent-info success post reset connection status"
+    use_regex: "yes"
+  -
+    input: 'global get-agent-info 2'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    stage: "global agent get-agent-info success post reset connection status"
+    use_regex: "yes"
+  -
+    input: 'global get-agent-info 3'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"disconnected"}]'
+    stage: "global agent get-agent-info success post reset connection status"
+    use_regex: "yes"
+-
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."
   test_case:
@@ -251,6 +284,10 @@
     stage: "global delete-group after insert"
   -
     input: 'global delete-agent 1'
+    output: "ok"
+    stage: "global delete-agent after insert"
+  -
+    input: 'global delete-agent 2'
     output: "ok"
     stage: "global delete-agent after insert"
   -

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -78,7 +78,7 @@
     output: "ok"
     stage: "global update-agent-name success"
   -
-    input: 'global update-agent-data {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq","labels":"TestKey1:TestLabel1"}'
+    input: 'global update-agent-data {"id":1,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"0.0.0.1","sync_status":"syncreq","connection_status":"never_connected","labels":"TestKey1:TestLabel1"}'
     output: "ok"
     stage: "global update-agent-data success"
   -
@@ -97,10 +97,6 @@
     input: 'global update-reg-offset {"id":1,"offset":100}'
     output: "ok"
     stage: "global update-reg-offset success"
-  -
-    input: 'global update-keepalive {"id":1,"sync_status":"syncreq"}'
-    output: "ok"
-    stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
     output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
@@ -140,6 +136,15 @@
   -
     input: 'global get-agent-info 1'
     output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    stage: "global get-agent-info success after updates"
+    use_regex: "yes"
+  -
+    input: 'global update-keepalive {"id":1,"sync_status":"syncreq","connection_status":"active"}'
+    output: "ok"
+    stage: "global update-keepalive success"
+  -
+    input: 'global get-agent-info 1'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -225,7 +230,7 @@
     output: 'ok []'
     stage: "global sync-agent-info-get after first get success"
   -
-    input: 'global update-keepalive {"id":1,"sync_status":"syncreq"}'
+    input: 'global update-keepalive {"id":1,"sync_status":"syncreq","connection_status":"active"}'
     output: "ok"
     stage: "global update-keepalive success"
   -
@@ -350,6 +355,46 @@
     output: 'ok [{"id":2},{"id":3}]'
     stage: "global get-agents-by-connection-status disconnected success"
 -
+  name: "disconnect-agents command"
+  description: "Check the right behavior of disconnect-agents command on global DB."
+  test_case:
+  -
+    input: 'global sql UPDATE agent SET last_keepalive = 100 WHERE id = 1;'
+    output: "ok []"
+    stage: "global updating agent's 1 keepalive to 100"
+  -
+    input: 'global update-connection-status {"id":1,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status as active for agent 1 success"
+  -
+    input: 'global sql UPDATE agent SET last_keepalive = 150 WHERE id = 2;'
+    output: "ok []"
+    stage: "global updating agent's 2 keepalive to 150"
+  -
+    input: 'global update-connection-status {"id":2,"connection_status":"pending"}'
+    output: "ok"
+    stage: "global update-connection-status as pending for agent 2 success"
+  -
+    input: 'global sql UPDATE agent SET last_keepalive = 200 WHERE id = 3;'
+    output: "ok []"
+    stage: "global updating agent's 3 keepalive to 200"
+  -
+    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    output: "ok"
+    stage: "global update-connection-status as active for agent 3 success"
+  -
+    input: 'global get-agents-by-connection-status disconnected'
+    output: 'ok []'
+    stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
+  -
+    input: 'global disconnect-agents 175'
+    output: 'ok [{"id":1}]'
+    stage: "global disconnect-agents success"
+  -
+    input: 'global get-agents-by-connection-status disconnected'
+    output: 'ok [{"id":1}]'
+    stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
+-
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."
   test_case:
@@ -383,7 +428,7 @@
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
-    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"127.0.0.1","sync_status":"synced"}'
+    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","agent_ip":"127.0.0.1","sync_status":"synced","connection_status":"active"}'
     output: "ok"
     stage: "global manager update-agent-data success"
   -
@@ -392,7 +437,7 @@
     stage: "global manager get-agent-info success post update with IP"
     use_regex: "yes"
   -
-    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced"}'
+    input: 'global update-agent-data {"id":0,"os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_platform":"TestOsPlatfor","os_build":"TestOsBuild","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","sync_status":"synced","connection_status":"active"}'
     output: "ok"
     stage: "global manager update-agent-data success"
   -


### PR DESCRIPTION
Hello team,

This PR includes new test cases to validate the right behavior of all the new Wazuh DB commands developed as part of the [Epic 5887](https://github.com/wazuh/wazuh/issues/5887).

For more details about the commands, see the **Description** section of the Pull https://github.com/wazuh/wazuh/pull/6396.

Closes [Epic 5887](https://github.com/wazuh/wazuh/issues/5887).

# Tests logic

- It checks the correct parsing and execution of the commands.
- It checks that the statuses `never_connected`, `pending`, `active`, and `disconnected` can be properly set and managed.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

![image](https://user-images.githubusercontent.com/5703274/97945073-284d7780-1d65-11eb-939c-4ec00d3927d2.png)
