### PR TITLE
Adapt integration tests after moving syscheck internal options to regular configuration.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -996,41 +996,6 @@ def modify_file(path, name, new_content=None, is_binary=False):
     modify_file_win_attributes(path, name)
 
 
-def change_internal_options(param, value, opt_path=None):
-    """
-    Change the value of a given parameter in local_internal_options.
-
-    Parameters
-    ----------
-    param : str
-        Parameter to change.
-    value : str or int
-        New value.
-    opt_path : str, optional
-        local_internal_options.conf path. Default `None`
-    """
-    if opt_path is None:
-        local_conf_path = os.path.join(WAZUH_PATH, 'local_internal_options.conf') if sys.platform == 'win32' else \
-            os.path.join(WAZUH_PATH, 'etc', 'local_internal_options.conf')
-    else:
-        local_conf_path = opt_path
-
-    add_pattern = True
-    with open(local_conf_path, "r") as sources:
-        lines = sources.readlines()
-
-    with open(local_conf_path, "w") as sources:
-        for line in lines:
-            sources.write(
-                re.sub(f'{param}=[0-9]*', f'{param}={value}', line))
-            if param in line:
-                add_pattern = False
-
-    if add_pattern:
-        with open(local_conf_path, "a") as sources:
-            sources.write(f'\n\n{param}={value}')
-
-
 def change_conf_param(param, value):
     """
     Change the value of a given parameter in ossec.conf.

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/common.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/common.py
@@ -78,10 +78,3 @@ def extra_configuration_before_yield():
     create_file(SYMLINK, symlinkdir, 'symlink', target=os.path.join(testdir1, 'regular1'))
     # Symlink pointing to /testdir_target/
     create_file(SYMLINK, symlinkdir, 'symlink2', target=testdir_target)
-    # Set symlink_scan_interval to a given value
-    change_internal_options(param='syscheck.symlink_scan_interval', value=symlink_interval)
-
-
-def extra_configuration_after_yield():
-    """Set symlink_scan_interval to default value"""
-    change_internal_options(param='syscheck.symlink_scan_interval', value=600)

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/common.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/common.py
@@ -4,8 +4,7 @@ import shutil
 import subprocess
 import sys
 
-from wazuh_testing.fim import callback_audit_loaded_rule, create_file, REGULAR, SYMLINK, callback_symlink_scan_ended, \
-    change_internal_options
+from wazuh_testing.fim import callback_audit_loaded_rule, create_file, REGULAR, SYMLINK, callback_symlink_scan_ended
 from wazuh_testing.tools import PREFIX
 
 # variables

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/data/wazuh_conf.yaml
@@ -9,6 +9,8 @@
     elements:
     - disabled:
         value: 'no'
+    - symlink_scan_interval:
+        value: SYM_INTERVAL
     - directories:
         value: '/testdir_link'
         attributes:
@@ -30,6 +32,8 @@
     elements:
     - disabled:
         value: 'no'
+    - symlink_scan_interval:
+        value: SYM_INTERVAL
     - directories:
         value: '/testdir_link/symlink'
         attributes:
@@ -55,6 +59,8 @@
     elements:
     - disabled:
         value: 'no'
+    - symlink_scan_interval:
+        value: SYM_INTERVAL
     - directories:
         value: '/testdir_link/symlink2'
         attributes:

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target.py
@@ -7,8 +7,8 @@ import pytest
 from test_fim.test_files.test_follow_symbolic_link.common import configurations_path, testdir1, \
     modify_symlink, testdir_link, wait_for_symlink_check, wait_for_audit, testdir_target, testdir_not_target
 # noinspection PyUnresolvedReferences
-from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_after_yield, \
-    extra_configuration_before_yield
+from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
+    symlink_interval
 
 from wazuh_testing import logger
 from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_detect_event,
@@ -22,7 +22,7 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target_inside_folder.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target_inside_folder.py
@@ -8,7 +8,7 @@ from test_fim.test_files.test_follow_symbolic_link.common import configurations_
     modify_symlink, testdir_link, wait_for_symlink_check, wait_for_audit, testdir_target, testdir2
 # noinspection PyUnresolvedReferences
 from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
-    extra_configuration_after_yield
+    symlink_interval
 
 from wazuh_testing import logger
 from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_detect_event,
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_delete_symlink.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_delete_symlink.py
@@ -8,7 +8,7 @@ from test_fim.test_files.test_follow_symbolic_link.common import configurations_
     testdir_link, wait_for_symlink_check, testdir_target, testdir_not_target, delete_f
 # noinspection PyUnresolvedReferences
 from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
-    extra_configuration_after_yield
+    symlink_interval
 
 from wazuh_testing import logger
 from wazuh_testing.fim import (generate_params, create_file, REGULAR, SYMLINK, callback_detect_event,
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_delete_target.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_delete_target.py
@@ -9,7 +9,7 @@ from test_fim.test_files.test_follow_symbolic_link.common import configurations_
     wait_for_symlink_check, wait_for_audit, testdir_target, testdir_not_target, delete_f, symlink_interval
 # noinspection PyUnresolvedReferences
 from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
-    extra_configuration_after_yield
+    symlink_interval
 
 from wazuh_testing import logger
 from wazuh_testing.fim import generate_params, create_file, REGULAR, callback_detect_event, \
@@ -24,7 +24,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_follow_symbolic_disabled.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_follow_symbolic_disabled.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 from test_fim.test_files.test_follow_symbolic_link.common import test_directories, testdir_target, testdir1,\
-    extra_configuration_before_yield, extra_configuration_after_yield
+    extra_configuration_before_yield, symlink_interval
 
 from wazuh_testing import logger
 from wazuh_testing.fim import (LOG_FILE_PATH,
@@ -27,7 +27,7 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'no'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'no', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_monitor_symlink.py
@@ -7,7 +7,7 @@ from test_fim.test_files.test_follow_symbolic_link.common import configurations_
     testdir_target, delete_f
 # noinspection PyUnresolvedReferences
 from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
-    extra_configuration_after_yield
+    symlink_interval
 
 from wazuh_testing.fim import (generate_params, create_file, REGULAR, callback_detect_event,
                                check_time_travel, modify_file_content, LOG_FILE_PATH)
@@ -20,7 +20,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_not_following_symbolic_link.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_not_following_symbolic_link.py
@@ -5,7 +5,7 @@
 import os
 
 import pytest
-from test_fim.test_files.test_follow_symbolic_link.common import modify_symlink
+from test_fim.test_files.test_follow_symbolic_link.common import modify_symlink, symlink_interval
 
 from wazuh_testing import global_parameters, logger
 from wazuh_testing.fim import (LOG_FILE_PATH,
@@ -31,7 +31,7 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_revert_symlink.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_revert_symlink.py
@@ -5,10 +5,9 @@ import os
 
 import pytest
 from test_fim.test_files.test_follow_symbolic_link.common import configurations_path, testdir1, \
-    modify_symlink, testdir_link, wait_for_symlink_check, wait_for_audit
+    modify_symlink, testdir_link, wait_for_symlink_check, wait_for_audit, symlink_interval
 # noinspection PyUnresolvedReferences
-from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
-    extra_configuration_after_yield
+from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield
 
 from wazuh_testing import logger
 from wazuh_testing.fim import (generate_params, callback_detect_event,
@@ -24,7 +23,7 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # configurations
 
-conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes'})
+conf_params, conf_metadata = generate_params(extra_params={'FOLLOW_MODE': 'yes', 'SYM_INTERVAL': symlink_interval})
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_report_changes/common.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/common.py
@@ -8,6 +8,9 @@ import re
 
 from wazuh_testing.fim import WAZUH_PATH
 
+default_file_max_size = 1024
+default_rt_delay = 5
+
 
 def generate_string(stringLength=10, character='0'):
     """Generate a string with line breaks.
