### PR TITLE
Integration tests for report_changes in Windows registries

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 from json import JSONDecodeError
 from stat import ST_ATIME, ST_MTIME
 from typing import Sequence, Union, Generator, Any
+from hashlib import sha1
 
 import pytest
 from jsonschema import validate
@@ -2226,6 +2227,32 @@ def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64K
 
     if triggers_event_delete:
         logger.info("'deleted' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
+
+
+def calculate_registry_diff_paths(reg_key, reg_subkey, arch, value_name):
+    """
+    Calculate the diff folder path of a value.
+    Parameters
+    ---------
+    reg_key: str
+        Registry name (HKEY_* constants).
+    reg_subkey: str
+        Path of the subkey.
+    arch: int
+        architecture of the registry.
+    value_name: str
+        name of the value.
+
+    Returns
+    -------
+    A tuple with the diff folder path of the key and the path of the value.
+    """
+    key_path = os.path.join(reg_key, reg_subkey)
+    folder_path = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                 sha1(key_path.encode()).hexdigest())
+    diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_path,
+                             sha1(value_name.encode()).hexdigest(), 'last-entry.gz')
+    return (folder_path, diff_file)
 
 
 def detect_initial_scan(file_monitor):

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
@@ -6,6 +6,8 @@
   - test_report_changes
   - test_report_changes_deleted
   - test_report_changes_more_changes
+  - test_file_size_default
+  - test_disk_quota_default
   sections:
   - section: syscheck
     elements:
@@ -69,38 +71,3 @@
           attributes:
             - arch: '64bit'
             - report_changes: REPORT_CHANGES_2
-- tags:
-  - test_limits
-  apply_to_modules:
-  - test_file_size_disabled
-  - test_file_size_default
-  - test_file_size_values
-  sections:
-  - section: syscheck
-    elements:
-      - disabled:
-          value: 'no'
-      - windows_registry:
-          value: WINDOWS_REGISTRY_1
-          attributes:
-            - arch: 'both'
-            - report_changes: 'yes'
-      - windows_registry:
-          value: WINDOWS_REGISTRY_2
-          attributes:
-            - arch: '64bit'
-            - report_changes: 'yes'
-      - diff:
-          elements:
-          - file_size:
-              elements:
-              - enabled:
-                  value: FILE_SIZE_ENABLED
-              - limit:
-                  value: FILE_SIZE_LIMIT
-          - disk_quota:
-              elements:
-              - enabled:
-                  value: DISK_QUOTA_ENABLED
-              - limit:
-                  value: DISK_QUOTA_LIMIT

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
@@ -1,0 +1,21 @@
+---
+# Test report changes
+- tags:
+  - test_report_changes
+  apply_to_modules:
+  - test_report_changes
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: 'both'
+            - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
@@ -4,6 +4,7 @@
   - test_report_changes
   apply_to_modules:
   - test_report_changes
+  - test_report_changes_deleted
   sections:
   - section: syscheck
     elements:
@@ -14,6 +15,35 @@
           attributes:
             - arch: 'both'
             - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+- tags:
+  - test_duplicate_report
+  apply_to_modules:
+  - test_report_changes_deleted
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'no'
       - windows_registry:
           value: WINDOWS_REGISTRY_2
           attributes:

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
@@ -5,6 +5,7 @@
   apply_to_modules:
   - test_report_changes
   - test_report_changes_deleted
+  - test_report_changes_more_changes
   sections:
   - section: syscheck
     elements:

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
@@ -20,6 +20,7 @@
           attributes:
             - arch: '64bit'
             - report_changes: 'yes'
+
 - tags:
   - test_duplicate_report
   apply_to_modules:
@@ -49,3 +50,39 @@
           attributes:
             - arch: '64bit'
             - report_changes: 'yes'
+
+- tags:
+  - test_limits
+  apply_to_modules:
+  - test_file_size_disabled
+  - test_file_size_default
+  - test_file_size_values
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: 'both'
+            - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+      - diff:
+          elements:
+          - file_size:
+              elements:
+              - enabled:
+                  value: FILE_SIZE_ENABLED
+              - limit:
+                  value: FILE_SIZE_LIMIT
+          - disk_quota:
+              elements:
+              - enabled:
+                  value: DISK_QUOTA_ENABLED
+              - limit:
+                  value: DISK_QUOTA_LIMIT

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes.yaml
@@ -20,7 +20,6 @@
           attributes:
             - arch: '64bit'
             - report_changes: 'yes'
