### PR TITLE
Fix Wazuh_DB test cases to work with every keepalive value

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -67,7 +67,7 @@ def generate_default_alert():
 def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
                      custom_callback_vulnerability=make_vuln_callback(callback_string_vulnerability)):
     """
-    Check if an alert is not fired during the ingnore time  interval
+    Check if an alert is not fired during the ignore time  interval
     """
     generate_default_alert()
     ignore_time = get_configuration['metadata']['ignore_time']

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import time
 
 import pytest
 import yaml
@@ -130,10 +131,10 @@ def test_wazuh_db_chunks(configure_sockets_environment, connect_to_sockets_modul
                .format(command, 'due', status)
 
     # Check get-all-agents chunk limit
-    send_chunk_command(f'global get-all-agents last_id 0')
+    send_chunk_command('global get-all-agents last_id 0')
     # Check sync-agent-info-get chunk limit
-    send_chunk_command(f'global sync-agent-info-get last_id 0')
+    send_chunk_command('global sync-agent-info-get last_id 0')
     # Check get-agents-by-connection-status chunk limit
-    send_chunk_command(f'global get-agents-by-connection-status 0 active')
+    send_chunk_command('global get-agents-by-connection-status 0 active')
     # Check disconnect-agents chunk limit
-    send_chunk_command(f'global disconnect-agents 0 100 syncreq')
+    send_chunk_command('global disconnect-agents 0 {} syncreq'.format(str(int(time.time())+1)))


### PR DESCRIPTION
Hello team,

This PR fixes test_wazuh_db after changing how the keepalive is updated in the database. Previously, the first update writes it as 0, now writes it as the current time.
The test now creates a command using the current time +1 to match this new database logic.

Closes #966

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**

Best regards.
