### PR TITLE
Add file_limit tests for registry scan in FIM

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1272,11 +1272,11 @@ def callback_non_existing_monitored_registry(line):
 
 
 def callback_registry_count_entries(line):
-    if sys.platform != 'win32':
-        match = re.match(r".*Number of keys: (\d+), value count: (\d+)", line)
+    if sys.platform == 'win32':
+        match = re.match(r".*Fim registry entries: (\d+)", line)
 
     if match:
-        return match.group(1), match.group(2)
+        return match.group(1)
 
 
 def callback_value_event(line):

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1370,7 +1370,7 @@ def callback_file_limit_back_to_normal(line):
 
 
 def callback_file_limit_full_database(line):
-    match = re.match(r".*Couldn't insert '.*' entry into DB\. The DB is full, please check your configuration\.", line)
+    match = re.match(r".*Couldn't insert '.*' (value )?entry into DB\. The DB is full.*", line)
 
     if match:
         return True

--- a/tests/integration/test_fim/test_registry/test_file_limit/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_file_limit/data/wazuh_conf.yaml
@@ -1,0 +1,23 @@
+---
+#conf 1
+- tags:
+  - file_limit_registry_conf
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - frequency:
+        value: 30
+    - windows_registry:
+        value: WINDOWS_REGISTRY
+        attributes:
+        - arch: '64bit'
+    - file_limit:
+        elements:
+        - enabled:
+            value: 'yes'
+        - entries:
+            value: FILE_LIMIT

