### PR TITLE
Added test_timezone_changes to test_fim

### DIFF
--- a/tests/integration/test_fim/test_timezone_changes/data/wazuh_timezone_conf.yaml
+++ b/tests/integration/test_fim/test_timezone_changes/data/wazuh_timezone_conf.yaml
@@ -1,0 +1,16 @@
+---
+# conf 1
+- tags:
+  - timezone_conf
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_timezone_changes/test_timezone_changes.py
+++ b/tests/integration/test_fim/test_timezone_changes/test_timezone_changes.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from wazuh_testing.fim import (LOG_FILE_PATH, REGULAR, callback_detect_event, callback_detect_end_scan, create_file,
+                               generate_params, delete_file, global_parameters, check_time_travel)
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=2)
+
+# variables
+
+testdir1 = os.path.join(PREFIX, 'testdir1')
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_timezone_conf.yaml')
+
+# configurations
+
+conf_params = {'TEST_DIRECTORIES': testdir1, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+def callback_detect_event_before_end_scan(line):
+    ended_scan = callback_detect_end_scan(line)
+    if ended_scan is None:
+        event = callback_detect_event(line)
+        assert event is None, 'Event detected before end scan'
+        return None
+    else:
+        return True
+
+
+def extra_configuration_before_yield():
+    os.system('tzutil /s "Romance Standard Time"')
+    create_file(REGULAR, testdir1, 'regular', content='')
+
+
+def extra_configuration_after_yield():
+    delete_file(testdir1, 'regular')
+    os.system('tzutil /s "Romance Standard Time"')
+
+
+def test_timezone_changes(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Check if events are appearing after the baseline
+    The message 'File integrity monitoring scan ended' informs about the end of the first scan,
+    which generates the baseline
+
+    It creates a file, checks if the baseline has generated before the file addition event, and then
+    if this event has generated.
+    """
+    check_apply_test({'timezone_conf'}, get_configuration['tags'])
+
+    # Change time zone
+    os.system('tzutil /s "Egypt Standard Time"')
+
+    check_time_travel(True, monitor=wazuh_log_monitor)
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event_before_end_scan,
+                            error_message='Did not receive expected event before end the scan')


### PR DESCRIPTION
Hello team,


Closes https://github.com/wazuh/wazuh/issues/4167

This PR adds to the integration test, test_fim, a test to check that a timezone change does not generate a modified events in files.

Test failing before fix:
![image](https://user-images.githubusercontent.com/60003131/100857116-94b6b600-348c-11eb-8433-851596afa5d6.png)


Test passing after fix:
![image](https://user-images.githubusercontent.com/60003131/100852827-4d79f680-3487-11eb-823b-8f719b2707b7.png)
