### PR TITLE
Update integration test with renamed daemons.

### DIFF
--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -37,11 +37,11 @@ def get_configuration(request):
 # Functions
 
 def extra_configuration_before_yield():
-    control_service('stop', daemon='ossec-authd')
+    control_service('stop', daemon='wazuh-authd')
 
 
 def extra_configuration_after_yield():
-    control_service('start', daemon='ossec-authd')
+    control_service('start', daemon='wazuh-authd')
 
 
 # Tests
@@ -52,9 +52,9 @@ def extra_configuration_after_yield():
 ])
 def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
                    restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of ossec-authd when adding an agent.
+    """Check if use_only_authd forces the use of wazuh-authd when adding an agent.
 
-    Verify that when 'use_only_authd' option is enabled, if the ossec-authd service
+    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
     is not active, an error is returned.
 
     Parameters
@@ -72,11 +72,11 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
             'ip': IPv4Address(getrandbits(32)).compressed}
 
     if use_only_authd:
-        control_service('stop', daemon='ossec-authd')
+        control_service('stop', daemon='wazuh-authd')
     # Add agent POST request
     post_response = requests.post(api_details['base_url'], json=data, headers=api_details['auth_headers'], verify=False)
 
-    # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
+    # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
         assert post_response.status_code == 500, 'Expected status code was 500, ' \
                                                  f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
@@ -97,9 +97,9 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
 ])
 def test_insert_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of ossec-authd when inserting an agent.
+    """Check if use_only_authd forces the use of wazuh-authd when inserting an agent.
 
-    Verify that when 'use_only_authd' option is enabled, if the ossec-authd service
+    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
     is not active, an error is returned.
 
     Parameters
@@ -122,7 +122,7 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
     post_response = requests.post(api_details['base_url'] + '/insert', json=data, headers=api_details['auth_headers'],
                                   verify=False)
 
-    # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
+    # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
         assert post_response.status_code == 500, 'Expected status code was 500, ' \
                                                  f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
@@ -142,9 +142,9 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
 ])
 def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_environment,
                             restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of ossec-authd when quick inserting an agent.
+    """Check if use_only_authd forces the use of wazuh-authd when quick inserting an agent.
 
-    Verify that when 'use_only_authd' option is enabled, if the ossec-authd service
+    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
     is not active, an error is returned.
 
     Parameters
@@ -163,7 +163,7 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
     post_url = api_details['base_url'] + f'/insert/quick?agent_name={token_hex(16)}'
     post_response = requests.post(post_url, headers=api_details['auth_headers'], verify=False)
 
-    # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
+    # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
         assert post_response.status_code == 500, 'Expected status code was 500, ' \
                                                  f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
@@ -183,10 +183,10 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
 ])
 def test_delete_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of ossec-authd when deleting an agent.
+    """Check if use_only_authd forces the use of wazuh-authd when deleting an agent.
 
-    Verify that when 'use_only_authd' option is enabled, if the ossec-authd service
-    is not active, an error is returned. In this test, ossec-authd is activated in order
+    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
+    is not active, an error is returned. In this test, wazuh-authd is activated in order
     to create an agent before it can be deleted.
 
     Parameters
@@ -200,17 +200,17 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
     api_details['base_url'] += '/agents'
 
     if use_only_authd:
-        control_service('start', daemon='ossec-authd')
+        control_service('start', daemon='wazuh-authd')
         time.sleep(1)
 
-    # Create an agent to delete (we need ossec-authd daemon running if use_only_authd in the configuration)
+    # Create an agent to delete (we need wazuh-authd daemon running if use_only_authd in the configuration)
     post_url = api_details['base_url'] + f'/insert/quick?agent_name={token_hex(16)}'
     post_response = requests.post(post_url, headers=api_details['auth_headers'], verify=False)
     assert post_response.status_code == 200, 'Status code expected after quick inserting agent was 200. Full response: ' \
                                              f'{post_response.text}'
 
     if use_only_authd:
-        control_service('stop', daemon='ossec-authd')
+        control_service('stop', daemon='wazuh-authd')
         time.sleep(1)
 
     # It is necessary to wait a bit after adding the agent before deleting or querying it.
@@ -219,7 +219,7 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
                  f"?agents_list={post_response.json()['data']['id']}&purge=true&status=&older_than=0s&status=all"
     delete_response = requests.delete(delete_url, headers=api_details['auth_headers'], verify=False).json()
 
