### PR TITLE
Updating IT for update-connection-status and reset-agents-connection

### DIFF
--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -91,7 +91,7 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"pending"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"pending","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status pending success"
   -
@@ -100,7 +100,7 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"active"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"active","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status active success"
   -
@@ -109,7 +109,7 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"disconnected"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"disconnected","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status disconnected success"
   -
@@ -118,7 +118,7 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"dummy_status"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"dummy_status","sync_status":"syncreq"}'
     output: "err Cannot execute Global database query; CHECK constraint failed: agent"
     stage: "global update-connection-status dummy_status error"
   -
@@ -251,15 +251,15 @@
   description: "Check success use cases for reset connection status command."
   test_case:
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"pending"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"pending","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status pending success"
   -
-    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status active success"
   -
-    input: 'global reset-agents-connection'
+    input: 'global reset-agents-connection synced'
     output: 'ok'
     stage: "global reset-agents-connection success"
   -
@@ -287,15 +287,15 @@
   description: "Check success use cases for get-agents-by-connection-status command on global DB."
   test_case:
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"never_connected"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"never_connected","sync_status":"synced"}'
     output: "ok"
     stage: "global update-connection-status never_connected"
   -
-    input: 'global update-connection-status {"id":2,"connection_status":"pending"}'
+    input: 'global update-connection-status {"id":2,"connection_status":"pending","sync_status":"synced"}'
     output: "ok"
     stage: "global update-connection-status pending"
   -
-    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"synced"}'
     output: "ok"
     stage: "global update-connection-status active"
   -
@@ -311,7 +311,7 @@
     output: 'ok 3'
     stage: "global get-agents-by-connection-status active success"
   -
-    input: 'global reset-agents-connection'
+    input: 'global reset-agents-connection synced'
     output: 'ok'
     stage: "global reset-agents-connection"
   -
@@ -327,7 +327,7 @@
     output: "ok []"
     stage: "global updating agent's 1 keepalive to 100"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"active"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"active","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status as active for agent 1 success"
   -
@@ -335,7 +335,7 @@
     output: "ok []"
     stage: "global updating agent's 2 keepalive to 150"
   -
-    input: 'global update-connection-status {"id":2,"connection_status":"pending"}'
+    input: 'global update-connection-status {"id":2,"connection_status":"pending","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status as pending for agent 2 success"
   -
@@ -343,7 +343,7 @@
     output: "ok []"
     stage: "global updating agent's 3 keepalive to 200"
   -
-    input: 'global update-connection-status {"id":3,"connection_status":"active"}'
+    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status as active for agent 3 success"
   -

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -367,9 +367,17 @@
     output: 'ok '
     stage: "global get-agents-by-connection-status disconnected before disconnecting agents success"
   -
-    input: 'global disconnect-agents 0 175'
+    input: 'global sql UPDATE agent SET sync_status = "synced" WHERE id =1'
+    output: 'ok []'
+    stage: "global setting sync_status before disconnecting-agents command"
+  -
+    input: 'global disconnect-agents 0 175 syncreq'
     output: 'ok 1'
     stage: "global disconnect-agents success"
+  -
+    input: 'global sql SELECT id,sync_status FROM agent WHERE id =1'
+    output: 'ok [{"id":1,"sync_status":"syncreq"}]'
+    stage: "global testing sync_status after disconnecting-agents command"
   -
     input: 'global get-agents-by-connection-status 0 disconnected'
     output: 'ok 1'

--- a/tests/integration/test_wazuh_db/data/global_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global_messages.yaml
@@ -100,12 +100,12 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"active","sync_status":"syncreq"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"active","sync_status":"synced"}'
     output: "ok"
     stage: "global update-connection-status active success"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"active"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"synced","connection_status":"active"}]'
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
@@ -118,7 +118,7 @@
     stage: "global get-agent-info success after updates"
     use_regex: "yes"
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"dummy_status","sync_status":"syncreq"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"dummy_status","sync_status":"synced"}'
     output: "err Cannot execute Global database query; CHECK constraint failed: agent"
     stage: "global update-connection-status dummy_status error"
   -
@@ -251,17 +251,25 @@
   description: "Check success use cases for reset connection status command."
   test_case:
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"pending","sync_status":"syncreq"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"pending","sync_status":"synced"}'
     output: "ok"
     stage: "global update-connection-status pending success"
   -
-    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"syncreq"}'
+    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"synced"}'
     output: "ok"
     stage: "global update-connection-status active success"
   -
-    input: 'global reset-agents-connection synced'
+    input: 'global sql SELECT id,sync_status FROM agent'
+    output: 'ok [{"id":0,"sync_status":"synced"},{"id":1,"sync_status":"synced"},{"id":2,"sync_status":"synced"},{"id":3,"sync_status":"synced"}]'
+    stage: "global checking sync_status before reset-agents-connection"
+  -
+    input: 'global reset-agents-connection syncreq'
     output: 'ok'
     stage: "global reset-agents-connection success"
