### PR TITLE
Added some cases in test_ignore_valid, to check entire disk ignore

### DIFF
--- a/tests/integration/test_fim/test_files/test_ignore/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_ignore/data/wazuh_conf.yaml
@@ -217,3 +217,20 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+# conf 12
+- tags:
+  - ignore_disk
+  apply_to_modules:
+  - test_ignore_valid
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: "/testdir1,/testdir2"
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE
+    - ignore:
+        value: "/"

--- a/tests/integration/test_fim/test_files/test_ignore/data/wazuh_conf_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_ignore/data/wazuh_conf_win32.yaml
@@ -198,3 +198,20 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+# conf 12
+- tags:
+  - ignore_disk
+  apply_to_modules:
+  - test_ignore_valid
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: "c:\\testdir1,c:\\testdir2"
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE
+    - ignore:
+        value: "c:\\."

--- a/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
@@ -77,7 +77,8 @@ def get_configuration(request):
     (testdir1, 'mytest', "test", True, {'negation_regex'}),
     (testdir1, 'othername', "test", False, {'negation_regex'}),
     (testdir1, 'file1', "test", False, {'incomplete_regex'}),
-    (testdir1_ignore_folder, 'file2', "test", False, {'incomplete_regex'})
+    (testdir1_ignore_folder, 'file2', "test", False, {'incomplete_regex'}),
+    (testdir1, 'file1', "test", False, {'ignore_disk'})
 ])
 def test_ignore_subdirectory(folder, filename, content, triggers_event,
                              tags_to_apply, get_configuration,

--- a/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
@@ -115,8 +115,8 @@ def test_ignore_subdirectory(folder, filename, content, triggers_event,
                                         callback=callback_detect_event,
                                         error_message='Did not receive expected '
                                                       '"Sending FIM event: ..." event').result()
-        assert event['data']['type'] == 'added', f'Event type not equal'
-        assert event['data']['path'] == os.path.join(folder, filename), f'Event path not equal'
+        assert event['data']['type'] == 'added', 'Event type not equal'
+        assert event['data']['path'] == os.path.join(folder, filename), 'Event path not equal'
     else:
         while True:
             ignored_file = wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 2,


### PR DESCRIPTION
## Description
This PR adds a new case into `test_ignore_valid` to check that the entire disk is ignored when using:
<ignore>c:\.</ignore>

It's related to this issue:
https://github.com/wazuh/wazuh/issues/5252

## Configuration
```
<directories check_all="yes" whodata="yes">c:\testdir1,c:\testdir2</directories>
<ignore>c:\.</ignore>
```

- No events should appear in those folders