### PR TITLE
Tests for Active Response - analysisd

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/keepalives.txt
+++ b/deps/wazuh_testing/wazuh_testing/data/keepalives.txt
@@ -18,6 +18,10 @@ ubuntu18.04
 #!-Linux |agent-ubuntu18 |4.15.0-76-generic |#220-Ubuntu SMP Thu May 9 12:40:49 UTC 2019 |x86_64 [Ubuntu|ubuntu: 18.04.4 LTS (Bionic Beaver)] - Wazuh v3.11.3 / ab73af41699f13fdd81903b5f23d8d00
 d6e3ac3e75ca0319af3e7c262776f331 merged.mg
 #"_agent_ip":172.16.5.9
+ubuntu20.04
+#!-Linux |agent-ubuntu20 |5.4.0-62-generic |#220-Ubuntu SMP Thu May 9 12:40:49 UTC 2019 |x86_64 [Ubuntu|ubuntu: 20.04.4 LTS (Focal Fossa)] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00
+d6e3ac3e75ca0319af3e7c262776f331 merged.mg
+#"_agent_ip":172.16.5.10
 debian7
 #!-Linux |agent-debian7 |3.16.0-9-amd64 |#1 SMP Debian 3.16.68-1 (2019-05-22) |x86_64 [Debian GNU/Linux|debian: 7 (wheezy)] - Wazuh v3.11.3 / ab73af41699f13fdd81903b5f23d8d00
 d6e3ac3e75ca0319af3e7c262776f331 merged.mg

--- a/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
@@ -1,0 +1,25 @@
+- tags:
+  - valid_conf
+  apply_to_modules:
+  - test_os_exec
+  sections:
+  - section: command
+    attributes:
+      - name: 'command'
+    elements:
+    - name:
+        value: 'restart-wazuh'
+    - executable:
+        value: 'restart-wazuh'
+  - section: active-response
+    attributes:
+      - name: 'active-response'
+    elements:
+    - disabled:
+        value: 'no'
+    - command:
+        value: 'restart-wazuh'
+    - location:
+        value: 'local'
+    - rules_id:
+        value: '554'

--- a/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
@@ -11,6 +11,10 @@
         value: AR_NAME
     - executable:
         value: AR_NAME
+    - extra_args:
+        value: EXTRA_ARGS
+    - timeout_allowed:
+        value: TIMEOUT_ALLOWED
   - section: active-response
     attributes:
       - name: 'active-response'
@@ -20,6 +24,8 @@
     - command:
         value: AR_NAME
     - location:
-        value: 'local'
+        value: AR_LOCATION
     - rules_id:
         value: RULE_ID
+    - timeout:
+        value: TIMEOUT

--- a/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
@@ -22,4 +22,4 @@
     - location:
         value: 'local'
     - rules_id:
-        value: '554'
+        value: '5715'

--- a/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/wazuh_conf.yaml
@@ -1,5 +1,5 @@
 - tags:
-  - valid_conf
+  - local_ar
   apply_to_modules:
   - test_os_exec
   sections:
@@ -8,9 +8,9 @@
       - name: 'command'
     elements:
     - name:
-        value: 'restart-wazuh'
+        value: AR_NAME
     - executable:
-        value: 'restart-wazuh'
+        value: AR_NAME
   - section: active-response
     attributes:
       - name: 'active-response'
@@ -18,8 +18,8 @@
     - disabled:
         value: 'no'
     - command:
-        value: 'restart-wazuh'
+        value: AR_NAME
     - location:
         value: 'local'
     - rules_id:
-        value: '5715'
+        value: RULE_ID

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -213,11 +213,11 @@ def wait_ar_line(line):
     return None
 
 
-def validate_old_ar_message(id, name, message, extra_args, timeout, all_agents):
+def validate_old_ar_message(id, message, extra_args, timeout, all_agents):
     args = message.split()
 
-    assert args[0] == f'({name})', 'Agent name did not match expected!'
-    assert args[1] == LOG_LOCATION, 'Event location did not match expected!'
+    assert args[0] == f'(local_source)', 'Event location did not match expected!'
+    assert args[1] == '[]', 'Source IP did not match expected!'
     if all_agents == 'yes':
         assert args[2] == 'NNS', 'AR flags did not match expected!'
         assert args[3] in id, 'Agent ID did not match expected!'
@@ -237,11 +237,11 @@ def validate_old_ar_message(id, name, message, extra_args, timeout, all_agents):
         assert args[13] == ARG2, 'ARG2 did not match expected!'
 
 
-def validate_new_ar_message(id, name, message, extra_args, timeout, all_agents):
+def validate_new_ar_message(id, message, extra_args, timeout, all_agents):
     args = message.split(' ', 4)
 
-    assert args[0] == f'({name})', 'Agent name did not match expected!'
-    assert args[1] == LOG_LOCATION, 'Event location did not match expected!'
+    assert args[0] == f'(local_source)', 'Event location did not match expected!'
+    assert args[1] == '[]', 'Source IP did not match expected!'
     if all_agents == 'yes':
         assert args[2] == 'NNS', 'AR flags did not match expected!'
         assert args[3] in id, 'Agent ID did not match expected!'
@@ -316,10 +316,10 @@ def test_os_exec(set_debug_mode, get_configuration, configure_environment, resta
 
             if agent.os == 'ubuntu20.04':
                 # Version 4.2
-                validate_new_ar_message(agents_id, SERVER_NAME, last_log, extra_args, timeout, all_agents)
+                validate_new_ar_message(agents_id, last_log, extra_args, timeout, all_agents)
             else:
                 # Version < 4.2
-                validate_old_ar_message(agents_id, SERVER_NAME, last_log, extra_args, timeout, all_agents)
+                validate_old_ar_message(agents_id, last_log, extra_args, timeout, all_agents)
 
     else:
         for agent in agents:
@@ -336,10 +336,10 @@ def test_os_exec(set_debug_mode, get_configuration, configure_environment, resta
 
             if agent.os == 'ubuntu20.04':
                 # Version 4.2
-                validate_new_ar_message(agent.id, agent.name, last_log, extra_args, timeout, all_agents)
+                validate_new_ar_message(agent.id, last_log, extra_args, timeout, all_agents)
             else:
                 # Version < 4.2
-                validate_old_ar_message(agent.id, agent.name, last_log, extra_args, timeout, all_agents)
+                validate_old_ar_message(agent.id, last_log, extra_args, timeout, all_agents)
 
     for injector in injectors:
         injector.stop_receive()

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -249,7 +249,7 @@ def validate_new_ar_message(id, message, extra_args, timeout, all_agents):
         assert args[2] == 'NRN', 'AR flags did not match expected!'
         assert args[3] == id, 'Agent ID did not match expected!'
 
-    json_alert = json.loads(args[4]) # Alert in JSON
+    json_alert = json.loads(args[4])  # Alert in JSON
     assert json_alert['version'], 'Missing version in JSON message'
     assert json_alert['version'] == 1, 'Invalid version in JSON message'
     assert json_alert['origin'], 'Missing origin in JSON message'
@@ -276,8 +276,7 @@ def validate_new_ar_message(id, message, extra_args, timeout, all_agents):
         assert json_alert['parameters']['extra_args'][1] == ARG2, 'Missing arg1 in JSON message'
 
 
- # TESTS
-
+# TESTS
 def test_os_exec(set_debug_mode, get_configuration, configure_environment, restart_service, configure_agents):
     metadata = get_configuration.get('metadata')
     protocol = metadata['protocol']

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import json
+import os
+import pytest
+import socket
+import time
+
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.agent_simulator import Sender, Injector, Agent, create_agents
+from wazuh_testing.tools.services import control_service
+
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+ANALYSISD_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue')
+
+SERVER_ADDRESS = 'localhost'
+CRYPTO = "aes"
+
+cases = [
+    {
+        'metadata': {
+            'agents_number': 1,
+            'agents_os': ['ubuntu20.04'],
+            'protocol': 'tcp'
+        }
+    }
+]
+
+metadata = [case['metadata'] for case in cases]
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__, metadata=metadata)
+
+# List where the agents objects will be stored
+agents = []
+
+
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module"""
+    yield request.param
+
+
+@pytest.fixture(scope="function")
+def restart_service():
+    control_service('restart')
+    yield
+
+
+@pytest.fixture(scope="function")
+def configure_agents(request, get_configuration):
+    metadata = get_configuration.get('metadata')
+    agents_number = metadata['agents_number']
+    agents_os = metadata['agents_os']
+    agents_created = create_agents(agents_number, SERVER_ADDRESS, CRYPTO, os=agents_os)
+    setattr(request.module, 'agents', agents_created)
+
+
+def send_message(data_object, socket_path):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.connect(socket_path)
+    sock.send(data_object.encode())
+    sock.close()
+
+
+def wait_expected_line(line, expected):
+    if (expected in line):
+        return line
+    return None
+
+
+def test_os_exec(get_configuration, configure_environment, restart_service, configure_agents):
+    metadata = get_configuration.get('metadata')
+    protocol = metadata['protocol']
+    sender = Sender(SERVER_ADDRESS, protocol=protocol)
+    injectors = []
+
+    # Agents
+    for agent in agents:
+        injector = Injector(sender, agent)
+        injectors.append(injector)
+        injector.run()
+        if protocol == "tcp":
+            sender = Sender(manager_address=SERVER_ADDRESS, protocol=protocol)
+
+    agents_id = [int(x.id) for x in agents]
+
+    # Give time for registration key to be available and send a few heartbeats
+    time.sleep(10)
+
+    for agent_id in agents_id:
+        # Send upgrade request
+        message = "8:[" + str(agent_id) + "] (vm-agent) 1.1.1.1->syscheck:{\"type\":\"event\",\"data\":{\"path\":\"/home/test/file\",\"mode\":\"realtime\",\"type\":\"added\",\"timestamp\":1575421292,\"attributes\":{\"type\":\"file\"}}}"
+        send_message(message, ANALYSISD_SOCKET)
+        # TODO
+
+    for injector in injectors:
+        injector.stop_receive()

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -8,10 +8,12 @@ import pytest
 import socket
 import time
 
-from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.agent_simulator import Sender, Injector, Agent, create_agents
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import FileMonitor
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
@@ -25,7 +27,8 @@ cases = [
         'metadata': {
             'agents_number': 1,
             'agents_os': ['ubuntu20.04'],
-            'protocol': 'tcp'
+            'protocol': 'tcp',
+            'log_message': 'Jan 27 11:52:25 vm-test sshd[32046]: Accepted password for root from 172.16.5.15 port 62300 ssh2'
         }
     }
 ]
@@ -40,6 +43,19 @@ configurations = load_wazuh_configurations(configurations_path, __name__, metada
 agents = []
 
 
+@pytest.fixture(scope="session")
+def set_debug_mode():
+    local_int_conf_path = os.path.join(WAZUH_PATH, 'etc', 'local_internal_options.conf')
+    debug_line = 'remoted.debug=2\n'
+    with open(local_int_conf_path, 'r') as local_file_read:
+        lines = local_file_read.readlines()
+        for line in lines:
+            if line == debug_line:
+                return
+    with open(local_int_conf_path, 'a') as local_file_write:
+        local_file_write.write('\n'+debug_line)
+
+
 @pytest.fixture(scope="module", params=configurations)
 def get_configuration(request):
     """Get configurations from the module"""
@@ -48,6 +64,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope="function")
 def restart_service():
+    clean_logs()
     control_service('restart')
     yield
 
@@ -68,16 +85,22 @@ def send_message(data_object, socket_path):
     sock.close()
 
 
-def wait_expected_line(line, expected):
-    if (expected in line):
+def clean_logs():
+    truncate_file(LOG_FILE_PATH)
+
+
+def wait_ar_line(line):
+    if ('Active response request received: ' in line):
         return line
     return None
 
 
-def test_os_exec(get_configuration, configure_environment, restart_service, configure_agents):
+def test_os_exec(set_debug_mode, get_configuration, configure_environment, restart_service, configure_agents):
     metadata = get_configuration.get('metadata')
     protocol = metadata['protocol']
+    log_message = metadata['log_message']
     sender = Sender(SERVER_ADDRESS, protocol=protocol)
+    log_monitor = FileMonitor(LOG_FILE_PATH)
     injectors = []
 
     # Agents
@@ -88,16 +111,22 @@ def test_os_exec(get_configuration, configure_environment, restart_service, conf
         if protocol == "tcp":
             sender = Sender(manager_address=SERVER_ADDRESS, protocol=protocol)
 
-    agents_id = [int(x.id) for x in agents]
-
     # Give time for registration key to be available and send a few heartbeats
-    time.sleep(10)
+    time.sleep(15)
 
-    for agent_id in agents_id:
-        # Send upgrade request
-        message = "8:[" + str(agent_id) + "] (vm-agent) 1.1.1.1->syscheck:{\"type\":\"event\",\"data\":{\"path\":\"/home/test/file\",\"mode\":\"realtime\",\"type\":\"added\",\"timestamp\":1575421292,\"attributes\":{\"type\":\"file\"}}}"
+    for agent in agents:
+        message = "1:[" + str(agent.id) + "] (" + agent.name + ") any->logcollector:" + log_message
         send_message(message, ANALYSISD_SOCKET)
-        # TODO
+
+        # Checking AR in logs
+        try:
+            log_monitor.start(timeout=10, callback=wait_ar_line)
+        except TimeoutError as err:
+            raise AssertionError("AR message tooks too much!")
+
+        last_log = log_monitor.result()
+        assert '' in last_log, \
+            'AR did not match expected!'
 
     for injector in injectors:
         injector.stop_receive()

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -20,24 +20,57 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 ANALYSISD_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue')
 
 SERVER_ADDRESS = 'localhost'
-CRYPTO = "aes"
+CRYPTO = 'aes'
+
+AR_NAME = 'restart-wazuh'
+RULE_ID = '5715'
+LOG_LOCATION = 'any->logcollector'
+SRC_IP = '172.16.5.15'
+DST_USR = 'root'
+LOG_MESSAGE = 'Jan 27 11:52:25 vm-test sshd[32046]: Accepted password for ' + DST_USR + ' from ' + SRC_IP + ' port 62300 ssh2'
 
 cases = [
     {
+        'params': {
+            'AR_NAME': AR_NAME,
+            'RULE_ID': RULE_ID
+        },
         'metadata': {
             'agents_number': 1,
             'agents_os': ['ubuntu20.04'],
-            'protocol': 'tcp',
-            'log_message': 'Jan 27 11:52:25 vm-test sshd[32046]: Accepted password for root from 172.16.5.15 port 62300 ssh2'
+            'protocol': 'tcp'
+        }
+    },
+    {
+        'params': {
+            'AR_NAME': AR_NAME,
+            'RULE_ID': RULE_ID
+        },
+        'metadata': {
+            'agents_number': 1,
+            'agents_os': ['debian8'],
+            'protocol': 'tcp'
+        }
+    },
+    {
+        'params': {
+            'AR_NAME': AR_NAME,
+            'RULE_ID': RULE_ID
+        },
+        'metadata': {
+            'agents_number': 2,
+            'agents_os': ['debian8', 'ubuntu20.04'],
+            'protocol': 'tcp'
         }
     }
 ]
 
+params = [case['params'] for case in cases]
 metadata = [case['metadata'] for case in cases]
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
-configurations = load_wazuh_configurations(configurations_path, __name__, metadata=metadata)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
 # List where the agents objects will be stored
 agents = []
@@ -91,14 +124,54 @@ def clean_logs():
 
 def wait_ar_line(line):
     if ('Active response request received: ' in line):
-        return line
+        return line.split('Active response request received: ', 1)[1]
     return None
 
+
+def validate_old_ar_message(agent, message):
+    args = message.split()
+    assert args[0] == f'({agent.name})', 'Agent name did not match expected!'
+    assert args[1] == LOG_LOCATION, 'Event location did not match expected!'
+    assert args[2] == 'NRN', 'AR flags did not match expected!'
+    assert args[3] == agent.id, 'Agent ID did not match expected!'
+    assert args[4] == f'{AR_NAME}0', 'AR name did not match expected!'
+    assert args[5] == DST_USR, 'Destination user did not match expected!'
+    assert args[6] == SRC_IP, 'Source IP did not match expected!'
+    assert args[8] == RULE_ID, 'Rule ID did not match expected!'
+
+
+def validate_new_ar_message(agent, message):
+    args = message.split(' ', 4)
+    assert args[0] == f'({agent.name})', 'Agent name did not match expected!'
+    assert args[1] == LOG_LOCATION, 'Event location did not match expected!'
+    assert args[2] == 'NRN', 'AR flags did not match expected!'
+    assert args[3] == agent.id, 'Agent ID did not match expected!'
+
+    json_alert = json.loads(args[4]) # Alert in JSON
+    assert json_alert['version'], 'Missing version in JSON message'
+    assert json_alert['version'] == 1, 'Invalid version in JSON message'
+    assert json_alert['origin'], 'Missing origin in JSON message'
+    assert json_alert['origin']['module'], 'Missing module in JSON message'
+    assert json_alert['origin']['module'] == 'wazuh-analysisd', 'Invalid module in JSON message'
+    assert json_alert['command'], 'Missing command in JSON message'
+    assert json_alert['command'] == f'{AR_NAME}0', 'Invalid command in JSON message'
+    assert json_alert['parameters'], 'Missing parameters in JSON message'
+    assert json_alert['parameters']['alert'], 'Missing alert in JSON message'
+    assert json_alert['parameters']['alert']['rule'], 'Missing rule in JSON message'
+    assert json_alert['parameters']['alert']['rule']['id'], 'Missing rule ID in JSON message'
+    assert json_alert['parameters']['alert']['rule']['id'] == RULE_ID, 'Invalid rule ID in JSON message'
+    assert json_alert['parameters']['alert']['data'], 'Missing data in JSON message'
+    assert json_alert['parameters']['alert']['data']['srcip'], 'Missing source IP in JSON message'
+    assert json_alert['parameters']['alert']['data']['srcip'] == SRC_IP, 'Invalid source IP in JSON message'
+    assert json_alert['parameters']['alert']['data']['dstuser'], 'Missing destination user in JSON message'
+    assert json_alert['parameters']['alert']['data']['dstuser'] == DST_USR, 'Invalid destination user in JSON message'
+
+
+ # TESTS
 
 def test_os_exec(set_debug_mode, get_configuration, configure_environment, restart_service, configure_agents):
     metadata = get_configuration.get('metadata')
     protocol = metadata['protocol']
-    log_message = metadata['log_message']
     sender = Sender(SERVER_ADDRESS, protocol=protocol)
     log_monitor = FileMonitor(LOG_FILE_PATH)
     injectors = []
@@ -115,7 +188,7 @@ def test_os_exec(set_debug_mode, get_configuration, configure_environment, resta
     time.sleep(15)
 
     for agent in agents:
-        message = "1:[" + str(agent.id) + "] (" + agent.name + ") any->logcollector:" + log_message
+        message = "1:[" + str(agent.id) + "] (" + agent.name + ") " + LOG_LOCATION + ":" + LOG_MESSAGE
         send_message(message, ANALYSISD_SOCKET)
 
         # Checking AR in logs
@@ -125,8 +198,13 @@ def test_os_exec(set_debug_mode, get_configuration, configure_environment, resta
             raise AssertionError("AR message tooks too much!")
 
         last_log = log_monitor.result()
-        assert '' in last_log, \
-            'AR did not match expected!'
+
+        if agent.os == 'ubuntu20.04':
+            # Version 4.2
+            validate_new_ar_message(agent, last_log)
+        else:
+            # Version < 4.2
+            validate_old_ar_message(agent, last_log)
 
     for injector in injectors:
         injector.stop_receive()


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh-qa/issues/981

# Tests cases

- Single AR in one agent -> old version.
- Single AR in one agent -> new version.
- Single AR in two agents -> old and new version.
- Single AR with extra args.
- Single AR with timeout.
- AR executed in all agents -> old and new version.

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Tested and passed in Jenkins. Build URL: `<YOUR_JENKINS_BUILD_URL>`
  - Manager RPM: https://ci.wazuh.info/job/test_integration/1069/console
  - Manager DEB: https://ci.wazuh.info/job/test_integration/1070/console

## RPM manager

- When the expected behavior occurs:

```
17:14:18  [0;33m============================= test session starts ==============================[0m
17:14:18  [0;33mplatform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /bin/python3[0m
17:14:18  [0;33mcachedir: .pytest_cache[0m
17:14:18  [0;33mmetadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-centos-7.4.1708-Core', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
17:14:18  [0;33mrootdir: /tmp/test_integration_B1069_20210129210534/tests/integration, inifile: pytest.ini[0m
17:14:18  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
17:14:18  [0;33mcollecting ... collected 6 items[0m
17:14:18  [0;33m[0m
17:14:18  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration0] PASSED [ 16%][0m
17:14:18  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration1] PASSED [ 33%][0m
17:14:18  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration2] PASSED [ 50%][0m
17:14:18  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration3] PASSED [ 66%][0m
17:14:18  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration4] PASSED [ 83%][0m
17:14:18  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration5] PASSED [100%][0m
17:14:18  [0;33m[0m
17:14:18  [0;33m- generated html file: file:///tmp/test_integration_B1069_20210129210534/report.html -[0m
17:14:18  [0;33m======================== 6 passed in 334.33s (0:05:34) =========================[0m
```

## DEB manager

- When the expected behavior occurs:

```
17:15:54  [0;33m============================= test session starts ==============================[0m
17:15:54  [0;33mplatform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3[0m
17:15:54  [0;33mcachedir: .pytest_cache[0m
17:15:54  [0;33mmetadata: {'Python': '3.6.9', 'Platform': 'Linux-4.15.0-1060-aws-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}[0m
17:15:54  [0;33mrootdir: /tmp/test_integration_B1070_20210129210534/tests/integration, inifile: pytest.ini[0m
17:15:54  [0;33mplugins: metadata-1.8.0, html-2.0.1, testinfra-5.0.0[0m
17:15:54  [0;33mcollecting ... collected 6 items[0m
17:15:54  [0;33m[0m
17:15:54  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration0] PASSED [ 16%][0m
17:15:54  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration1] PASSED [ 33%][0m
17:15:54  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration2] PASSED [ 50%][0m
17:15:54  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration3] PASSED [ 66%][0m
17:15:54  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration4] PASSED [ 83%][0m
17:15:54  [0;33mtest_active_response/test_analysisd/test_os_exec.py::test_os_exec[get_configuration5] PASSED [100%][0m
17:15:54  [0;33m[0m
17:15:54  [0;33m- generated html file: file:///tmp/test_integration_B1070_20210129210534/report.html -[0m
17:15:54  [0;33m======================== 6 passed in 331.65s (0:05:31) =========================[0m
```