### PR TITLE
Added new case to test_basic_usage_changes to check wildcards

### DIFF
--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf.yaml
@@ -14,3 +14,19 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+
+# conf 2
+- tags:
+  - ossec_conf_wildcards
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_WILDCARDS
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.py
@@ -26,21 +26,14 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 testdir1, testdir2 = test_directories
-subdir1 = os.path.join(PREFIX, 'testdir3/subdir1')
-subdir2 = os.path.join(PREFIX, 'testdir3/subdir2')
+
 
 # configurations
 
-conf_params = {'TEST_DIRECTORIES': directory_str, 'TEST_WILDCARDS': os.path.join(PREFIX, 'testdir3/*'), 'MODULE_NAME': __name__}
+conf_params = {'TEST_DIRECTORIES': directory_str, 'TEST_WILDCARDS': os.path.join(PREFIX, 'testdir?'),
+               'MODULE_NAME': __name__}
 p, m = generate_params(extra_params=conf_params)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
-
-
-# Extra functions
-
-def extra_configuration_before_yield():
-    os.makedirs(subdir1, exist_ok=True, mode=0o777)
-    os.makedirs(subdir2, exist_ok=True, mode=0o777)
 
 
 # fixtures
@@ -92,8 +85,6 @@ def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,
         Syscheck checkers (check_all).
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    if tags_to_apply == {'ossec_conf_wildcards'}:
-        folder = subdir1 if folder == testdir1 else subdir2
     mult = 1 if sys.platform == 'win32' else 2
 
     if encoding is not None:

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_dir_with_commas.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_dir_with_commas.py
@@ -10,7 +10,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, regular_file_cud
-from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 
 # Marks
 pytestmark = pytest.mark.tier(level=2)
@@ -52,6 +52,8 @@ def test_directories_with_commas(directory, get_configuration, put_env_variables
     """
     Test alerts are generated when monitor environment variables
     """
+    check_apply_test({'ossec_conf'}, get_configuration['tags'])
+
     regular_file_cud(directory, wazuh_log_monitor, file_list=["testing_env_variables"],
                      min_timeout=global_parameters.default_timeout,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')


### PR DESCRIPTION
Hello team,
this PR adds new cases to test_basic_usage_changes, checking wildcards configuring this way:

```
  <syscheck>
    <disabled>no</disabled>
    <directories check_all="yes">/testdir?</directories>
  </syscheck>
```
And testing events in files:
- `/testdir1/regular1`
- `/testdir2/regular1`

Example result:
![image](https://user-images.githubusercontent.com/60003131/104589326-fa8c8500-5669-11eb-87ea-069fffbb85a2.png)


Closes #1008

Best regards.
