### PR TITLE
Registry integration test: Ambiguous configurations

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -2033,7 +2033,11 @@ def registry_value_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_6
 
         value_list = aux_dict
 
-    if options is not None and CHECK_MTIME not in options:
+    options_set = REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_ALL]
+    if options is not None:
+        options_set = options_set.intersection(options)
+
+    if options_set is not None and CHECK_MTIME not in options_set:
         value_list[registry_path] = ('', None)
 
     triggers_event_add = triggers_event and triggers_event_add
@@ -2044,7 +2048,7 @@ def registry_value_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_6
                                        validators_after_delete, validators_after_cud)
 
     registry_event_checker = RegistryEventChecker(log_monitor=log_monitor, registry_key=registry_path,
-                                                  registry_dict=value_list, options=options,
+                                                  registry_dict=value_list, options=options_set,
                                                   custom_validator=custom_validator, encoding=encoding,
                                                   callback=callback, is_value=True)
 
@@ -2170,7 +2174,11 @@ def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64K
 
         key_list = aux_dict
 
-    if options is not None and CHECK_MTIME not in options:
+    options_set = REQUIRED_REG_KEY_ATTRIBUTES[CHECK_ALL]
+    if options is not None:
+        options_set = options_set.intersection(options)
+
+    if options_set is not None and CHECK_MTIME not in options_set:
         key_list[registry_path] = ('', None)
 
     triggers_event_add = triggers_event and triggers_event_add