-
 - tags:
   - test_duplicate_report
   apply_to_modules:
@@ -50,7 +49,25 @@
           attributes:
             - arch: '64bit'
             - report_changes: 'yes'
-
+- tags:
+  - test_delete_after_restart
+  apply_to_modules:
+  - test_report_changes_deleted
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: '64bit'
+            - report_changes: REPORT_CHANGES_1
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: REPORT_CHANGES_2
 - tags:
   - test_limits
   apply_to_modules:

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes_limits_quota.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes_limits_quota.yaml
@@ -33,3 +33,25 @@
                   value: DISK_QUOTA_ENABLED
               - limit:
                   value: DISK_QUOTA_LIMIT
+
+- tags:
+  - test_diff_size_limit
+  apply_to_modules:
+  - test_diff_size_limit_values
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: 'both'
+            - report_changes: 'yes'
+            - DIFF_SIZE_LIMIT
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+            - DIFF_SIZE_LIMIT

--- a/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes_limits_quota.yaml
+++ b/tests/integration/test_fim/test_registry/test_report_changes/data/wazuh_registry_report_changes_limits_quota.yaml
@@ -1,0 +1,35 @@
+- tags:
+  - test_limits
+  apply_to_modules:
+  - test_all_limits_disabled
+  - test_file_size_values
+  - test_disk_quota_values
+  sections:
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'no'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_1
+          attributes:
+            - arch: 'both'
+            - report_changes: 'yes'
+      - windows_registry:
+          value: WINDOWS_REGISTRY_2
+          attributes:
+            - arch: '64bit'
+            - report_changes: 'yes'
+      - diff:
+          elements:
+          - file_size:
+              elements:
+              - enabled:
+                  value: FILE_SIZE_ENABLED
+              - limit:
+                  value: FILE_SIZE_LIMIT
+          - disk_quota:
+              elements:
+              - enabled:
+                  value: DISK_QUOTA_ENABLED
+              - limit:
+                  value: DISK_QUOTA_LIMIT

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_diff_size_limit_values.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_diff_size_limit_values.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params, \
+                              calculate_registry_diff_paths
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import generate_string
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+size_limit_configured = 10 * 1024
+
+
+# Configurations
+
+p, m = generate_params(modes=['scheduled'], extra_params={'WINDOWS_REGISTRY_1': reg1,
+                                                          'WINDOWS_REGISTRY_2': reg2,
+                                                          'DIFF_SIZE_LIMIT': {'diff_size_limit': '10KB'}})
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes_limits_quota.yaml')
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('size', [
+    (4 * 1024),
+    (16 * 1024),
+])
+@pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_diff_size_limit'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_diff_size_limit'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_diff_size_limit'})
+])
+def test_diff_size_limit_values(key, subkey, arch, value_name, tags_to_apply, size,
+                                get_configuration, configure_environment, restart_syscheckd,
+                                wait_for_fim_start):
+    """
+    Check that no events are sent when the diff_size_limit exceeded
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    size : int
+        Size of the content to write in value
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    value_content = generate_string(size, '0')
+    values = {value_name: value_content}
+
+    _, diff_file = calculate_registry_diff_paths(key, subkey, arch, value_name)
+
+    def report_changes_validator_no_diff(event):
+        """Validate content_changes attribute exists in the event"""
+        assert event['data'].get('content_changes') is None, 'content_changes isn\'t empty'
+
+    def report_changes_validator_diff(event):
+        """Validate content_changes attribute exists in the event"""
+        assert os.path.exists(diff_file), '{diff_file} does not exist'
+        assert event['data'].get('content_changes') is not None, 'content_changes is empty'
+
+    if size > size_limit_configured:
+        callback_test = report_changes_validator_no_diff
+    else:
+        callback_test = report_changes_validator_diff
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[callback_test])

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_disk_quota_values.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_disk_quota_values.py
@@ -6,7 +6,8 @@ import os
 import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params, \
-                              calculate_registry_diff_paths
+                              calculate_registry_diff_paths, create_registry, delete_registry, registry_parser, \
+                              check_time_travel
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 from test_fim.test_files.test_report_changes.common import generate_string
@@ -18,8 +19,8 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 # Variables
 
 key = "HKEY_LOCAL_MACHINE"
-sub_key_1 = "SOFTWARE\\test_key"
-sub_key_2 = "SOFTWARE\\Classes\\test_key"
+sub_key_1 = "SOFTWARE\\key1"
+sub_key_2 = "SOFTWARE\\key2"
 
 test_regs = [os.path.join(key, sub_key_1),
              os.path.join(key, sub_key_2)]
@@ -34,10 +35,10 @@ size_limit_configured = 10 * 1024
 
 p, m = generate_params(modes=['scheduled'], extra_params={'WINDOWS_REGISTRY_1': reg1,
                                                           'WINDOWS_REGISTRY_2': reg2,
-                                                          'FILE_SIZE_ENABLED': 'yes',
+                                                          'FILE_SIZE_ENABLED': 'no',
                                                           'FILE_SIZE_LIMIT': '10KB',
-                                                          'DISK_QUOTA_ENABLED': 'no',
-                                                          'DISK_QUOTA_LIMIT': '4KB'})
+                                                          'DISK_QUOTA_ENABLED': 'yes',
+                                                          'DISK_QUOTA_LIMIT': '1KB'})
 
 configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes_limits_quota.yaml')
 
@@ -54,18 +55,18 @@ def get_configuration(request):
 
 @pytest.mark.parametrize('size', [
     (4 * 1024),
-    (16 * 1024),
+    (32 * 1024)
 ])
 @pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply', [
     (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_limits'}),
     (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_limits'}),
     (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_limits'})
 ])
-def test_file_size_values(key, subkey, arch, value_name, tags_to_apply, size,
-                          get_configuration, configure_environment, restart_syscheckd,
-                          wait_for_fim_start):
+def test_disk_quota_values(key, subkey, arch, value_name, tags_to_apply, size,
+                           get_configuration, configure_environment, restart_syscheckd,
+                           wait_for_fim_start):
     """
