### PR TITLE
Rename all ossec-control references

### DIFF
--- a/tests/system/provisioning/agentless_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/tasks/main.yml
@@ -63,4 +63,4 @@
     backrefs: yes
 
 - name: Restart Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/tasks/main.yml
@@ -71,4 +71,4 @@
     backrefs: yes
 
 - name: Restart Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/basic_cluster/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/agent-role/tasks/main.yml
@@ -70,4 +70,4 @@
     backrefs: yes
 
 - name: Restart Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
@@ -64,7 +64,7 @@
     backrefs: yes
 
 - name: Stop Wazuh
-  command: /var/ossec/bin/ossec-control stop
+  command: /var/ossec/bin/wazuh-control stop
 
 - name: Remove client.keys
   file:
@@ -92,4 +92,4 @@
     create: yes
 
 - name: Start Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
@@ -80,4 +80,4 @@
       wazuh_db.debug=2
 
 - name: Restart Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
@@ -63,7 +63,7 @@
     backrefs: yes
 
 - name: Stop Wazuh
-  command: /var/ossec/bin/ossec-control stop
+  command: /var/ossec/bin/wazuh-control stop
 
 - name: Remove client.keys
   file:
@@ -78,4 +78,4 @@
       wazuh_clusterd.debug=2
 
 - name: Start Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/tasks/main.yml
@@ -78,4 +78,4 @@
       wazuh_clusterd.debug=2
 
 - name: Restart Wazuh
-  command: /var/ossec/bin/ossec-control restart
+  command: /var/ossec/bin/wazuh-control restart


### PR DESCRIPTION
Hello team,

This PR simply renames all `ossec-control` references to `wazuh-control` in the `system` tests. As a side note, the other tools listed in the issue are currently not being used.

Closes #958

# Tests checks

- [ ] Proven that tests **pass** when they have to pass
- [ ] Proven that tests **fail** when they have to fail
- [ ] Proven that tests have the expected behavior in **RPM and DEB**
- [ ] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)
- [ ] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`

Best regards.
