### PR TITLE
Remove /manager/api/config from API tests.

### DIFF
--- a/tests/integration/test_api/test_config/test_DOS_blocking_system/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_DOS_blocking_system/data/conf.yaml
@@ -1,9 +1,11 @@
 ---
 - tags:
   - config1
-  conf:
-    max_request_per_minute: 50
+  configuration:
+    access:
+      max_request_per_minute: 50
 - tags:
   - config2
-  conf:
-    max_request_per_minute: 10
+  configuration:
+    access:
+      max_request_per_minute: 10

--- a/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
@@ -48,17 +48,8 @@ def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_env
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    max_request_per_minute = get_configuration['conf']['max_request_per_minute']
-
-    # PUT configuration for api.yaml
+    max_request_per_minute = get_configuration['configuration']['access']['max_request_per_minute']
     api_details = get_api_details()
-    data = {'access': {'max_request_per_minute': max_request_per_minute}}
-    put_response = requests.put(api_details['base_url'] + '/manager/api/config', json=data,
-                                headers=api_details['auth_headers'], verify=False)
-    assert put_response.status_code == 200, f'Expected status code was 200, ' \
-                                            f'but {put_response.status_code} was returned. \nFull response: {put_response.text}'
-
-    control_service('restart')
 
     # Provoke an api block (default: 300 requests)
     api_details['base_url'] += '/agents'
@@ -77,10 +68,3 @@ def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_env
     # After blocking time, status code will be 200 again 
     assert get_response.status_code == 200, f'Expected status code was 200, ' \
                                             f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
-
-    # DELETE configuration for api.yaml
-    api_details = get_api_details()
-    delete_response = requests.delete(api_details['base_url'] + '/manager/api/config', json=data,
-                                      headers=api_details['auth_headers'], verify=False)
-    assert delete_response.status_code == 200, f'Expected status code was 200, ' \
-                                               f'but {delete_response.status_code} was returned. \nFull response: {delete_response.text}'

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/data/conf.yaml
@@ -1,11 +1,15 @@
 ---
 - tags:
   - config1
-  conf:
-    block_time: 10
-    max_login_attempts: 10
+  configuration:
+    access:
+      block_time: 10
+      max_login_attempts: 10
+      max_request_per_minute: 300
 - tags:
   - config2
-  conf:
-    block_time: 6
-    max_login_attempts: 3
+  configuration:
+    access:
+      block_time: 6
+      max_login_attempts: 3
+      max_request_per_minute: 300

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -49,19 +49,8 @@ def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    block_time = get_configuration['conf']['block_time']
-    max_login_attempts = get_configuration['conf']['max_login_attempts']
-
-    # PUT configuration for api.yaml
-    api_details = get_api_details()
-    data = {
-        'access': {'block_time': block_time, 'max_login_attempts': max_login_attempts, 'max_request_per_minute': 300}}
-    put_response = requests.put(api_details['base_url'] + '/manager/api/config', json=data,
-                                headers=api_details['auth_headers'], verify=False)
-    assert put_response.status_code == 200, f'Expected status code was 200, ' \
-                                            f'but {put_response.status_code} was returned. \nFull response: {put_response.text}'
-
-    control_service('restart')
+    block_time = get_configuration['configuration']['access']['block_time']
+    max_login_attempts = get_configuration['configuration']['access']['max_login_attempts']
 
     # Provoke a block from an unknown IP ('max_login_attempts' attempts with incorrect credentials).
     for _ in range(max_login_attempts):
@@ -77,15 +66,3 @@ def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_
 
     # Request after time expires.
     time.sleep(block_time)  # 300 = default blocking time
-
-    try:
-        api_details = get_api_details()
-    except Exception as e:
-        pytest.fail("No exception was expected when obtaining login token after 'block_time' has expired, but"
-                    f"this was returned: {e}")
-
-    # DELETE configuration for api.yaml
-    delete_response = requests.delete(api_details['base_url'] + '/manager/api/config', json=data,
-                                      headers=api_details['auth_headers'], verify=False)
-    assert delete_response.status_code == 200, f'Expected status code was 200, ' \
-                                               f'but {delete_response.status_code} was returned. \nFull response: {delete_response.text}'


### PR DESCRIPTION
This PR closes #1005 

This tests have been run in [Wazuh 4.0.4](https://github.com/wazuh/wazuh/tree/4.0.4) 

## Description

Hi team! After the deprecation of PUT and DELETE methods for /api/config endpoints, some integration tests needed to be updated as explained in #1005.

## Results
```
/var/ossec/framework/python/bin/python3 -m pytest test_api/
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.2, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-1.11.0, tavern-1.12.2, cov-2.10.1
collected 86 items                                                                                                                                                     

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss.                                                                                   [  4%]
test_api/test_config/test_behind_proxy_server/test_behind_proxy_server.py FsFssFsF                                                                               [ 13%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss.                                                                     [ 18%]
test_api/test_config/test_cache/test_cache.py .ss.                                                                                                               [ 23%]
test_api/test_config/test_cors/test_cors.py x.                                                                                                                   [ 25%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.                                                                                           [ 30%]
test_api/test_config/test_experimental_features/test_experimental_features.py .ss.                                                                               [ 34%]
test_api/test_config/test_host_port/test_host_port.py .s.ss.s.                                                                                                   [ 44%]
test_api/test_config/test_https/test_https.py .ss.                                                                                                               [ 48%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                               [ 53%]
test_api/test_config/test_logs/test_logs.py .ss.                                                                                                                 [ 58%]
test_api/test_config/test_rbac/test_rbac_mode.py .ss.                                                                                                            [ 62%]
test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.sFsEFs.s.sFE                                                                                [ 81%]
test_api/test_rbac/test_add_old_resource.py ....                                                                                                                 [ 86%]
test_api/test_rbac/test_admin_resources.py F...                                                                                                                  [ 90%]
test_api/test_rbac/test_policy_position.py .                                                                                                                     [ 91%]
test_api/test_rbac/test_remove_relationship.py ...                                                                                                               [ 95%]
test_api/test_rbac/test_remove_resource.py ....                                                                                                                  [100%]

======================================== 8 failed, 43 passed, 33 skipped, 1 xfailed, 48 warnings, 2 errors in 740.36s (0:12:20) ========================================
```

## Errors

There are multiple tests that fail as a consequence of using the same testing branch in `wazuh-qa` for all existing branches in the https://github.com/wazuh/wazuh repository. 

For example, in  `Wazuh 4.0.4`, authd is called `ossec-authd`. However, the master branch of wazuh-qa makes references to `wazuh-authd`, which only exists from the master branch of `wazuh/wazuh`.

**Only failures related to the deprecation of `/manager/api/config` have been fixed in this PR.**

Best regards,
Selu.