### PR TITLE
Add new functionality for mocking agents

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -9,6 +9,9 @@ import random
 import string
 import xml.etree.ElementTree as ET
 import zipfile
+import stat
+import shutil
+
 from os.path import exists
 
 import filetype
@@ -234,3 +237,15 @@ def compress_gzip_file(src_path, dest_path):
     with gzip.open(dest_path, 'wb') as dest:
         with open(src_path, 'rb') as source:
             dest.write(source.read())
+
+
+def copy(source, destination):
+    """
+    Copy file with metadata and ownership to a specific destination
+    Args:
+        source (str): Source file path to copy
+        destination (str): Destination file
+    """
+    shutil.copy2(source, destination)
+    source_stats = os.stat(source)
+    os.chown(destination, source_stats[stat.ST_UID], source_stats[stat.ST_GID])

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -7,7 +7,9 @@ import json
 import os
 import re
 import sqlite3
+import random
 from time import time, sleep
+from shutil import copyfile
 
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.services import control_service, check_if_process_is_running
@@ -16,13 +18,14 @@ VULN_DETECTOR_GLOBAL_TIMEOUT = 20
 VULN_DETECTOR_SCAN_TIMEOUT = 40
 DEBIAN_IMPORT_FEED_TIMEOUT = 50
 
-PACKAGES_DB_PATH = f"{WAZUH_PATH}/queue/db/"
+DB_PATH = f"{WAZUH_PATH}/queue/db/"
 CVE_DB_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/cve.db"
 GLOBAL_DB_PATH = f"{WAZUH_PATH}/queue/db/global.db"
 MSU_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/dictionaries/msu.json.gz"
 CPE_HELPER_PATH = f"{WAZUH_PATH}/queue/vulnerabilities/dictionaries/cpe_helper.json"
 DEFAULT_PACKAGE_NAME = "wazuhintegrationpackage"
 DEFAULT_VULNERABILITY_ID = "WVE-000"
+CLIENT_KEYS_PATH = '/var/ossec/etc/client.keys'
 
 REAL_NVD_FEED = 'real_nvd_feed.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'
@@ -201,9 +204,9 @@ def clean_vd_tables(agent="000"):
     Clean the tables involved with vuln detector packages and feeds
     """
     tables = [
-        {"name": "sys_programs", "path": os.path.join(PACKAGES_DB_PATH, f"{agent}.db")},
-        {"name": "sys_hotfixes", "path": os.path.join(PACKAGES_DB_PATH, f"{agent}.db")},
-        {"name": "sys_osinfo", "path": os.path.join(PACKAGES_DB_PATH, f"{agent}.db")},
+        {"name": "sys_programs", "path": os.path.join(DB_PATH, f"{agent}.db")},
+        {"name": "sys_hotfixes", "path": os.path.join(DB_PATH, f"{agent}.db")},
+        {"name": "sys_osinfo", "path": os.path.join(DB_PATH, f"{agent}.db")},
         {"name": "vulnerabilities", "path": CVE_DB_PATH},
         {"name": "vulnerabilities_info", "path": CVE_DB_PATH},
         {"name": "references_info", "path": CVE_DB_PATH},
@@ -232,14 +235,14 @@ def update_last_scan(last_scan=0, agent="000"):
     """
     Changes the value of the last scan of an agent.
     """
-    path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f"UPDATE vuln_metadata SET LAST_SCAN={last_scan}"
     make_query(path, [query_string])
 
 
 def insert_hotfix(agent="000", scan_id=int(time()), scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
                   hotfix="000000"):
-    path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_hotfixes
         (scan_id, scan_time, hotfix)
         VALUES
@@ -255,7 +258,7 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
                   os_name="Microsoft Windows Server 2016 Datacenter Evaluation",
                   os_version="10.0.14393", os_major="10", os_minor="0", os_build="14393", version="6.2",
                   os_release="1607", os_patch="0", release="0.0.0"):
-    path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_osinfo
         (scan_id, scan_time, hostname, architecture, os_name, os_version, os_major, os_minor, os_patch, os_build,
          release, version, os_release)
@@ -276,7 +279,7 @@ def insert_package(agent="000", scan_id=int(time()), format="rpm", name=DEFAULT_
     Insert a new package in the installed package database, with the parameters given as arguments.
     If used in conjunction with insert_vulnerability using the default arguments it will generate an alert.
     """
