### PR TITLE
Improving GCloud Integration Tests stability 

### DIFF
--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -94,13 +94,9 @@ def get_remote_configuration(component_name, config):
     try:
         if rec_msg_ok.startswith('ok'):
             remote_configuration = json.loads(rec_msg)
-            if host_type == 'server':
-                remote_configuration_gcp = remote_configuration['wmodules'][6]['gcp-pubsub']
-            else:
-                if sys.platform == 'darwin':
-                    remote_configuration_gcp = remote_configuration['wmodules'][3]['gcp-pubsub']
-                else:
-                    remote_configuration_gcp = remote_configuration['wmodules'][5]['gcp-pubsub']
+       	    for	element	in remote_configuration['wmodules']:
+       	       	if 'gcp-pubsub'	in element:
+                    remote_configuration_gcp = element['gcp-pubsub']
         else:
             s.close()
             raise ValueError(rec_msg_ok)

--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -76,7 +76,6 @@ def get_remote_configuration(component_name, config):
     socket_path = os.path.join(WAZUH_PATH, 'queue', 'ossec')
     dest_socket = os.path.join(socket_path, component_name)
     command = f"getconfig {config}"
-    host_type = 'agent' if 'agent' in WAZUH_SERVICE else 'server'
 
     # Socket connection
     s = SocketController(dest_socket)

--- a/tests/integration/test_gcloud/test_functioning/test_rules.py
+++ b/tests/integration/test_gcloud/test_functioning/test_rules.py
@@ -84,10 +84,13 @@ def test_rules(get_configuration, configure_environment,
     rules_id = []
     file_ind = 0
 
-    for number in range(65004, 65037):
+    for number in range(65005, 65011):
         rules_id.append(number)
 
-    for number in range(65039, 65045):
+    for number in range(65012, 65039):
+        rules_id.append(number)
+
+    for number in range(65041, 65047):
         rules_id.append(number)
 
     events_file = open(file_path, 'r')


### PR DESCRIPTION
Hello team,

After running all the `gcloud` tests in a local environment, it was found that some of them may need a reliability improvement.
These tests were updated:

- **test_rules.py**: the sample data consumed by the test was generating a different list of rules ID than the one previously defined
- **test_remote_configuration.py**: this _gcloud_ test now has a more general way to find the JSON field 'gcp-pubsub'

The rest work as expected. It would be useful in the future to include them in a Jenkins pipeline.

Closes #994 

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail

Best regards.
