### PR TITLE
Vulnerability Detector: Fixed ignore_time test

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
@@ -16,16 +16,6 @@
         value: IGNORE_TIME
     - provider:
         attributes:
-        - name: 'canonical'
-        elements:
-        - enabled:
-            value: 'yes'
-        - os:
-            value: 'focal'
-        - update_interval:
-            value: '100d'
-    - provider:
-        attributes:
         - name: nvd
         elements:
         - enabled:

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -55,9 +55,9 @@ def generate_default_alert():
     Generate an alert with the default values
     """
     control_service('stop', daemon='wazuh-db')
-    sleep(5)
+    sleep(4)
     clean_vd_tables()
-    insert_package()
+    insert_package(vendor="Red Hat, Inc.")
     insert_vulnerability()
     update_last_scan()
     modify_system()

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -18,7 +18,6 @@ from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_V
                                                  insert_vulnerability, insert_package, make_vuln_callback, \
                                                  REAL_NVD_FEED
 
-
 # Marks
 pytestmark = pytest.mark.tier(level=0)
 
@@ -35,12 +34,13 @@ callback_string_vulnerability = f"'{DEFAULT_PACKAGE_NAME}'.+is vulnerable to '{D
 parameters = [{'IGNORE_TIME': '3600s', 'INTERVAL': '5s', 'NVD_FEED_PATH': nvd_feed_path},
               {'IGNORE_TIME': '60m', 'INTERVAL': '5s', 'NVD_FEED_PATH': nvd_feed_path},
               {'IGNORE_TIME': '1h', 'INTERVAL': '5s', 'NVD_FEED_PATH': nvd_feed_path}]
-metadata= [{'ignore_time': '3600s', 'timeout': 30, 'jumps': 2, 'interval': '5s'},
-           {'ignore_time': '60m', 'timeout': 30, 'jumps': 2, 'interval': '5s'},
-           {'ignore_time': '1h', 'timeout': 30, 'jumps': 2, 'interval': '5s'}]
+metadata = [{'ignore_time': '3600s', 'timeout': 30, 'jumps': 2, 'interval': '5s'},
+            {'ignore_time': '60m', 'timeout': 30, 'jumps': 2, 'interval': '5s'},
+            {'ignore_time': '1h', 'timeout': 30, 'jumps': 2, 'interval': '5s'}]
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
 
 # fixtures
 @pytest.fixture(scope='module', params=configurations)
@@ -49,7 +49,7 @@ def get_configuration(request):
     return request.param
 
 
-#functions
+# functions
 def generate_default_alert():
     """
     Generate an alert with the default values
@@ -65,15 +65,14 @@ def generate_default_alert():
 
 
 def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
-                     tags_to_apply = 'test_ignore_time',
-                     custom_callback_vulnerability = make_vuln_callback(callback_string_vulnerability)):
+                     custom_callback_vulnerability=make_vuln_callback(callback_string_vulnerability)):
     """
     Check if an alert is not fired during the ingnore time  interval
     """
     generate_default_alert()
     ignore_time = get_configuration['metadata']['ignore_time']
     jumps = get_configuration['metadata']['jumps']
-    seconds_to_travel = time_to_seconds(ignore_time)/jumps
+    seconds_to_travel = time_to_seconds(ignore_time) / jumps
 
     # Check for initial alert
     wazuh_log_monitor.start(timeout=get_configuration['metadata']['timeout'],


### PR DESCRIPTION
Hello team,

I modified the `test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py` test, adding an official vendor to the packages. Also, I have fixed the test format.

Closes #953 

# Tests logic

- [x] test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)

## DEB manager
### test_general_settings_ignore_time

```
======================================= test session starts ========================================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-53-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.0.2', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'testinfra': '5.0.0', 'metadata': '1.10.0'}}
rootdir: /home/daniel/Wazuh/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.10.0
collected 3 items                                                                                   

test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0] PASSED [ 33%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration1] PASSED [ 66%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration2] PASSED [100%]

```

### tier 0

