### PR TITLE
Add new test case for duplicate registry entries.

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_duplicated_entries.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_duplicated_entries.yaml
@@ -156,3 +156,23 @@
         attributes:
           - report_changes: "no"
           - arch: "64bit"
+# Single registry and a list of registries
+- tags:
+  - single_registry_and_list
+  apply_to_modules:
+  - test_registry_ambiguous_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY_1
+        attributes:
+          - check_all: "yes"
+          - arch: "64bit"
+    - windows_registry:
+        value: WINDOWS_REGISTRY_LIST
+        attributes:
+          - check_all: "yes"
+          - arch: "64bit"

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_duplicated_entries.py
@@ -26,13 +26,20 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=2)]
 key = "HKEY_LOCAL_MACHINE"
 subkey_1 = "SOFTWARE\\test_key1"
 subkey_2 = "SOFTWARE\\test_key2"
+subkey_3 = "SOFTWARE\\test_key3"
+subkey_4 = "SOFTWARE\\test_key4"
 
 test_regs = [os.path.join(key, subkey_1),
-             os.path.join(key, subkey_2)
+             os.path.join(key, subkey_2),
+             os.path.join(key, subkey_3),
+             os.path.join(key, subkey_4)
              ]
+
+registry_list = "{},{},{},{}".format(test_regs[0], test_regs[1], test_regs[2], test_regs[3])
 
 conf_params = {'WINDOWS_REGISTRY_1': test_regs[0],
                'WINDOWS_REGISTRY_2': test_regs[1],
+               'WINDOWS_REGISTRY_LIST': registry_list,
                'RESTRICT_1': "overwritten_restrict$",
                'RESTRICT_2': "restrict_test_|test_key"
                }
@@ -77,6 +84,11 @@ def get_configuration(request):
     (subkey_1, KEY_WOW64_64KEY, ['restrict_test_key'], ['restrict_test_value'], checkers_key_1, {'complex_entries'}),
     (subkey_2, KEY_WOW64_64KEY, ['random_key'], ['random_value'], checkers_key_2, {'complex_entries'}),
     (subkey_2, KEY_WOW64_32KEY, ['random_key'], ['random_value'], checkers_key_2, {'complex_entries'}),
+    (subkey_1, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'single_registry_and_list'}),
+    (subkey_2, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'single_registry_and_list'}),
+    (subkey_3, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'single_registry_and_list'}),
+    (subkey_4, KEY_WOW64_64KEY, ['random_key'], ['test_value'], key_all_attrs, {'single_registry_and_list'}),
+
 ])
 def test_duplicate_entries(key, subkey, arch, key_list, value_list, checkers, tags_to_apply,
                            get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):


### PR DESCRIPTION
Hello team,

This PR aims to add a new test as explained in #732

Closes #732 

# Tests logic
The test will monitor the following configuration: 
```xml
    <windows_registry>HKLM\software\key1</windows_registry>
    <windows_registry>HKLM\\software\key1,HKLM\\software\key2,HKLM\\software\key3,...<windows_registry>
```
The test will create events in all the monitored keys and wait for the expected events.

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail

Best regards.