-    path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_programs
         (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, \
             architecture, multiarch, source, description, location, triaged)
@@ -345,7 +348,7 @@ def update_package(version, package, agent="000"):
     Update version of installed package in database.
     Used to simulate upgrades and downgrades of the package given as argument.
     """
-    path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    path = os.path.join(DB_PATH, f"{agent}.db")
     update_query_string = f'UPDATE sys_programs SET version="{version}" WHERE name="{package}"'
     make_query(path, [update_query_string])
 
@@ -355,7 +358,7 @@ def delete_package(package, agent="000"):
     Remove package from database.
     Used to simulate uninstall of the package given as argument or remove a package after a test.
     """
-    path = os.path.join(PACKAGES_DB_PATH, f"{agent}.db")
+    path = os.path.join(DB_PATH, f"{agent}.db")
     delete_query_string = f'DELETE FROM sys_programs WHERE name="{package}"'
     make_query(path, [delete_query_string])
 
@@ -708,50 +711,73 @@ def restart_modulesd():
     control_service('restart', daemon='wazuh-modulesd')
     sleep(1)
 
-def update_client_keys_entry(agent_id, agent_name, agent_ip="any", agent_key="31a4281e09b71809c7f7818ba27a0679462f139261cd086d21b80eef75ce020f"):
-    with open("/var/ossec/etc/client.keys", 'r') as client_keys:
-        client_entries = client_keys.readlines()
 
-    with open("/tmp/new_client.keys", 'w') as tmp_keys:
-        for entry in client_entries:
-            _agent_id, _agent_name, _agent_ip, _agent_key = entry.split()
-            if agent_id != _agent_id:
-                tmp_keys.write(f"{_agent_id} {_agent_name} {_agent_ip} {_agent_key}\n")
+def add_client_keys_entry(agent_id, agent_name, agent_ip='any', agent_key=None):
+    """
+    Add new entry to client keys file. If the agent_id already exists, this will be overwritten.
 
-        tmp_keys.write(f"{agent_id} {agent_name} {agent_ip} {agent_key}\n")
+    Args:
+        agent_id (str): Agent identifier.
+        agent_name (str): Agent name.
+        agent_ip (str): Agent ip.
+        agent_key (str): Agent key.
+    """
+    registered_client_key_entries_dict = {}
 
-    with open("/var/ossec/etc/client.keys", 'w') as client_keys, open("/tmp/new_client.keys", 'r') as tmp_keys:
-        client_keys.write(tmp_keys.read())
+    # Generate new key if necessary
+    if agent_key is None:
+        agent_key = ''.join(random.choice('0123456789abcdef') for i in range(64))
 
-def create_agent(id=None, name="centos8-agent", ip="127.0.0.1", register_ip="127.0.0.1", internal_key="",
+    # Read client keys data
+    with open(CLIENT_KEYS_PATH, 'r') as client_keys:
+        registered_client_key_entries_str = client_keys.readlines()
+
+    # Process current client key entries
+    for client_key_entry in registered_client_key_entries_str:
+        _agent_id, _agent_name, _agent_ip, _agent_key = client_key_entry.split()
+        registered_client_key_entries_dict[_agent_id] = f"{_agent_id} {_agent_name} {_agent_ip} {_agent_key}"
+
+    # Add the new client key entry
+    registered_client_key_entries_dict[agent_id] = f"{agent_id} {agent_name} {agent_ip} {agent_key}"
+
+    # Save new client keys content
+    with open(CLIENT_KEYS_PATH, 'w') as client_keys:
+        for _, client_key_entry in registered_client_key_entries_dict.items():
+            client_keys.write(f"{client_key_entry}\n")
+
+
+def create_agent(name="centos8-agent", ip="127.0.0.1", register_ip="127.0.0.1", internal_key="",
                  os_name="CentOS Linux", os_version="7.1", os_major="7", os_minor="1", os_codename="centos-8",
                  os_build="4.18.0-147.8.1.el8_1.x86_64", os_platform="#1 SMP Thu Apr 9 13:49:54 UTC 2020",
                  os_uname="x86_64", os_arch="x86_64", version="4.2", config_sum="", merged_sum="",
                  manager_host="centos-8", node_name="node01", date_add="1612942494", last_keepalive="253402300799",
-                 group="", sync_status="synced", connection_status="active"):
+                 group="", sync_status="synced", connection_status="active", client_key_secret=None):
+    """
+    Mock a new agent creating a new client keys entry, adding it to the global db and creating a new agent id DB
+    """
 
