### PR TITLE
disconnect-agents by chunks integration tests changes

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -351,8 +351,8 @@
     output: 'ok []'
     stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
   -
-    input: 'global disconnect-agents 175'
-    output: 'ok [{"id":1}]'
+    input: 'global disconnect-agents 0 175'
+    output: 'ok 1'
     stage: "global disconnect-agents success"
   -
     input: 'global get-agents-by-connection-status disconnected'

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -133,3 +133,5 @@ def test_wazuh_db_chunks(configure_sockets_environment, connect_to_sockets_modul
     send_chunk_command(f'global get-all-agents last_id 0')
     # Check sync-agent-info-get chunk limit
     send_chunk_command(f'global sync-agent-info-get last_id 0')
+    # Check disconnect-agents chunk limit
+    send_chunk_command(f'global disconnect-agents 0 100')


### PR DESCRIPTION
Hello team,
This PR adapts the integration tests to handle the new chunks logic on the disconnect-agents command.

- Adapts the existing tests
- Adds disconnect-agents to the chunks check

Best regards.