--- a/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_capacity_alerts.py
+++ b/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_capacity_alerts.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, modify_registry_value, callback_file_limit_capacity, \
+    callback_registry_count_entries, check_time_travel, delete_registry_value, callback_file_limit_back_to_normal, \
+    registry_parser, KEY_WOW64_64KEY
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from win32con import REG_SZ, KEY_ALL_ACCESS
+from win32api import RegOpenKeyEx, RegCloseKey
+
+# Marks
+
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+
+KEY = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+
+
+test_regs = [os.path.join(KEY, sub_key_1)]
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1 = test_regs[0]
+
+# Configurations
+
+
+file_limit_list = ['100']
+
+conf_params = {'WINDOWS_REGISTRY': reg1, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params,
+                       apply_to_all=({'FILE_LIMIT': file_limit_elem} for file_limit_elem in file_limit_list),
+                       modes=['scheduled'])
+
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Tests
+
+
+@pytest.mark.parametrize('percentage,tags_to_apply', [
+    (80, {'file_limit_registry_conf'}),
+    (90, {'file_limit_registry_conf'}),
+    (0, {'file_limit_registry_conf'})
+])
+def test_file_limit_capacity_alert(percentage, tags_to_apply, get_configuration, configure_environment,
+                                   restart_syscheckd, wait_for_fim_start):
+    """
+    Checks that the corresponding alerts appear in schedule mode for different capacity thresholds.
+
+    Parameters
+    ----------
+    tags_to_apply : set
+        Run test if matches with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+
+    NUM_REGS = percentage + 1
+
+    if percentage == 0:
+        NUM_REGS = 0
+
+    reg1_handle = RegOpenKeyEx(registry_parser[KEY], sub_key_1, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY)
+
+    if percentage >= 80:    # Percentages 80 and 90
+        for i in range(NUM_REGS):
+            modify_registry_value(reg1_handle, f'value_{i}', REG_SZ, 'added')
+    else:   # Database back to normal
+        for i in range(91):
+            delete_registry_value(reg1_handle, f'value_{i}')
+
+    RegCloseKey(reg1_handle)
+
+    check_time_travel(scheduled, monitor=wazuh_log_monitor)
+
+    if percentage >= 80:    # Percentages 80 and 90
+        file_limit_capacity = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                                      callback=callback_file_limit_capacity,
+                                                      error_message='Did not receive expected '
+                                                      '"DEBUG: ...: Sending DB ...% full alert." event'
+                                                      ).result()
+
+        if file_limit_capacity:
+            assert file_limit_capacity == str(percentage), 'Wrong capacity log for DB file_limit'
+        else:
+            pytest.fail('Wrong capacity log for DB file_limit')
+    else:   # Database back to normal
+        event_found = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                              callback=callback_file_limit_back_to_normal,
+                                              error_message='Did not receive expected '
+                                              '"DEBUG: ...: Sending DB back to normal alert." event'
+                                              ).result()
+
+        assert event_found, 'Event "Sending DB back to normal alert." not found'
+
+    entries = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                      callback=callback_registry_count_entries,
+                                      error_message='Did not receive expected '
+                                      '"Fim inode entries: ..., path count: ..." event'
+                                      ).result()
+
+    if entries:
+        # We add 1 because of the key created to hold the values
+        assert entries == str(NUM_REGS + 1), 'Wrong number of entries count.'
+    else:
+        pytest.fail('Wrong number of entries count')

--- a/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_full.py
+++ b/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_full.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, modify_registry_value, callback_file_limit_capacity, \
+    callback_registry_count_entries, callback_file_limit_full_database, registry_parser, KEY_WOW64_64KEY
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from win32con import REG_SZ, KEY_ALL_ACCESS
+from win32api import RegOpenKeyEx, RegCloseKey
+
+# Marks
+
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+
+KEY = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+
+test_regs = [os.path.join(KEY, sub_key_1)]
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1 = test_regs[0]
+NUM_REGS = 10
+
+# Configurations
+
+
+file_limit_list = ['10']
+
+conf_params = {'WINDOWS_REGISTRY': reg1, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params,
+                       apply_to_all=({'FILE_LIMIT': file_limit_elem} for file_limit_elem in file_limit_list),
+                       modes=['scheduled'])
+
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Functions
+
+
+def extra_configuration_before_yield():
+    """Generate files to fill database"""
+    reg1_handle = RegOpenKeyEx(registry_parser[KEY], sub_key_1, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY)
+
+    for i in range(0, NUM_REGS):
+        modify_registry_value(reg1_handle, f'value_{i}', REG_SZ, 'added')
+
+    RegCloseKey(reg1_handle)
+
+# Tests
+
+
+@pytest.mark.parametrize('tags_to_apply', [
+    {'file_limit_registry_conf'}
+])
+def test_file_limit_full(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
+    """
+    Check that the full database alerts are being sent.
+
+    Parameters
+    ----------
+    tags_to_apply : set
+        Run test if matches with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    database_state = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                             callback=callback_file_limit_capacity,
+                                             error_message='Did not receive expected '
+                                             '"DEBUG: ...: Sending DB 100% full alert." event').result()
+
+    if database_state:
+        assert database_state == '100', 'Wrong value for full database alert.'
+    else:
+        pytest.fail('Did not receive the value of the database state,')
+
+    reg1_handle = RegOpenKeyEx(registry_parser[KEY], sub_key_1, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY)
+
+    modify_registry_value(reg1_handle, 'value_full', REG_SZ, 'added')
+
+    RegCloseKey(reg1_handle)
+
+    wazuh_log_monitor.start(timeout=40, callback=callback_file_limit_full_database,
+                            error_message='Did not receive expected '
+                            '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
+
+    entries = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                      callback=callback_registry_count_entries,
+                                      error_message='Did not receive expected '
+                                      '"Fim inode entries: ..., path count: ..." event'
+                                      ).result()
+
+    if entries:
+        assert entries == str(get_configuration['metadata']['file_limit']), 'Wrong number of entries count.'
+    else:
+        pytest.fail('Wrong number of entries count')

--- a/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_full.py
+++ b/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_full.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
@@ -11,8 +12,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, generate_params, modify_registry_va
     callback_registry_count_entries, callback_file_limit_full_database, registry_parser, KEY_WOW64_64KEY
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from win32con import REG_SZ, KEY_ALL_ACCESS
-from win32api import RegOpenKeyEx, RegCloseKey
+
+if sys.platform == 'win32':
+    from win32con import REG_SZ, KEY_ALL_ACCESS
+    from win32api import RegOpenKeyEx, RegCloseKey
 
 # Marks
 
@@ -56,7 +59,7 @@ def get_configuration(request):
 
 
 def extra_configuration_before_yield():