-    if id is None:
-        query_last_id = 'select id from agent order by id desc limit 1;'
-        last_id = get_query_result(GLOBAL_DB_PATH, query_last_id)
-        id = int(last_id[0][0]) + 1
+    # Get new agent_id
+    last_id = get_query_result(GLOBAL_DB_PATH, 'SELECT id FROM agent order by id desc limit 1;')
+    agent_id = int(last_id[0][0]) + 1
 
     query_create_agent = f'''INSERT INTO AGENT
-           (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, 
-            os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, 
+           (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor,
+            os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum,
             manager_host, node_name, date_add, last_keepalive, "group", sync_status, connection_status)
            VALUES
-           ( "{id}", "{name}", "{ip}", "{register_ip}", "{internal_key}", "{os_name}", "{os_version}",
+           ( "{agent_id}", "{name}", "{ip}", "{register_ip}", "{internal_key}", "{os_name}", "{os_version}",
              "{os_major}", "{os_minor}", "{os_codename}", "{os_build}", "{os_platform}", "{os_uname}",
              "{os_arch}", "{version}", "{config_sum}", "{merged_sum}", "{manager_host}", "{node_name}",
              "{date_add}", "{last_keepalive}", "{group}", "{sync_status}", "{connection_status}")
            '''
 
-    id_str = str(id).zfill(3)
+    agent_id_str = str(agent_id).zfill(3)  # Convert from x to 00x
 
-    update_client_keys_entry(id_str, name, agent_ip=ip)
-    os.popen(f"cp /var/ossec/queue/db/000.db /var/ossec/queue/db/{id_str}.db")
+    add_client_keys_entry(agent_id_str, name, ip, client_key_secret)
 
-    try:
-        make_query(GLOBAL_DB_PATH, [query_create_agent])
-    except sqlite3.IntegrityError:
-        print("Could not add agent. Check if the selected id is already used by another agent.")
+    # Copy agent db to create a new one
+    copyfile(os.path.join(DB_PATH, '000.db'), os.path.join(DB_PATH, f"{agent_id_str}.db"))
+
+    make_query(GLOBAL_DB_PATH, [query_create_agent])
+
+    return agent_id_str

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -9,9 +9,9 @@ import re
 import sqlite3
 import random
 from time import time, sleep
-from shutil import copyfile
 
 from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools import file
 from wazuh_testing.tools.services import control_service, check_if_process_is_running
 
 VULN_DETECTOR_GLOBAL_TIMEOUT = 20
@@ -803,7 +803,7 @@ def create_mocked_agent(name="centos8-agent", ip="127.0.0.1", register_ip="127.0
     add_client_keys_entry(agent_id_str, name, ip, client_key_secret)
 
     # Copy agent db to create a new one
-    copyfile(os.path.join(DB_PATH, '000.db'), os.path.join(DB_PATH, f"{agent_id_str}.db"))
+    file.copy(os.path.join(DB_PATH, '000.db'), os.path.join(DB_PATH, f"{agent_id_str}.db"))
 
     make_query(GLOBAL_DB_PATH, [query_create_agent])
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -257,14 +257,14 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
                   hostname="WINDOWS", architecture="x86_64",
                   os_name="Microsoft Windows Server 2016 Datacenter Evaluation",
                   os_version="10.0.14393", os_major="10", os_minor="0", os_build="14393", version="6.2",
-                  os_release="1607", os_patch="0", release="0.0.0"):
+                  os_release="1607", os_patch="0", release="0.0.0", checksum="dummychecksum"):
     path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_osinfo
         (scan_id, scan_time, hostname, architecture, os_name, os_version, os_major, os_minor, os_patch, os_build,
-         release, version, os_release)
+         release, version, os_release, checksum)
         VALUES
         ("{scan_id}", "{scan_time}", "{hostname}", "{architecture}", "{os_name}", "{os_version}", "{os_major}",
-        "{os_minor}", "{os_patch}", "{os_build}", "{release}", "{version}", "{os_release}")
+        "{os_minor}", "{os_patch}", "{os_build}", "{release}", "{version}", "{os_release}", "{checksum}")
         '''
     make_query(path, [query_string])
 
@@ -274,7 +274,7 @@ def insert_package(agent="000", scan_id=int(time()), format="rpm", name=DEFAULT_
                    architecture="x86_64", multiarch="", description="Wazuh Integration tests mock package",
                    source="Wazuh Integration tests mock package", location="", triaged=0,
                    install_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
-                   scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S")):
+                   scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"), checksum="dummychecksum"):
     """
     Insert a new package in the installed package database, with the parameters given as arguments.
     If used in conjunction with insert_vulnerability using the default arguments it will generate an alert.
@@ -282,11 +282,11 @@ def insert_package(agent="000", scan_id=int(time()), format="rpm", name=DEFAULT_
     path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_programs
         (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, \
-            architecture, multiarch, source, description, location, triaged)
+            architecture, multiarch, source, description, location, triaged, checksum)
         VALUES
         ({scan_id}, "{scan_time}", "{format}", "{name}", "{priority}", "{section}", "{size}", "{vendor}",
         "{install_time}", "{version}", "{architecture}", "{multiarch}", "{source}", "{description}",
-        "{location}", "{triaged}")
+        "{location}", "{triaged}", "{checksum}")
         '''
     make_query(path, [query_string])
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -149,14 +149,14 @@ def make_query(db_path, query_list):
     """
     Makes a query to the database in db_path for each item in query_list
     """
+    connect = sqlite3.connect(db_path)
+
     try:
-        db = load_db(db_path)
-        for item in query_list:
-            db[1].execute(item)
-        db[0].commit()
+        with connect:
+            for item in query_list:
+                connect.execute(item)
     finally:
