### PR TITLE
Configuration tags normalization to Wazuh standard - QA tests changes implementation

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -251,19 +251,19 @@ def set_section_wazuh_conf(sections, template=None):
                 tag.tail = "\n    "
         tag.tail = "\n  "
 
-    def purge_multiple_root_elements(str_list: List[str], root_delimeter: str = "</ossec_config>") -> List[str]:
+    def purge_multiple_root_elements(str_list: List[str], root_delimeter: str = "</wazuh_config>") -> List[str]:
         """
         Remove from the list all the lines located after the root element ends.
 
         This operation is needed before attempting to convert the list to ElementTree because if the ossec.conf had more
-        than one `<ossec_config>` element as root the conversion would fail.
+        than one `<wazuh_config>` element as root the conversion would fail.
 
         Parameters
         ----------
         str_list : list of str
             The content of the ossec.conf file in a list of str.
         root_delimeter : str, optional
-            The expected string to identify when the first root element ends, by default "</ossec_config>"
+            The expected string to identify when the first root element ends, by default "</wazuh_config>"
 
         Returns
         -------

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -250,7 +250,7 @@ This is a sample yaml used for `FIM`:
 
 - **tags**: Informative tag that could be used to filter out within test functions for the same module.
 - **apply_to_modules**: Module/s that will load this configuration.
-- **section**: Section that will be modified within `<ossec_config`.
+- **section**: Section that will be modified within `<wazuh_config`.
 - **elements**: Elements that will be written within the given section.
     - disabled: `<disabled>no</disabled>`
     - directories: `<directories check_all="yes">/sample_directory</directories>`

--- a/tests/integration/test_fim/test_files/test_audit/data/ossec.conf
+++ b/tests/integration/test_fim/test_files/test_audit/data/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/integration/test_fim/test_files/test_audit/data/ossec.conf
+++ b/tests/integration/test_fim/test_files/test_audit/data/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -291,4 +291,4 @@
     <disabled>yes</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/data/template_wazuh_conf.conf
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/data/template_wazuh_conf.conf
@@ -11,7 +11,7 @@ Mailing list: https://groups.google.com/forum/#!forum/wazuh
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/data/template_wazuh_conf.conf
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/data/template_wazuh_conf.conf
@@ -3,7 +3,7 @@ Wazuh - Manager - Default configuration for rhel 7
 More info at: https://documentation.wazuh.com
 Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -296,4 +296,4 @@ Mailing list: https://groups.google.com/forum/#!forum/wazuh
     <state>periodic_diff</state>
     <arguments>/etc /usr/bin /usr/sbin</arguments>
   </agentless>
-</ossec_config>
+</wazuh_config>

--- a/tests/legacy/test_sca/test_basic_usage/data/sca_files_test_suite.yml
+++ b/tests/legacy/test_sca/test_basic_usage/data/sca_files_test_suite.yml
@@ -80,13 +80,13 @@ checks:
    title: PASS -- Full rule regex match
    condition: any
    rules:
-     - f:/var/ossec/etc/ossec.conf -> r:^<ossec_config>
+     - f:/var/ossec/etc/ossec.conf -> r:^<wazuh_config>
 
  - id: 200301
    title: FAIL -- negated full rule regex match
    condition: any
    rules:
-     - not f:/var/ossec/etc/ossec.conf -> r:^<ossec_config>
+     - not f:/var/ossec/etc/ossec.conf -> r:^<wazuh_config>
 
  - id: 200302
    title: FAIL -- Full rule regex does not match
@@ -147,7 +147,7 @@ checks:
      - f:/var/ossec/etc/ossec.conf,/var/ossec/etc/internal_options.conf -> r:^FAKE
 
  - id: 200403
-   title: INVALID -- Content not exist. One file does not exists 
+   title: INVALID -- Content not exist. One file does not exists
    condition: any
    rules:
      - f:/var/ossec/etc/ossec.conf,/var/ossec/etc/internal_options.conf,/var/ossec/etc/ossec.conf_FAKE1 -> r:^FAKE

--- a/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -279,4 +279,4 @@
     <disabled>no</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -279,4 +279,4 @@
     <disabled>no</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/basic_cluster/roles/agent-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/agent-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <client>
     <server>
       <address>MANAGER_IP</address>
@@ -174,4 +174,4 @@
     <log_format>plain</log_format>
   </logging>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -279,4 +279,4 @@
     <disabled>no</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -279,4 +279,4 @@
     <disabled>no</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/enrollment_cluster/roles/agent-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/agent-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <client>
     <server>
       <address>MANAGER_IP</address>
@@ -174,4 +174,4 @@
     <log_format>plain</log_format>
   </logging>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -279,4 +279,4 @@
     <disabled>no</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
@@ -12,7 +12,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
@@ -4,7 +4,7 @@
   Mailing list: https://groups.google.com/forum/#!forum/wazuh
 -->
 
-<ossec_config>
+<wazuh_config>
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
@@ -279,4 +279,4 @@
     <disabled>no</disabled>
   </cluster>
 
-</ossec_config>
+</wazuh_config>


### PR DESCRIPTION
Hello team,

This PR adapts the config tag usage with the new Wazuh naming standard.

- Closes #1011 : Configuration tags normalization to Wazuh standard - QA tests changes

# Tests checks

- [x] Proven that tests **pass** when they have to pass
- [x] Proven that tests **fail** when they have to fail
- [x] Proven that tests have the expected behavior in **RPM and DEB**
- [x] Checked that **all vulnerability detector tests work correctly** (my changes don't break anything)

Best regards.