-    Check that no events are sent when the file_size exceeded
+    Check that no events are sent when the disk_quota exceeded
 
     Parameters
     ----------
@@ -90,7 +91,6 @@ def test_file_size_values(key, subkey, arch, value_name, tags_to_apply, size,
 
     def report_changes_validator_no_diff(event):
         """Validate content_changes attribute exists in the event"""
-        assert not os.path.exists(diff_file), '{diff_file} exist, it shouldn\'t'
         assert event['data'].get('content_changes') is None, 'content_changes isn\'t empty'
 
     def report_changes_validator_diff(event):
@@ -103,7 +103,12 @@ def test_file_size_values(key, subkey, arch, value_name, tags_to_apply, size,
     else:
         callback_test = report_changes_validator_diff
 
+    create_registry(registry_parser[key], subkey, arch)
+
     registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
                        time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
                        min_timeout=global_parameters.default_timeout, triggers_event=True,
                        validators_after_update=[callback_test])
+
+    delete_registry(registry_parser[key], subkey, arch)
+    check_time_travel(True, monitor=wazuh_log_monitor)

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_default.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from hashlib import sha1
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import generate_string
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+
+p, m = generate_params(modes=['scheduled'], extra_params={'WINDOWS_REGISTRY_1': reg1,
+                                                          'WINDOWS_REGISTRY_2': reg2,
+                                                          'FILE_SIZE_ENABLED': 'yes',
+                                                          'FILE_SIZE_LIMIT': '1KB',
+                                                          'DISK_QUOTA_ENABLED': 'no',
+                                                          'DISK_QUOTA_LIMIT': '4KB'})
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes.yaml')
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply, size', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_limits'}, 2048),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_limits'}, 2048),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_limits'}, 2048)
+])
+def test_file_size_default(key, subkey, arch, value_name, tags_to_apply, size,
+                           get_configuration, configure_environment, restart_syscheckd,
+                           wait_for_fim_start):
+    """
+    Check that no events are sent when the file_size exceeded
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    size : int
+        Size of the content to write in value
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    value_content = generate_string(size, '0')
+    values = {value_name: value_content}
+
+    def report_changes_validator_no_diff(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_key = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_key,
+                                     sha1(value.encode()).hexdigest(), 'last-entry.gz')
+
+            assert not os.path.exists(diff_file), '{diff_file} exist, it shouldn\'t'
+            assert event['data'].get('content_changes') is None, 'content_changes isn\'t empty'
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator_no_diff])

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_default.py
@@ -67,7 +67,7 @@ def get_configuration(request):
     (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_report_changes'})
 ])
 def test_file_size_default(key, subkey, arch, value_name, tags_to_apply,
-                            get_configuration, configure_environment, restart_syscheckd_each_time):
+                           get_configuration, configure_environment, restart_syscheckd_each_time):
     """
     Check that no events are sent when the disk_quota exceeded
 

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_disabled.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_disabled.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from hashlib import sha1
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import generate_string
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+
+p, m = generate_params(modes=['scheduled'], extra_params={'WINDOWS_REGISTRY_1': reg1,
+                                                          'WINDOWS_REGISTRY_2': reg2,
+                                                          'FILE_SIZE_ENABLED': 'no',
+                                                          'FILE_SIZE_LIMIT': '1KB',
+                                                          'DISK_QUOTA_ENABLED': 'no',
+                                                          'DISK_QUOTA_LIMIT': '4KB'})
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes.yaml')
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply, size', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_limits'}, 2048),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_limits'}, 2048),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_limits'}, 2048)
+])
+def test_file_size_disabled(key, subkey, arch, value_name, tags_to_apply, size,
+                            get_configuration, configure_environment, restart_syscheckd,
+                            wait_for_fim_start):
+    """
+    Check that events are still sent when the file_size exceeded
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    size : int
+        Size of the content to write in value
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    value_content = generate_string(size, '0')
+    values = {value_name: value_content}
+
+    def report_changes_validator_diff(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_key = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_key,
+                                     sha1(value.encode()).hexdigest(), 'last-entry.gz')
+
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator_diff])

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_file_size_values.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from hashlib import sha1
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import generate_string
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+
+p, m = generate_params(modes=['scheduled'], extra_params={'WINDOWS_REGISTRY_1': reg1,
+                                                          'WINDOWS_REGISTRY_2': reg2,
+                                                          'FILE_SIZE_ENABLED': 'yes',
+                                                          'FILE_SIZE_LIMIT': '2KB',
+                                                          'DISK_QUOTA_ENABLED': 'no',
+                                                          'DISK_QUOTA_LIMIT': '4KB'})
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes.yaml')
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('size', [
+    (512),
+    (10240)
+])
+@pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_limits'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_limits'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_limits'})
+])
+def test_file_size_values(key, subkey, arch, value_name, tags_to_apply, size,
+                          get_configuration, configure_environment, restart_syscheckd,
+                          wait_for_fim_start):
+    """
+    Check that no events are sent when the file_size exceeded
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    size : int
+        Size of the content to write in value
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    value_content = generate_string(size, '0')
+    values = {value_name: value_content}
+
+    def report_changes_validator_no_diff(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_key = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_key,
+                                     sha1(value.encode()).hexdigest(), 'last-entry.gz')
+
+            assert not os.path.exists(diff_file), '{diff_file} exist, it shouldn\'t'
+            assert event['data'].get('content_changes') is None, 'content_changes isn\'t empty'
+
+    def report_changes_validator_diff(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_key = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_key,
+                                     sha1(value.encode()).hexdigest(), 'last-entry.gz')
+
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
+
+    if size > 2048:
+        callback_test = report_changes_validator_no_diff
+    else:
+        callback_test = report_changes_validator_diff
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[callback_test])

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
@@ -57,8 +57,8 @@ def test_report_changes(key, subkey, arch, value_name, tags_to_apply,
                         get_configuration, configure_environment, restart_syscheckd,
                         wait_for_fim_start):
     """
-    Check the only values detected are those matching the restrict using the value path.
-    It also checks that all the files in the report_changes folders are deleted after the values are deleted.
+    Checks that events of keys configured using report changes are correct.
+    It also checks that the diff file is created for each value.
 
     Parameters
     ----------

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
@@ -4,10 +4,9 @@
 
 import os
 import pytest
-from hashlib import sha1
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
-from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.fim import LOG_FILE_PATH, calculate_registry_diff_paths, registry_value_cud, KEY_WOW64_32KEY, \
+                              KEY_WOW64_64KEY, generate_params
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -79,10 +78,7 @@ def test_report_changes(key, subkey, arch, value_name, tags_to_apply,
     def report_changes_validator(event):
         """Validate content_changes attribute exists in the event"""
         for value in values:
-            folder_key = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
-                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
-            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_key,
-                                     sha1(value.encode()).hexdigest(), 'last-entry.gz')
+            _, diff_file = calculate_registry_diff_paths(key, subkey, arch, value)
 
             assert os.path.exists(diff_file), '{diff_file} does not exist'
             assert event['data'].get('content_changes') is not None, 'content_changes is empty'

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from hashlib import sha1
+from time import sleep
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+
+conf_params = {'WINDOWS_REGISTRY_1': reg1,
+               'WINDOWS_REGISTRY_2': reg2}
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes.yaml')
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_report_changes'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_report_changes'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_report_changes'})
+])
+def test_report_changes(key, subkey, arch, value_name, tags_to_apply,
+                        get_configuration, configure_environment, restart_syscheckd,
+                        wait_for_fim_start):
+    """
+    Check the only values detected are those matching the restrict using the value path.
+    It also checks that all the files in the report_changes folders are deleted after the values are deleted.
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    values = {value_name: "some content"}
+
+    def report_changes_validator(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                        sha1(os.path.join(key, subkey).encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str,
+                                     sha1(value.encode()).hexdigest())
+
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes') is not None, 'content_changes is empty'
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator])

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes.py
@@ -5,8 +5,6 @@
 import os
 import pytest
 from hashlib import sha1
