### PR TITLE
Added new cases to test_env_variables to check some possible errors

### DIFF
--- a/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
@@ -19,20 +19,18 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables and configuration
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-if sys.platform == 'win32':
-    long_path = 'a' * 234 + '\\'
-else:
-    long_path = os.path.join(*[('a' * 255) for i in range(15)], 'a' * 230) + '\\'
-
 test_directories = [os.path.join(PREFIX, 'testdir1'),
-                    os.path.join(PREFIX, long_path),
+                    os.path.join(PREFIX, 'testdir2'),
                     os.path.join(PREFIX, 'testdir3'),
                     os.path.join(PREFIX, 'testdir4')
                     ]
 dir1, dir2, dir3, dir4 = test_directories
 
-multiples_paths = "{1}{0}{2}{0}{3}".format(os.pathsep, dir2, dir3, dir4)
-environment_variables = [("TEST_ENV_ONE_PATH", dir1), ("TEST_ENV_MULTIPLES_PATH", multiples_paths)]
+# Check big environment variables ending with backslash
+paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [dir2, dir3, dir4]
+multiple_env_var = os.pathsep.join(paths)
+
+environment_variables = [("TEST_ENV_ONE_PATH", dir1), ("TEST_ENV_MULTIPLES_PATH", multiple_env_var)]
 
 if sys.platform == 'win32':
     test_env = "%TEST_ENV_ONE_PATH%, %TEST_ENV_MULTIPLES_PATH%"

--- a/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
@@ -19,8 +19,13 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables and configuration
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
+if sys.platform == 'win32':
+    long_path = 'a' * 234 + '\\'
+else:
+    long_path = os.path.join(*[('a' * 255) for i in range(15)], 'a' * 230) + '\\'
+
 test_directories = [os.path.join(PREFIX, 'testdir1'),
-                    os.path.join(PREFIX, 'testdir2'),
+                    os.path.join(PREFIX, long_path),
                     os.path.join(PREFIX, 'testdir3'),
                     os.path.join(PREFIX, 'testdir4')
                     ]

