### PR TITLE
Added cases to test_scan_day_and_time to check noon and midnight

### DIFF
--- a/tests/integration/test_fim/test_files/test_scan/test_scan_day_and_time.py
+++ b/tests/integration/test_fim/test_files/test_scan/test_scan_day_and_time.py
@@ -27,8 +27,8 @@ test_directories = [os.path.join(PREFIX, 'testdir1')]
 
 directory_str = ','.join(test_directories)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-scan_days = ['thursday', 'wednesday']
-scan_times = ['9PM', '20:00']
+scan_days = ['thursday', 'wednesday', 'saturday', 'monday']
+scan_times = ['9PM', '20:00', '12am', '12pm']
 
 # configurations
 


### PR DESCRIPTION
Hello team,
This PR adds two new cases to integration test `test_scan_day_and_time` to check 12 noon and 12 midnight hours, due to a bug where the `__gethour` function misinterpreted these values.
So the test checks that this bug does not occur.

These new cases fail when executed:
![image](https://user-images.githubusercontent.com/60003131/102494100-7350ef00-4074-11eb-871b-5c01a56e98c7.png)


And after the fix:
![image](https://user-images.githubusercontent.com/60003131/102493973-41d82380-4074-11eb-8b22-c60087324ce5.png)


