### PR TITLE
Replace restart wazuh by restart syscheckd in fim tests.

### DIFF
--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target.py
@@ -44,7 +44,7 @@ def get_configuration(request):
     ({'monitored_dir'}, testdir_target, testdir_not_target)
 ])
 def test_symbolic_change_target(tags_to_apply, main_folder, aux_folder, get_configuration, configure_environment,
-                                restart_wazuh, wait_for_fim_start):
+                                restart_syscheckd, wait_for_fim_start):
     """
     Check if syscheck updates the symlink target properly
 


### PR DESCRIPTION
Hello team,

This PR aims to change the tests where the fixture `restart_wazuh` is used. Now all test uses the  `restart_syscheck` fixture.
Closes #843 

Best regards.
