### PR TITLE
Change command task_result with upgrade_result in wpk test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -63,7 +63,7 @@ class Agent:
         self.fim = None
         self.fim_integrity = None
         self.modules = {
-            "keepalive": {"status": "enabled", "frequency": 60.0},
+            "keepalive": {"status": "enabled", "frequency": 10.0},
             "fim": {"status": "enabled", "eps": self.fim_eps},
             "fim_integrity": {"status": "disabled", "eps": self.fim_integrity_eps},
             "syscollector": {"status": "disabled", "frequency": 60.0, "eps": 200},

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -53,7 +53,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [True],
             'expected_response': 'Success'
         }
@@ -75,7 +75,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [2],
-            'status': ['Failed'],
+            'status': ['Error'],
             'error_msg': ['Upgrade procedure exited with error code'],
             'upgrade_notification': [True],
             'expected_response': 'Success'
@@ -98,7 +98,7 @@ cases = [
             'sha_list': ['INVALID'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'error_msg': ['Send verify sha1 error'],
             'upgrade_notification': [False],
             'expected_response': 'Success'
@@ -121,7 +121,7 @@ cases = [
             'sha_list': ['VALIDSHA1', 'INVALIDSHA', 'VALIDSHA1'],
             'upgrade_exec_result': ['0', '0', '0'],
             'upgrade_script_result': [0, 0, 2],
-            'status': ['Done', 'Failed', 'Failed'],
+            'status': ['Updated', 'Error', 'Error'],
             'error_msg': ['', 'Send verify sha1 error','Upgrade procedure exited with error code'],
             'upgrade_notification': [True, False, True],
             'expected_response': 'Success'
@@ -144,7 +144,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [True],
             'message_params': {'version': 'v3.5.0', 'force_upgrade': False},
             'expected_response': 'Current agent version is greater or equal'
@@ -168,7 +168,7 @@ cases = [
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
             'upgrade_notification': [False],
-            'status': ['Failed'],
+            'status': ['Error'],
             'message_params': {'version': 'v4.55.55', 'force_upgrade': True},
             'error_msg': ['The version of the WPK does not exist in the repository'],
             'expected_response': 'Success'
@@ -191,7 +191,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'message_params': {'version': 'v4.1.0', 'force_upgrade': False},
             'error_msg': ['The repository is not reachable'],
@@ -215,7 +215,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [False],
             'expected_response': 'The WPK for this platform is not available'
         }
@@ -237,7 +237,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [False],
             'expected_response': 'Current agent version is greater or equal'
         }
@@ -260,7 +260,7 @@ cases = [
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
             'upgrade_notification': [False],
-            'status': ['Failed'],
+            'status': ['Error'],
             'message_params': {'version': 'v4.55.55', 'force_upgrade': False},
             'expected_response': 'Upgrading an agent to a version higher than the manager requires the force flag'
         }
@@ -282,7 +282,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [True],
             'message_params': {'force_upgrade': True},
             'expected_response': 'Success'
@@ -305,7 +305,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [False],
             'message_params': {'force_upgrade': False},
             'expected_response': 'Current agent version is greater or equal'
@@ -328,7 +328,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Legacy'],
+            'status': ['Legacy upgrade: check the result manually since the agent cannot report the result of the task'],
             'upgrade_notification': [False],
             'message_params': {'version': 'v3.13.1'},
             'expected_response': 'Success'
@@ -351,10 +351,10 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [False],
             'expected_response': 'Upgrade procedure could not start. Agent already upgrading',
-            'first_attempt': 'In progress'
+            'first_attempt': 'Updating'
         }
     },
     # 14. Upgrade an agent that previous task's result is timeout - Success
@@ -374,10 +374,10 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['In progress'],
+            'status': ['Updating'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
-            'first_attempt': 'Timeout'
+            'first_attempt': 'Timeout reached while waiting for the response from the agent'
         }
     },
     # 15. Disconnect Agent open error - Fail
@@ -397,7 +397,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
             'error_msg': ['Send open file error'],
@@ -420,7 +420,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
             'error_msg': ['Send write file error'],
