### PR TITLE
Fix test_follow_symbolic_disabled.

### DIFF
--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_follow_symbolic_disabled.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_follow_symbolic_disabled.py
@@ -6,6 +6,9 @@ import os
 
 import pytest
 from test_fim.test_files.test_follow_symbolic_link.common import testdir_target, testdir1
+# noinspection PyUnresolvedReferences
+from test_fim.test_files.test_follow_symbolic_link.common import test_directories, extra_configuration_before_yield, \
+     extra_configuration_after_yield
 from wazuh_testing import logger
 from wazuh_testing.fim import (LOG_FILE_PATH,
                                generate_params, create_file, REGULAR, callback_detect_event,

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_symlink_to_dir_between_scans.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_symlink_to_dir_between_scans.py
@@ -6,8 +6,8 @@ import os
 from shutil import rmtree
 
 import pytest
-from test_fim.test_files.test_follow_symbolic_link.common import wait_for_symlink_check, symlink_interval, testdir_link, \
-    testdir_target
+from test_fim.test_files.test_follow_symbolic_link.common import wait_for_symlink_check, symlink_interval, \
+    testdir_link, testdir_target
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import SYMLINK, REGULAR, LOG_FILE_PATH, generate_params, create_file, change_internal_options, \
     check_time_travel, callback_detect_event


### PR DESCRIPTION
|Related issue|
|---|
|#1051|

## Description
This PR aims to add the missing variables that were removed after the refactor of the python code. These variables were removed because of a missing ` # noinspection PyUnresolvedReferences` before the unused (but necessary) imports.
Kind regards.

Closes #1051 

## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove this check if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`