### PR TITLE
Integration tests for registries basic usages

### DIFF
--- a/tests/integration/test_fim/test_registry/test_basic_usage/data/wazuh_conf_reg_attr.yaml
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/data/wazuh_conf_reg_attr.yaml
@@ -3,22 +3,16 @@
 - tags:
   - ossec_conf_2
   apply_to_modules:
-  - test_basic_usage_match_key_count
-  - test_basic_usage_no_key
+  - test_basic_usage_entries_match_key_count
+  - test_basic_usage_registry_new_key
+  - test_long_registry_path
   sections:
   - section: syscheck
     elements:
     - disabled:
         value: 'no'
-    - frequency:
-        value: FREQUENCY
     - windows_registry:
         value: WINDOWS_REGISTRY_1
         attributes:
           - ATTRIBUTE
-          - arch: 64bit
-    - windows_registry:
-        value: WINDOWS_REGISTRY_2
-        attributes:
-          - ATTRIBUTE
-          - arch: both
+          - arch: "64bit"

--- a/tests/integration/test_fim/test_registry/test_basic_usage/data/wazuh_conf_registry_both.yaml
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/data/wazuh_conf_registry_both.yaml
@@ -4,7 +4,6 @@
   - ossec_conf_2
   apply_to_modules:
   - test_basic_usage_delete_registry
-  - test_basic_usage_new_key
   - test_basic_usage_registry_baseline_generation
   - test_basic_usage_registry_changes
   sections:
@@ -16,9 +15,9 @@
         value: WINDOWS_REGISTRY_1
         attributes:
           - ATTRIBUTE
-          - arch: 64bit
+          - arch: "64bit"
     - windows_registry:
         value: WINDOWS_REGISTRY_2
         attributes:
           - ATTRIBUTE
-          - arch: both
+          - arch: "both"

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_delete_registry.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_delete_registry.py
@@ -3,25 +3,20 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import shutil
-from collections import Counter
-
 import pytest
-
+from collections import Counter
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_registry, modify_registry_value, delete_registry, \
-    callback_detect_event, check_time_travel, validate_registry_event, registry_parser
-from wazuh_testing.tools import PREFIX
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+    callback_detect_event, check_time_travel, validate_registry_value_event, registry_parser
+from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
+import win32con
 
-if sys.platform == 'win32':
-    import win32api
-    import win32con
 
 # Marks
 
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
+
 
 # Variables
 key = "HKEY_LOCAL_MACHINE"
@@ -29,19 +24,24 @@ sub_key_1 = "SOFTWARE\\Classes\\testkey"
 sub_key_2 = "SOFTWARE\\testkey"
 
 test_regs = [os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)]
-registry_str = ",".join(test_regs)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-registr_str, registry2 = test_regs
+reg1, reg2 = test_regs
 
-monitoring_modes = ['scheduled', 'scheduled']
+monitoring_modes = ['scheduled']
+
 
 # Configurations
 
-conf_params = {'WINDOWS_REGISTRY_1': registr_str, 'WINDOWS_REGISTRY_2' : registry2}
+conf_params = {'WINDOWS_REGISTRY_1': reg1, 'WINDOWS_REGISTRY_2': reg2}
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_registry_both.yaml')
 p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+registry_list = [(key, sub_key_1, win32con.KEY_WOW64_64KEY),
+                 (key, sub_key_2, win32con.KEY_WOW64_32KEY),
+                 (key, sub_key_2, win32con.KEY_WOW64_64KEY)]
+
 
 # fixtures
 
@@ -51,48 +51,52 @@ def get_configuration(request):
     return request.param
 
 
-# tests
+# test
 