```
test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration0-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration0-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled] SKIPPED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration1-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled] SKIPPED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py::test_enabled[get_configuration1-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration0] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration1] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py::test_ignore_time[get_configuration2] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1s] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1m] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1h] PASSED [ 90%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[1d] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2s] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2m] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2h] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[2d] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5s] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5m] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5h] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_interval.py::test_interval[5d] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_yes] PASSED [ 91%]
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_no] PASSED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-canonical] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-debian] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-redhat] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-nvd] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[yes-msu] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-canonical] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-debian] SKIPPED [ 91%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-redhat] SKIPPED [ 92%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-nvd] SKIPPED [ 92%]
test_vulnerability_detector/test_providers/test_providers_enabled.py::test_enabled[no-msu] SKIPPED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_default] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_path] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_multipath] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_path_multipath] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_url] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_multiurl] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_redhat_url_multiurl] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_default] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_path] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_multipath] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_path_multipath] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_url] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_multiurl] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py::test_multiple_providers[test_debian_url_multiurl] PASSED [ 92%]
test_vulnerability_detector/test_providers/test_providers_no_os.py::test_providers_no_os[canonical] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_no_os.py::test_providers_no_os[debian] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_no_os.py::test_providers_no_os[redhat] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_no_os.py::test_providers_no_os[nvd] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_no_os.py::test_providers_no_os[msu] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[canonical-trusty] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[canonical-xenial] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[canonical-bionic] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[debian-stretch] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[debian-buster] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[redhat-5] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[redhat-6] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[redhat-7] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[redhat-8] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[nvd-] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_os.py::test_providers[msu-] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_1998] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2001] SKIPPED [ 93%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2002] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2005] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2010] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2015] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[redhat_2020] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_1998] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2001] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2002] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2005] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2010] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2015] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_from_year.py::test_update_from_year[nvd_2020] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Redhat_60s] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Canonical_60s] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Debian_60s] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[NVD_60s] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[MSU_60s] SKIPPED [ 94%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Redhat_60m] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Canonical_60m] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Debian_60m] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[NVD_60m] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[MSU_60m] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Redhat_1h] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Canonical_1h] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Debian_1h] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[NVD_1h] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[MSU_1h] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Redhat_1d] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Canonical_1d] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[Debian_1d] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[NVD_1d] SKIPPED [ 95%]
test_vulnerability_detector/test_providers/test_providers_update_interval.py::test_update_interval[MSU_1d] SKIPPED [ 95%]
test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py::test_debian_vulnerabilities_report[debian_scan_configuration-BUSTER] PASSED [ 95%]
test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py::test_debian_vulnerabilities_report[debian_scan_configuration-STRETCH] PASSED [ 95%]
test_vulnerability_detector/test_scan_results/test_macos_inventory.py::test_macos_vulnerabilities_report[macos_scan_configuration-MAC0] PASSED [ 95%]
test_vulnerability_detector/test_scan_results/test_macos_inventory.py::test_macos_vulnerabilities_report[macos_scan_configuration-MAC1] PASSED [ 96%]
test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py::test_vulnerabilities_report[msu_scan_configuration-WINDOWS10] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py::test_vulnerabilities_report[msu_scan_configuration-WINDOWS_SERVER_2016] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py::test_vulnerabilities_report[msu_scan_configuration-WINDOWS_SERVER_2019] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan0] PASSED [ 96%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan1] PASSED [ 96%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan2] PASSED [ 96%]
test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py::test_redhat_vulnerabilities_report[redhat_scan_configuration-mock_vulnerability_scan3] PASSED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL8] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL7] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL6] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-RHEL5] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-BIONIC] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-XENIAL] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-TRUSTY] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-BUSTER] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_different_cves.py::test_vulnerabilities_report[test_different_cves-STRETCH] SKIPPED [ 96%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-WINDOWS10] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC0] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC1] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-MAC2] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL8] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL7] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL6] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-RHEL5] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BIONIC] PASSED [ 97%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-XENIAL] PASSED [ 98%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-TRUSTY] PASSED [ 98%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-BUSTER] PASSED [ 98%]
test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py::test_vulnerabilities_report[scan_nvd_configuration-STRETCH] PASSED [ 98%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py::test_ubuntu_vulnerabilities_report[ubuntu_scan_configuration-mock_vulnerability_scan0] PASSED [ 98%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py::test_ubuntu_vulnerabilities_report[ubuntu_scan_configuration-mock_vulnerability_scan1] PASSED [ 98%]
test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py::test_ubuntu_vulnerabilities_report[ubuntu_scan_configuration-mock_vulnerability_scan2] PASSED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2013] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2013_R2] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_XP] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_VISTA] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_7] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_8] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_8.1] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_10] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2008] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2008_R2] SKIPPED [ 98%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2012] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2012_R2] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2016] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2019] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2013_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2013_R2_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_XP_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_VISTA_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_7_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_8_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_8.1_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_10_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2008_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2008_R2_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2012_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2012_R2_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2016_I386] SKIPPED [ 99%]
test_vulnerability_detector/test_windows/test_cpe_indexing.py::test_window_version_indexing[cpe_index_configuration-WINDOWS_SERVER_2019_I386] SKIPPED [100%]

=========================== 66 passed, 1683 skipped in 661.12s (0:11:01) ============================

```

Best regards.