--- a/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
@@ -27,15 +27,15 @@ test_directories = [os.path.join(PREFIX, 'testdir1'),
 dir1, dir2, dir3, dir4 = test_directories
 
 # Check big environment variables ending with backslash
-paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [dir2, dir3, dir4]
-multiple_env_var = os.pathsep.join(paths)
-
-environment_variables = [("TEST_ENV_ONE_PATH", dir1), ("TEST_ENV_MULTIPLES_PATH", multiple_env_var)]
-
 if sys.platform == 'win32':
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + [dir2, dir3, dir4]
     test_env = "%TEST_ENV_ONE_PATH%, %TEST_ENV_MULTIPLES_PATH%"
 else:
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [dir2, dir3, dir4]
     test_env = "$TEST_ENV_ONE_PATH, $TEST_ENV_MULTIPLES_PATH"
+
+multiple_env_var = os.pathsep.join(paths)
+environment_variables = [("TEST_ENV_ONE_PATH", dir1), ("TEST_ENV_MULTIPLES_PATH", multiple_env_var)]
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_dir.yaml')

--- a/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
@@ -20,27 +20,20 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables and configuration
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-if sys.platform == 'win32':
-    long_path = 'a' * 234 + '\\'
-else:
-    long_path = os.path.join(*[('a' * 255) for i in range(15)], 'a' * 230) + '\\'
-
 test_directories = [os.path.join(PREFIX, 'testdir1'),
-                    os.path.join(PREFIX, long_path),
+                    os.path.join(PREFIX, 'testdir2'),
                     os.path.join(PREFIX, 'testdir3'),
                     os.path.join(PREFIX, 'testdir4')
                     ]
 dir1, dir2, dir3, dir4 = test_directories
 
-multiples_paths = "{1}{0}{2}".format(os.pathsep, dir2, dir3)
-environment_variables = [("TEST_IGN_ENV", multiples_paths)]
+# Check big environment variables ending with backslash
+paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [dir2, dir3]
+multiple_env_var = os.pathsep.join(paths)
 
-if sys.platform == 'win32':
-    dir2 = os.path.join(PREFIX, 'a' * 234)
-else:
-    dir2 = dir2 + '\\'
+environment_variables = [("TEST_IGN_ENV", multiple_env_var)]
 
-dir_config = "{1}{0}{2}{0}{3}{0}{4}".format(", ", dir1, dir2, dir3, dir4)
+dir_config = ",".join(test_directories)
 
 if sys.platform == 'win32':
     test_env = "%TEST_IGN_ENV%"
@@ -75,8 +68,6 @@ def test_tag_ignore(directory, event_generated, get_configuration, configure_env
     """
     Test environment variables are ignored
     """
-
-    pytest.xfail(reason='Xfailed due to issue: https://github.com/wazuh/wazuh/issues/7344')
 
     # Create text files
     filename = "test"

--- a/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
@@ -20,16 +20,27 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables and configuration
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
+if sys.platform == 'win32':
+    long_path = 'a' * 234 + '\\'
+else:
+    long_path = os.path.join(*[('a' * 255) for i in range(15)], 'a' * 230) + '\\'
+
 test_directories = [os.path.join(PREFIX, 'testdir1'),
-                    os.path.join(PREFIX, 'testdir2'),
+                    os.path.join(PREFIX, long_path),
                     os.path.join(PREFIX, 'testdir3'),
-                    os.path.join(PREFIX, 'testdir4'),
+                    os.path.join(PREFIX, 'testdir4')
                     ]
 dir1, dir2, dir3, dir4 = test_directories
-dir_config = "{1}{0}{2}{0}{3}{0}{4}".format(", ", dir1, dir2, dir3, dir4)
 
 multiples_paths = "{1}{0}{2}".format(os.pathsep, dir2, dir3)
 environment_variables = [("TEST_IGN_ENV", multiples_paths)]
+
+if sys.platform == 'win32':
+    dir2 = os.path.join(PREFIX, 'a' * 234)
+else:
+    dir2 = dir2 + '\\'
+
+dir_config = "{1}{0}{2}{0}{3}{0}{4}".format(", ", dir1, dir2, dir3, dir4)
 
 if sys.platform == 'win32':
     test_env = "%TEST_IGN_ENV%"
@@ -64,6 +75,8 @@ def test_tag_ignore(directory, event_generated, get_configuration, configure_env
     """
     Test environment variables are ignored
     """
+
+    pytest.xfail(reason='Xfailed due to issue: https://github.com/wazuh/wazuh/issues/7344')
 
     # Create text files
     filename = "test"

--- a/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
@@ -28,17 +28,17 @@ test_directories = [os.path.join(PREFIX, 'testdir1'),
 dir1, dir2, dir3, dir4 = test_directories
 
 # Check big environment variables ending with backslash
-paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [dir2, dir3]
-multiple_env_var = os.pathsep.join(paths)
+if sys.platform == 'win32':
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + [dir2, dir3]
+    test_env = "%TEST_IGN_ENV%"
+else:
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [dir2, dir3]
+    test_env = "$TEST_IGN_ENV"
 
+multiple_env_var = os.pathsep.join(paths)
 environment_variables = [("TEST_IGN_ENV", multiple_env_var)]
 
 dir_config = ",".join(test_directories)
-
-if sys.platform == 'win32':
-    test_env = "%TEST_IGN_ENV%"
-else:
-    test_env = "$TEST_IGN_ENV"
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_ignore.yaml')

--- a/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
@@ -19,26 +19,25 @@ pytestmark = pytest.mark.tier(level=2)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 test_directories = [os.path.join(PREFIX, 'testdir1'),
-                    os.path.join(PREFIX, 'testdir2\\'),
+                    os.path.join(PREFIX, 'testdir2'),
                     os.path.join(PREFIX, 'testdir3'),
                     os.path.join(PREFIX, 'testdir4')
                     ]
 dir1, dir2, dir3, dir4 = test_directories
 
-multiples_paths = "{1}{0}{2}".format(os.pathsep, dir2, dir3)
-environment_variables = [("TEST_IGN_ENV", multiples_paths)]
+# Check big environment variables ending with backslash
+paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [os.path.join(dir2, "test.txt"),
+                                                                       os.path.join(dir3, "test.txt")]
+multiple_env_var = os.pathsep.join(paths)
+
+environment_variables = [("TEST_NODIFF_ENV", multiple_env_var)]
+
+dir_config = ",".join(test_directories)
 
 if sys.platform == 'win32':
-    dir2 = os.path.join(PREFIX, 'testdir2')
+    test_env = "%TEST_NODIFF_ENV%"
 else:
-    dir2 = dir2 + '\\'
-
-dir_config = "{1}{0}{2}{0}{3}{0}{4}".format(", ", dir1, dir2, dir3, dir4)
-
-if sys.platform == 'win32':
-    test_env = "%TEST_IGN_ENV%"
-else:
-    test_env = "$TEST_IGN_ENV"
+    test_env = "$TEST_NODIFF_ENV"
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_nodiff.yaml')
@@ -75,8 +74,6 @@ def test_tag_nodiff(directory, filename, hidden_content, get_configuration, put_
     hidden_content : bool
         True if content must be truncated,, False otherwise.
     """
-
-    pytest.xfail(reason='Xfailed due to issue: https://github.com/wazuh/wazuh/issues/7344')
 
     files = {filename: b'Hello word!'}
 

--- a/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
@@ -26,18 +26,17 @@ test_directories = [os.path.join(PREFIX, 'testdir1'),
 dir1, dir2, dir3, dir4 = test_directories
 
 # Check big environment variables ending with backslash
-paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [os.path.join(dir2, "test.txt"),
-                                                                       os.path.join(dir3, "test.txt")]
-multiple_env_var = os.pathsep.join(paths)
+if sys.platform == 'win32':
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
+    test_env = "%TEST_NODIFF_ENV%"
+else:
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
+    test_env = "$TEST_NODIFF_ENV"
 
+multiple_env_var = os.pathsep.join(paths)
 environment_variables = [("TEST_NODIFF_ENV", multiple_env_var)]
 
 dir_config = ",".join(test_directories)
-
-if sys.platform == 'win32':
-    test_env = "%TEST_NODIFF_ENV%"
-else:
-    test_env = "$TEST_NODIFF_ENV"
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_nodiff.yaml')

--- a/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
@@ -19,15 +19,21 @@ pytestmark = pytest.mark.tier(level=2)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 test_directories = [os.path.join(PREFIX, 'testdir1'),
-                    os.path.join(PREFIX, 'testdir2'),
+                    os.path.join(PREFIX, 'testdir2\\'),
                     os.path.join(PREFIX, 'testdir3'),
-                    os.path.join(PREFIX, 'testdir4'),
+                    os.path.join(PREFIX, 'testdir4')
                     ]
 dir1, dir2, dir3, dir4 = test_directories
-dir_config = "{1}{0}{2}{0}{3}{0}{4}".format(", ", dir1, dir2, dir3, dir4)
 
-multiples_paths = "{3}{1}{2}{0}{4}{1}{2}".format(os.pathsep, os.sep, "test.txt", dir2, dir3)
+multiples_paths = "{1}{0}{2}".format(os.pathsep, dir2, dir3)
 environment_variables = [("TEST_IGN_ENV", multiples_paths)]
+
+if sys.platform == 'win32':
+    dir2 = os.path.join(PREFIX, 'testdir2')
+else:
+    dir2 = dir2 + '\\'
+
+dir_config = "{1}{0}{2}{0}{3}{0}{4}".format(", ", dir1, dir2, dir3, dir4)
 
 if sys.platform == 'win32':
     test_env = "%TEST_IGN_ENV%"
@@ -69,6 +75,8 @@ def test_tag_nodiff(directory, filename, hidden_content, get_configuration, put_
     hidden_content : bool
         True if content must be truncated,, False otherwise.
     """
+
+    pytest.xfail(reason='Xfailed due to issue: https://github.com/wazuh/wazuh/issues/7344')
 
     files = {filename: b'Hello word!'}
 


### PR DESCRIPTION
Hello team,
This PR adds new cases to **test_env_variables**, making one of the paths configured in the env variable too long and ending with a backslash:


```
if sys.platform == 'win32':
    long_path = 'a' * 235 + '\\'
else:
    long_path = 'a' * 4071 + '\\'

test_directories = [os.path.join(PREFIX, long_path),
                    os.path.join(PREFIX, 'testdir2'),
                    os.path.join(PREFIX, 'testdir3'),
                    os.path.join(PREFIX, 'testdir4')
                    ]
```

This way we made sure to check for the error that occurs when the expanded environment variables were longer than the maximum path allowed by the OS. We also check that even if one of those paths ends with a '\' it will still be configured correctly.

Closes #999
Testing these cases in the master branch of wazuh, generate these errors:

[env_variables_report.zip](https://github.com/wazuh/wazuh-qa/files/5888667/env_variables_report.zip)
We can see in the log, wrong configured paths:
```
2020/12/06 18:55:25 wazuh-agent[2276] syscheck.c:182 at Start_win32_Syscheck(): INFO: (6003): Monitoring path: 'c:\aaaaaaaa[...]aaaaaaa;c:\testdir4', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | whodata'.
2020/12/06 18:55:25 wazuh-agent[2276] syscheck.c:182 at Start_win32_Syscheck(): INFO: (6003): Monitoring path: 'c:\testdir1', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | whodata'.
2020/12/06 18:55:25 wazuh-agent[2276] syscheck.c:182 at Start_win32_Syscheck(): INFO: (6003): Monitoring path: 'c:\testdir2', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | whodata'.

```
Best regards.