@@ -2181,7 +2189,7 @@ def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64K
                                        validators_after_delete, validators_after_cud)
 
     registry_event_checker = RegistryEventChecker(log_monitor=log_monitor, registry_key=registry_path,
-                                                  registry_dict=key_list, options=options,
+                                                  registry_dict=key_list, options=options_set,
                                                   custom_validator=custom_validator, encoding=encoding,
                                                   callback=callback, is_value=False)
 

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_ambiguous_simple.yaml
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_ambiguous_simple.yaml
@@ -1,0 +1,122 @@
+---
+# Restrict configuration
+- tags:
+  - ambiguous_restrict
+  apply_to_modules:
+  - test_ambiguous_simple
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - restrict_key: RESTRICT_KEY
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_1
+        attributes:
+        - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - restrict_value: RESTRICT_VALUE
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_2
+        attributes:
+        - arch: "64bit"
+# Tag configuration
+- tags:
+  - ambiguous_tag
+  apply_to_modules:
+  - test_ambiguous_simple
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - arch: "64bit"
+        - tags: TAG_1
+    - windows_registry:
+        value: SUBKEY_1
+        attributes:
+        - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - arch: "both"
+        - tags: TAG_1
+    - windows_registry:
+        value: SUBKEY_2
+        attributes:
+        - arch: "both"
+# Recursion configuration
+- tags:
+  - ambiguous_recursion
+  apply_to_modules:
+  - test_ambiguous_simple
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: REGISTRY_RECURSION_1
+        attributes:
+        - arch: "64bit"
+        - recursion_level: RECURSION_LEVEL_1
+        - check_mtime: "no"
+    - windows_registry:
+        value: RECURSION_SUBKEY_1
+        attributes:
+        - arch: "64bit"
+    - windows_registry:
+        value: REGISTRY_RECURSION_2
+        attributes:
+        - arch: "both"
+        - check_mtime: "no"
+        - recursion_level: RECURSION_LEVEL_2
+    - windows_registry:
+        value: RECURSION_SUBKEY_2
+        attributes:
+        - arch: "both"
+# Checks configuration
+- tags:
+  - ambiguous_checks
+  apply_to_modules:
+  - test_ambiguous_simple
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - arch: "64bit"
+        - check_all: "yes"
+    - windows_registry:
+        value: SUBKEY_1
+        attributes:
+        - check_size: "no"
+        - check_owner: "no"
+        - check_group: "no"
+        - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - arch: "64bit"
+        - check_all: "no"
+        - check_mtime: "yes"
+        - check_size: "yes"
+        - check_sum: "yes"
+    - windows_registry:
+        value: SUBKEY_2
+        attributes:
+        - check_all: "yes"
+        - arch: "64bit"

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_complex_entries.yaml
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_complex_entries.yaml
@@ -1,0 +1,96 @@
+---
+# Configuration 1
+- tags:
+  - complex_checks
+  apply_to_modules:
+  - test_ambiguous_complex
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: KEY1
+        attributes:
+        - check_all: "yes"
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_1
+        attributes:
+        - check_all: "no"
+        - check_type: "yes"
+        - check_mtime: "yes"
+        - check_size: "yes"
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_2
+        attributes:
+        - check_all: "yes"
+        - check_sum: "no"
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_3
+        attributes:
+        - check_all: "yes"
+        - check_owner: "no"
+        - check_group: "no"
+        - arch: "64bit"
+# Configuration 3
+- tags:
+  - complex_report_changes
+  apply_to_modules:
+  - test_ambiguous_complex
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: KEY1
+        attributes:
+        - report_changes: "yes"
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_1
+        attributes:
+        - report_changes: "no"
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_2
+        attributes:
+        - report_changes: "no"
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_3
+        attributes:
+        - report_changes: "yes"
+        - arch: "64bit"
+# Configuration 3
+- tags:
+  - complex_tags
+  apply_to_modules:
+  - test_ambiguous_complex
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: KEY1
+        attributes:
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_1
+        attributes:
+        - tags: TAG_1
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_2
+        attributes:
+        - tags: TAG_2
+        - arch: "64bit"
+    - windows_registry:
+        value: SUBKEY_3
+        attributes:
+        - tags: TAG_3
+        - arch: "64bit"

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_duplicated_entries.yaml
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_duplicated_entries.yaml
@@ -1,0 +1,158 @@
+---
+# Duplicate entries simple configuration for keys
+- tags:
+  - duplicate_entries
+  apply_to_modules:
+  - test_ambiguous_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - arch: "both"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - arch: "both"
+# Duplicate restrict configuration for keys
+- tags:
+  - duplicate_restrict_entries
+  apply_to_modules:
+  - test_ambiguous_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - restrict_value: RESTRICT_1
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - restrict_value: RESTRICT_2
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - restrict_key: RESTRICT_1
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - restrict_key: RESTRICT_2
+          - arch: "64bit"
+# Duplicate arch configuration for keys
+- tags:
+  - duplicate_arch_entries
+  apply_to_modules:
+  - test_ambiguous_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - arch: "32bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - arch: "32bit"
+# Duplicate complex configuration for keys
+- tags:
+  - duplicate_complex_entries
+  apply_to_modules:
+  - test_ambiguous_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - check_all: "no"
+          - check_type: "yes"
+          - restrict_key: "overwritten"
+          - restrict_value: "overwritten"
+          - arch: "32bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - check_all: "yes"
+          - check_type: "no"
+          - check_group: "no"
+          - restrict_key: RESTRICT_2
+          - restrict_value: RESTRICT_2
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - arch: "32bit"
+          - check_all: "yes"
+          - report_changes: "yes"
+          - check_mtime: "no"
+          - check_sum: "no"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - arch: "both"
+          - check_all: "no"
+          - report_changes: "no"
+          - check_mtime: "yes"
+          - check_sum: "yes"
+          - check_type: "yes"
+          - check_size: "yes"
+# Duplicate report configuration for keys
+- tags:
+  - duplicate_report_entries
+  apply_to_modules:
+  - test_ambiguous_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - report_changes: "no"
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - report_changes: "yes"
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - report_changes: "yes"
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+          - report_changes: "no"
+          - arch: "64bit"

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_ignore_over_restrict.yaml
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/data/wazuh_ignore_over_restrict.yaml
@@ -1,0 +1,59 @@
+---
+# Restrict configuration for keys
+- tags:
+  - ambiguous_ignore_restrict_key
+  apply_to_modules:
+  - test_ambiguous_ignore_works_over_restrict
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - restrict_key: RESTRICT_KEY_1
+        - arch: "64bit"
+    - registry_ignore:
+          value: REGISTRY_IGNORE
+          attributes:
+          - arch: '64bit'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - restrict_key: RESTRICT_KEY_2
+        - arch: "both"
+    - registry_ignore:
+          value: "REGISTRY_IGNORE_REGEX"
+          attributes:
+          - type: 'sregex'
+          - arch: 'both'
+# Restrict configuration for values
+- tags:
+  - ambiguous_ignore_restrict_values
+  apply_to_modules:
+  - test_ambiguous_ignore_works_over_restrict
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+        - restrict_value: RESTRICT_VALUE_1
+        - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_2
+        attributes:
+        - restrict_value: RESTRICT_VALUE_2
+        - arch: "both"
+    - registry_ignore_value:
+          value: REGISTRY_IGNORE_VALUE
+          attributes:
+          - arch: '64bit'
+    - registry_ignore_value:
+          value: "REGISTRY_IGNORE_VALUE_REGEX"
+          attributes:
+          - type: 'sregex'
+          - arch: 'both'

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_complex.py
@@ -1,0 +1,214 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import CHECK_OWNER, LOG_FILE_PATH, registry_value_cud, registry_key_cud, \
+                              generate_params, CHECK_SUM, CHECK_TYPE, CHECK_GROUP, \
+                              CHECK_ALL, CHECK_MTIME, CHECK_SIZE, \
+                              REQUIRED_REG_KEY_ATTRIBUTES, REQUIRED_REG_VALUE_ATTRIBUTES
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+from wazuh_testing.tools import WAZUH_PATH
+from hashlib import sha1
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+registry = "SOFTWARE\\random_key"
+
+tag_1 = "tag_1"
+tag_2 = "tag_2"
+tag_3 = "tag_3"
+
+subkey_1 = os.path.join(registry, "subkey_1")
+subkey_2 = os.path.join(subkey_1, "subkey_2")
+subkey_3 = os.path.join(subkey_2, "subkey_3")
+
+test_regs = [os.path.join(key, registry),
+             os.path.join(key, subkey_1),
+             os.path.join(key, subkey_2),
+             os.path.join(key, subkey_3),
+             ]
+
+confs_params = {'KEY1': test_regs[0],
+                'SUBKEY_1': test_regs[1],
+                'SUBKEY_2': test_regs[2],
+                'SUBKEY_3': test_regs[3],
+                'TAG_1': tag_1,
+                'TAG_2': tag_2,
+                'TAG_3': tag_3
+                }
+
+
+key_all_attrs = REQUIRED_REG_KEY_ATTRIBUTES[CHECK_ALL].union(REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_ALL])
+
+checkers_key = key_all_attrs
+checkers_subkey1 = {CHECK_TYPE, CHECK_MTIME, CHECK_SIZE}
+checkers_subkey2 = key_all_attrs - REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_SUM]
+checkers_subkey3 = key_all_attrs - {CHECK_GROUP, CHECK_OWNER}
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_complex_entries.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+p, m = generate_params(extra_params=confs_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+@pytest.mark.parametrize('key', [
+    key
+])
+@pytest.mark.parametrize('subkey, key_checkers', [
+                        (registry, checkers_key),
+                        (subkey_1, checkers_subkey1),
+                        (subkey_2, checkers_subkey2),
+                        (subkey_3, checkers_subkey3)
+])
+def test_ambiguous_complex_checks(key, subkey, key_checkers,
+                                  get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if the events of every configured key has the proper check attributes.
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_key: str
+        Path of the configured key.
+    key_checkers: set
+        Set of checks that are expected.
+    """
+    check_apply_test({"complex_checks"}, get_configuration['tags'])
+    # Test registry keys.
+    registry_key_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                     options=key_checkers, time_travel=True)
+
+    # Test registry values.
+    registry_value_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                       options=key_checkers, time_travel=True)
+
+
+@pytest.mark.parametrize('key', [
+    key
+])
+@pytest.mark.parametrize('subkey, value_list, report,', [
+                        (registry, ['test_value'], True),
+                        (subkey_1, ['test_value'], False),
+                        (subkey_2, ['test_value'], False),
+                        (subkey_3, ['test_value'], True)
+])
+def test_ambiguous_report_changes(key, subkey, value_list, report,
+                                  get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if report changes works properly for every configured entry
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_key: str
+        Path of the configured key.
+    value_list: list
+        List with the name of the values that will be used in the cud operation.
+    report: boolean
+        True if the key is configured with report changes.
+    """
+    check_apply_test({'complex_report_changes'}, get_configuration['tags'])
+
+    validator_after_update = None
+
+    def report_changes_validator(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in value_list:
+            folder_str = "{} {}".format("[x64]", sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str,
+                                     sha1(value.encode()).hexdigest())
+
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
+
+    if report:
+        validator_after_update = [report_changes_validator]
+    # Test registry values.
+    registry_value_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                       value_list=value_list, time_travel=True, validators_after_update=validator_after_update)
+
+
+@pytest.mark.parametrize('key', [
+    key
+])
+@pytest.mark.parametrize('subkey, tag', [
+                        (registry, None),
+                        (subkey_1, tag_1),
+                        (subkey_2, tag_2),
+                        (subkey_3, tag_3)
+])
+def test_ambiguous_report_tags(key, subkey, tag,
+                               get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if syscheck detects the event property 'tags' for each configured entry.
+
+    This test validates both situations, making sure that if tags='no', there won't be a
+    tags event property.
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_key: str
+        Path of the configured key.
+    tag: str
+        Tag that is configured for each entry. If None, the entry isn't configured with a tag.
+    """
+    check_apply_test({'complex_tags'}, get_configuration['tags'])
+
+    def no_tag_validator(event):
+        """Validate tags event property does not exist in the event."""
+        assert 'tags' not in event['data'].keys(), "'Tags' attribute found in event"
+
+    def tag_validator(event):
+        """Validate tags event property exists in the event."""
+        assert tag == event['data']['tags'], 'Defined_tags are not equal'
+
+    validator_after_create = [no_tag_validator]
+    validator_after_update = [no_tag_validator]
+    validator_after_delete = [no_tag_validator]
+
+    if tag is not None:
+        validator_after_create = [tag_validator]
+        validator_after_update = [tag_validator]
+        validator_after_delete = [tag_validator]
+
+    # Test registry values.
+    registry_key_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                     time_travel=True, validators_after_create=validator_after_create,
+                     validators_after_update=validator_after_update, validators_after_delete=validator_after_delete
+                     )
+
+    # Test registry values.
+    registry_value_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                       time_travel=True, validators_after_create=validator_after_create,
+                       validators_after_update=validator_after_update, validators_after_delete=validator_after_delete
+                       )

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_duplicated_entries.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, registry_key_cud, \
+                              generate_params, CHECK_GROUP, CHECK_TYPE, \
+                              CHECK_ALL, CHECK_MTIME, CHECK_SIZE, CHECK_SUM, KEY_WOW64_32KEY, \
+                              KEY_WOW64_64KEY, REQUIRED_REG_KEY_ATTRIBUTES, REQUIRED_REG_VALUE_ATTRIBUTES
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+subkey_1 = "SOFTWARE\\test_key1"
+subkey_2 = "SOFTWARE\\test_key2"
+
+test_regs = [os.path.join(key, subkey_1),
+             os.path.join(key, subkey_2)
+             ]
+
+conf_params = {'WINDOWS_REGISTRY_1': test_regs[0],
+               'WINDOWS_REGISTRY_2': test_regs[1],
+               'RESTRICT_1': "overwritten_restrict$",
+               'RESTRICT_2': "restrict_test_|test_key"
+               }
+
+
+key_all_attrs = REQUIRED_REG_KEY_ATTRIBUTES[CHECK_ALL].union(REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_ALL])
+
+checkers_key_1 = key_all_attrs - {CHECK_GROUP, CHECK_TYPE}
+checkers_key_2 = REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_SUM].union({CHECK_MTIME, CHECK_TYPE, CHECK_SIZE})
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_duplicated_entries.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+@pytest.mark.parametrize('key', [
+    key
+])
+@pytest.mark.parametrize('subkey, arch, key_list, value_list, checkers, tags_to_apply', [
+    (subkey_1, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_entries'}),
+    (subkey_2, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_entries'}),
+    (subkey_2, KEY_WOW64_32KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_entries'}),
+    (subkey_1, KEY_WOW64_64KEY, None, ['restrict_test_value'], key_all_attrs, {'duplicate_restrict_entries'}),
+    (subkey_2, KEY_WOW64_64KEY, ['restrict_test_key'], None, key_all_attrs, {'duplicate_restrict_entries'}),
+    (subkey_1, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_arch_entries'}),
+    (subkey_1, KEY_WOW64_32KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_arch_entries'}),
+    (subkey_2, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_arch_entries'}),
+    (subkey_2, KEY_WOW64_32KEY, ['random_key'], ['test_value'], key_all_attrs, {'duplicate_arch_entries'}),
+    (subkey_1, KEY_WOW64_64KEY, ['restrict_test_key'], ['restrict_test_value'], checkers_key_1, {'complex_entries'}),
+    (subkey_2, KEY_WOW64_64KEY, ['random_key'], ['random_value'], checkers_key_2, {'complex_entries'}),
+    (subkey_2, KEY_WOW64_32KEY, ['random_key'], ['random_value'], checkers_key_2, {'complex_entries'}),
+])
+def test_duplicate_entries(key, subkey, arch, key_list, value_list, checkers, tags_to_apply,
+                           get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check that duplicate antries are overwritten by the last entry.
+
+    Parameters
+    ----------
+    key: str
+        Root key (HKEY_*)
+    subkey: str
+        path of the registry where the test will be executed.
+    arch: str
+        Architecture of the registry.
+    key_list: list
+        List with the name of the keys that will be used for cud. If None, registry_key_cud won't be executed.
+    value_list: list
+        List with the name of the values that will be used for cud. If None, registry_value_cud won't be executed.
+    checkers: set
+        Set with the checkers that are expected in the events.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    # Test registry keys.
+    if key_list is not None:
+        registry_key_cud(key, subkey, wazuh_log_monitor, arch=arch, key_list=key_list, options=checkers,
+                         min_timeout=global_parameters.default_timeout, time_travel=True, triggers_event=True)
+
+    if value_list is not None:
+        registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=value_list, options=checkers,
+                           min_timeout=global_parameters.default_timeout, time_travel=True, triggers_event=True)
+
+
+@pytest.mark.parametrize('key', [
+    key
+])
+@pytest.mark.parametrize('subkey, arch, value_list, tags_to_apply, report_changes', [
+                        (subkey_1, KEY_WOW64_64KEY, ['test_value'], {'duplicate_report_entries'}, True),
+                        (subkey_2, KEY_WOW64_64KEY, ['test_value'], {'duplicate_report_entries'}, False),
+])
+def test_duplicate_entries_rc(key, subkey, arch, value_list, tags_to_apply, report_changes,
+                              get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check registry entries are overwritten when report changes is activated/deactivated.
+
+    Parameters
+    ----------
+    key: str
+        Root key (HKEY_* constants).
+    subkey: str
+        path of the registry where the test will be executed.
+    arch: str
+        Architecture of the registry.
+    value_list: list
+        List with the name of the values that will be used for cud.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    from wazuh_testing.tools import WAZUH_PATH
+    from hashlib import sha1
+
+    def report_changes_validator(event):
+        """Validate content_changes attribute exists in the event"""
+        if not report_changes:
+            return
+
+        for value in value_list:
+            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str,
+                                     sha1(value.encode()).hexdigest())
+
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=value_list,
+                       time_travel=True, min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator])

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_duplicated_entries.py
@@ -6,7 +6,9 @@
 import os
 
 import pytest
+from hashlib import sha1
 
+from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, registry_key_cud, \
                               generate_params, CHECK_GROUP, CHECK_TYPE, \
@@ -132,9 +134,6 @@ def test_duplicate_entries_rc(key, subkey, arch, value_list, tags_to_apply, repo
         List with the name of the values that will be used for cud.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-
-    from wazuh_testing.tools import WAZUH_PATH
-    from hashlib import sha1
 
     def report_changes_validator(event):
         """Validate content_changes attribute exists in the event"""

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_ignore_works_over_restrict.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, registry_key_cud, \
+                              KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+subkey_1 = "SOFTWARE\\testkey1"
+subkey_2 = "SOFTWARE\\testkey2"
+
+test_regs = [os.path.join(key, subkey_1),
+             os.path.join(key, subkey_2)
+             ]
+
+conf_params = {'WINDOWS_REGISTRY_1': test_regs[0],
+               'WINDOWS_REGISTRY_2': test_regs[1],
+               'RESTRICT_KEY_1': "restrict_key$",
+               'RESTRICT_KEY_2': "key_restrict$",
+               'REGISTRY_IGNORE': os.path.join(test_regs[0], "restrict_key"),
+               'REGISTRY_IGNORE_REGEX': 'key_restrict$',
+               'RESTRICT_VALUE_1': 'restrict_value$',
+               'RESTRICT_VALUE_2': 'value_restrict$',
+               'REGISTRY_IGNORE_VALUE': os.path.join(test_regs[0], "restrict_value"),
+               'REGISTRY_IGNORE_VALUE_REGEX': 'value_restrict$'
+               }
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_ignore_over_restrict.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+@pytest.mark.parametrize('key, subkey, arch, key_name', [
+                        (key, subkey_1, KEY_WOW64_64KEY, 'restrict_key'),
+                        (key, subkey_1, KEY_WOW64_64KEY, 'key_restrict'),
+                        (key, subkey_2, KEY_WOW64_64KEY, 'key_restrict'),
+                        (key, subkey_2, KEY_WOW64_32KEY, 'key_restrict')
+])
+def test_ignore_over_restrict_key(key, subkey, key_name, arch,
+                                  get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check registry values are ignored according to configuration.
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry where the test will be executed.
+    arch : str
+        Architecture of the registry.
+    """
+    check_apply_test({"ambiguous_ignore_restrict_key"}, get_configuration['tags'])
+
+    # Test registry keys.
+    registry_key_cud(key, subkey, wazuh_log_monitor, arch=arch, key_list=[key_name],
+                     min_timeout=global_parameters.default_timeout, time_travel=True, triggers_event=False)
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name', [
+                        (key, subkey_1, KEY_WOW64_64KEY, 'restrict_value'),
+                        (key, subkey_1, KEY_WOW64_64KEY, 'value_restrict'),
+                        (key, subkey_2, KEY_WOW64_64KEY, 'value_restrict'),
+                        (key, subkey_2, KEY_WOW64_32KEY, 'value_restrict')
+])
+def test_ignore_over_restrict_values(key, subkey, value_name, arch,
+                                     get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check registry values are ignored according to configuration.
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry where the test will be executed.
+    arch : str
+        Architecture of the registry.
+    """
+    check_apply_test({"ambiguous_ignore_restrict_values"}, get_configuration['tags'])
+
+    # Test registry keys.
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=[value_name],
+                       min_timeout=global_parameters.default_timeout, time_travel=True, triggers_event=False)

--- a/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_registry/test_ambiguous_confs/test_ambiguous_simple.py
@@ -1,0 +1,239 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, registry_key_cud, CHECK_GROUP, \
+                              CHECK_ALL, CHECK_MTIME, CHECK_OWNER, CHECK_SIZE, CHECK_SUM, KEY_WOW64_32KEY, \
+                              KEY_WOW64_64KEY, REQUIRED_REG_KEY_ATTRIBUTES, REQUIRED_REG_VALUE_ATTRIBUTES, \
+                              generate_params
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+subkey_1 = "SOFTWARE\\testkey1"
+subkey_2 = "SOFTWARE\\testkey2"
+key_name = "test_subkey"
+
+recursion_key = "some_key\\sub_key\\sub_sub_key"
+
+# Checkers
+
+key_all_attrs = REQUIRED_REG_KEY_ATTRIBUTES[CHECK_ALL]
+value_all_attrs = REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_ALL]
+
+checkers_key_case1 = key_all_attrs.union(value_all_attrs)
+checkers_subkey_case1 = (key_all_attrs - {CHECK_GROUP} - {CHECK_OWNER}).union((value_all_attrs - {CHECK_SIZE}))
+
+checkers_key_case2 = {CHECK_MTIME, CHECK_SIZE}.union(REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_SUM])
+checkers_subkey_case2 = key_all_attrs.union(value_all_attrs)
+
+tag = 'insert_a_random_tag'
+
+test_regs = [os.path.join(key, subkey_1),
+             os.path.join(key, subkey_2),
+             os.path.join(key, subkey_1, key_name),
+             os.path.join(key, subkey_2, key_name),
+             os.path.join(key, subkey_1),
+             os.path.join(key, os.path.join(subkey_1, recursion_key, key_name)),
+             os.path.join(key, subkey_2),
+             os.path.join(key, os.path.join(subkey_2, recursion_key, key_name))
+             ]
+
+conf_params = {'WINDOWS_REGISTRY_1': test_regs[0],
+               'WINDOWS_REGISTRY_2': test_regs[1],
+               'SUBKEY_1': test_regs[2],
+               'SUBKEY_2': test_regs[3],
+               'RESTRICT_KEY': "test_",
+               'RESTRICT_VALUE': "test_value",
+               'TAG_1': tag,
+               'REGISTRY_RECURSION_1': test_regs[4],
+               'RECURSION_SUBKEY_1': test_regs[5],
+               'RECURSION_LEVEL_1': 3,
+               'REGISTRY_RECURSION_2': test_regs[6],
+               'RECURSION_SUBKEY_2': test_regs[7],
+               'RECURSION_LEVEL_2': 3,
+               }
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_ambiguous_simple.yaml')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+@pytest.mark.parametrize('key, sub_keys, is_key, name', [
+                        (key, (subkey_1, os.path.join(subkey_1, key_name)), True, "onekey"),
+                        (key, (subkey_2, os.path.join(subkey_2, key_name)), False, "other_value")
+])
+def test_ambiguous_restrict(key, sub_keys, is_key, name,
+                            get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check restrict configuration events.
+
+    Check if syscheck detects changes (add, modify, delete) of key/events depending on its restrict configuration.
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_keys: tuple
+        Tuple where the first element is the path of a key that won't raise alerts due to the restrict and the
+        second element is a key that will raise alerts.
+    is_key: boolean
+        Variable to distinguish if the restrict is for keys or for values.
+    name: str
+        String with the name of the value/key that will be created.
+    """
+    check_apply_test({"ambiguous_restrict"}, get_configuration['tags'])
+
+    if is_key:
+        registry_key_cud(key, sub_keys[0], wazuh_log_monitor, key_list=[name], arch=KEY_WOW64_64KEY,
+                         triggers_event=False, time_travel=True, min_timeout=global_parameters.default_timeout)
+        registry_key_cud(key, sub_keys[1], wazuh_log_monitor, key_list=[name], arch=KEY_WOW64_64KEY,
+                         triggers_event=True, time_travel=True, min_timeout=global_parameters.default_timeout)
+    else:
+        registry_value_cud(key, sub_keys[0], wazuh_log_monitor, value_list=[name], arch=KEY_WOW64_64KEY,
+                           triggers_event=False, time_travel=True, min_timeout=global_parameters.default_timeout)
+        registry_value_cud(key, sub_keys[1], wazuh_log_monitor, value_list=[name],
+                           triggers_event=True, time_travel=True, min_timeout=global_parameters.default_timeout)
+
+
+@pytest.mark.parametrize('key, sub_keys, arch', [
+                        (key, (subkey_1, os.path.join(subkey_1, key_name)), KEY_WOW64_64KEY),
+                        (key, (subkey_2, os.path.join(subkey_2, key_name)), KEY_WOW64_64KEY),
+                        (key, (subkey_2, os.path.join(subkey_2, key_name)), KEY_WOW64_32KEY)
+])
+def test_ambiguous_tags(key, sub_keys, arch,
+                        get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """Check if syscheck detects the event property 'tags' for each event.
+
+    This test validates both situations, making sure that if tags='no', there won't be a
+    tags event property.
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_keys: tuple
+        Tuple where the first element is the path of a key that will have the tag attribute
+        and the second won't have the tag attribute.
+    arch: int
+        Architecture of the key.
+    """
+
+    def tag_validator(event):
+        """Validate tags event property exists in the event."""
+        assert tag == event['data']['tags'], 'Defined_tags are not equal'
+
+    def no_tag_validator(event):
+        """Validate tags event property does not exist in the event."""
+        assert 'tags' not in event['data'].keys(), "'Tags' attribute found in event"
+
+    check_apply_test({"ambiguous_tag"}, get_configuration['tags'])
+
+    registry_key_cud(key, sub_keys[0], wazuh_log_monitor, arch=arch, time_travel=True,
+                     min_timeout=global_parameters.default_timeout, validators_after_cud=[tag_validator])
+
+    registry_key_cud(key, sub_keys[1], wazuh_log_monitor, arch=arch, time_travel=True,
+                     min_timeout=global_parameters.default_timeout, validators_after_cud=[no_tag_validator])
+
+
+@pytest.mark.parametrize('key, subkey, arch', [
+                        (key, os.path.join(subkey_1, recursion_key), KEY_WOW64_64KEY),
+                        (key, os.path.join(subkey_2, recursion_key), KEY_WOW64_64KEY),
+                        (key, os.path.join(subkey_2, recursion_key), KEY_WOW64_32KEY)
+])
+def test_ambiguous_recursion(key, subkey, arch,
+                             get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if syscheck detects the event property 'tags' for each event.
+
+    This test validates both situations, making sure that if tags='no', there won't be a
+    tags event property.
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_keys: str
+        Path of the subkey that will be used for the test (must have a higher recursion level than the configured key).
+        Example:
+        <windows_registry recursion_level="2">HKLM//some_key</windows_registry>
+        subkey = HKLM//some_key//1//2//3
+
+    arch: int
+        Architecture of the key.
+    """
+    expected_recursion_key = os.path.join(subkey, key_name)
+    check_apply_test({"ambiguous_recursion"}, get_configuration['tags'])
+
+    registry_key_cud(key, subkey, wazuh_log_monitor, arch=arch,
+                     time_travel=True, triggers_event=False, min_timeout=global_parameters.default_timeout)
+
+    registry_key_cud(key, expected_recursion_key, wazuh_log_monitor, arch=arch,
+                     time_travel=True, triggers_event=True, min_timeout=global_parameters.default_timeout)
+
+    registry_value_cud(key, expected_recursion_key, wazuh_log_monitor, arch=arch,
+                       time_travel=True, triggers_event=True, min_timeout=global_parameters.default_timeout)
+
+
+@pytest.mark.parametrize('key, subkey, key_checkers, subkey_checkers', [
+                        (key, (subkey_1, os.path.join(subkey_1, key_name)), checkers_key_case1, checkers_subkey_case1),
+                        (key, (subkey_2, os.path.join(subkey_2, key_name)), checkers_key_case2, checkers_subkey_case2)
+])
+def test_ambiguous_checks(key, subkey, key_checkers, subkey_checkers,
+                          get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if syscheck detects the event property 'tags' for each event.
+
+    This test validates both situations, making sure that if tags='no', there won't be a
+    tags event property.
+
+    Parameters
+    ----------
+    key: str
+        Key of the registry (HKEY_* constants).
+    sub_keys: tuple
+        Tuple where ther first element is the configured key and the second is the configured subkey.
+    arch: int
+        Architecture of the key.
+    """
+    check_apply_test({"ambiguous_checks"}, get_configuration['tags'])
+    # Test registry keys.
+    registry_key_cud(key, subkey[0], wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                     options=key_checkers, time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')
+
+    # Test registry values.
+    registry_value_cud(key, subkey[0], wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                       options=key_checkers, time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')
+
+    # Test registry keys.
+    registry_key_cud(key, subkey[1], wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                     options=subkey_checkers, time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')
+
+    # Test registry values.
+    registry_value_cud(key, subkey[1], wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                       options=subkey_checkers, time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')


### PR DESCRIPTION
Hello team,
This PR aims to add a new test for the Windows registry integration test.

Closes #890

# Tests logic
The logic of these test is to make sure that: 
- Duplicate entries are overwritten correctly
- If a subkey is monitored differently from its parent key, the events of the subkey are correct.
- The ignore options prevail over restrict options (for keys and values)

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

# Windows
```
python -m pytest --html=C:\report1\report.html test_ambiguous_confs\
======================= test session starts ==================

collected 162 items

test_ambiguous_confs\test_ambiguous_complex.py ....ssssssssssss....ssssssssssss....
[ 22%] test_ambiguous_confs\test_ambiguous_duplicated_entries.py ...ssssssssssssss..ssssssssssssss....sssssssssssssssssssssssssssssss..
[ 65%] test_ambiguous_confs\test_ambiguous_ignore_works_over_restrict.py ....ssssssss....
[ 75%] test_ambiguous_confs\test_ambiguous_simple.py ..ssssssssss...ssssssssss...ssssssssss..
[100%]
================================================== 41 passed, 121 skipped in 944.86s (0:15:44) ======
```

Best regards.