-    # Assert if an error code was returned when ossec-authd is disabled and use_only_authd enabled.
+    # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if not use_only_authd:
         assert delete_response['data']['total_affected_items'] == 1, 'Total_affected_items field expected to be 1.' \
                                                                      f'Full response: {delete_response}'
@@ -227,7 +227,7 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
         assert delete_response['data']['failed_items'][0]['error']['code'] == 1726, 'Expected error code was 1726.' \
                                                                                     f'Full response: {delete_response}'
         # Delete created agent
-        control_service('start', daemon='ossec-authd')
+        control_service('start', daemon='wazuh-authd')
         time.sleep(1)
         requests.delete(api_details['base_url'] + '?purge=true&status=&older_than=0s&status=all',
                         headers=api_details['auth_headers'], verify=False)


### PR DESCRIPTION
## Description

Hi team!

This PR updates both the integration and the system tests in order to apply the rename of Wazuh daemons. Actually, only one test needed to be modified: `test_use_only_authd.py`.

The tests have been run on wazuh/wazuh branch [dev-6793-wazuh-daemons-framework-api](https://github.com/wazuh/wazuh/tree/dev-6793-wazuh-daemons-framework-api), which comes from [dev-wstack-daemons](https://github.com/wazuh/wazuh/tree/dev-wstack-daemons).

## Results
### Integration tests
There is a test that fails since 4.0.x and has not yet been corrected.

```
/var/ossec/framework/python/bin/python3 -m pytest test_api/
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-1.11.0, tavern-1.12.1, cov-2.10.1
collected 86 items                                                                                                                                                                                           

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss.                                                                                                                         [  4%]
test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py Fs.ss.s.                                                                                                                     [ 13%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss.                                                                                                           [ 18%]
test_api/test_config/test_cache/test_cache.py .ss.                                                                                                                                                     [ 23%]
test_api/test_config/test_cors/test_cors.py x.                                                                                                                                                         [ 25%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.                                                                                                                                 [ 30%]
test_api/test_config/test_experimental_features/test_experimental_features.py .ss.                                                                                                                     [ 34%]
test_api/test_config/test_host_port/test_host_port.py .s.ss.s.                                                                                                                                         [ 44%]
test_api/test_config/test_https/test_https.py .ss.                                                                                                                                                     [ 48%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                                                                     [ 53%]
test_api/test_config/test_logs/test_logs.py .ss.                                                                                                                                                       [ 58%]
test_api/test_config/test_rbac/test_rbac_mode.py .ss.                                                                                                                                                  [ 62%]
test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.s.ss.s.s.s.                                                                                                                       [ 81%]
test_api/test_rbac/test_add_old_resource.py ....                                                                                                                                                       [ 86%]
test_api/test_rbac/test_admin_resources.py ....                                                                                                                                                        [ 90%]
test_api/test_rbac/test_policy_position.py .                                                                                                                                                           [ 91%]
test_api/test_rbac/test_remove_relationship.py ...                                                                                                                                                     [ 95%]
test_api/test_rbac/test_remove_resource.py ....                                                                                                                                                        [100%]
================================================================ 1 failed, 50 passed, 34 skipped, 1 xfailed, 52 warnings in 841.03s (0:14:01) ================================================================
```

### System tests
#### test_agent_enrollment
```

python3 -m pytest test_agent_enrollment/
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                                                                                                                                                                                             

test_agent_enrollment/test_agent_enrollment.py .                                                                                                                                                       [100%]

======================================================================================== 1 passed in 71.80s (0:01:11) ========================================================================================
```

#### test_agent_info_sync
```
python3 -m pytest test_agent_info_sync/
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 2 items                                                                                                                                                                                            

test_agent_info_sync/test_agent_info_sync.py ..                                                                                                                                                        [100%]

======================================================================================= 2 passed in 152.04s (0:02:32) ========================================================================================
```

#### test_jwt_invalidation
```
python3 -m pytest test_jwt_invalidation/
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh-qa/tests/system
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 19 items                                                                                                                                                                                           

test_jwt_invalidation/test_change_rbac_mode.py ....                                                                                                                                                    [ 21%]
test_jwt_invalidation/test_change_security_resources.py ....                                                                                                                                           [ 42%]
test_jwt_invalidation/test_disconnected_nodes.py .                                                                                                                                                     [ 47%]
test_jwt_invalidation/test_revoke_endpoint.py ......                                                                                                                                                   [ 78%]
test_jwt_invalidation/test_update_password.py ....                                                                                                                                                     [100%]

======================================================================================= 19 passed in 881.66s (0:14:41) =======================================================================================
```

Best regards!
Selu.