@@ -61,94 +64,6 @@ def translate_size(configured_size='1KB'):
         translated_size = configured_value * 1024 * 1024 * 1024
 
     return translated_size
-
-
-def disable_file_max_size():
-    """
-    Disable the syscheck.file_max_size option from the internal_options.conf file.
-    """
-    new_content = ''
-
-    if sys.platform == 'win32':
-        internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
-    else:
-        internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
-
-    with open(internal_options, 'r') as f:
-        lines = f.readlines()
-
-        for line in lines:
-            new_line = line.replace('syscheck.file_max_size=1024', 'syscheck.file_max_size=0')
-            new_content += new_line
-
-    with open(internal_options, 'w') as f:
-        f.write(new_content)
-
-
-def restore_file_max_size():
-    """
-    Restore the syscheck.file_max_size option from the internal_options.conf file.
-    """
-    new_content = ''
-
-    if sys.platform == 'win32':
-        internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
-    else:
-        internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
-
-    with open(internal_options, 'r') as f:
-        lines = f.readlines()
-
-        for line in lines:
-            new_line = line.replace('syscheck.file_max_size=0', 'syscheck.file_max_size=1024')
-            new_content += new_line
-
-    with open(internal_options, 'w') as f:
-        f.write(new_content)
-
-
-def disable_rt_delay():
-    """
-    Disable the syscheck.rt_delay option from the internal_options.conf file.
-    """
-    new_content = ''
-
-    if sys.platform == 'win32':
-        internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
-    else:
-        internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
-
-    with open(internal_options, 'r') as f:
-        lines = f.readlines()
-
-        for line in lines:
-            new_line = line.replace('syscheck.rt_delay=5', 'syscheck.rt_delay=1000')
-            new_content += new_line
-
-    with open(internal_options, 'w') as f:
-        f.write(new_content)
-
-
-def restore_rt_delay():
-    """
-    Restore the syscheck.rt_delay option from the internal_options.conf file.
-    """
-    new_content = ''
-
-    if sys.platform == 'win32':
-        internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
-    else:
-        internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
-
-    with open(internal_options, 'r') as f:
-        lines = f.readlines()
-
-        for line in lines:
-            new_line = line.replace('syscheck.rt_delay=1000', 'syscheck.rt_delay=5')
-            new_content += new_line
-
-    with open(internal_options, 'w') as f:
-        f.write(new_content)
 
 
 def make_diff_file_path(folder='/testdir1', filename='regular_0'):