-from time import sleep
-
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params
 from wazuh_testing.tools import WAZUH_PATH
@@ -81,10 +79,10 @@ def test_report_changes(key, subkey, arch, value_name, tags_to_apply,
     def report_changes_validator(event):
         """Validate content_changes attribute exists in the event"""
         for value in values:
-            folder_str = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+            folder_key = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
                                         sha1(os.path.join(key, subkey).encode()).hexdigest())
-            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_str,
-                                     sha1(value.encode()).hexdigest())
+            diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_key,
+                                     sha1(value.encode()).hexdigest(), 'last-entry.gz')
 
             assert os.path.exists(diff_file), '{diff_file} does not exist'
             assert event['data'].get('content_changes') is not None, 'content_changes is empty'

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes_deleted.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes_deleted.py
@@ -4,14 +4,12 @@
 import os
 
 import pytest
-from hashlib import sha1
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, check_time_travel, delete_registry, detect_initial_scan, \
                               registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, registry_parser, generate_params, \
                               create_registry, modify_registry_value, calculate_registry_diff_paths
 from wazuh_testing.tools.services import restart_wazuh_with_new_conf
 
-from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test, set_section_wazuh_conf
 from wazuh_testing.tools.monitoring import FileMonitor
 from win32con import REG_SZ
