### PR TITLE
Updating IT for wdb-get-agents-by-connection-status

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -299,24 +299,24 @@
     output: "ok"
     stage: "global update-connection-status active"
   -
-    input: 'global get-agents-by-connection-status never_connected'
-    output: 'ok [{"id":1}]'
+    input: 'global get-agents-by-connection-status 0 never_connected'
+    output: 'ok 1'
     stage: "global get-agents-by-connection-status never_connected success"
   -
-    input: 'global get-agents-by-connection-status pending'
-    output: 'ok [{"id":2}]'
+    input: 'global get-agents-by-connection-status 0 pending'
+    output: 'ok 2'
     stage: "global get-agents-by-connection-status pending success"
   -
-    input: 'global get-agents-by-connection-status active'
-    output: 'ok [{"id":3}]'
+    input: 'global get-agents-by-connection-status 0 active'
+    output: 'ok 3'
     stage: "global get-agents-by-connection-status active success"
   -
     input: 'global reset-agents-connection'
     output: 'ok'
     stage: "global reset-agents-connection"
   -
-    input: 'global get-agents-by-connection-status disconnected'
-    output: 'ok [{"id":2},{"id":3}]'
+    input: 'global get-agents-by-connection-status 0 disconnected'
+    output: 'ok 2,3'
     stage: "global get-agents-by-connection-status disconnected success"
 -
   name: "disconnect-agents command"
@@ -347,16 +347,16 @@
     output: "ok"
     stage: "global update-connection-status as active for agent 3 success"
   -
-    input: 'global get-agents-by-connection-status disconnected'
-    output: 'ok []'
+    input: 'global get-agents-by-connection-status 0 disconnected'
+    output: 'ok '
     stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
   -
     input: 'global disconnect-agents 0 175'
     output: 'ok 1'
     stage: "global disconnect-agents success"
   -
-    input: 'global get-agents-by-connection-status disconnected'
-    output: 'ok [{"id":1}]'
+    input: 'global get-agents-by-connection-status 0 disconnected'
+    output: 'ok 1'
     stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
 -
   name: "Delete commands"

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -357,7 +357,7 @@
   -
     input: 'global get-agents-by-connection-status 0 disconnected'
     output: 'ok 1'
-    stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
+    stage: "global get-agents-by-connection-status disconnected after disconnecting agents success"
 -
   name: "Delete commands"
   description: "Check success use cases for delete commands on global DB."

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -133,5 +133,7 @@ def test_wazuh_db_chunks(configure_sockets_environment, connect_to_sockets_modul
     send_chunk_command(f'global get-all-agents last_id 0')
     # Check sync-agent-info-get chunk limit
     send_chunk_command(f'global sync-agent-info-get last_id 0')
+    # Check get-agents-by-connection-status chunk limit
+    send_chunk_command(f'global get-agents-by-connection-status 0 active')
     # Check disconnect-agents chunk limit
     send_chunk_command(f'global disconnect-agents 0 100')


### PR DESCRIPTION
Hello team,

This PR updates the IT for the command **wdb_get_agents_by_connection_status** and adds the corresponding chunks logic test.

Closes #929
# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

Best regards.