--- a/tests/integration/test_fim/test_files/test_report_changes/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_report_changes/data/wazuh_conf.yaml
@@ -7,6 +7,10 @@
   sections:
   - section: syscheck
     elements:
+    - rt_delay:
+        value: RT_DELAY
+    - file_max_size:
+        value: FILE_MAX_SIZE
     - disabled:
         value: 'no'
     - directories:
@@ -26,6 +30,10 @@
   sections:
   - section: syscheck
     elements:
+    - rt_delay:
+        value: RT_DELAY
+    - file_max_size:
+        value: FILE_MAX_SIZE
     - disabled:
         value: 'no'
     - directories:
@@ -57,6 +65,10 @@
   sections:
   - section: syscheck
     elements:
+    - rt_delay:
+        value: RT_DELAY
+    - file_max_size:
+        value: FILE_MAX_SIZE
     - disabled:
         value: 'no'
     - directories:
@@ -74,6 +86,10 @@
   sections:
   - section: syscheck
     elements:
+    - rt_delay:
+        value: RT_DELAY
+    - file_max_size:
+        value: FILE_MAX_SIZE
     - disabled:
         value: 'no'
     - directories:

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
@@ -11,7 +11,7 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_diff_size_limit_value, gen
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-
+from test_fim.test_files.test_report_changes.common import default_rt_delay, default_file_max_size
 
 # Marks
 
@@ -38,6 +38,8 @@ conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'r
                                                            'FILE_SIZE_LIMIT': '1GB',
                                                            'DISK_QUOTA_ENABLED': 'no',
                                                            'DISK_QUOTA_LIMIT': '2KB',
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'MODULE_NAME': __name__})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
@@ -11,6 +11,7 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_diff_size_limit_value, gen
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import default_rt_delay, default_file_max_size
 
 
 # Marks