@@ -443,7 +443,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
             'error_msg': ['Send close file error'],
@@ -466,7 +466,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
             'error_msg': ['Send lock restart error'],
@@ -489,7 +489,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
             'error_msg': ['Send verify sha1 error'],
@@ -512,7 +512,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'expected_response': 'Success',
             'error_msg': ['Send upgrade command error'],
@@ -535,7 +535,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [True],
             'checks': ['chunk_size'],
             'chunk_size': 31111,
@@ -559,7 +559,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['In progress'],
+            'status': ['Updating'],
             'upgrade_notification': [False],
             'message_params': {'file_path': 'wpk_test.wpk'},
             'checks': ['wpk_name'],
@@ -584,7 +584,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Failed'],
+            'status': ['Error'],
             'upgrade_notification': [False],
             'message_params': {'file_path': 'invalid/path/to.wpk'},
             'error_msg': ['The WPK file does not exist'],
@@ -609,7 +609,7 @@ cases = [
             'sha_list': ['NOT_NEED'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['In progress'],
+            'status': ['Updating'],
             'upgrade_notification': [False],
             'message_params': {'file_path': 'wpk_test.wpk', 'installer': 'custom_installer.sh'},
             'error_msg': ['Not need'],
@@ -635,7 +635,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [True],
             'message_params': {'use_http': True},
             'checks': ['use_http', 'version'],
@@ -659,7 +659,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'upgrade_notification': [True],
             'checks': ['use_http', 'version'],
             'expected_response': 'Success'
@@ -682,7 +682,7 @@ cases = [
             'sha_list': ['VALIDSHA1'],
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
-            'status': ['Done'],
+            'status': ['Updated'],
             'message_params': {'use_http': True},
             'upgrade_notification': [True],
             'checks': ['use_http', 'version'],
@@ -1003,7 +1003,7 @@ def test_wpk_manager(set_debug_mode, get_configuration, configure_environment,
             time.sleep(30)
             response = send_message(data, TASK_SOCKET)
             retries = 0
-            while response['data'][0]['status'] == 'In progress' and retries < 30 and \
+            while response['data'][0]['status'] == 'Updating' and retries < 30 and \
                     response['data'][0]['status'] != expected_status[index]:
                 time.sleep(30)
                 response = send_message(data, TASK_SOCKET)
@@ -1011,7 +1011,7 @@ def test_wpk_manager(set_debug_mode, get_configuration, configure_environment,
             assert expected_status[index] == response['data'][0]['status'], \
                 f'Upgrade status did not match expected! ' \
                 f'Expected {expected_status[index]} obtained {response["data"][0]["status"]} at index {index}'
-            if expected_status[index] == 'Failed':
+            if expected_status[index] == 'Error':
                 assert expected_error_msg[index] == response['data'][0]['error_msg'], \
                     f'Error msg did not match expected! ' \
                     f'Expected {expected_error_msg[index]} obtained {response["data"][0]["error_msg"]} at index {index}'

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -956,15 +956,15 @@ def test_wpk_manager(set_debug_mode, get_configuration, configure_environment,
 
         repeat_message = data
         # Continue with the validations of first attempt
-        task_ids = [item.get('task_id') for item in response['data']]
-        for index, task_id in enumerate(task_ids):
+        task_ids = [item.get('agent') for item in response['data']]
+        for index, agent_id in enumerate(task_ids):
             data = {
                 "origin": {
                     "module": "api"
                 },
-                "command": 'task_result',
+                "command": 'upgrade_result',
                 "parameters": {
-                    "tasks": [task_id]
+                    "agents": [agent_id]
                 }
             }
             time.sleep(30)
@@ -989,15 +989,15 @@ def test_wpk_manager(set_debug_mode, get_configuration, configure_environment,
             f'Expected {metadata.get("expected_response")} obtained {response["data"][0]["message"]}'
 
         # Continue with the test validations
-        task_ids = [item.get('task_id') for item in response['data']]
-        for index, task_id in enumerate(task_ids):
+        task_ids = [item.get('agent') for item in response['data']]
+        for index, agent_id in enumerate(task_ids):
             data = {
                 "origin": {
                     "module": "api"
                 },
-                "command": 'task_result',
+                "command": 'upgrade_result',
                 "parameters": {
-                    "tasks": [task_id]
+                    "agents": [agent_id]
                 }
             }
             time.sleep(30)

--- a/tests/integration/test_wpk/test_wpk_manager_task_states.py
+++ b/tests/integration/test_wpk/test_wpk_manager_task_states.py
@@ -282,7 +282,8 @@ def test_wpk_manager_task_states(get_configuration, configure_environment,
 
     if upgrade_after_change_name:
         injectors = []
-
+        sender = Sender(manager_address=SERVER_ADDRESS,
+                                protocol=protocol)
         for index, agent in enumerate(agents):
             injector = Injector(sender, agent)
             injectors.append(injector)


### PR DESCRIPTION
Hello team,

This PR change command task_result with upgrade_result in wpk test because task_result was removed.

Jenkins: https://ci.wazuh.info/job/test_integration/641/console

## RPM manager

```
15:55:12  [0;33m============================= test session starts ==============================[0m
15:55:12  [0;33mplatform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /bin/python3[0m
15:55:12  [0;33mcachedir: .pytest_cache[0m
15:55:12  [0;33mmetadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-centos-7.4.1708-Core', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
15:55:12  [0;33mrootdir: /tmp/test_integration_B641_20201126184716/tests/integration, inifile: pytest.ini[0m
15:55:12  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
15:55:12  [0;33mcollecting ... collected 37 items[0m
15:55:12  [0;33m[0m
15:55:12  [0;33mtest_wpk/test_wpk_agent.py::test_wpk_agent[get_configuration0] SKIPPED   [  2%][0m
15:55:12  [0;33mtest_wpk/test_wpk_agent.py::test_wpk_agent[get_configuration1] SKIPPED   [  5%][0m
15:55:12  [0;33mtest_wpk/test_wpk_agent.py::test_wpk_agent[get_configuration2] SKIPPED   [  8%][0m
15:55:12  [0;33mtest_wpk/test_wpk_agent.py::test_wpk_agent[get_configuration3] SKIPPED   [ 10%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration0] PASSED [ 13%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration1] PASSED [ 16%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration2] PASSED [ 18%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration3] PASSED [ 21%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration4] PASSED [ 24%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration5] PASSED [ 27%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration6] PASSED [ 29%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration7] PASSED [ 32%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration8] PASSED [ 35%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration9] PASSED [ 37%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration10] PASSED [ 40%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration11] PASSED [ 43%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration12] PASSED [ 45%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration13] PASSED [ 48%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration14] PASSED [ 51%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration15] PASSED [ 54%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration16] PASSED [ 56%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration17] PASSED [ 59%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration18] PASSED [ 62%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration19] PASSED [ 64%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration20] PASSED [ 67%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration21] PASSED [ 70%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration22] PASSED [ 72%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration23] PASSED [ 75%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration24] PASSED [ 78%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration25] PASSED [ 81%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration26] PASSED [ 83%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager.py::test_wpk_manager[get_configuration27] PASSED [ 86%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager_task_states.py::test_wpk_manager_task_states[get_configuration0] PASSED [ 89%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager_task_states.py::test_wpk_manager_task_states[get_configuration1] PASSED [ 91%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager_task_states.py::test_wpk_manager_task_states[get_configuration2] PASSED [ 94%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager_task_states.py::test_wpk_manager_task_states[get_configuration3] PASSED [ 97%][0m
15:55:12  [0;33mtest_wpk/test_wpk_manager_task_states.py::test_wpk_manager_task_states[get_configuration4] PASSED [100%][0m
15:55:12  [0;33m[0m
15:55:12  [0;33m- generated html file: file:///tmp/test_integration_B641_20201126184716/report.html -[0m
15:55:12  [0;33m================== 33 passed, 4 skipped in 3889.12s (1:04:49) ==================[0m
```
