### PR TITLE
Skip/xfail tests for deprecated or in development features.

### DIFF
--- a/tests/integration/test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py
+++ b/tests/integration/test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py
@@ -35,6 +35,7 @@ def get_configuration(request):
 
 # Tests
 
+@pytest.mark.xfail(reason='To be deprecated in https://github.com/wazuh/wazuh/issues/7006')
 @pytest.mark.parametrize('tags_to_apply', [
     {'bps_enabled'},
     {'bps_disabled'},

--- a/tests/integration/test_cluster/test_key_polling/test_key_polling_master.py
+++ b/tests/integration/test_cluster/test_key_polling/test_key_polling_master.py
@@ -60,6 +60,7 @@ def get_configuration(request):
 
 # Tests
 
+@pytest.mark.skip(reason='Development in progress: https://github.com/wazuh/wazuh/issues/4387')
 @pytest.mark.parametrize('cmd, counter, payload, expected', [
     (b'run_keypoll', 1, b'{"message": "id:001"}', "id:001"),
     (b'run_keypoll', 2, b'{"message": "ip:124.0.0.1"}', "ip:124.0.0.1")
@@ -85,7 +86,6 @@ def test_key_polling_master(cmd, counter, payload, expected, configure_environme
     expected : str
         Expected message in krequest socket
     """
-    pytest.xfail("Development in progress: https://github.com/wazuh/wazuh/issues/4387")
     # Build message and send it to the master
     message = cluster_msg_build(cmd=cmd, counter=counter, payload=payload, encrypt=True)
     receiver_sockets[0].send(message)

--- a/tests/integration/test_cluster/test_key_polling/test_key_polling_worker.py
+++ b/tests/integration/test_cluster/test_key_polling/test_key_polling_worker.py
@@ -55,6 +55,7 @@ def get_configuration(request):
 # Tests
 
 
+@pytest.mark.skip(reason='Development in progress: https://github.com/wazuh/wazuh/issues/4387')
 @pytest.mark.parametrize('cmd, counter, payload', [
     (b'run_keypoll', 1, b'{"message": "id:001"}'),
     (b'run_keypoll', 2, b'{"message": "ip:124.0.0.1"}')
@@ -78,7 +79,6 @@ def test_key_polling_worker(cmd, counter, payload, configure_environment, config
     payload : bytes
         Cluster message payload data
     """
-    pytest.xfail("Development in progress: https://github.com/wazuh/wazuh/issues/4387")
     # Build message to send to c-internal.sock in the worker and send it
     message = cluster_msg_build(cmd=cmd, counter=counter, payload=payload, encrypt=False)
     receiver_sockets[0].send(message)

--- a/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
+++ b/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
@@ -33,6 +33,7 @@ def configure_environment(host_manager):
     host_manager.clear_file(host='wazuh-agent2', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
 
 
+@pytest.mark.skip(reason='Development in progress: https://github.com/wazuh/wazuh/issues/4387')
 def test_agent_key_polling(inventory_path):
     """Check that the agent key polling cycle works correctly. To do this, we use the messages and the hosts defined
     in data/messages.yml and the hosts inventory.
@@ -42,7 +43,6 @@ def test_agent_key_polling(inventory_path):
     inventory_path : str
         Path to the Ansible hosts inventory
     """
-    pytest.xfail("Development in progress: https://github.com/wazuh/wazuh/issues/4387")
     actual_path = os.path.dirname(os.path.abspath(__file__))
     host_manager = HostManager(inventory_path=inventory_path)
     configure_environment(host_manager)


### PR DESCRIPTION
This issue closes https://github.com/wazuh/wazuh-qa/issues/985

## Description

Hi team!

- Agent key-polling tests have been marked as `skip` until the development of said feature is finished (https://github.com/wazuh/wazuh/issues/4387).
- Behind_proxy_server API option tests have been marked as `xfailed` after removing it from `POST /agents` and `POST /agents/insert` (https://github.com/wazuh/wazuh/issues/7015). Once said option is completly removed (https://github.com/wazuh/wazuh/issues/7006), the test will be deleted too (https://github.com/wazuh/wazuh-qa/issues/986)

## Output
### Agent key-polling
#### Integration tests
```
/var/ossec/framework/python/bin/python3 -m pytest test_cluster/ -vv
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-6.2.1, py-1.10.0, pluggy-0.13.1 -- /var/ossec/framework/python/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.2.5', 'Packages': {'pytest': '6.2.1', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '1.11.0', 'tavern': '1.12.1', 'cov': '2.10.1'}}
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-1.11.0, tavern-1.12.1, cov-2.10.1
collected 4 items                                                                                                                                                                                            

test_cluster/test_key_polling/test_key_polling_master.py::test_key_polling_master[get_configuration0-run_keypoll-1-{"message": "id:001"}-id:001] SKIPPED (Development in progress: https://github....) [ 25%]
test_cluster/test_key_polling/test_key_polling_master.py::test_key_polling_master[get_configuration0-run_keypoll-2-{"message": "ip:124.0.0.1"}-ip:124.0.0.1] SKIPPED (Development in progress: htt...) [ 50%]
test_cluster/test_key_polling/test_key_polling_worker.py::test_key_polling_worker[get_configuration0-run_keypoll-1-{"message": "id:001"}] SKIPPED (Development in progress: https://github.com/waz...) [ 75%]
test_cluster/test_key_polling/test_key_polling_worker.py::test_key_polling_worker[get_configuration0-run_keypoll-2-{"message": "ip:124.0.0.1"}] SKIPPED (Development in progress: https://github.c...) [100%]

======================================================================================= 4 skipped, 1 warning in 0.07s ========================================================================================
```

#### System tests
```
pytest -vv test_agent_key_polling/ -vv
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                                                                                                                                                                                             

test_agent_key_polling/test_agent_key_polling.py::test_agent_key_polling SKIPPED                                                                                                                       [100%]

============================================================================================= 1 skipped in 0.10s =============================================================================================
```

### behind_proxy_server
```
/var/ossec/framework/python/bin/python3 -m pytest test_api/test_config/test_behind_proxy_server/ --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-1.11.0, tavern-1.12.1, cov-2.10.1
collected 8 items                                                                                                                                                                                            

test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py xsXssXsX                                                                                                                     [100%]

=========================================================================== 4 skipped, 1 xfailed, 3 xpassed, 5 warnings in 35.46s ============================================================================
```

Best regards,
Selu.