### PR TITLE
Vulnerability Detector: Added vendor to Red Hat packages

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/redhat_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/redhat_vulnerabilities.json
@@ -10,7 +10,8 @@
                 "package": {
                     "name": "firefox-0",
                     "version": "68.1.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-11764",
@@ -22,7 +23,8 @@
                 "package": {
                     "name": "glibc-0",
                     "version": "2.27",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-19126",
@@ -34,7 +36,8 @@
                 "package": {
                     "name": "sqlite-0",
                     "version": "3.25.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-13753",
@@ -46,7 +49,8 @@
                 "package": {
                     "name": "git-0",
                     "version": "2.18.1",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-1352",
@@ -58,7 +62,8 @@
                 "package": {
                     "name": "haproxy-0",
                     "version": "2.0.12",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-19330",
@@ -79,7 +84,8 @@
                 "package": {
                     "name": "nodejs",
                     "version": "11.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-16776",
@@ -91,7 +97,8 @@
                 "package": {
                     "name": "firefox-0",
                     "version": "68.1",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-11764",
@@ -103,7 +110,8 @@
                 "package": {
                     "name": "ansible-0",
                     "version": "2.8.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-14864",
@@ -115,7 +123,8 @@
                 "package": {
                     "name": "php",
                     "version": "7.1",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-11043",
@@ -127,7 +136,8 @@
                 "package": {
                     "name": "samba-0",
                     "version": "4.10.3",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-10218",
@@ -148,7 +158,8 @@
                 "package": {
                     "name": "python-twisted-web-0",
                     "version": "8.1.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2020-10108",
@@ -160,7 +171,8 @@
                 "package": {
                     "name": "squid",
                     "version": "3",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-12519",
@@ -172,7 +184,8 @@
                 "package": {
                     "name": "vim-2",
                     "version": "7.3",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-12735",
@@ -184,7 +197,8 @@
                 "package": {
                     "name": "rh-java-common-xmlrpc-1",
                     "version": "3.1.2",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-17570",
@@ -196,7 +210,8 @@
                 "package": {
                     "name": "chromium-browser-0",
                     "version": "69.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2019-13724",
@@ -217,7 +232,8 @@
                 "package": {
                     "name": "pam-0",
                     "version": "0.98.0",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2010-3853",
@@ -229,7 +245,8 @@
                 "package": {
                     "name": "seamonkey-0",
                     "version": "1.0.8",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2010-3180",
@@ -241,7 +258,8 @@
                 "package": {
                     "name": "subversion",
                     "version": "1.9",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-0203",
@@ -253,7 +271,8 @@
                 "package": {
                     "name": "mariadb",
                     "version": "10.2",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
             },
                 "cve": {
                     "cveid": "CVE-2019-2739",
@@ -265,7 +284,8 @@
                 "package": {
                     "name": "thunderbird-0",
                     "version": "3.1.5",
-                    "format": "rpm"
+                    "format": "rpm",
+                    "vendor": "Red Hat, Inc."
                 },
                 "cve": {
                     "cveid": "CVE-2010-3175",

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/vulnerabilities.json
@@ -61,7 +61,8 @@
         {
             "package": {
                 "name": "wazuhintegrationpackage-5",
-                "version": "0.9"
+                "version": "0.9",
+                "vendor": "Red Hat, Inc."
             },
             "cve": {
                 "cveid": "CVE-005",
@@ -72,7 +73,8 @@
         {
             "package": {
                 "name": "wazuhintegrationpackage-6",
-                "version": "0.9"
+                "version": "0.9",
+                "vendor": "Red Hat, Inc."
             },
             "cve": {
                 "cveid": "CVE-006",
@@ -83,7 +85,8 @@
         {
             "package": {
                 "name": "wazuhintegrationpackage-7",
-                "version": "0.9"
+                "version": "0.9",
+                "vendor": "Red Hat, Inc."
             },
             "cve": {
                 "cveid": "CVE-007",
@@ -94,7 +97,8 @@
         {
             "package": {
                 "name": "wazuhintegrationpackage-8",
-                "version": "0.9"
+                "version": "0.9",
+                "vendor": "Red Hat, Inc."
             },
             "cve": {
                 "cveid": "CVE-008",
@@ -105,7 +109,8 @@
         {
             "package": {
                 "name": "wazuhintegrationpackage-9",
-                "version": "0.9"
+                "version": "0.9",
+                "vendor": "Red Hat, Inc."
             },
             "cve": {
                 "cveid": "CVE-009",
@@ -172,7 +177,8 @@
       {
           "package": {
               "name": "provider_vulnerable_package",
-              "version":"1.0"
+              "version":"1.0",
+              "vendor": "Red Hat, Inc."
           },
           "cve": {
               "cveid": "CVE-021",
@@ -184,7 +190,8 @@
       {
           "package": {
               "name": "no_patch_nvd_vulnerable_package",
-              "version":"1.0"
+              "version":"1.0",
+              "vendor": "Red Hat, Inc."
           },
           "cve": {
               "cveid": "CVE-022",
@@ -208,7 +215,8 @@
       {
           "package": {
               "name": "vulnerable_package",
-              "version":"1.0"
+              "version":"1.0",
+              "vendor": "Red Hat, Inc."
           },
           "cve": {
               "cveid": "CVE-024",

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -11,7 +11,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, REAL_NVD_FEED, \
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, REAL_NVD_FEED, \
                                                  insert_vulnerability, modify_system, clean_vd_tables
 from wazuh_testing.tools.services import control_service
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -8,11 +8,10 @@ import json
 import wazuh_testing.vulnerability_detector as vd
 
 from time import sleep
-from shutil import copy
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.file import truncate_file, compress_gzip_file
+from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
 
 # Marks
@@ -26,12 +25,11 @@ configurations_path = os.path.join(test_data_path, 'wazuh_msu_inventory.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-
 # Set configuration
 parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED),
-                'MSU_JSON_PATH': custom_msu_json_path}]
+               'MSU_JSON_PATH': custom_msu_json_path}]
 metadata = [{'nvd_json_path': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED),
-                'msu_json_path': custom_msu_json_path}]
+             'msu_json_path': custom_msu_json_path}]
 ids = ['msu_scan_configuration']
 
 # read vulnerabilities
@@ -42,21 +40,28 @@ with open(custom_msu_json_path, 'r') as f:
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 system_data = [
-        {"target": "WINDOWS10", "os_name": "Microsoft Windows 10", "os_major": "10", "os_release": "1809",
-        "os_minor": "0", "name": "windows", "hotfixes" : ["4540670", "KB4550947"]}, # Scenario: Two supersedences, and no original patch.
-        {"target": "WINDOWS_SERVER_2016", "os_name": "Microsoft Windows Server 2016", "os_major": "10", "os_release": "1607",
-        "os_minor": "0", "name": "windows", "hotfixes" : ["4534271","4556813"]}, # Scenario: Original patch + supersedence.
-        {"target": "WINDOWS_SERVER_2019", "os_name": "Microsoft Windows Server 2019", "os_major": "10", "os_release": "1809",
-        "os_minor": "0", "name": "windows", "hotfixes": ["4534275"]}, # Scenario: Original patch of a recently released CVE. (only supersedence)
+    {"target": "WINDOWS10", "os_name": "Microsoft Windows 10", "os_major": "10", "os_release": "1809",
+     "os_minor": "0", "name": "windows", "hotfixes": ["4540670", "KB4550947"]},
+    # Scenario: Two supersedences, and no original patch.
+    {"target": "WINDOWS_SERVER_2016", "os_name": "Microsoft Windows Server 2016", "os_major": "10",
+     "os_release": "1607",
+     "os_minor": "0", "name": "windows", "hotfixes": ["4534271", "4556813"]},
+    # Scenario: Original patch + supersedence.
+    {"target": "WINDOWS_SERVER_2019", "os_name": "Microsoft Windows Server 2019", "os_major": "10",
+     "os_release": "1809",
+     "os_minor": "0", "name": "windows", "hotfixes": ["4534275"]},
+    # Scenario: Original patch of a recently released CVE. (only supersedence)
 ]
 
 system_data_ids = [system['target'] for system in system_data]
 MODULESD_PREFIX = r'.*wazuh-modulesd.*'
 
+
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
+
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
 def mock_vulnerability_scan(request):
@@ -74,9 +79,9 @@ def mock_vulnerability_scan(request):
     # usual x86_64.
     vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=request.param['name'], os_arch="x64")
-    
+
     vd.insert_osinfo(os_name=request.param['os_name'], os_release=request.param['os_release'])
-    
+
     for patch in request.param["hotfixes"]:
         vd.insert_hotfix(hotfix=patch)
 
@@ -108,14 +113,14 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
     for cve, item in vulnerabilities['vulnerabilities'].items():
         installed, hotfix = is_hotfix_installed(item[0]['patch'], dep, hotfixes)
         if installed is True:
-                wazuh_log_monitor.start(
+            wazuh_log_monitor.start(
                 timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
                 update_position=False,
                 callback=vd.make_vuln_callback(
                     f"Agent '000' has installed '{hotfix}' that corrects the vulnerability '{cve}'"
                 ),
                 error_message=f"Could not find the report which says that the patch {hotfix}" +
-                f" solves {cve}"
+                              f" solves {cve}"
             )
         else:
             wazuh_log_monitor.start(
@@ -125,8 +130,9 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
                     f"Agent '000' is vulnerable to '{cve}'. Condition: 'KB{hotfix} patch is not installed'"
                 ),
                 error_message=f"Could not find the report which says that the system" +
-                f" is vulnerable to {cve} due to missing {hotfix}"
+                              f" is vulnerable to {cve} due to missing {hotfix}"
             )
+
 
 def is_hotfix_installed(cve_patch, dependencies, hotfixes):
     """
@@ -153,5 +159,4 @@ def is_hotfix_installed(cve_patch, dependencies, hotfixes):
                     if super_patch in hotfixes:
                         return True, super_patch
 
-        return False, cve_patch     
-        
+        return False, cve_patch

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -11,7 +11,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, REAL_NVD_FEED, \
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, REAL_NVD_FEED, \
                                                  insert_vulnerability, modify_system, clean_vd_tables
 from wazuh_testing.tools.services import control_service
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
@@ -4,7 +4,6 @@
 
 import os
 import pytest
-import json
 import wazuh_testing.vulnerability_detector as vd
 
 from time import sleep
@@ -18,16 +17,13 @@ from wazuh_testing.tools.file import read_json
 # Marks
 pytestmark = pytest.mark.tier(level=1)
 
-
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_different_cves.yaml')
 vulnerabilities_data_path = os.path.join(test_data_path, vd.VULNERABILITIES)
 
-
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 
 # Set configuration
 parameters = [{'NVD_JSON_PATH': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED)}]
@@ -47,28 +43,32 @@ deb_expected_alerts_provider = len(list(filter(lambda x: x['vulnerable'] in ['al
 
 system_data = [
     {"target": "RHEL8", "os_name": "CentOS Linux", "os_major": "8", "os_minor": "1", "name": "centos8",
-               "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd, "provider_vulnerabilities_number": rpm_expected_alerts_provider},
+     "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd,
+     "provider_vulnerabilities_number": rpm_expected_alerts_provider},
     {"target": "RHEL7", "os_name": "CentOS Linux", "os_major": "7", "os_minor": "8", "name": "centos7",
-               "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd, "provider_vulnerabilities_number": rpm_expected_alerts_provider},
+     "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd,
+     "provider_vulnerabilities_number": rpm_expected_alerts_provider},
     {"target": "RHEL6", "os_name": "CentOS Linux", "os_major": "6", "os_minor": "10", "name": "centos6",
-               "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd, "provider_vulnerabilities_number": rpm_expected_alerts_provider},
+     "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd,
+     "provider_vulnerabilities_number": rpm_expected_alerts_provider},
     {"target": "RHEL5", "os_name": "CentOS Linux", "os_major": "5", "os_minor": "11", "name": "centos5",
-               "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd, "provider_vulnerabilities_number": rpm_expected_alerts_provider},
+     "format": "rpm", "nvd_vulnerabilities_number": rpm_expected_alerts_nvd,
+     "provider_vulnerabilities_number": rpm_expected_alerts_provider},
     {"target": "BIONIC", "os_name": "Ubuntu", "os_major": "18", "os_minor": "04", "name": "Ubuntu-bionic",
-               "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
-               "provider_vulnerabilities_number": deb_expected_alerts_provider},
+     "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
+     "provider_vulnerabilities_number": deb_expected_alerts_provider},
     {"target": "XENIAL", "os_name": "Ubuntu", "os_major": "16", "os_minor": "04", "name": "Ubuntu-xenial",
-               "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
-               "provider_vulnerabilities_number": deb_expected_alerts_provider},
+     "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
+     "provider_vulnerabilities_number": deb_expected_alerts_provider},
     {"target": "TRUSTY", "os_name": "Ubuntu", "os_major": "14", "os_minor": "04", "name": "Ubuntu-trusty",
-               "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
-               "provider_vulnerabilities_number": deb_expected_alerts_provider},
+     "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
+     "provider_vulnerabilities_number": deb_expected_alerts_provider},
     {"target": "BUSTER", "os_name": "Debian GNU/Linux", "os_major": "10", "os_minor": "", "name": "debian10",
-               "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
-               "provider_vulnerabilities_number": deb_expected_alerts_provider},
+     "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
+     "provider_vulnerabilities_number": deb_expected_alerts_provider},
     {"target": "STRETCH", "os_name": "Debian GNU/Linux", "os_major": "9", "os_minor": "", "name": "debian9",
-               "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
-               "provider_vulnerabilities_number": deb_expected_alerts_provider}
+     "format": "deb", "nvd_vulnerabilities_number": deb_expected_alerts_nvd,
+     "provider_vulnerabilities_number": deb_expected_alerts_provider}
 ]
 system_data_ids = [system['target'] for system in system_data]
 
@@ -99,17 +99,17 @@ def mock_vulnerability_scan(request):
 
     # Mock system
     vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                  os_minor=request.param['os_minor'], name=request.param['name'])
+                     os_minor=request.param['os_minor'], name=request.param['name'])
 
     # Insert half vulnerabilities for provider feed
     for vulnerability in vulnerabilities_provider:
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
-                             target=request.param['target'])
+                                target=request.param['target'])
 
     # Insert vulnerable packages
     for vulnerability in vulnerabilities_nvd:
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
-                       format=request.param['format'], agent="000")
+                          format=request.param['format'], agent="000")
 
     control_service('start', daemon='wazuh-db')
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -13,7 +13,7 @@ import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.file import truncate_file, compress_gzip_file
+from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.fim import check_time_travel
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -11,7 +11,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, clean_table, REAL_NVD_FEED, \
+from wazuh_testing.vulnerability_detector import make_vuln_callback, insert_package, REAL_NVD_FEED, \
                                                  insert_vulnerability, modify_system, clean_vd_tables
 from wazuh_testing.tools.services import control_service
 


### PR DESCRIPTION
Hello team,

I have added the vendor to the packages configuration. Also, I fixed warnings in some tests from test_scan_results.

Closes #945 

# Tests logic

- [x] Added vendors is redhat_vulnerabilities.json
- [x] Added vendors in vulnerabilities.json 

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Checked that **vulnerability detector/test_scan_results tests work correctly** (my changes don't break anything)

## DEB Manager

- When the expected behavior occurs:

```
======================================== test session starts ========================================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-53-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.0.2', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'testinfra': '5.0.0', 'metadata': '1.10.0'}}
rootdir: /home/daniel/Wazuh/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.10.0
collected 45 items                                                                                  

test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py::test_debian_vulnerabilities_report[debian_scan_configuration-BUSTER] PASSED [  2%]
test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py::test_debian_vulnerabilities_report[debian_scan_configuration-STRETCH] PASSED [  4%]
test_vulnerability_detector/test_scan_results/test_macos_inventory.py::test_macos_vulnerabilities_report[macos_scan_configuration-MAC0] PASSED [  6%]
test_vulnerability_detector/test_scan_results/test_macos_inventory.py::test_macos_vulnerabilities_report[macos_scan_configuration-MAC1] PASSED [  8%]
test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py::test_vulnerabilities_report[msu_scan_configuration-WINDOWS10] PASSED [ 11%]
test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py::test_vulnerabilities_report[msu_scan_configuration-WINDOWS_SERVER_2016] PASSED [ 13%]
test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py::test_vulnerabilities_report[msu_scan_configuration-WINDOWS_SERVER_2019] PASSED [ 15%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan0] PASSED [ 17%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan1] PASSED [ 20%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan2] PASSED [ 22%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan3] PASSED [ 24%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL8] PASSED [ 26%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL7] PASSED [ 28%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL6] PASSED [ 31%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL5] PASSED [ 33%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-BIONIC] PASSED [ 35%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-XENIAL] PASSED [ 37%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-TRUSTY] PASSED [ 40%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-BUSTER] PASSED [ 42%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-STRETCH] PASSED [ 44%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10] PASSED [ 46%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [ 48%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 51%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 53%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 55%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 57%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 60%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 62%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 64%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 66%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC0] PASSED [ 68%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC1] PASSED [ 71%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC2] PASSED [ 73%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [ 75%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 77%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 80%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 82%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 84%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 86%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 88%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 91%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 93%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py::test_ubuntu_vulnerabilities_report[ubuntu_scan_configuration-mock_vulnerability_scan0] PASSED [ 95%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py::test_ubuntu_vulnerabilities_report[ubuntu_scan_configuration-mock_vulnerability_scan1] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py::test_ubuntu_vulnerabilities_report[ubuntu_scan_configuration-mock_vulnerability_scan2] PASSED [100%]

================================== 45 passed in 558.98s (0:09:18) ===================================
```

Best regards.
