### PR TITLE
Replaced wazuh tools

### DIFF
--- a/.github/ISSUE_TEMPLATE/test--gcp.md
+++ b/.github/ISSUE_TEMPLATE/test--gcp.md
@@ -66,7 +66,7 @@ Fields project_id, subscription_name and credentials_file are required to run th
 
 **Expected outputs**
 ```
-# /var/ossec/bin/ossec-control restart
+# /var/ossec/bin/wazuh-control restart
 ```
 > 2019/11/26 10:21:05 wazuh-modulesd: ERROR: No value defined for tag 'project_id' in module 'gcp-pubsub'
 > 2019/11/26 10:21:05 wazuh-modulesd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.

--- a/.github/ISSUE_TEMPLATE/test--mitre.md
+++ b/.github/ISSUE_TEMPLATE/test--mitre.md
@@ -229,7 +229,7 @@ Add the following lines in /var/ossec/etc/rules/local_rules.xml
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -295,7 +295,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -364,7 +364,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -431,7 +431,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -497,7 +497,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -565,7 +565,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -632,7 +632,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -702,7 +702,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 </group>
  ```
  ```
- ossec-control restart
+ wazuh-control restart
  CTRL + D
  sudo su
  CRTL + D
@@ -771,7 +771,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 sqlite3 /var/ossec/var/db/mitre.db
 sqlite> DROP TABLE has_phase;
 CTRL + D
-ossec-control restart
+wazuh-control restart
  ```
 **Compatible versions**
 
@@ -846,7 +846,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 sqlite3 /var/ossec/var/db/mitre.db
 sqlite> DROP TABLE attack;
 CTRL + D
-ossec-control restart
+wazuh-control restart
  ```
 **Compatible versions**
 
@@ -1070,7 +1070,7 @@ Delete rule '100002' and add the following lines in /var/ossec/etc/rules/local_r
 
 ```
 rm /var/ossec/var/db/mitre*
-ossec-control restart
+wazuh-control restart
  ```
 **Compatible versions**
 

--- a/.github/ISSUE_TEMPLATE/test--ruleset.md
+++ b/.github/ISSUE_TEMPLATE/test--ruleset.md
@@ -34,7 +34,7 @@ assignees: ''
 - [ ] Make the manager fails when starting by setting a duplicated rule ID, as well as other invalid fields.
 - [ ] Decode static and dynamic fields and use them into a rule.
 - [ ] Trigger a rule depending on a CDB list.
-- [ ] Trigger an alert by using `ossec-logtest`.
+- [ ] Trigger an alert by using `wazuh-logtest`.
 
 https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/rules.html
 

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -82,7 +82,7 @@ def set_wazuh_conf(wazuh_conf: List[str]):
     """
     write_wazuh_conf(wazuh_conf)
     print("Restarting Wazuh...")
-    command = os.path.join(WAZUH_PATH, 'bin/ossec-control')
+    command = os.path.join(WAZUH_PATH, 'bin/wazuh-control')
     arguments = ['restart']
     check_call([command] + arguments, stdout=DEVNULL, stderr=DEVNULL)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -112,7 +112,7 @@ def control_service(action, daemon=None, debug_mode=False):
     else:  # Default Unix
         if daemon is None:
             if sys.platform == 'darwin' or sys.platform == 'sunos5':
-                result = subprocess.run([f'{WAZUH_PATH}/bin/ossec-control', action]).returncode
+                result = subprocess.run([f'{WAZUH_PATH}/bin/wazuh-control', action]).returncode
             else:
                 result = subprocess.run(['service', WAZUH_SERVICE, action]).returncode
             action == 'stop' and delete_sockets()

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -55,7 +55,7 @@ sed -i "s:<time-reconnect>60</time-reconnect>:<time-reconnect>99999999999</time-
 echo 'monitord.rotate_log=0' >> $wazuh_path/etc/local_internal_options.conf
 
 # Restart Wazuh
-/var/ossec/bin/ossec-control restart
+/var/ossec/bin/wazuh-control restart
 ```
 
 ### Windows
@@ -128,7 +128,7 @@ gsed -i "s:<time-reconnect>60</time-reconnect>:<time-reconnect>99999999999</time
 echo 'monitord.rotate_log=0' >> /Library/Ossec/etc/local_internal_options.conf
 
 # Restart Wazuh
-/Library/Ossec/bin/ossec-control restart
+/Library/Ossec/bin/wazuh-control restart
 ```
 
 -----------

--- a/tests/integration/test_gcloud/README.md
+++ b/tests/integration/test_gcloud/README.md
@@ -110,7 +110,7 @@ sed -i "s:<time-reconnect>60</time-reconnect>:<time-reconnect>99999999999</time-
 echo 'monitord.rotate_log=0' >> $wazuh_path/etc/local_internal_options.conf
 
 # Restart Wazuh
-/var/ossec/bin/ossec-control restart
+/var/ossec/bin/wazuh-control restart
 ```
 
 ### MacOS
@@ -146,7 +146,7 @@ gsed -i "s:<time-reconnect>60</time-reconnect>:<time-reconnect>99999999999</time
 echo 'monitord.rotate_log=0' >> /Library/Ossec/etc/local_internal_options.conf
 
 # Restart Wazuh
-/Library/Ossec/bin/ossec-control restart
+/Library/Ossec/bin/wazuh-control restart
 ```
 
 Finally, copy your `wazuh-qa` repository within your testing environment and you are set.


### PR DESCRIPTION
Hello team,

I have modified the references to the wazuh tools, so that the ossec prefix is ​​replaced by the new wazuh prefix. The tool that has received the most changes has been `wazuh-control`. 

The changes that can affect the tests are found in:
- `deps/wazuh_testing/wazuh_testing/tools/configuration.py`
- `deps/wazuh_testing/wazuh_testing/tools/services.py`

Closes #957 

# Tests logic

I have tried all the tests found in **_/test_vulnerability_detector_** , because it uses the _control_service_ function found in **_services.py_** and where "wazuh-control" has been modified.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)

## DEB manager

- Tier 0:

```
66 passed, 1683 skipped in 702.95s (0:11:42)
```

- Tier 1:

```
253 passed, 1472 skipped, 24 xfailed in 4261.86s (1:11:01)
```

- Tier 2:

```
1382 passed, 345 skipped, 22 xfailed in 13347.79s (3:42:27)
```



Best regards.
