### PR TITLE
Removing fim_offset, reg_offset, and status global.db columns checks from Wazuh DB integration tests

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -43,7 +43,7 @@
     stage: "global insert-agent success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"group":"TestGroup1","sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":1,"name":"TestName1","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","node_name":"unknown","date_add":1599223378,"group":"TestGroup1","sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after insert"
   -
     input: 'global find-agent {"name":"TestName1","ip":"0.0.0.1"}'
@@ -59,7 +59,7 @@
     stage: "global insert-agent minimal fields success"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info after minimal fields insert"
   -
     input: 'global delete-agent 2'
@@ -82,24 +82,12 @@
     output: "ok"
     stage: "global update-agent-data success"
   -
-    input: 'global update-agent-status {"id":1,"status":"updated"}'
-    output: "ok"
-    stage: "global update-agent-status success"
-  -
     input: 'global update-agent-group {"id":1,"group":"TestGroup2"}'
     output: "ok"
     stage: "global update-agent-group success"
   -
-    input: 'global update-fim-offset {"id":1,"offset":100}'
-    output: "ok"
-    stage: "global update-fim-offset success"
-  -
-    input: 'global update-reg-offset {"id":1,"offset":100}'
-    output: "ok"
-    stage: "global update-reg-offset success"
-  -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -108,7 +96,7 @@
     stage: "global update-connection-status pending success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"pending"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"pending"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -117,7 +105,7 @@
     stage: "global update-connection-status active success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -126,7 +114,7 @@
     stage: "global update-connection-status disconnected success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -135,7 +123,7 @@
     stage: "global update-connection-status dummy_status error"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -144,7 +132,7 @@
     stage: "global update-keepalive success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
 -
@@ -175,18 +163,6 @@
     input: 'global select-agent-group  1'
     output: 'ok [{"group":"TestGroup2"}]'
     stage: "global select-agent-group success"
-  -
-    input: 'global select-agent-status 1'
-    output: 'ok [{"status":"updated"}]'
-    stage: "global select-agent-status success"
-  -
-    input: 'global select-fim-offset 1'
-    output: 'ok [{"fim_offset":100}]'
-    stage: "global select-fim-offset success"
-  -
-    input: 'global select-reg-offset 1'
-    output: 'ok [{"reg_offset":100}]'
-    stage: "global select-reg-offset success"
   -
     input: 'global select-keepalive TestName2 0.0.0.1'
     output: 'ok [{"last_keepalive":*}]'
@@ -252,7 +228,7 @@
     stage: "global sync-agent-info-set success"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global get-agent-info success after sync-agent-info-set success"
 -
   name: "Belongs commands"
@@ -288,22 +264,22 @@
     stage: "global reset-agents-connection success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post reset connection status"
     use_regex: "yes"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"status":"updated","fim_offset":100,"reg_offset":100,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
   -
     input: 'global get-agent-info 2'
-    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"never_connected"}]'
+    output: 'ok [{"id":2,"name":"TestName2","node_name":"unknown","date_add":1599223378,"sync_status":"synced","connection_status":"never_connected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"status":"empty","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"disconnected"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"sync_status":"synced","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
 -
@@ -412,7 +388,7 @@
   test_case:
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success pre update"
     use_regex: "yes"
   -
@@ -421,7 +397,7 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update with IP"
     use_regex: "yes"
   -
@@ -430,6 +406,6 @@
     stage: "global manager update-agent-data success"
   -
     input: 'global get-agent-info 0'
-    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"status":"*","fim_offset":0,"reg_offset":0,"sync_status":"synced","connection_status":"active"}]'
+    output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
     stage: "global manager get-agent-info success post update without IP"
     use_regex: "yes"


### PR DESCRIPTION
Hello team,

This PR updates all the Wazuh DB integration tests in order to stop checking the `fim_offset`, `reg_offset`, and `status` **global.db** columns. These columns were removed as part of the issue https://github.com/wazuh/wazuh/issues/6569.

For more details about the commands, see the **Description** section of the issue https://github.com/wazuh/wazuh/issues/6569.

Closes https://github.com/wazuh/wazuh/issues/6569.

# Tests logic

- It checks the correct parsing and execution of the commands.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail