### PR TITLE
wazuh-agentd stats IT

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -58,7 +58,7 @@ def set_state_interval(interval, internal_file_path):
                       from internal_options.conf
     """
     if interval is not None:
-        change_internal_options('agent.state_interval', interval, opt_path=internal_file_path)
+        change_internal_options('agent.state_interval', interval, internal_file_path, '.*')
     else:
         new_content = ''
         with open(internal_file_path) as opts:

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import re
+
+
+# Callbacks
+def callback_state_interval_not_valid(line):
+    match = re.match(r'.*Invalid definition for agent.state_interval:', line)
+    if match:
+        return True
+    return None
+
+
+def callback_state_interval_not_found(line):
+    match = re.match(r".*Definition not found for: 'agent.state_interval'",
+                     line)
+    if match:
+        return True
+    return None
+
+
+def callback_state_file_not_enabled(line):
+    match = re.match(r'.*State file is disabled', line)
+    if match:
+        return True
+    return None
+
+
+def callback_state_file_enabled(line):
+    match = re.match(r'.*State file updating thread started', line)
+    if match:
+        return True
+    return None

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -33,3 +33,30 @@ def callback_state_file_enabled(line):
     if match:
         return True
     return None
+
+
+def callback_state_file_updated(line):
+    match = re.match(r'.*Updating state file', line)
+    if match:
+        return True
+    return None
+
+
+def callback_ack(line):
+    match = re.match(r".*Received message: '#!-agent ack ", line)
+    if match:
+        return True
+    return None
+
+
+def callback_keepalive(line):
+    match = re.match(r'.*Sending keep alive', line)
+    if match:
+        return True
+    return None
+
+def callback_connected_to_server(line):
+    match = re.match(r'.*Connected to the server', line)
+    if match:
+        return True
+    return None

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -4,59 +4,67 @@
 
 import re
 
+from wazuh_testing.fim import change_internal_options
+
 
 # Callbacks
 def callback_state_interval_not_valid(line):
     match = re.match(r'.*Invalid definition for agent.state_interval:', line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
 
 
 def callback_state_interval_not_found(line):
-    match = re.match(r".*Definition not found for: 'agent.state_interval'",
-                     line)
-    if match:
-        return True
-    return None
+    match = re.match(r".*Definition not found for: 'agent.state_interval'", line)
+    return True if match is not None else None
 
 
 def callback_state_file_not_enabled(line):
     match = re.match(r'.*State file is disabled', line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
 
 
 def callback_state_file_enabled(line):
     match = re.match(r'.*State file updating thread started', line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
 
 
 def callback_state_file_updated(line):
     match = re.match(r'.*Updating state file', line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
 
 
 def callback_ack(line):
     match = re.match(r".*Received message: '#!-agent ack ", line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
 
 
 def callback_keepalive(line):
     match = re.match(r'.*Sending keep alive', line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
+
 
 def callback_connected_to_server(line):
     match = re.match(r'.*Connected to the server', line)
-    if match:
-        return True
-    return None
+    return True if match is not None else None
+
+
+def set_state_interval(interval, internal_file_path):
+    """Set agent.state_interval value on internal_options.conf
+    Args:
+        interval:
+            - Different than `None`: set agent.state_interval
+                                     value on internal_options.conf
+            - `None`: agent.state_interval will be removed
+                      from internal_options.conf
+    """
+    if interval is not None:
+        change_internal_options('agent.state_interval', interval, opt_path=internal_file_path)
+    else:
+        new_content = ''
+        with open(internal_file_path) as opts:
+            for line in opts:
+                new_line = line if 'agent.state_interval' not in line else ''
+                new_content += new_line
+
+        with open(internal_file_path, 'w') as opts:
+            opts.write(new_content)

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -920,13 +920,14 @@ def modify_file(path, name, new_content=None, is_binary=False):
     modify_file_win_attributes(path, name)
 
 
-def change_internal_options(param, value, opt_path=None):
+def change_internal_options(param, value, opt_path=None, value_regex='[0-9]*'):
     """Change the value of a given parameter in local_internal_options.
 
     Args:
         param (str): parameter to change.
         value (obj): new value.
         opt_path (str, optional): local_internal_options.conf path. Defaults `None`
+        value_regex (str, optional): regex to match value in local_internal_options.conf. Default '[0-9]*'
     """
     if opt_path is None:
         local_conf_path = os.path.join(WAZUH_PATH, 'local_internal_options.conf') if sys.platform == 'win32' else \
@@ -941,7 +942,7 @@ def change_internal_options(param, value, opt_path=None):
     with open(local_conf_path, "w") as sources:
         for line in lines:
             sources.write(
-                re.sub(f'{param}=.*', f'{param}={value}', line))
+                re.sub(f'{param}={value_regex}', f'{param}={value}', line))
             if param in line:
                 add_pattern = False
 

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -941,7 +941,7 @@ def change_internal_options(param, value, opt_path=None):
     with open(local_conf_path, "w") as sources:
         for line in lines:
             sources.write(
-                re.sub(f'{param}=[0-9]*', f'{param}={value}', line))
+                re.sub(f'{param}=.*', f'{param}={value}', line))
             if param in line:
                 add_pattern = False
 

--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -664,12 +664,14 @@ class RemotedSimulator:
             if timeout is not None:
                 timeout -= 1
         return self.upgrade_notification
-    """
-    Send request to agent
-    message: Request content
-    """
+
     def request(self, message):
+        """
+        Send request to agent using current request counter
+        message: Request content
+        """
+
         if self.last_client:
-            message = "#!-req 111 " + message
-            request = self.create_sec_message(message, 'aes')
+            request_message = f'#!-req {self.request_counter} {message}'
+            request = self.create_sec_message(request_message, 'aes')
             self.send(self.last_client, request)

--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -670,8 +670,6 @@ class RemotedSimulator:
         Send request to agent using current request counter
         message: Request content
         """
-
         if self.last_client:
-            request_message = f'#!-req {self.request_counter} {message}'
-            request = self.create_sec_message(request_message, 'aes')
+            request = self.create_sec_message(f'#!-req {self.request_counter} {message}', 'aes')
             self.send(self.last_client, request)

--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -72,6 +72,7 @@ class RemotedSimulator:
         self.wcom_message_version = None
         self.active_response_message = None
         self.listener_thread = None
+        self.last_client = None
         if start_on_init:
             self.start()
 
@@ -379,21 +380,23 @@ class RemotedSimulator:
                 # Wait for a connection
                 try:
                     connection, client_address = self.sock.accept()
+                    self.last_client = connection
                     while self.running:
                         data = self.recv_all(connection, 4)
                         data_size = struct.unpack('<I', data[0:4])[0]
                         data = self.recv_all(connection, data_size)
-
                         try:
                             ret = self.process_message(client_address, data)
                         except Exception:
                             time.sleep(1)
                             connection.close()
+                            self.last_client = None
 
                         # Response -1 means connection have to be closed
                         if ret == -1:
                             time.sleep(0.1)
                             connection.close()
+                            self.last_client = None
                             break
                         # If there is a response, answer it
                         elif ret:
@@ -661,3 +664,12 @@ class RemotedSimulator:
             if timeout is not None:
                 timeout -= 1
         return self.upgrade_notification
+    """
+    Send request to agent
+    message: Request content
+    """
+    def request(self, message):
+        if self.last_client:
+            message = "#!-req 111 " + message
+            request = self.create_sec_message(message, 'aes')
+            self.send(self.last_client, request)

--- a/tests/integration/test_agentd/data/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/data/wazuh_conf.yaml
@@ -142,6 +142,7 @@
       - all
       apply_to_modules:
       - test_agentd_state_config
+      - test_agentd_state
       sections:
       - section: client
         elements:
@@ -149,3 +150,8 @@
                 elements:
                 - address: 
                     value: '127.0.0.1'
+                - port:
+                    value: '1514'
+                - protocol:
+                    value: 'tcp'
+        

--- a/tests/integration/test_agentd/data/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/data/wazuh_conf.yaml
@@ -138,3 +138,14 @@
                     value: MAX_RETRIES
                 - retry_interval:
                     value: RETRY_INTERVAL
+    - tags:
+      - all
+      apply_to_modules:
+      - test_agentd_state_config
+      sections:
+      - section: client
+        elements:
+            - server:
+                elements:
+                - address: 
+                    value: '127.0.0.1'

--- a/tests/integration/test_agentd/data/wazuh_state_config_tests.yaml
+++ b/tests/integration/test_agentd/data/wazuh_state_config_tests.yaml
@@ -1,0 +1,43 @@
+---
+-
+  name: "Negative state interval"
+  test_case:
+    log_expect: 'interval_not_valid'
+    interval: -1
+    state_file_exist: false
+    agentd_ends: true
+-
+  name: "Undefined state interval value"
+  test_case:
+    log_expect: 'file_not_enabled'
+    interval: " "
+    state_file_exist: false
+    agentd_ends: false
+-
+  name: "State interval option dont exist"
+  test_case:
+    log_expect: 'interval_not_found'
+    interval: null
+    state_file_exist: false
+    agentd_ends: true
+-
+  name: "Zero state interval"
+  test_case:
+    log_expect: 'file_not_enabled'
+    interval: 0
+    state_file_exist: false
+    agentd_ends: false
+-
+  name: "Too big state interval"
+  test_case:
+    log_expect: 'interval_not_valid'
+    interval: 86401
+    state_file_exist: false
+    agentd_ends: true
+-
+  name: "Default state interval"
+  test_case:
+    log_expect: 'file_enabled'
+    interval: 5
+    state_file_exist: true
+    agentd_ends: false

--- a/tests/integration/test_agentd/data/wazuh_state_tests.yaml
+++ b/tests/integration/test_agentd/data/wazuh_state_tests.yaml
@@ -1,0 +1,48 @@
+---
+-
+  name: "No connection with remoted"
+  test_case:
+    input:
+      remoted: false
+    output:
+    -
+      type: "file"
+      fields:
+        status: "pending"
+        last_keepalive: ""
+        last_ack: ""
+        msg_count: ""
+-
+  name: "Successful connection with remoted"
+  test_case:
+    input:
+      remoted: true
+    output:
+    -
+      type: "file"
+      fields:
+        status: "connected"
+        last_keepalive: true
+        last_ack: true
+        msg_count: true
+    -
+      type: "remote"
+      fields:
+        status: "connected"
+        last_keepalive: true
+        last_ack: true
+        msg_count: true
+-
+  name: "Only remote request available"
+  test_case:
+    input:
+      remoted: true
+      interval: '0'
+    output:
+    -
+      type: "remote"
+      fields:
+        status: "connected"
+        last_keepalive: true
+        last_ack: true
+        msg_count: true

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -1,0 +1,275 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+import os
+import yaml
+import sys
+import json
+
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.remoted_sim import RemotedSimulator
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.fim import (change_internal_options)
+from conftest import CLIENT_KEYS_PATH
+from time import sleep
+from wazuh_testing.agent import (callback_ack,
+                                 callback_keepalive,
+                                 callback_connected_to_server,
+                                 callback_state_file_updated
+                                 )
+from wazuh_testing.tools.services import (control_service,
+                                          check_if_process_is_running)
+
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.win32,
+              pytest.mark.tier(level=0), pytest.mark.agent]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'data')
+test_data_file = os.path.join(test_data_path, 'wazuh_state_tests.yaml')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__)
+with open(test_data_file) as f:
+    test_cases = yaml.safe_load(f)
+
+remoted_server = None
+configurations = load_wazuh_configurations(configurations_path, __name__)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+# Variables
+if sys.platform == 'win32':
+    state_file_path = os.path.join(WAZUH_PATH, 'wazuh-agentd.state')
+    internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
+else:
+    state_file_path = os.path.join(WAZUH_PATH, 'var', 'run',
+                                   'wazuh-agentd.state')
+    internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module"""
+    return request.param
+
+
+# Functions
+def control_service_unconditionally(action, daemon=None):
+    try:
+        control_service(action, daemon=daemon)
+    except Exception:
+        pass
+
+
+def extra_configuration_before_yield():
+    change_internal_options('agent.debug', '2')
+
+
+def extra_configuration_after_yield():
+    change_internal_options('agent.debug', '0')
+    global remoted_server
+    if remoted_server is not None:
+        remoted_server.stop()
+
+
+def set_state_interval(interval):
+    if interval is not None:
+        change_internal_options('agent.state_interval', interval,
+                                opt_path=internal_options)
+    else:
+        new_content = ''
+        with open(internal_options, 'r') as f:
+            lines = f.readlines()
+
+        for line in lines:
+            new_line = line if 'agent.state_interval' not in line else ''
+            new_content += new_line
+
+        with open(internal_options, 'w') as f:
+            f.write(new_content)
+
+
+def files_setup():
+    truncate_file(LOG_FILE_PATH)
+    os.remove(state_file_path) if os.path.exists(state_file_path) else None
+
+
+def set_keys():
+    with open(CLIENT_KEYS_PATH, 'w+') as f:
+        f.write("100 ubuntu-agent any TopSecret")
+
+
+# Tests
+@pytest.mark.parametrize('test_case',
+                         [test_case['test_case'] for test_case in test_cases],
+                         ids=[test_case['name'] for test_case in test_cases])
+def test_agentd_state(configure_environment, test_case: list):
+    global remoted_server
+    if remoted_server is not None:
+        remoted_server.stop()
+
+    control_service_unconditionally('stop')
+
+    if 'interval' in test_case['input']:
+        set_state_interval(test_case['input']['interval'])
+    else:
+        set_state_interval(1)
+
+    files_setup()
+    set_keys()
+
+    control_service_unconditionally('start')
+
+    if('remoted' in test_case['input'] and
+       test_case['input']['remoted'] == True):
+        remoted_server = RemotedSimulator(protocol='tcp', mode='DUMMY_ACK',
+                                          client_keys=CLIENT_KEYS_PATH)
+
+    for expected_output in test_case['output']:
+        check_fields(expected_output)
+
+
+def parse_state_file():
+    wait_state_update()
+    state = {}
+    with open(state_file_path, 'r') as f:
+        lines = f.readlines()
+
+    for line in lines:
+        line = line.rstrip('\n')
+        if not line or line.startswith('#'):
+            continue
+        (key, value) = line.split('=', 1)
+        state[key] = value.strip("'")
+    return state
+
+
+def remoted_get_state():
+    global remoted_server
+    remoted_server.request("agent getstate")
+    sleep(2)
+    response = json.loads(remoted_server.request_answer)
+    return response['data']
+
+
+def check_fields(expected_output):
+
+    checks = {
+        'last_ack': {'handler': check_last_ack, 'precondition': [wait_ack]},
+        'last_keepalive': {'handler': check_last_keepalive,
+                           'precondition': [wait_keepalive]},
+        'msg_count': {'handler': check_last_keepalive,
+                      'precondition': [wait_keepalive]},
+        'status': {'handler': check_status, 'precondition': []}
+        }
+
+    if expected_output['type'] == 'file':
+        get_state = parse_state_file
+    else:
+        get_state = remoted_get_state
+
+    for field, expected_value in expected_output['fields'].items():
+        # Check if expected value is valiable and mandatory
+
+        if expected_value != '':
+            for precondition in checks[field].get('precondition'):
+                precondition()
+        assert checks[field].get('handler')(expected_value,
+                                            get_state_callback=get_state)
+
+
+def check_last_ack(expected_value=None, get_state_callback=None):
+    if get_state_callback:
+        current_value = get_state_callback()['last_ack']
+        if expected_value == '':
+            return expected_value == current_value
+
+    with open(LOG_FILE_PATH, 'r') as f:
+        lines = f.readlines()
+
+    for line in lines:
+        if(current_value.replace("-", "/") in line
+           and "Received message: '#!-agent ack '" in line):
+            return True
+    return False
+
+
+def check_last_keepalive(expected_value=None, get_state_callback=None):
+    if get_state_callback:
+        current_value = get_state_callback()['last_keepalive']
+        if expected_value == '':
+            return expected_value == current_value
+
+    with open(LOG_FILE_PATH, 'r') as f:
+        lines = f.readlines()
+
+    for line in lines:
+        if(current_value.replace("-", "/") in line and
+           ("Sending keep alive" in line or
+           "Sending agent notification" in line)):
+            return True
+    return False
+
+
+def check_msg_count(expected_value=None, get_state_callback=None):
+    if get_state_callback:
+        current_value = get_state_callback()['msg_count']
+        if expected_value == '':
+            return expected_value == current_value
+    sent_messages = 0
+    with open(LOG_FILE_PATH, 'r') as f:
+        lines = f.readlines()
+
+    for line in lines:
+        if "Sending keep alive" in line:
+            sent_messages += 1
+
+    return sent_messages >= current_value
+
+
+def check_status(expected_value=None, get_state_callback=None):
+    if expected_value != 'pending':
+        wait_keepalive(True)
+        if get_state_callback == parse_state_file:
+            wait_state_update(True)
+    current_value = get_state_callback()['status']
+    return expected_value == current_value
+
+
+def wait_connect(update_position=False):
+    global wazuh_log_monitor
+    wazuh_log_monitor.start(timeout=120,
+                            callback=callback_connected_to_server,
+                            update_position=update_position,
+                            error_message='Agent connected not found')
+
+
+def wait_ack(update_position=False):
+    global wazuh_log_monitor
+    wazuh_log_monitor.start(timeout=120,
+                            callback=callback_ack,
+                            update_position=update_position,
+                            error_message='Ack not found')
+
+
+def wait_keepalive(update_position=False):
+    global wazuh_log_monitor
+    wazuh_log_monitor.start(timeout=120,
+                            callback=callback_keepalive,
+                            update_position=update_position,
+                            error_message='Keepalive not found')
+
+
+def wait_state_update(update_position=True):
+    global wazuh_log_monitor
+    wazuh_log_monitor.start(timeout=120,
+                            callback=callback_state_file_updated,
+                            update_position=update_position,
+                            error_message='State file update not found')

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -62,7 +62,6 @@ def extra_configuration_before_yield():
 
 
 def extra_configuration_after_yield():
-    global remoted_server
     if remoted_server is not None:
         remoted_server.stop()
 
@@ -116,11 +115,10 @@ def test_agentd_state(configure_environment, test_case: list):
 
 
 def parse_state_file():
-    """
-    Parse state file and return the content as dict
+    """Parse state file
 
     Returns:
-        dict: state info
+        state info
     """
     # Wait until state file is dumped
     wait_state_update()
@@ -139,13 +137,13 @@ def parse_state_file():
 
 
 def remoted_get_state():
-    """
+    """Get state via remoted
+
     Send getstate request to agent (via RemotedSimulator) and return state info as dict.
 
     Returns:
-        dict: state info
+        state info
     """
-    global remoted_server
     remoted_server.request('agent getstate')
     sleep(2)
     response = json.loads(remoted_server.request_answer)
@@ -288,8 +286,7 @@ def wait_connect(update_position=False):
         update_position (bool, optional): update position after reading.
                                           Defaults to False.
     """
-    global wazuh_log_monitor
-    wazuh_log_monitor.start(timeout=120,
+    wazuh_log_monitor.start(timeout=240,
                             callback=callback_connected_to_server,
                             update_position=update_position,
                             error_message='Agent connected not found')
@@ -302,8 +299,7 @@ def wait_ack(update_position=False):
         update_position (bool, optional): update position after reading.
                                           Defaults to False.
     """
-    global wazuh_log_monitor
-    wazuh_log_monitor.start(timeout=120,
+    wazuh_log_monitor.start(timeout=240,
                             callback=callback_ack,
                             update_position=update_position,
                             error_message='Ack not found')
@@ -316,8 +312,7 @@ def wait_keepalive(update_position=False):
         update_position (bool, optional): update position after reading.
                                           Defaults to False.
     """
-    global wazuh_log_monitor
-    wazuh_log_monitor.start(timeout=120,
+    wazuh_log_monitor.start(timeout=240,
                             callback=callback_keepalive,
                             update_position=update_position,
                             error_message='Keepalive not found')
@@ -330,8 +325,7 @@ def wait_state_update(update_position=True):
         update_position (bool, optional): update position after reading.
                                           Defaults to True.
     """
-    global wazuh_log_monitor
-    wazuh_log_monitor.start(timeout=120,
+    wazuh_log_monitor.start(timeout=240,
                             callback=callback_state_file_updated,
                             update_position=update_position,
                             error_message='State file update not found')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -22,7 +22,8 @@ from wazuh_testing.tools.services import (control_service,
                                           check_if_process_is_running)
 
 # Marks
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.agent]
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0),
+              pytest.mark.agent]
 
 # Configurations
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -106,9 +107,6 @@ def test_agentd_state_config(configure_environment, test_case: list):
     set_state_interval(test_case['interval'])
     control_agentd_unconditionally('start')
 
-    if 'agentd_ends' in test_case:
-        assert (test_case['agentd_ends']
-                is not check_if_process_is_running('wazuh-agentd'))
     if 'state_file_exist' in test_case:
         if test_case['state_file_exist'] is True:
             time.sleep(test_case['interval'])
@@ -118,5 +116,7 @@ def test_agentd_state_config(configure_environment, test_case: list):
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             callback=callbacks.get(test_case['log_expect']),
                             error_message='Event not found')
-
+    if 'agentd_ends' in test_case:
+        assert (test_case['agentd_ends']
+                is not check_if_process_is_running('wazuh-agentd'))
     assert wazuh_log_monitor.result()

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+import os
+import yaml
+import sys
+import time
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.agent import (callback_state_interval_not_valid,
+                                 callback_state_interval_not_found,
+                                 callback_state_file_enabled,
+                                 callback_state_file_not_enabled)
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.fim import (change_internal_options)
+from wazuh_testing.tools.services import (control_service,
+                                          check_if_process_is_running)
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.agent]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'data')
+test_data_file = os.path.join(test_data_path, 'wazuh_state_config_tests.yaml')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__)
+
+with open(test_data_file) as f:
+    test_cases = yaml.safe_load(f)
+
+# Variables
+if sys.platform == 'win32':
+    state_file_path = os.path.join(WAZUH_PATH, 'wazuh-agentd.state')
+    internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
+else:
+    state_file_path = os.path.join(WAZUH_PATH, 'var', 'run',
+                                   'wazuh-agentd.state')
+    internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
+
+callbacks = {
+    "interval_not_valid": callback_state_interval_not_valid,
+    "interval_not_found": callback_state_interval_not_found,
+    "file_enabled": callback_state_file_enabled,
+    "file_not_enabled": callback_state_file_not_enabled
+}
+
+
+# Functions
+def control_agentd_unconditionally(action):
+    try:
+        control_service(action, daemon='wazuh-agentd')
+    except Exception:
+        pass
+
+
+def extra_configuration_before_yield():
+    change_internal_options('agent.debug', '2')
+
+
+def extra_configuration_after_yield():
+    change_internal_options('agent.debug', '0')
+
+
+def set_state_interval(interval):
+    if interval is not None:
+        change_internal_options('agent.state_interval', interval,
+                                opt_path=internal_options)
+    else:
+        new_content = ''
+        with open(internal_options, 'r') as f:
+            lines = f.readlines()
+
+        for line in lines:
+            new_line = line if 'agent.state_interval' not in line else ''
+            new_content += new_line
+
+        with open(internal_options, 'w') as f:
+            f.write(new_content)
+
+
+def files_setup():
+    truncate_file(LOG_FILE_PATH)
+    os.remove(state_file_path) if os.path.exists(state_file_path) else None
+
+
+# Fixture
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.mark.parametrize('test_case',
+                         [test_case['test_case'] for test_case in test_cases],
+                         ids=[test_case['name'] for test_case in test_cases])
+def test_agentd_state_config(configure_environment, test_case: list):
+
+    control_agentd_unconditionally('stop')
+    files_setup()
+    set_state_interval(test_case['interval'])
+    control_agentd_unconditionally('start')
+
+    if 'agentd_ends' in test_case:
+        assert (test_case['agentd_ends']
+                is not check_if_process_is_running('wazuh-agentd'))
+    if 'state_file_exist' in test_case:
+        if test_case['state_file_exist'] is True:
+            time.sleep(test_case['interval'])
+        assert test_case['state_file_exist'] == os.path.exists(state_file_path)
+
+    wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callbacks.get(test_case['log_expect']),
+                            error_message='Event not found')
+
+    assert wazuh_log_monitor.result()

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -2,32 +2,30 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import pytest
 import os
-import yaml
 import sys
 import time
 
+import pytest
+import yaml
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
-from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.agent import (callback_state_interval_not_valid,
+from wazuh_testing.agent import (set_state_interval,
+                                 callback_state_interval_not_valid,
                                  callback_state_interval_not_found,
                                  callback_state_file_enabled,
                                  callback_state_file_not_enabled)
-from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.fim import (change_internal_options)
-from wazuh_testing.tools.services import (control_service,
-                                          check_if_process_is_running)
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service, check_if_process_is_running
 
 # Marks
-pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0),
-              pytest.mark.agent]
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0), pytest.mark.agent]
 
 # Configurations
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                              'data')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_data_file = os.path.join(test_data_path, 'wazuh_state_config_tests.yaml')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 configurations = load_wazuh_configurations(configurations_path, __name__)
@@ -41,37 +39,19 @@ if sys.platform == 'win32':
     state_file_path = os.path.join(WAZUH_PATH, 'wazuh-agent.state')
     internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
 else:
-    state_file_path = os.path.join(WAZUH_PATH, 'var', 'run',
-                                   'wazuh-agentd.state')
+    state_file_path = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-agentd.state')
     internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
 
 # ossec.log watch callbacks
 callbacks = {
-    "interval_not_valid": callback_state_interval_not_valid,
-    "interval_not_found": callback_state_interval_not_found,
-    "file_enabled": callback_state_file_enabled,
-    "file_not_enabled": callback_state_file_not_enabled
+    'interval_not_valid': callback_state_interval_not_valid,
+    'interval_not_found': callback_state_interval_not_found,
+    'file_enabled': callback_state_file_enabled,
+    'file_not_enabled': callback_state_file_not_enabled
 }
 
 
 # Functions
-def control_service_unconditionally(action, daemon=None):
-    """Control services avoiding handling exception
-
-    Parameters
-    ----------
-        action : {'stop', 'start', 'restart'}
-            Action to be done with the service/daemon.
-        daemon : str, optional
-            Name of the daemon to be controlled.
-                None to control the whole Wazuh service. Default `None`.
-    """
-    try:
-        control_service(action, daemon=daemon)
-    except Exception:
-        pass
-
-
 def extra_configuration_before_yield():
     change_internal_options('agent.debug', '2')
 
@@ -79,38 +59,7 @@ def extra_configuration_before_yield():
 def extra_configuration_after_yield():
     # Set default values
     change_internal_options('agent.debug', '0')
-    set_state_interval(5)
-
-
-def set_state_interval(interval):
-    """Set agent.state_interval value on internal_options.conf
-    Args:
-        interval:
-            - Different than `None`: set agent.state_interval
-                                     value on internal_options.conf
-            - `None`: agent.state_interval will be removed
-                      from internal_options.conf
-    """
-    if interval is not None:
-        change_internal_options('agent.state_interval', interval,
-                                opt_path=internal_options)
-    else:
-        new_content = ''
-        with open(internal_options) as f:
-            lines = f.readlines()
-
-        for line in lines:
-            new_line = line if 'agent.state_interval' not in line else ''
-            new_content += new_line
-
-        with open(internal_options, 'w') as f:
-            f.write(new_content)
-
-
-def files_setup():
-    """Truncate ossec.log and remote state file"""
-    truncate_file(LOG_FILE_PATH)
-    os.remove(state_file_path) if os.path.exists(state_file_path) else None
+    set_state_interval(5, internal_options)
 
 
 # Fixture
@@ -125,16 +74,22 @@ def get_configuration(request):
                          ids=[test_case['name'] for test_case in test_cases])
 def test_agentd_state_config(configure_environment, test_case: list):
 
-    control_service_unconditionally('stop', 'wazuh-agentd')
+    control_service('stop', 'wazuh-agentd')
 
-    files_setup()
-    set_state_interval(test_case['interval'])
+    # Truncate ossec.log in order to watch it correctly
+    truncate_file(LOG_FILE_PATH)
 
-    control_service_unconditionally('start', 'wazuh-agentd')
+    # Remove state file to check if agent behavior is as expected
+    os.remove(state_file_path) if os.path.exists(state_file_path) else None
+
+    # Set state interval value according to test case specs
+    set_state_interval(test_case['interval'], internal_options)
+
+    control_service('start', 'wazuh-agentd')
 
     # Check if test require checking state file existance
     if 'state_file_exist' in test_case:
-        if test_case['state_file_exist'] is True:
+        if test_case['state_file_exist']:
             # Wait until state file was dumped
             time.sleep(test_case['interval'])
         assert test_case['state_file_exist'] == os.path.exists(state_file_path)

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -32,18 +32,20 @@ test_data_file = os.path.join(test_data_path, 'wazuh_state_config_tests.yaml')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 configurations = load_wazuh_configurations(configurations_path, __name__)
 
+# Open test cases description file
 with open(test_data_file) as f:
     test_cases = yaml.safe_load(f)
 
 # Variables
 if sys.platform == 'win32':
-    state_file_path = os.path.join(WAZUH_PATH, 'wazuh-agentd.state')
+    state_file_path = os.path.join(WAZUH_PATH, 'wazuh-agent.state')
     internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
 else:
     state_file_path = os.path.join(WAZUH_PATH, 'var', 'run',
                                    'wazuh-agentd.state')
     internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
 
+# ossec.log watch callbacks
 callbacks = {
     "interval_not_valid": callback_state_interval_not_valid,
     "interval_not_found": callback_state_interval_not_found,
@@ -53,9 +55,19 @@ callbacks = {
 
 
 # Functions
-def control_agentd_unconditionally(action):
+def control_service_unconditionally(action, daemon=None):
+    """Control services avoiding handling exception
+
+    Parameters
+    ----------
+        action : {'stop', 'start', 'restart'}
+            Action to be done with the service/daemon.
+        daemon : str, optional
+            Name of the daemon to be controlled.
+                None to control the whole Wazuh service. Default `None`.
+    """
     try:
-        control_service(action, daemon='wazuh-agentd')
+        control_service(action, daemon=daemon)
     except Exception:
         pass
 
@@ -65,16 +77,26 @@ def extra_configuration_before_yield():
 
 
 def extra_configuration_after_yield():
+    # Set default values
     change_internal_options('agent.debug', '0')
+    set_state_interval(5)
 
 
 def set_state_interval(interval):
+    """Set agent.state_interval value on internal_options.conf
+    Args:
+        interval:
+            - Different than `None`: set agent.state_interval
+                                     value on internal_options.conf
+            - `None`: agent.state_interval will be removed
+                      from internal_options.conf
+    """
     if interval is not None:
         change_internal_options('agent.state_interval', interval,
                                 opt_path=internal_options)
     else:
         new_content = ''
-        with open(internal_options, 'r') as f:
+        with open(internal_options) as f:
             lines = f.readlines()
 
         for line in lines:
@@ -86,6 +108,7 @@ def set_state_interval(interval):
 
 
 def files_setup():
+    """Truncate ossec.log and remote state file"""
     truncate_file(LOG_FILE_PATH)
     os.remove(state_file_path) if os.path.exists(state_file_path) else None
 
@@ -102,21 +125,28 @@ def get_configuration(request):
                          ids=[test_case['name'] for test_case in test_cases])
 def test_agentd_state_config(configure_environment, test_case: list):
 
-    control_agentd_unconditionally('stop')
+    control_service_unconditionally('stop', 'wazuh-agentd')
+
     files_setup()
     set_state_interval(test_case['interval'])
-    control_agentd_unconditionally('start')
 
+    control_service_unconditionally('start', 'wazuh-agentd')
+
+    # Check if test require checking state file existance
     if 'state_file_exist' in test_case:
         if test_case['state_file_exist'] is True:
+            # Wait until state file was dumped
             time.sleep(test_case['interval'])
         assert test_case['state_file_exist'] == os.path.exists(state_file_path)
 
+    # Follow ossec.log to find desired messages by a callback
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             callback=callbacks.get(test_case['log_expect']),
                             error_message='Event not found')
+    assert wazuh_log_monitor.result()
+
+    # Check if test require checking agentd status
     if 'agentd_ends' in test_case:
         assert (test_case['agentd_ends']
                 is not check_if_process_is_running('wazuh-agentd'))
-    assert wazuh_log_monitor.result()


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1034 |

## Description

Hi team! 
This PR aims to add integration test for `wazuh-agentd` stats mechanism, that consist in:

- [x] Test different `agent.state_interval` values
- [x] Test remote request (`getstate`) and their correct value 

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove this check if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`

Regards,
Nico