@@ -33,6 +34,8 @@ DEFAULT_SIZE = 50 * 1024
 
 conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': 'yes'},
                                                            'TEST_DIRECTORIES': directory_str,
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'MODULE_NAME': __name__})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_default.py
@@ -11,6 +11,7 @@ from wazuh_testing.fim import LOG_FILE_PATH, callback_disk_quota_default, genera
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import default_rt_delay, default_file_max_size
 
 
 # Marks
@@ -33,6 +34,8 @@ DEFAULT_SIZE = 1 * 1024 * 1024
 
 conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': 'yes'},
                                                            'TEST_DIRECTORIES': directory_str,
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'MODULE_NAME': __name__})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_disabled.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_disabled.py
@@ -9,7 +9,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_disk_quota_limit_reached, generate_params, create_file, \
     check_time_travel
-from test_fim.test_files.test_report_changes.common import generate_string
+from test_fim.test_files.test_report_changes.common import generate_string, default_file_max_size, default_rt_delay
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -38,6 +38,8 @@ conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'r
                                                            'FILE_SIZE_LIMIT': '1KB',
                                                            'DISK_QUOTA_ENABLED': 'no',
                                                            'DISK_QUOTA_LIMIT': '2KB',
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'MODULE_NAME': __name__})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
@@ -9,10 +9,10 @@ import pytest
 
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, callback_disk_quota_limit_reached, generate_params
-from test_fim.test_files.test_report_changes.common import disable_file_max_size, restore_file_max_size
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import default_rt_delay
 
 
 # Marks
@@ -50,6 +50,8 @@ conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'r
                                                            'FILE_SIZE_ENABLED': 'no',
                                                            'FILE_SIZE_LIMIT': '10MB',
                                                            'DISK_QUOTA_ENABLED': 'yes',
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': 0,
                                                            'MODULE_NAME': __name__},
                                              apply_to_all=({'DISK_QUOTA_LIMIT': disk_quota_elem}
                                                            for disk_quota_elem in disk_quota_values))
@@ -63,22 +65,6 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
-
-
-# Functions
-
-def extra_configuration_before_yield():
-    """
-    Disable syscheck.file_max_size internal option
-    """
-    disable_file_max_size()
-
-
-def extra_configuration_after_yield():
-    """
-    Restore syscheck.file_max_size internal option
-    """
-    restore_file_max_size()
 
 
 # Tests

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
@@ -10,7 +10,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_file_size_limit_reached, generate_params, create_file, \
     check_time_travel, callback_detect_event, modify_file_content
 from test_fim.test_files.test_report_changes.common import generate_string, translate_size, make_diff_file_path, \
-    disable_file_max_size, restore_file_max_size, make_diff_file_path, disable_rt_delay, restore_rt_delay
+     make_diff_file_path, default_file_max_size
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -35,6 +35,8 @@ testdir1 = test_directories[0]
 
 conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': 'yes'},
                                                            'TEST_DIRECTORIES': directory_str,
+                                                           'RT_DELAY': 1000,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'MODULE_NAME': __name__})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
@@ -46,22 +48,6 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
-
-
-# Functions
-
-def extra_configuration_before_yield():
-    """
-    Disable syscheck.rt_delay internal option
-    """
-    disable_rt_delay()
-
-
-def extra_configuration_after_yield():
-    """
-    Restore syscheck.rt_delay internal option
-    """
-    restore_rt_delay()
 
 
 # Tests

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
@@ -10,7 +10,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_file_size_limit_reached, generate_params, create_file, \
     check_time_travel, callback_detect_event, modify_file_content
 from test_fim.test_files.test_report_changes.common import generate_string, translate_size, make_diff_file_path, \
-     make_diff_file_path, default_file_max_size
+     default_file_max_size
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_disabled.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_disabled.py
@@ -9,7 +9,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_file_size_limit_reached, generate_params, create_file, \
     check_time_travel
-from test_fim.test_files.test_report_changes.common import generate_string
+from test_fim.test_files.test_report_changes.common import generate_string, default_file_max_size, default_rt_delay
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -38,6 +38,8 @@ conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'r
                                                            'FILE_SIZE_LIMIT': '1KB',
                                                            'DISK_QUOTA_ENABLED': 'yes',
                                                            'DISK_QUOTA_LIMIT': '2KB',
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'MODULE_NAME': __name__})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_values.py
@@ -9,8 +9,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, REGULAR, callback_file_size_limit_reached, generate_params, create_file, \
     check_time_travel, callback_detect_event, modify_file_content, callback_deleted_diff_folder