+  -
+    input: 'global sql SELECT id,sync_status FROM agent'
+    output: 'ok [{"id":0,"sync_status":"synced"},{"id":1,"sync_status":"syncreq"},{"id":2,"sync_status":"synced"},{"id":3,"sync_status":"syncreq"}]'
+    stage: "global checking sync_status after reset-agents-connection"
   -
     input: 'global get-agent-info 0'
     output: 'ok [{"id":0,*,"last_keepalive":253402300799,"sync_status":"synced","connection_status":"active"}]'
@@ -269,7 +277,7 @@
     use_regex: "yes"
   -
     input: 'global get-agent-info 1'
-    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"synced","connection_status":"disconnected"}]'
+    output: 'ok [{"id":1,"name":"TestName2","ip":"0.0.0.1","register_ip":"0.0.0.1","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","version":"TestVersion","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":*,"group":"TestGroup2","sync_status":"syncreq","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
   -
@@ -279,7 +287,7 @@
     use_regex: "yes"
   -
     input: 'global get-agent-info 3'
-    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"sync_status":"synced","connection_status":"disconnected"}]'
+    output: 'ok [{"id":3,"name":"TestName3","ip":"0.0.0.3","register_ip":"0.0.0.3","internal_key":"TopSecret","os_name":"TestOsName","os_version":"TestOsVersion","os_major":"TestOsMajor","os_minor":"TestOsMinor","os_codename":"TestOsCodeName","os_build":"TestOsBuild","os_platform":"TestOsPlatfor","os_uname":"TestOsUname","os_arch":"TestOsArch","config_sum":"TestConfigSum","merged_sum":"TestMergedSum","manager_host":"TestManagerHost","node_name":"TestNodeName","date_add":1599223378,"last_keepalive":200,"sync_status":"syncreq","connection_status":"disconnected"}]'
     stage: "global agent get-agent-info success post reset connection status"
     use_regex: "yes"
 -
@@ -287,15 +295,15 @@
   description: "Check success use cases for get-agents-by-connection-status command on global DB."
   test_case:
   -
-    input: 'global update-connection-status {"id":1,"connection_status":"never_connected","sync_status":"synced"}'
+    input: 'global update-connection-status {"id":1,"connection_status":"never_connected","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status never_connected"
   -
-    input: 'global update-connection-status {"id":2,"connection_status":"pending","sync_status":"synced"}'
+    input: 'global update-connection-status {"id":2,"connection_status":"pending","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status pending"
   -
-    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"synced"}'
+    input: 'global update-connection-status {"id":3,"connection_status":"active","sync_status":"syncreq"}'
     output: "ok"
     stage: "global update-connection-status active"
   -
@@ -311,9 +319,17 @@
     output: 'ok 3'
     stage: "global get-agents-by-connection-status active success"
   -
+    input: 'global sql SELECT id,sync_status FROM agent'
+    output: 'ok [{"id":0,"sync_status":"synced"},{"id":1,"sync_status":"syncreq"},{"id":2,"sync_status":"syncreq"},{"id":3,"sync_status":"syncreq"}]'
+    stage: "global checking sync_status before reset-agents-connection"
+  -
     input: 'global reset-agents-connection synced'
     output: 'ok'
     stage: "global reset-agents-connection"
+  -
+    input: 'global sql SELECT id,sync_status FROM agent'
+    output: 'ok [{"id":0,"sync_status":"synced"},{"id":1,"sync_status":"syncreq"},{"id":2,"sync_status":"synced"},{"id":3,"sync_status":"synced"}]'
+    stage: "global checking sync_status after reset-agents-connection"
   -
     input: 'global get-agents-by-connection-status 0 disconnected'
     output: 'ok 2,3'

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -136,4 +136,4 @@ def test_wazuh_db_chunks(configure_sockets_environment, connect_to_sockets_modul
     # Check get-agents-by-connection-status chunk limit
     send_chunk_command(f'global get-agents-by-connection-status 0 active')
     # Check disconnect-agents chunk limit
-    send_chunk_command(f'global disconnect-agents 0 100')
+    send_chunk_command(f'global disconnect-agents 0 100 syncreq')


### PR DESCRIPTION
Hello team,

Now that the issue [6600](https://github.com/wazuh/wazuh/issues/6600) has modified the **update-connection-status**, **reset-agents-connection** and **disconnect-agents** commands to change the _sync_status_ column, this PR adapts the IT accordingly. 

Also, the correct update of **sync_status** is verified:
- _update-connection-status_ only changes the column on success
- _reset-agents-connection_ doesn't modify the status for never connected agents
- _disconnect-agents_ for an active agent

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

Best regards.