-@pytest.mark.parametrize('registry_key, registry_subkey, arch, value_list', [
+@pytest.mark.parametrize('key, subkey, arch, value_list', [
     (key, sub_key_1, win32con.KEY_WOW64_64KEY, ['value1', 'value2', 'value3']),
     (key, sub_key_2, win32con.KEY_WOW64_32KEY, ['value1', 'value2', 'value3']),
     (key, sub_key_2, win32con.KEY_WOW64_64KEY, ['value1', 'value2', 'value3'])
 
 ])
-def test_delete_registry(registry_key, registry_subkey, arch, value_list,
+def test_delete_registry(key, subkey, arch, value_list,
                          get_configuration, configure_environment,
-                         restart_syscheckd, wait_for_initial_scan):
+                         restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheckd detects 'deleted' events from the values contained
     in a registry key that is being deleted.
 
     Parameters
     ----------
-    registry_key : str
+    key : str
         Root key where the sub key will be created (HKEY_LOCAL_MACHINE, etc)
-    registry_subkey : str
+    subkey : str
         Path of the registry subkey
+    arch : int
+        Arch of the registry subkey
     value_list : list
         Names of the values.
     """
 
-    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     mode = get_configuration['metadata']['fim_mode']
+    scheduled = mode == 'scheduled'
 
-    key_h = create_registry(registry_parser[registry_key], registry_subkey, arch)
+    key_h = create_registry(registry_parser[key], subkey, arch)
+
     # Create values inside subkey
-    for value in value_list:
-        modify_registry_value(key_h, value, win32con.REG_SZ, "some content")
+    modify_registry_value(key_h, value_list[0], win32con.REG_SZ, "some content")
+    modify_registry_value(key_h, value_list[1], win32con.REG_MULTI_SZ, "some content\0second string\0")
+    modify_registry_value(key_h, value_list[2], win32con.REG_DWORD, 1234)
 
     check_time_travel(scheduled, monitor=wazuh_log_monitor)
     events = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
                                      accum_results=len(value_list) + 1, error_message='Did not receive expected '
                                      '"Sending FIM event: ..." event').result()
     for ev in events:
-        validate_registry_event(ev, mode=mode)
+        validate_registry_value_event(ev, mode=mode)
 
     # Remove registry
-    delete_registry(registry_parser[registry_key], registry_subkey, arch)
+    delete_registry(registry_parser[key], subkey, arch)
     check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
     # Expect deleted events
@@ -100,13 +104,13 @@ def test_delete_registry(registry_key, registry_subkey, arch, value_list,
                                          error_message='Did not receive expected '
                                                        '"Sending FIM event: ..." event',
                                          accum_results=len(value_list) + 1).result()
-    path_list = set([event['data']['path'] for event in event_list])
     counter_type = Counter([event['data']['type'] for event in event_list])
 
     for ev in events:
-        validate_registry_event(ev, mode=mode)
+        validate_registry_value_event(ev, mode=mode)
 
     assert counter_type['deleted'] == len(value_list) + 1, f'Number of "deleted" events should be {len(value_list) + 1}'
 
+    name_list = set([event['data']['value_name'] for event in event_list[1:]])
     for value in value_list:
-        assert os.path.join(value_list, value) in path_list, f'Value {value} not found within the events'
+        assert value in name_list, f'Value {value} not found within the events'

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_baseline_generation.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_baseline_generation.py
@@ -4,6 +4,7 @@
 
 import os
 import pytest
+from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, callback_detect_event, \
     modify_registry_value, callback_detect_end_scan, registry_parser, create_registry
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -91,5 +92,5 @@ def test_wait_until_baseline(key, subkey, arch, value_type, content, get_configu
 
     modify_registry_value(key_handle, "value_name", value_type, content)
 
-    wazuh_log_monitor.start(timeout=10, callback=callback_detect_event_before_end_scan,
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event_before_end_scan,
                             error_message='Did not receive expected event before end the scan')

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_baseline_generation.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_baseline_generation.py
@@ -3,18 +3,13 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from time import time
-
 import pytest
-
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, delete_registry, timedelta, callback_detect_event, \
-    check_time_travel, create_registry, registry_value_cud, callback_detect_end_scan, registry_parser
-from wazuh_testing.tools import PREFIX
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, callback_detect_event, \
+    modify_registry_value, callback_detect_end_scan, registry_parser, create_registry
+from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-
-from wazuh_testing import global_parameters
-
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import truncate_file
 import win32con
 
 
@@ -22,7 +17,9 @@ import win32con
 
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
 
+
 # Variables
+
 key = "HKEY_LOCAL_MACHINE"
 sub_key_1 = "SOFTWARE\\Classes\\testkey"
 sub_key_2 = "SOFTWARE\\testkey"
@@ -31,24 +28,33 @@ test_regs = [os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)]
 registry_str = ",".join(test_regs)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-registr_str, registry2 = test_regs
+reg1, reg2 = test_regs
 
-monitoring_modes = ['scheduled', 'scheduled']
+monitoring_modes = ['scheduled']
+
 
 # Configurations
 
-
-conf_params = {'WINDOWS_REGISTRY_1': registr_str, 'WINDOWS_REGISTRY_2' : registry2}
-attributes = [{'tags': 'test_tag'}]
+conf_params = {'WINDOWS_REGISTRY_1': reg1, 'WINDOWS_REGISTRY_2': reg2}
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_registry_both.yaml')
-p, m = generate_params(extra_params=conf_params, apply_to_all=({'ATTRIBUTE': attr} for attr in attributes),
-                       modes=monitoring_modes)
+p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
-registry_list = [(key, sub_key_1, win32con.KEY_WOW64_32KEY),
+registry_list = [(key, sub_key_1, win32con.KEY_WOW64_64KEY),
                  (key, sub_key_2, win32con.KEY_WOW64_32KEY),
                  (key, sub_key_2, win32con.KEY_WOW64_64KEY)]
+
+
 # fixtures
+
+@pytest.fixture(scope='function')
+def restart_syscheckd_each_time(request):
+    control_service('stop', daemon='ossec-syscheckd')
+    truncate_file(LOG_FILE_PATH)
+    file_monitor = FileMonitor(LOG_FILE_PATH)
+    setattr(request.module, 'wazuh_log_monitor', file_monitor)
+    control_service('start', daemon='ossec-syscheckd')
+
 
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
@@ -68,36 +74,22 @@ def callback_detect_event_before_end_scan(line):
         return True
 
 
-def extra_configuration_before_yield():
-    for key, subkey, arch in registry_list:
-        create_registry(registry_parser[key], subkey, arch)
-
-
-def extra_configuration_after_yield():
-    """Make sure to delete the key after performing the test"""
-    for key, subkey, arch in registry_list:
-        try:
-            delete_registry(registry_parser[key], subkey, arch)
-        except win32api.error:
-            pass
-
-
-@pytest.mark.parametrize('registry_key, registry_subkey, arch', [
-    (key, sub_key_1, win32con.KEY_WOW64_64KEY),
-    (key, sub_key_2, win32con.KEY_WOW64_32KEY),
-    (key, sub_key_2, win32con.KEY_WOW64_64KEY)
+@pytest.mark.parametrize('key, subkey, arch, value_type, content', [
+    (key, sub_key_1, win32con.KEY_WOW64_64KEY, win32con.REG_SZ, 'added'),
+    (key, sub_key_2, win32con.KEY_WOW64_32KEY, win32con.REG_SZ, 'added'),
+    (key, sub_key_2, win32con.KEY_WOW64_64KEY, win32con.REG_SZ, 'added')
 ])
-def test_basic_usage_registry_baseline_generation(registry_key, registry_subkey, arch,
-                                                  get_configuration, configure_environment, restart_syscheckd):
+def test_wait_until_baseline(key, subkey, arch, value_type, content, get_configuration,
+                             configure_environment, restart_syscheckd_each_time):
     """
     Check if events are appearing after the baseline
     The message 'File integrity monitoring scan ended' informs about the end of the first scan,
     which generates the baseline
     """
-    check_apply_test({'ossec_conf'}, get_configuration['tags'])
 
-    # Create a file during initial scan to check if the event is logged after the 'scan ended' message
-    registry_value_cud(key, registry_subkey, arch,  wazuh_log_monitor, time_travel=True)
+    key_handle = create_registry(registry_parser[key], subkey, arch)
 
-    wazuh_log_monitor.start(timeout=120, callback=callback_detect_event_before_end_scan,
+    modify_registry_value(key_handle, "value_name", value_type, content)
+
+    wazuh_log_monitor.start(timeout=10, callback=callback_detect_event_before_end_scan,
                             error_message='Did not receive expected event before end the scan')

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_changes.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_changes.py
@@ -3,49 +3,47 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
-
 import pytest
-
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, timedelta, callback_detect_event,  \
-     check_time_travel, registry_value_cud, create_registry, delete_registry, registry_parser
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, registry_value_cud, registry_key_cud
+from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from win32api
-
 import win32con
+
 
 # Marks
 
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
 
+
 # Variables
+
 key = "HKEY_LOCAL_MACHINE"
 sub_key_1 = "SOFTWARE\\Classes\\testkey"
 sub_key_2 = "SOFTWARE\\testkey"
 
-handle_list = list()
 test_regs = [os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)]
 registry_str = ",".join(test_regs)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-registr_str, registry2 = test_regs
+reg1, reg2 = test_regs
 
-registry_list = [(sub_key_1, win32con.KEY_WOW64_64KEY), (sub_key_2, win32con.KEY_WOW64_32KEY),
-                 (sub_key_2, win32con.KEY_WOW64_64KEY)]
+monitoring_modes = ['scheduled']
 
-monitoring_modes = ['scheduled', 'scheduled']
 
 # Configurations
 
-
-conf_params = {'WINDOWS_REGISTRY_1': registr_str, 'WINDOWS_REGISTRY_2' : registry2}
+conf_params = {'WINDOWS_REGISTRY_1': reg1, 'WINDOWS_REGISTRY_2': reg2}
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_registry_both.yaml')
 p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
-# Fixtures
+registry_list = [(key, sub_key_1, win32con.KEY_WOW64_64KEY),
+                 (key, sub_key_2, win32con.KEY_WOW64_32KEY),
+                 (key, sub_key_2, win32con.KEY_WOW64_64KEY)]
+
+
+# fixtures
 
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
@@ -53,52 +51,29 @@ def get_configuration(request):
     return request.param
 
 
-# Tests
+# tests
 
-def extra_configuration_before_yield():
-    """Make sure to delete any existing key with the same name before performing the test"""
-    for reg_key, arch in registry_list:
-        try:
-            delete_registry(registry_parser[key], reg_key, arch)
-        except win32api.error:  # Ignore the error in case the key doesn't exists
-            pass
-
-
-def extra_configuration_after_yield():
-    """Make sure to delete the key after performing the test"""
-    for reg_key, arch in registry_list:
-        try:
-            delete_registry(registry_parser[key], reg_key, arch)
-        except win32api.error:  # Ignore the error in case the key doesn't exists
-            pass
-
-
-@pytest.mark.parametrize('registry_key, registry_subkey, arch', [
+@pytest.mark.parametrize('value_type', [
+    win32con.REG_SZ,
+    win32con.REG_MULTI_SZ,
+    win32con.REG_DWORD
+])
+@pytest.mark.parametrize('key, subkey, arch', [
     (key, sub_key_1, win32con.KEY_WOW64_64KEY),
     (key, sub_key_2, win32con.KEY_WOW64_32KEY),
     (key, sub_key_2, win32con.KEY_WOW64_64KEY)
 ])
-def test_basic_usage_registry_changes(registry_key, registry_subkey, arch, get_configuration, configure_environment,
-                                      restart_syscheckd, wait_for_initial_scan):
+def test_registry_changes(key, subkey, arch, value_type, get_configuration, configure_environment, restart_syscheckd):
     """
-    Check if syscheckd detects value changes (add, modify, delete)
-
-    Parameters
-    ----------
-    registry_key : str
-        Root of the registry key (HKEY_* constants)
-    registry_subkey : str
-        Path of the registry
-    arch : str
-        Architecture
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
+    Check if events appear for subkeys/values of a monitored key
     """
-    def shared_registry_validator_after_modify(event):
-        assert event['data']['type'] == 'modified'
-        assert '[x64]' in event['data'].get('path'),  f'Architecture is not correct'
 
-    create_registry(registry_parser[key], registry_subkey, 0, arch)
+    registry_key_cud(key, subkey, wazuh_log_monitor, arch=arch,
+                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                     min_timeout=global_parameters.default_timeout,
+                     triggers_event=True)
 
-    registry_value_cud(registry_key, registry_subkey, arch, wazuh_log_monitor, value_list={'value_name': 'asdfg'},
-                       time_travel=True, validators_after_update=[shared_registry_validator_after_modify])
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout,
+                       triggers_event=True, value_type=value_type)

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_new_key.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_basic_usage_registry_new_key.py
@@ -5,8 +5,8 @@
 import os
 import pytest
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, callback_registry_count_entries,  \
-     check_time_travel, create_registry, modify_registry_value, registry_parser
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, \
+     check_time_travel, create_registry, registry_parser, registry_value_cud
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 import win32con
@@ -18,7 +18,6 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
 
 
 # Variables
-
 arch = win32con.KEY_WOW64_64KEY
 key = "HKEY_LOCAL_MACHINE"
 sub_key_1 = "SOFTWARE\\Classes\\testkey"
@@ -49,27 +48,16 @@ def get_configuration(request):
 
 # tests
 
-def extra_configuration_before_yield():
-    key_h = create_registry(registry_parser[key], sub_key_1, arch)
-
-    modify_registry_value(key_h, "value1", win32con.REG_SZ, "some content")
-    modify_registry_value(key_h, "value2", win32con.REG_MULTI_SZ, "some content\0second string\0")
-    modify_registry_value(key_h, "value3", win32con.REG_DWORD, 1234)
-
-
-def test_entries_match_key_count(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+def test_new_key(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """
-    Check if FIM entries match the entries count
+    Check that a new monitored key generates events after the next scheduled scan.
     """
 
-    entries = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                      callback=callback_registry_count_entries,
-                                      error_message='Did not receive expected '
-                                                    '"Fim inode entries: ..., path count: ..." event'
-                                      ).result()
+    create_registry(registry_parser[key], sub_key_1, arch)
+
     check_time_travel(True, monitor=wazuh_log_monitor)
 
-    if entries:
-        assert entries == '4', 'Wrong number of entries'
-    else:
-        raise AssertionError('Wrong number of entries')
+    registry_value_cud(key, sub_key_1, wazuh_log_monitor, arch=arch,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout,
+                       triggers_event=True)

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_long_registry_path.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_long_registry_path.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, \
+     create_registry, delete_registry, registry_parser, registry_value_cud
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+import win32api
+import win32con
+
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
+
+# Variables
+arch = win32con.KEY_WOW64_64KEY
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\Classes"
+for i in range(30):
+    sub_key_1 += "\\"
+    for j in range(255):
+        sub_key_1 += "a"
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+reg1 = os.path.join(key, sub_key_1)
+
+monitoring_modes = ['scheduled']
+
+
+# Configurations
+
+conf_params = {'WINDOWS_REGISTRY_1': reg1}
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_reg_attr.yaml')
+p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+def extra_configuration_before_yield():
+    create_registry(registry_parser[key], sub_key_1, arch)
+
+
+def extra_configuration_after_yield():
+    """Make sure to delete the key after performing the test"""
+    try:
+        delete_registry(registry_parser[key], sub_key_1, arch)
+    except win32api.error:
+        pass
+
+
+def test_long_registry_path(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if long key names generates events
+    """
+    pytest.xfail(reason='Xfailed due to https://github.com/wazuh/wazuh/issues/6451')
+
+    max_value_name = "value_test"
+    for i in range(16372):
+        max_value_name += "a"
+
+    registry_value_cud(key, sub_key_1, wazuh_log_monitor, arch=arch,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout,
+                       triggers_event=True, value_list=[max_value_name])

--- a/tests/integration/test_fim/test_registry/test_basic_usage/test_long_registry_path.py
+++ b/tests/integration/test_fim/test_registry/test_basic_usage/test_long_registry_path.py
@@ -67,7 +67,6 @@ def test_long_registry_path(get_configuration, configure_environment, restart_sy
     """
     Check if long key names generates events
     """
-    pytest.xfail(reason='Xfailed due to https://github.com/wazuh/wazuh/issues/6451')
 
     max_value_name = "value_test"
     for i in range(16372):


### PR DESCRIPTION
Hello team,

This PR is part of the Integration test epic issue to Fim improvement registries.

Closes https://github.com/wazuh/wazuh-qa/issues/891

# Tests logic
- Check if events appear after the baseline
- Events are generated for keys and values
- Delete events are generated for each subkey (and it's values) and values
- Check if FIM entries match the number of monitored keys, subkeys, values
- After the key is created, events are generated in the next scheduled scan.
- Check syscheckd detects registry changes (add, modify, delete)

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