-from test_fim.test_files.test_report_changes.common import generate_string, translate_size, disable_file_max_size, \
-    restore_file_max_size, make_diff_file_path, disable_rt_delay, restore_rt_delay
+from test_fim.test_files.test_report_changes.common import generate_string, translate_size, make_diff_file_path
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -40,6 +39,8 @@ conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'r
                                                            'FILE_SIZE_ENABLED': 'yes',
                                                            'DISK_QUOTA_ENABLED': 'no',
                                                            'DISK_QUOTA_LIMIT': '2KB',
+                                                           'RT_DELAY': 1000,
+                                                           'FILE_MAX_SIZE': 0,
                                                            'MODULE_NAME': __name__},
                                              apply_to_all=({'FILE_SIZE_LIMIT': file_size_elem}
                                                            for file_size_elem in file_size_values))
@@ -53,24 +54,6 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
-
-
-# Functions
-
-def extra_configuration_before_yield():
-    """
-    Disable syscheck.file_max_size internal option
-    """
-    disable_file_max_size()
-    disable_rt_delay()
-
-
-def extra_configuration_after_yield():
-    """
-    Restore syscheck.file_max_size internal option
-    """
-    restore_file_max_size()
-    restore_rt_delay()
 
 
 # Tests

--- a/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
@@ -13,7 +13,7 @@ import pytest
 
 from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_event, REGULAR, create_file, \
     generate_params, check_time_travel
-from test_fim.test_files.test_report_changes.common import generate_string
+from test_fim.test_files.test_report_changes.common import generate_string, default_rt_delay, default_file_max_size
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import PREFIX, WAZUH_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -42,6 +42,8 @@ configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 
 conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': 'yes'},
                                                            'TEST_DIRECTORIES': directory_str,
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'NODIFF_FILE': nodiff_file,
                                                            'MODULE_NAME': __name__})
 configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
@@ -14,6 +14,7 @@ from wazuh_testing.fim import (CHECK_ALL, LOG_FILE_PATH, regular_file_cud, WAZUH
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
+from test_fim.test_files.test_report_changes.common import default_rt_delay, default_file_max_size
 
 # Marks
 
@@ -36,6 +37,8 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': 'yes'},
                                                            'TEST_DIRECTORIES': directory_str,
+                                                           'RT_DELAY': default_rt_delay,
+                                                           'FILE_MAX_SIZE': default_file_max_size,
                                                            'NODIFF_FILE': nodiff_file,
                                                            'MODULE_NAME': __name__})
 

--- a/tests/integration/test_fim/test_files/test_report_changes/test_report_deleted_diff.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_report_deleted_diff.py
@@ -16,6 +16,7 @@ from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import get_wazuh_conf, set_section_wazuh_conf, load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import restart_wazuh_with_new_conf
+from test_fim.test_files.test_report_changes.common import default_rt_delay, default_file_max_size
 
 # Marks
 
@@ -41,6 +42,8 @@ def change_conf(report_value):
     """"Return a new ossec configuration with a changed report_value"""
     conf_params, conf_metadata = generate_params(extra_params={'REPORT_CHANGES': {'report_changes': report_value},
                                                                'TEST_DIRECTORIES': directory_str,
+                                                               'RT_DELAY': default_rt_delay,
+                                                               'FILE_MAX_SIZE': default_file_max_size,
                                                                'NODIFF_FILE': nodiff_file,
                                                                'MODULE_NAME': __name__})
 


### PR DESCRIPTION
Hello team,

After the development of https://github.com/wazuh/wazuh/issues/5648 the integration tests that modify any option in the internal configuration must be changed. This PR adds the necessary changes to the integration tests

Closes  https://github.com/wazuh/wazuh/issues/5648

# Tests checks

- [X] Proven that tests **pass** when they have to pass
- [X] Proven that tests **fail** when they have to fail
- [ ] Proven that tests have the expected behavior in **RPM and DEB**
- [ ] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`

Best regards.