@@ -131,7 +129,6 @@ def test_report_when_deleted_key(key, subkey, arch, value_name, enabled, tags_to
     def report_changes_removed_diff_file_validator(unused_param):
         """
         Validator that checks if the files are removed when the values are removed.
-        event needs to be
         """
         assert not os.path.exists(diff_file), f'{diff_file} does exist'
 
@@ -139,7 +136,7 @@ def test_report_when_deleted_key(key, subkey, arch, value_name, enabled, tags_to
         vals_after_update = [report_changes_diff_file_validator]
         vals_after_delete = [report_changes_removed_diff_file_validator]
     else:
-        vals_after_delete = [report_changes_removed_diff_file_validator]
+        vals_after_update = [report_changes_removed_diff_file_validator]
         vals_after_delete = [report_changes_removed_diff_file_validator]
 
     registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list={value_name: "some content"},

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes_deleted.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes_deleted.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+
+import pytest
+from hashlib import sha1
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, delete_registry, registry_value_cud, KEY_WOW64_32KEY, KEY_WOW64_64KEY, \
+                              registry_parser, generate_params
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+
+conf_params = {'WINDOWS_REGISTRY_1': reg1,
+               'WINDOWS_REGISTRY_2': reg2}
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes.yaml')
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# Tests
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, enabled, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", True, {'test_report_changes'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", True, {'test_report_changes'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", True, {'test_report_changes'}),
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", False, {'test_duplicate_report'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", True, {'test_duplicate_report'})
+])
+def test_report_when_deleted_key(key, subkey, arch, value_name, enabled, tags_to_apply,
+                                 get_configuration, configure_environment, restart_syscheckd,
+                                 wait_for_fim_start):
+    """
+    Check that the diff files are generated when there is a modification in a value and these files are deleted when
+    the value is deleted.
+
+    It also checks that the diff folder of the key is deleted when the key is deleted.
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    enabled: boolean
+        True if report_changes is enabled
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    vals_after_update = None
+    vals_after_delete = None
+    key_path = os.path.join(key, subkey)
+    folder_path = "{} {}".format("[x32]" if arch == KEY_WOW64_32KEY else "[x64]",
+                                 sha1(key_path.encode()).hexdigest())
+    diff_file = os.path.join(WAZUH_PATH, 'queue', 'diff', 'registry', folder_path,
+                             sha1(value_name.encode()).hexdigest(), 'last-entry.gz')
+
+    def report_changes_diff_file_validator(unused_param):
+        """
+        Validator that checks if the files are created.
+        """
+        assert os.path.exists(diff_file), f'{diff_file} does not exist'
+
+    def report_changes_removed_diff_file_validator(unused_param):
+        """
+        Validator that checks if the files are removed when the values are removed.
+        event needs to be
+        """
+        assert not os.path.exists(diff_file), f'{diff_file} does exist'
+
+    if enabled:
+        vals_after_update = [report_changes_diff_file_validator]
+        vals_after_delete = [report_changes_removed_diff_file_validator]
+    else:
+        vals_after_delete = [report_changes_removed_diff_file_validator]
+        vals_after_delete = [report_changes_removed_diff_file_validator]
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list={value_name: "some content"},
+                       time_travel=True,
+                       min_timeout=global_parameters.default_timeout,
+                       validators_after_update=vals_after_update,
+                       validators_after_delete=vals_after_delete)
+
+    delete_registry(registry_parser[key], subkey, arch)
+
+    assert not os.path.exists(folder_path), f'{folder_path} exists'

--- a/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes_more_changes.py
+++ b/tests/integration/test_fim/test_registry/test_report_changes/test_report_changes_more_changes.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, calculate_registry_diff_paths, registry_value_cud, KEY_WOW64_32KEY, \
+                              KEY_WOW64_64KEY, generate_params
+
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import generate_string
+
+MAX_STR_MORE_CHANGES = 59391
+MORE_CHANGES_STR = "More changes..."
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\test_key"
+sub_key_2 = "SOFTWARE\\Classes\\test_key"
+
+test_regs = [os.path.join(key, sub_key_1),
+             os.path.join(key, sub_key_2)]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+reg1, reg2 = test_regs
+
+
+# Configurations
+
+conf_params = {'WINDOWS_REGISTRY_1': reg1,
+               'WINDOWS_REGISTRY_2': reg2}
+
+configurations_path = os.path.join(test_data_path, 'wazuh_registry_report_changes.yaml')
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('key, subkey, arch, value_name, tags_to_apply', [
+    (key, sub_key_1, KEY_WOW64_64KEY, "some_value", {'test_report_changes'}),
+    (key, sub_key_1, KEY_WOW64_32KEY, "some_value", {'test_report_changes'}),
+    (key, sub_key_2, KEY_WOW64_64KEY, "some_value", {'test_report_changes'})
+])
+def test_report_changes_more_changes(key, subkey, arch, value_name, tags_to_apply,
+                                     get_configuration, configure_environment, restart_syscheckd,
+                                     wait_for_fim_start):
+    """
+    Checks that "More changes..." diff string is MAX_STR_MORE_CHANGES
+
+    Parameters
+    ----------
+    key : str
+        Root key (HKEY_*)
+    subkey : str
+        path of the registry.
+    arch : str
+        Architecture of the registry.
+    value_name : str
+        Name of the value that will be created
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    values = {value_name:  generate_string(MAX_STR_MORE_CHANGES, '0')}
+    error_str = 'Expected {} in event'.format(MORE_CHANGES_STR)
+
+    def report_changes_validator(event):
+        """Validate content_changes attribute exists in the event"""
+        for value in values:
+            _, diff_file = calculate_registry_diff_paths(key, subkey, arch, value)
+            assert os.path.exists(diff_file), '{diff_file} does not exist'
+            assert event['data'].get('content_changes')[-len(MORE_CHANGES_STR):] == MORE_CHANGES_STR, error_str
+
+    registry_value_cud(key, subkey, wazuh_log_monitor, arch=arch, value_list=values,
+                       time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                       min_timeout=global_parameters.default_timeout, triggers_event=True,
+                       validators_after_update=[report_changes_validator])


### PR DESCRIPTION
Hello team,

This PR is to add all report_changes integration tests after Fim improvements registries

Closes https://github.com/wazuh/wazuh-qa/issues/901

# Tests checks

- [ ] Proven that tests **pass** when they have to pass
- [ ] Proven that tests **fail** when they have to fail

Best regards.
