### PR TITLE
Added macOS agents to the integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -367,13 +367,14 @@ def delete_vulnerability(cveid):
 
 
 def modify_system(os_name="CentOS Linux", os_major="7", name="centos7", agent_id=0, os_minor="1", os_arch="x86_64",
-                  os_version="7.1"):
+                  os_version="7.1", os_platform="centos", version="4.0"):
     """
     Modify the system of the manager.
     Used to select the feed that will be used to search vulnerabilities.
     """
-    query_string = f'update AGENT set OS_NAME="{os_name}", OS_VERSION="{os_version}", OS_MAJOR="{os_major}",\
-                     OS_MINOR="{os_minor}", OS_ARCH="{os_arch}", NAME="{name}" WHERE id="{agent_id}"'
+    query_string = f'update AGENT set OS_NAME="{os_name}", OS_VERSION="{os_version}", OS_MAJOR="{os_major}", ' \
+                   f'OS_MINOR="{os_minor}", OS_ARCH="{os_arch}", NAME="{name}", OS_PLATFORM="{os_platform}", ' \
+                   f'VERSION="{version}" WHERE id="{agent_id}"'
     make_query(GLOBAL_DB_PATH, [query_string])
 
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -254,14 +254,14 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
                   hostname="WINDOWS", architecture="x86_64",
                   os_name="Microsoft Windows Server 2016 Datacenter Evaluation",
                   os_version="10.0.14393", os_major="10",  os_minor="0", os_build="14393", version="6.2",
-                  os_release="1607"):
+                  os_release="1607", os_patch="0", release="0.0.0"):
     path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_osinfo