-        db[1].close()
-        db[0].close()
+        connect.close()
 
 
 def get_query_result(db_path, query):

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -707,3 +707,51 @@ def restart_modulesd():
     """
     control_service('restart', daemon='wazuh-modulesd')
     sleep(1)
+
+def update_client_keys_entry(agent_id, agent_name, agent_ip="any", agent_key="31a4281e09b71809c7f7818ba27a0679462f139261cd086d21b80eef75ce020f"):
+    with open("/var/ossec/etc/client.keys", 'r') as client_keys:
+        client_entries = client_keys.readlines()
+
+    with open("/tmp/new_client.keys", 'w') as tmp_keys:
+        for entry in client_entries:
+            _agent_id, _agent_name, _agent_ip, _agent_key = entry.split()
+            if agent_id != _agent_id:
+                tmp_keys.write(f"{_agent_id} {_agent_name} {_agent_ip} {_agent_key}\n")
+
+        tmp_keys.write(f"{agent_id} {agent_name} {agent_ip} {agent_key}\n")
+
+    with open("/var/ossec/etc/client.keys", 'w') as client_keys, open("/tmp/new_client.keys", 'r') as tmp_keys:
+        client_keys.write(tmp_keys.read())
+
+def create_agent(id=None, name="centos8-agent", ip="127.0.0.1", register_ip="127.0.0.1", internal_key="",
+                 os_name="CentOS Linux", os_version="7.1", os_major="7", os_minor="1", os_codename="centos-8",
+                 os_build="4.18.0-147.8.1.el8_1.x86_64", os_platform="#1 SMP Thu Apr 9 13:49:54 UTC 2020",
+                 os_uname="x86_64", os_arch="x86_64", version="4.2", config_sum="", merged_sum="",
+                 manager_host="centos-8", node_name="node01", date_add="1612942494", last_keepalive="253402300799",
+                 group="", sync_status="synced", connection_status="active"):
+
+    if id is None:
+        query_last_id = 'select id from agent order by id desc limit 1;'
+        last_id = get_query_result(GLOBAL_DB_PATH, query_last_id)
+        id = int(last_id[0][0]) + 1
+
+    query_create_agent = f'''INSERT INTO AGENT
+           (id, name, ip, register_ip, internal_key, os_name, os_version, os_major, os_minor, 
+            os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, 
+            manager_host, node_name, date_add, last_keepalive, "group", sync_status, connection_status)
+           VALUES
+           ( "{id}", "{name}", "{ip}", "{register_ip}", "{internal_key}", "{os_name}", "{os_version}",
+             "{os_major}", "{os_minor}", "{os_codename}", "{os_build}", "{os_platform}", "{os_uname}",
+             "{os_arch}", "{version}", "{config_sum}", "{merged_sum}", "{manager_host}", "{node_name}",
+             "{date_add}", "{last_keepalive}", "{group}", "{sync_status}", "{connection_status}")
+           '''
+
+    id_str = str(id).zfill(3)
+
+    update_client_keys_entry(id_str, name, agent_ip=ip)
+    os.popen(f"cp /var/ossec/queue/db/000.db /var/ossec/queue/db/{id_str}.db")
+
+    try:
+        make_query(GLOBAL_DB_PATH, [query_create_agent])
+    except sqlite3.IntegrityError:
+        print("Could not add agent. Check if the selected id is already used by another agent.")

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -746,16 +746,43 @@ def add_client_keys_entry(agent_id, agent_name, agent_ip='any', agent_key=None):
             client_keys.write(f"{client_key_entry}\n")
 
 
-def create_agent(name="centos8-agent", ip="127.0.0.1", register_ip="127.0.0.1", internal_key="",
-                 os_name="CentOS Linux", os_version="7.1", os_major="7", os_minor="1", os_codename="centos-8",
-                 os_build="4.18.0-147.8.1.el8_1.x86_64", os_platform="#1 SMP Thu Apr 9 13:49:54 UTC 2020",
-                 os_uname="x86_64", os_arch="x86_64", version="4.2", config_sum="", merged_sum="",
-                 manager_host="centos-8", node_name="node01", date_add="1612942494", last_keepalive="253402300799",
-                 group="", sync_status="synced", connection_status="active", client_key_secret=None):
+def delete_client_keys_entry(agent_id):
+    """
+    Delete an entry from client keys file.
+
+    Args:
+        agent_id (str): Agent identifier.
+    """
+    registered_client_key_entries_dict = {}
+
+    # Read client keys data
+    with open(CLIENT_KEYS_PATH, 'r') as client_keys:
+        registered_client_key_entries_str = client_keys.readlines()
+
+    # Process current client key entries
+    for client_key_entry in registered_client_key_entries_str:
+        _agent_id, _agent_name, _agent_ip, _agent_key = client_key_entry.split()
+        registered_client_key_entries_dict[_agent_id] = f"{_agent_id} {_agent_name} {_agent_ip} {_agent_key}"
+
+    # Remove client key entry
+    registered_client_key_entries_dict.pop(agent_id, None)
+
+    # Save new client keys content
+    with open(CLIENT_KEYS_PATH, 'w') as client_keys:
+        for _, client_key_entry in registered_client_key_entries_dict.items():
+            client_keys.write(f"{client_key_entry}\n")
+
+
+def create_mocked_agent(name="centos8-agent", ip="127.0.0.1", register_ip="127.0.0.1", internal_key="",
+                        os_name="CentOS Linux", os_version="7.1", os_major="7", os_minor="1", os_codename="centos-8",
+                        os_build="4.18.0-147.8.1.el8_1.x86_64", os_platform="#1 SMP Thu Apr 9 13:49:54 UTC 2020",
+                        os_uname="x86_64", os_arch="x86_64", version="4.2", config_sum="", merged_sum="",
+                        manager_host="centos-8", node_name="node01", date_add="1612942494",
+                        last_keepalive="253402300799", group="", sync_status="synced", connection_status="active",
+                        client_key_secret=None):
     """
     Mock a new agent creating a new client keys entry, adding it to the global db and creating a new agent id DB
     """
-
     # Get new agent_id
     last_id = get_query_result(GLOBAL_DB_PATH, 'SELECT id FROM agent order by id desc limit 1;')
     agent_id = int(last_id[0][0]) + 1
@@ -781,3 +808,17 @@ def create_agent(name="centos8-agent", ip="127.0.0.1", register_ip="127.0.0.1", 
     make_query(GLOBAL_DB_PATH, [query_create_agent])
 
     return agent_id_str
+
+
+def delete_mocked_agent(agent_id):
+    """
+    Delete a mocked agent removing it from the global db, client keys and db file
+    """
+    # Remove from global db
+    make_query(GLOBAL_DB_PATH, [f"DELETE FROM agent where id={int(agent_id)}"])
+
+    # Remove agent id DB file
+    os.remove(os.path.join(DB_PATH, f"{agent_id}.db"))
+
+    # Remove entry from client keys
+    delete_client_keys_entry(agent_id)

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -9,7 +9,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.vulnerability_detector import clean_vd_tables
+from wazuh_testing import vulnerability_detector as vd
 
 
 @pytest.fixture(scope='module')
@@ -28,11 +28,11 @@ def restart_modulesd(get_configuration, request):
 @pytest.fixture(scope='module')
 def clean_vuln_tables(request):
     """ Clean vulnerabilities tables """
-    clean_vd_tables()
+    vd.clean_vd_tables()
 
     yield
 
-    clean_vd_tables()
+    vd.clean_vd_tables()
 
 
 @pytest.fixture
@@ -45,3 +45,20 @@ def restart_modulesd_catching_ossec_conf_error(request):
         control_service('start', daemon='wazuh-modulesd')
     except (ValueError, CalledProcessError):
         pass
+
+
+@pytest.fixture(scope='session')
+def mock_agent():
+    control_service('stop', daemon='wazuh-db')
+
+    agent_id = vd.create_mocked_agent(name="mocked_agent")
+
+    control_service('start', daemon='wazuh-db')
+
+    yield agent_id
+
+    control_service('stop', daemon='wazuh-db')
+
+    vd.delete_mocked_agent(agent_id)
+
+    control_service('start', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
@@ -47,40 +47,38 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=macos_vulnerabilities, ids=macos_systems)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'],
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name='mocked_agent',
                      os_platform=request.param['os_platform'], version=request.param['version'])
 
     # Insert data in sys_osinfo and sys_programs tables
-    vd.insert_osinfo(os_name=request.param['os_name'], os_major=request.param['os_major'],
+    vd.insert_osinfo(agent=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], os_patch=request.param['os_patch'],
                      release=request.param['release'])
 
     for vulnerability in request.param['vulnerabilities']:
-        vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'])
+        vd.insert_package(**vulnerability['package'],agent=mock_agent, source=vulnerability['package']['name'])
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     # Truncate ossec.log
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_macos_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,


### PR DESCRIPTION
|Related issue|
|---|
|close #1049|

## Description

Hi,

This PR adds the following changes:

- Improve the way of stopping daemon processes.
- Add new tool function for copy files
- Add new function to mock agents and client.keys file
- Add new fixture to mock agents.
- Update `test_macos_inventory.py` test to use new mocking structure

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`

Regards.