-    """Generate files to fill database"""
+    """Generate registry entries to fill database"""
     reg1_handle = RegOpenKeyEx(registry_parser[KEY], sub_key_1, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY)
 
     for i in range(0, NUM_REGS):

--- a/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_values.py
+++ b/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_values.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, callback_value_file_limit, generate_params, \
+    callback_registry_count_entries, modify_registry_value, registry_parser, KEY_WOW64_64KEY
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from win32con import REG_SZ, KEY_ALL_ACCESS
+from win32api import RegOpenKeyEx, RegCloseKey
+
+# Marks
+
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+# import pdb; pdb.set_trace()
+
+KEY = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+
+test_regs = [os.path.join(KEY, sub_key_1)]
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1 = test_regs[0]
+
+# Configurations
+
+
+file_limit_list = ['1', '10', '100', '1000']
+
+conf_params = {'WINDOWS_REGISTRY': reg1, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params,
+                       apply_to_all=({'FILE_LIMIT': file_limit_elem} for file_limit_elem in file_limit_list),
+                       modes=['scheduled'])
+
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Functions
+
+
+def extra_configuration_before_yield():
+    """Generate files to fill database"""
+    reg1_handle = RegOpenKeyEx(registry_parser[KEY], sub_key_1, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY)
+
+    for i in range(0, int(file_limit_list[-1]) + 10):
+        modify_registry_value(reg1_handle, f'value_{i}', REG_SZ, 'added')
+
+    RegCloseKey(reg1_handle)
+
+# Tests
+
+
+@pytest.mark.parametrize('tags_to_apply', [
+    {'file_limit_registry_conf'}
+])
+def test_file_limit_values(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
+    """
+    Check that a list of different values gets configured correctly in file_limit.
+
+    Parameters
+    ----------
+    tags_to_apply : set
+        Run test if matches with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                               callback=callback_value_file_limit,
+                                               error_message='Did not receive expected '
+                                               '"DEBUG: ...: Maximum number of files to be monitored: ..." event'
+                                               ).result()
+
+    if file_limit_value:
+        assert file_limit_value == get_configuration['metadata']['file_limit'], 'Wrong value for file_limit.'
+    else:
+        pytest.fail('Wrong value for file_limit')
+
+    entries = wazuh_log_monitor.start(timeout=40,
+                                      callback=callback_registry_count_entries,
+                                      error_message='Did not receive expected '
+                                      '"Fim inode entries: ..., path count: ..." event'
+                                      ).result()
+
+    if entries:
+        assert entries == str(get_configuration['metadata']['file_limit']), 'Wrong number of entries count.'
+    else:
+        pytest.fail('Wrong number of entries count')

--- a/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_values.py
+++ b/tests/integration/test_fim/test_registry/test_file_limit/test_file_limit_values.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import sys
 
 import pytest
 
@@ -11,8 +12,10 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_value_file_limit, generate
     callback_registry_count_entries, modify_registry_value, registry_parser, KEY_WOW64_64KEY
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from win32con import REG_SZ, KEY_ALL_ACCESS
-from win32api import RegOpenKeyEx, RegCloseKey
+
+if sys.platform == 'win32':
+    from win32con import REG_SZ, KEY_ALL_ACCESS
+    from win32api import RegOpenKeyEx, RegCloseKey
 
 # Marks
 
@@ -20,7 +23,7 @@ from win32api import RegOpenKeyEx, RegCloseKey
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # Variables
-# import pdb; pdb.set_trace()
+
 
 KEY = "HKEY_LOCAL_MACHINE"
 sub_key_1 = "SOFTWARE\\test_key"
@@ -55,7 +58,7 @@ def get_configuration(request):
 
 
 def extra_configuration_before_yield():
-    """Generate files to fill database"""
+    """Generate registry entries to fill database"""
     reg1_handle = RegOpenKeyEx(registry_parser[KEY], sub_key_1, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY)
 
     for i in range(0, int(file_limit_list[-1]) + 10):


### PR DESCRIPTION
## Description

This pull request adds several tests for the file_limit functionality in the FIM scan for Windows registries.

Here is the report: [file_limit.zip](https://github.com/wazuh/wazuh-qa/files/5573322/file_limit.zip)

This pull request closes #898.