-        (scan_id, scan_time, hostname, architecture, os_name, os_version, os_major, os_minor, os_build, version,
-        os_release)
+        (scan_id, scan_time, hostname, architecture, os_name, os_version, os_major, os_minor, os_patch, os_build,
+         release, version, os_release)
         VALUES
         ("{scan_id}", "{scan_time}", "{hostname}", "{architecture}", "{os_name}", "{os_version}", "{os_major}",
-        "{os_minor}", "{os_build}", "{version}", "{os_release}")
+        "{os_minor}", "{os_patch}", "{os_build}", "{release}", "{version}", "{os_release}")
         '''
     make_query(path, [query_string])
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/macos_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/macos_vulnerabilities.json
@@ -1,0 +1,76 @@
+[
+  {
+    "target": "MAC",
+    "os_name": "Mac OS X",
+    "os_version": "10.15.1",
+    "os_major": "10",
+    "os_minor": "15",
+    "os_patch": "1",
+    "os_platform": "darwin",
+    "name": "macos_catalina",
+    "version": "Wazuh v4.1",
+    "release": "19.0.0",
+    "cve": "CVE-2018-14470",
+    "vulnerabilities": [
+      {
+        "package": {
+          "name": "safari",
+          "version": "13.0.3",
+          "format": "pkg",
+          "vendor": "Apple"
+        },
+        "cve": {
+          "cveid": "CVE-2020-9948"
+        }
+      },
+      {
+        "package": {
+          "name": "sqlite",
+          "version": "3.26.0",
+          "format": "pkg",
+          "vendor": ""
+        },
+        "cve": {
+          "cveid": "CVE-2020-13630"
+        }
+      }
+    ]
+  },
+  {
+    "target": "MAC",
+    "os_name": "Mac OS X Server",
+    "os_version": "10.6.8",
+    "os_major": "10",
+    "os_minor": "6",
+    "os_patch": "8",
+    "os_platform": "darwin",
+    "name": "macos_server",
+    "version": "Wazuh v4.1",
+    "release": "10.0.0",
+    "cve": "CVE-2013-0984",
+    "vulnerabilities": [
+      {
+        "package": {
+          "name": "safari",
+          "version": "12.0.3",
+          "format": "pkg",
+          "vendor": "Apple"
+        },
+        "cve": {
+          "cveid": "CVE-2020-9948"
+        }
+      },
+      {
+        "package": {
+          "name": "sqlite",
+          "version": "3.20.0",
+          "format": "pkg",
+          "vendor": ""
+        },
+        "cve": {
+          "cveid": "CVE-2020-13630"
+        }
+      }
+    ]
+  }
+]

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/real_nvd_feed.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/real_nvd_feed.json
@@ -83577,6 +83577,496 @@
     },
     "publishedDate" : "2013-03-05T21:38Z",
     "lastModifiedDate" : "2013-12-05T05:22Z"
+  }, {
+    "cve" : {
+      "data_type" : "CVE",
+      "data_format" : "MITRE",
+      "data_version" : "4.0",
+      "CVE_data_meta" : {
+        "ID" : "CVE-2013-0984",
+        "ASSIGNER" : "cve@mitre.org"
+      },
+      "problemtype" : {
+        "problemtype_data" : [ {
+          "description" : [ {
+            "lang" : "en",
+            "value" : "CWE-119"
+          } ]
+        } ]
+      },
+      "references" : {
+        "reference_data" : [ {
+          "url" : "http://lists.apple.com/archives/security-announce/2013/Jun/msg00000.html",
+          "name" : "APPLE-SA-2013-06-04-1",
+          "refsource" : "APPLE",
+          "tags" : [ "Vendor Advisory" ]
+        }, {
+          "url" : "http://support.apple.com/kb/HT5784",
+          "name" : "http://support.apple.com/kb/HT5784",
+          "refsource" : "CONFIRM",
+          "tags" : [ "Vendor Advisory" ]
+        } ]
+      },
+      "description" : {
+        "description_data" : [ {
+          "lang" : "en",
+          "value" : "Directory Service in Apple Mac OS X through 10.6.8 allows remote attackers to execute arbitrary code or cause a denial of service (daemon crash) via a crafted message."
+        } ]
+      }
+    },
+    "configurations" : {
+      "CVE_data_version" : "4.0",
+      "nodes" : [ {
+        "operator" : "OR",
+        "cpe_match" : [ {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.0.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.0.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.0.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.0.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.0.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.1.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.6:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.7:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.2.8:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.6:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.7:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.8:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.3.9:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.6:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.7:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.8:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.9:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.10:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.4.11:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.6:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.7:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.5.8:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.0:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.1:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.2:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.3:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.4:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.5:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.6:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:10.6.7:*:*:*:*:*:*:*"
+        }, {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:apple:mac_os_x_server:*:*:*:*:*:*:*:*",
+          "versionEndIncluding" : "10.6.8"
+        } ]
+      } ]
+    },
+    "impact" : {
+      "baseMetricV2" : {
+        "cvssV2" : {
+          "version" : "2.0",
+          "vectorString" : "AV:N/AC:M/Au:N/C:C/I:C/A:C",
+          "accessVector" : "NETWORK",
+          "accessComplexity" : "MEDIUM",
+          "authentication" : "NONE",
+          "confidentialityImpact" : "COMPLETE",
+          "integrityImpact" : "COMPLETE",
+          "availabilityImpact" : "COMPLETE",
+          "baseScore" : 9.3
+        },
+        "severity" : "HIGH",
+        "exploitabilityScore" : 8.6,
+        "impactScore" : 10.0,
+        "obtainAllPrivilege" : false,
+        "obtainUserPrivilege" : false,
+        "obtainOtherPrivilege" : false,
+        "userInteractionRequired" : false
+      }
+    },
+    "publishedDate" : "2013-06-05T14:39Z",
+    "lastModifiedDate" : "2013-06-05T16:11Z"
+  }, {
+    "cve" : {
+      "data_type" : "CVE",
+      "data_format" : "MITRE",
+      "data_version" : "4.0",
+      "CVE_data_meta" : {
+        "ID" : "CVE-2020-9948",
+        "ASSIGNER" : "cve@mitre.org"
+      },
+      "problemtype" : {
+        "problemtype_data" : [ {
+          "description" : [ {
+            "lang" : "en",
+            "value" : "CWE-843"
+          } ]
+        } ]
+      },
+      "references" : {
+        "reference_data" : [ {
+          "url" : "https://support.apple.com/HT211845",
+          "name" : "https://support.apple.com/HT211845",
+          "refsource" : "MISC",
+          "tags" : [ "Release Notes", "Vendor Advisory" ]
+        } ]
+      },
+      "description" : {
+        "description_data" : [ {
+          "lang" : "en",
+          "value" : "A type confusion issue was addressed with improved memory handling. This issue is fixed in Safari 14.0. Processing maliciously crafted web content may lead to arbitrary code execution."
+        } ]
+      }
+    },
+    "configurations" : {
+      "CVE_data_version" : "4.0",
+      "nodes" : [ {
+        "operator" : "OR",
+        "cpe_match" : [ {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:a:apple:safari:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "14.0"
+        } ]
+      } ]
+    },
+    "impact" : {
+      "baseMetricV3" : {
+        "cvssV3" : {
+          "version" : "3.1",
+          "vectorString" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "attackVector" : "NETWORK",
+          "attackComplexity" : "LOW",
+          "privilegesRequired" : "NONE",
+          "userInteraction" : "REQUIRED",
+          "scope" : "UNCHANGED",
+          "confidentialityImpact" : "HIGH",
+          "integrityImpact" : "HIGH",
+          "availabilityImpact" : "HIGH",
+          "baseScore" : 8.8,
+          "baseSeverity" : "HIGH"
+        },
+        "exploitabilityScore" : 2.8,
+        "impactScore" : 5.9
+      },
+      "baseMetricV2" : {
+        "cvssV2" : {
+          "version" : "2.0",
+          "vectorString" : "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+          "accessVector" : "NETWORK",
+          "accessComplexity" : "MEDIUM",
+          "authentication" : "NONE",
+          "confidentialityImpact" : "PARTIAL",
+          "integrityImpact" : "PARTIAL",
+          "availabilityImpact" : "PARTIAL",
+          "baseScore" : 6.8
+        },
+        "severity" : "MEDIUM",
+        "exploitabilityScore" : 8.6,
+        "impactScore" : 6.4,
+        "acInsufInfo" : false,
+        "obtainAllPrivilege" : false,
+        "obtainUserPrivilege" : false,
+        "obtainOtherPrivilege" : false,
+        "userInteractionRequired" : true
+      }
+    },
+    "publishedDate" : "2020-10-16T17:15Z",
+    "lastModifiedDate" : "2020-10-20T20:42Z"
+  }, {
+    "cve" : {
+      "data_type" : "CVE",
+      "data_format" : "MITRE",
+      "data_version" : "4.0",
+      "CVE_data_meta" : {
+        "ID" : "CVE-2020-13630",
+        "ASSIGNER" : "cve@mitre.org"
+      },
+      "problemtype" : {
+        "problemtype_data" : [ {
+          "description" : [ {
+            "lang" : "en",
+            "value" : "CWE-416"
+          } ]
+        } ]
+      },
+      "references" : {
+        "reference_data" : [ {
+          "url" : "https://bugs.chromium.org/p/chromium/issues/detail?id=1080459",
+          "name" : "https://bugs.chromium.org/p/chromium/issues/detail?id=1080459",
+          "refsource" : "MISC",
+          "tags" : [ "Permissions Required", "Third Party Advisory" ]
+        }, {
+          "url" : "https://lists.debian.org/debian-lts-announce/2020/08/msg00037.html",
+          "name" : "[debian-lts-announce] 20200822 [SECURITY] [DLA 2340-1] sqlite3 security update",
+          "refsource" : "MLIST",
+          "tags" : [ ]
+        }, {
+          "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/L7KXQWHIY2MQP4LNM6ODWJENMXYYQYBN/",
+          "name" : "FEDORA-2020-0477f8840e",
+          "refsource" : "FEDORA",
+          "tags" : [ "Third Party Advisory" ]
+        }, {
+          "url" : "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:22.sqlite.asc",
+          "name" : "FreeBSD-SA-20:22",
+          "refsource" : "FREEBSD",
+          "tags" : [ ]
+        }, {
+          "url" : "https://security.gentoo.org/glsa/202007-26",
+          "name" : "GLSA-202007-26",
+          "refsource" : "GENTOO",
+          "tags" : [ ]
+        }, {
+          "url" : "https://security.netapp.com/advisory/ntap-20200608-0002/",
+          "name" : "https://security.netapp.com/advisory/ntap-20200608-0002/",
+          "refsource" : "CONFIRM",
+          "tags" : [ "Third Party Advisory" ]
+        }, {
+          "url" : "https://sqlite.org/src/info/0d69f76f0865f962",
+          "name" : "https://sqlite.org/src/info/0d69f76f0865f962",
+          "refsource" : "MISC",
+          "tags" : [ "Patch", "Vendor Advisory" ]
+        }, {
+          "url" : "https://usn.ubuntu.com/4394-1/",
+          "name" : "USN-4394-1",
+          "refsource" : "UBUNTU",
+          "tags" : [ ]
+        }, {
+          "url" : "https://www.oracle.com/security-alerts/cpujul2020.html",
+          "name" : "https://www.oracle.com/security-alerts/cpujul2020.html",
+          "refsource" : "MISC",
+          "tags" : [ ]
+        }, {
+          "url" : "https://www.oracle.com/security-alerts/cpuoct2020.html",
+          "name" : "https://www.oracle.com/security-alerts/cpuoct2020.html",
+          "refsource" : "MISC",
+          "tags" : [ ]
+        } ]
+      },
+      "description" : {
+        "description_data" : [ {
+          "lang" : "en",
+          "value" : "ext/fts3/fts3.c in SQLite before 3.32.0 has a use-after-free in fts3EvalNextRow, related to the snippet feature."
+        } ]
+      }
+    },
+    "configurations" : {
+      "CVE_data_version" : "4.0",
+      "nodes" : [ {
+        "operator" : "OR",
+        "cpe_match" : [ {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:a:sqlite:sqlite:*:*:*:*:*:*:*:*",
+          "versionEndExcluding" : "3.32.0"
+        } ]
+      }, {
+        "operator" : "OR",
+        "cpe_match" : [ {
+          "vulnerable" : true,
+          "cpe23Uri" : "cpe:2.3:o:fedoraproject:fedora:32:*:*:*:*:*:*:*"
+        } ]
+      } ]
+    },
+    "impact" : {
+      "baseMetricV3" : {
+        "cvssV3" : {
+          "version" : "3.1",
+          "vectorString" : "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "attackVector" : "LOCAL",
+          "attackComplexity" : "HIGH",
+          "privilegesRequired" : "LOW",
+          "userInteraction" : "NONE",
+          "scope" : "UNCHANGED",
+          "confidentialityImpact" : "HIGH",
+          "integrityImpact" : "HIGH",
+          "availabilityImpact" : "HIGH",
+          "baseScore" : 7.0,
+          "baseSeverity" : "HIGH"
+        },
+        "exploitabilityScore" : 1.0,
+        "impactScore" : 5.9
+      },
+      "baseMetricV2" : {
+        "cvssV2" : {
+          "version" : "2.0",
+          "vectorString" : "AV:L/AC:M/Au:N/C:P/I:P/A:P",
+          "accessVector" : "LOCAL",
+          "accessComplexity" : "MEDIUM",
+          "authentication" : "NONE",
+          "confidentialityImpact" : "PARTIAL",
+          "integrityImpact" : "PARTIAL",
+          "availabilityImpact" : "PARTIAL",
+          "baseScore" : 4.4
+        },
+        "severity" : "MEDIUM",
+        "exploitabilityScore" : 3.4,
+        "impactScore" : 6.4,
+        "acInsufInfo" : false,
+        "obtainAllPrivilege" : false,
+        "obtainUserPrivilege" : false,
+        "obtainOtherPrivilege" : false,
+        "userInteractionRequired" : false
+      }
+    },
+    "publishedDate" : "2020-05-27T15:15Z",
+    "lastModifiedDate" : "2020-10-20T22:15Z"
   }
  ]
 }

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_macos_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_macos_inventory.yaml
@@ -1,0 +1,25 @@
+---
+# conf 1
+- tags:
+  - test_macos_inventory
+  apply_to_modules:
+  - test_macos_inventory
+  sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'no'
+    - interval:
+        value: '5'
+    - provider:
+        attributes:
+        - name: 'nvd'
+        elements:
+        - enabled:
+            value: 'yes'
+        - path:
+            value: NVD_JSON_PATH
+        - update_interval:
+            value: '10s'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import json
+from time import sleep
+
+import wazuh_testing.vulnerability_detector as vd
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, REAL_NVD_FEED, clean_vd_tables
+from wazuh_testing.tools.services import control_service
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+
+# Variables
+current_test_path = os.path.dirname(os.path.realpath(__file__))
+test_data_path = os.path.join(current_test_path, 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_macos_inventory.yaml')
+vulnerabilities_data_path = os.path.join(test_data_path, 'macos_vulnerabilities.json')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+SCAN_TIMEOUT = 40
+
+
+# Set configuration
+parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, REAL_NVD_FEED)}]
+metadata = [{'nvd_json_path': os.path.join(test_data_path, REAL_NVD_FEED)}]
+ids = ['macos_scan_configuration']
+
+
+# Read JSON data template
+with open(vulnerabilities_data_path, 'r') as f:
+    macos_vulnerabilities = json.loads(f.read())
+
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+@pytest.fixture(scope='module', params=configurations, ids=ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+macos_systems = [macos_system['target'] for macos_system in macos_vulnerabilities]
+
+
+@pytest.fixture(scope='module', params=macos_vulnerabilities, ids=macos_systems)
+def mock_vulnerability_scan(request):
+    """
+    It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
+    """
+    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-db')
+
+    # Wait until modulesd is restarted to avoid overwriting the system
+    sleep(4)
+
+    # Clean tables
+    clean_vd_tables(agent='000')
+
+    # Mock system
+    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=request.param['name'],
+                     os_platform=request.param['os_platform'], version=request.param['version'])
+    
+    # Insert data in sys_osinfo and sys_programs tables
+    vd.insert_osinfo(os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], os_patch=request.param['os_patch'],
+                     release=request.param['release'])
+
+    for vulnerability in request.param['vulnerabilities']:
+        insert_package(**vulnerability['package'], source=vulnerability['package']['name'])
+
+    control_service('start', daemon='wazuh-db')
+
+    # Truncate ossec.log
+    truncate_file(LOG_FILE_PATH)
+
+    yield request.param
+
+    control_service('stop', daemon='wazuh-db')
+
+    # Clean tables
+    vd.clean_vd_tables(agent='000')
+
+    sleep(1)
+
+    control_service('start', daemon='wazuh-db')
+
+
+def check_vuln_detector_event(package, cve):
+    """
+    Check if inserted vulnerable packages are reported by vulnerability detector.
+
+    Parameters
+    ----------
+    package: str
+        Name of custom package to check. Example: 'firefox-0'
+    cve : str
+        Package CVE. Example: 'CVE-2019-11764'
+    """
+    wazuh_log_monitor.start(
+        timeout=SCAN_TIMEOUT,
+        update_position=False,
+        callback=make_vuln_callback(f"The '{package}' package .* from agent .* is vulnerable to '{cve}'"),
+        error_message=f"Could not find the report which says that the package {package} is vulnerable with {cve}",
+    )
+
+
+def test_macos_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+                                      mock_vulnerability_scan):
+    """
+    Check if inserted vulnerable packages are reported by vulnerability detector
+    """
+    if mock_vulnerability_scan['os_name'] == "Mac OS X":
+        check_vuln_detector_event("mac_os_x", mock_vulnerability_scan['cve'])
+    else:
+        check_vuln_detector_event("mac_os_x_server", mock_vulnerability_scan['cve'])
+
+    for item in mock_vulnerability_scan['vulnerabilities']:
+        check_vuln_detector_event(item['package']['name'], item['cve']['cveid'])

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -47,26 +47,46 @@ with open(vulnerabilities_data_path, 'r') as f:
 
 
 system_data = [
-    {"target": "WINDOWS10", "os_name": "Microsoft Windows Server 2016 Datacenter Evaluation", "os_major": "10", # Hotfix scan is disables if there's no MSU data
-        "os_minor": "0", "name": "windows", "format": "win", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+    {"target": "WINDOWS10", "os_name": "Microsoft Windows Server 2016 Datacenter Evaluation",
+     "os_major": "10", "os_minor": "0", "name": "windows", "format": "win",
+     "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "windows", "version": "Wazuh v4.1"},
     {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8",
-        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "centos", "version": "Wazuh v4.1"},
     {"target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7",
-        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "centos", "version": "Wazuh v4.1"},
     {"target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6",
-        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "centos", "version": "Wazuh v4.1"},
     {"target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5",
-        "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "rpm", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "centos", "version": "Wazuh v4.1"},
     {"target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic",
-        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "ubuntu", "version": "Wazuh v4.1"},
     {"target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial",
-        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "ubuntu", "version": "Wazuh v4.1"},
     {"target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty",
-        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "ubuntu", "version": "Wazuh v4.1"},
     {"target": "BUSTER", "os_name": "Debian GNU/Linux", "os_major": "10", "os_minor": "", "name": "debian10",
-        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])},
+     "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "debian", "version": "Wazuh v4.1"},
     {"target": "STRETCH", "os_name": "Debian GNU/Linux", "os_major": "9", "os_minor": "", "name": "debian9",
-        "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd'])}
+     "format": "deb", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "debian", "version": "Wazuh v4.1"},
+    {"target": "MAC", "os_name": "Mac OS X", "os_major": "10", "os_minor": "15", "name": "macos-catalina",
+     "format": "pkg", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "darwin", "version": "Wazuh v4.1"},
+    {"target": "MAC", "os_name": "Mac OS X", "os_major": "10", "os_minor": "15", "name": "macos-catalina",
+     "format": "pkg", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "darwin", "version": "Wazuh v4.0"},
+    {"target": "MAC", "os_name": "Mac OS X Server", "os_major": "5", "os_minor": "10", "name": "macos-server",
+     "format": "pkg", "vulnerabilities_number": len(nvd_vulnerabilities['vulnerabilities_nvd']),
+     "os_platform": "darwin", "version": "Wazuh v4.1"}
 ]
 system_data_ids = [system['target'] for system in system_data]
 
@@ -95,7 +115,8 @@ def mock_vulnerability_scan(request):
 
     # Mock system
     vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'])
+                     os_minor=request.param['os_minor'], name=request.param['name'],
+                     os_platform=request.param['os_platform'], version=request.param['version'])
 
     # Clean tables
     vd.clean_vd_tables(agent='000')
@@ -151,7 +172,17 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
     Check if inserted vulnerable packages are reported by vulnerability detector
     """
     vulnerabilities_number = mock_vulnerability_scan["vulnerabilities_number"]
-
+    if mock_vulnerability_scan["format"] == "pkg" and mock_vulnerability_scan["version"] == "Wazuh v4.0":
+        version = mock_vulnerability_scan["version"]
+        wazuh_log_monitor.start(
+            timeout=SCAN_TIMEOUT,
+            update_position=False,
+            callback=vd.make_vuln_callback(
+                f"Agent '000' has an unsupported Wazuh version: '{version}'"
+            ),
+            error_message=f"The expected event 'Agent \'000\' has an unsupported Wazuh version' not found",
+        )
+        return
 
     # Check the vulnerabilities of inserted packages
     try:
@@ -168,8 +199,7 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
             timeout=SCAN_TIMEOUT,
             update_position=False,
             callback=vd.make_vuln_callback(
-                f"A total of '{vulnerabilities_number}' vulnerabilities have been reported for agent '.*' " +
-                "thanks to the 'NVD' feed."
+                f"A total of '{vulnerabilities_number}' vulnerabilities have been reported for agent '.*"
             ),
             error_message=f"The expected number of vulnerabilities for NVD have not been found",
         )


### PR DESCRIPTION
Hello team,

I have added two tests to verify the operation of NVD scan for macOS agents as the rest of available platforms.

Closes #873

# Tests logic

- [x] test_macos_inventory.py: This test verifies that the Vuln Detector generates a report when the system has vulnerable packages including the OS packages: Mac OS X and Mac OS X server. For that, I inserted some packages in the `sys_programs` table and some data in the `sys_osinfo` table.
- [x] test_scan_nvd_feed.py: This test verifies that the Vuln Detector accepts macOS agents with a version greater than or equal to 4.1 and skip macOS agents with a lower version than 4.1. Also, it verify the NVD scan and the report of vulnerabilities from generic packages.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)

## DEB manager

```
# python3 -m pytest -v test_macos_inventory.py test_scan_nvd_feed.py 
======================================== test session starts ========================================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-52-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.0.2', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'testinfra': '5.0.0', 'metadata': '1.10.0'}}
rootdir: /home/daniel/Wazuh/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.10.0
collected 15 items                                                                                  

test_macos_inventory.py::test_macos_vulnerabilities_report[macos_scan_configuration-MAC0] PASSED [  6%]
test_macos_inventory.py::test_macos_vulnerabilities_report[macos_scan_configuration-MAC1] PASSED [ 13%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10] PASSED  [ 20%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED  [ 26%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED  [ 33%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED  [ 40%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED  [ 46%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 53%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 60%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 66%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 73%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 80%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC0] PASSED  [ 86%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC1] PASSED  [ 93%]
test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC2] PASSED  [100%]

=============================== 15 passed in 145.01s (0:02:25) =============================
```

Best regards.
