### PR TITLE
Fix test_general_settings_ignore_time test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -237,6 +237,7 @@ def update_last_scan(last_scan=0, agent="000"):
     """
     path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f"UPDATE vuln_metadata SET LAST_SCAN={last_scan}"
+
     make_query(path, [query_string])
 
 
@@ -378,15 +379,16 @@ def delete_vulnerability(cveid):
                              delete_advisories_info_query_string])
 
 
-def modify_system(os_name="CentOS Linux", os_major="7", name="centos7", agent_id=0, os_minor="1", os_arch="x86_64",
+def modify_system(os_name="CentOS Linux", os_major="7", name="centos7", agent_id="000", os_minor="1", os_arch="x86_64",
                   os_version="7.1", os_platform="centos", version="4.0"):
     """
     Modify the system of the manager.
     Used to select the feed that will be used to search vulnerabilities.
     """
+
     query_string = f'update AGENT set OS_NAME="{os_name}", OS_VERSION="{os_version}", OS_MAJOR="{os_major}", ' \
                    f'OS_MINOR="{os_minor}", OS_ARCH="{os_arch}", NAME="{name}", OS_PLATFORM="{os_platform}", ' \
-                   f'VERSION="{version}" WHERE id="{agent_id}"'
+                   f'VERSION="{version}" WHERE id="{int(agent_id)}"'
     make_query(GLOBAL_DB_PATH, [query_string])
 
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
@@ -21,6 +21,14 @@
         - enabled:
             value: 'yes'
         - update_interval:
-            value: '10s'
+            value: '2h'
         - path:
             value: NVD_FEED_PATH
+    - provider:
+        attributes:
+          - name: 'redhat'
+        elements:
+          - update_interval:
+                value: '2h'
+          - enabled:
+              value: 'no'

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -4,19 +4,15 @@
 
 import os
 from datetime import timedelta
-from time import sleep
 
 import pytest
+import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.fim import check_time_travel
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.time import time_to_seconds
-from wazuh_testing.vulnerability_detector import DEFAULT_PACKAGE_NAME, DEFAULT_VULNERABILITY_ID, \
-    update_last_scan, modify_system, clean_vd_tables, \
-    insert_vulnerability, insert_package, make_vuln_callback, \
-    REAL_NVD_FEED
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -24,12 +20,12 @@ pytestmark = pytest.mark.tier(level=0)
 # variables
 test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(test_path, 'data')
-nvd_feed_path = os.path.join(os.path.dirname(test_path), 'test_scan_results', 'data', REAL_NVD_FEED)
+nvd_feed_path = os.path.join(os.path.dirname(test_path), 'test_scan_results', 'data', vd.REAL_NVD_FEED)
 configurations_path = os.path.join(test_data_path, 'wazuh_ignore_time.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-callback_string_vulnerability = f"'{DEFAULT_PACKAGE_NAME}'.+is vulnerable to '{DEFAULT_VULNERABILITY_ID}'"
+callback_string_vulnerability = f"'{vd.DEFAULT_PACKAGE_NAME}'.+is vulnerable to '{vd.DEFAULT_VULNERABILITY_ID}'"
 
 parameters = [{'IGNORE_TIME': '3600s', 'INTERVAL': '5s', 'NVD_FEED_PATH': nvd_feed_path},
               {'IGNORE_TIME': '60m', 'INTERVAL': '5s', 'NVD_FEED_PATH': nvd_feed_path},
@@ -49,27 +45,33 @@ def get_configuration(request):
     return request.param
 
 
-# functions
-def generate_default_alert():
-    """
-    Generate an alert with the default values
-    """
+@pytest.fixture(scope='module')
+def prepare_agent(mock_agent):
     control_service('stop', daemon='wazuh-db')
-    sleep(4)
-    clean_vd_tables()
-    insert_package(vendor="Red Hat, Inc.")
-    insert_vulnerability()
-    update_last_scan()
-    modify_system()
+
+    vd.clean_vd_tables(mock_agent)
+    vd.insert_package(agent=mock_agent, vendor="Red Hat, Inc.")
+    vd.insert_vulnerability()
+
     control_service('start', daemon='wazuh-db')
 
+    yield mock_agent
 
-def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
-                     custom_callback_vulnerability=make_vuln_callback(callback_string_vulnerability)):
+    vd.clean_vuln_and_sys_programs_tables(mock_agent)
+
+
+def test_ignore_time(get_configuration, configure_environment, restart_modulesd, prepare_agent,
+                     custom_callback_vulnerability=vd.make_vuln_callback(callback_string_vulnerability)):
     """
     Check if an alert is not fired during the ignore time  interval
     """
-    generate_default_alert()
+
+    control_service('stop', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-db')
+    vd.update_last_scan(agent=prepare_agent)
+    control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
+
     ignore_time = get_configuration['metadata']['ignore_time']
     jumps = get_configuration['metadata']['jumps']
     seconds_to_travel = time_to_seconds(ignore_time) / jumps


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1030 |


## Description

This PR adds some changes to `test_general_settings_ignore_time`, a check that was failing due to race conditions related to modulesd and wazuh-db restarts and database testing mocks. 

We've modified the test to use a mocked agent database instead of using the `000.db` (manager) database. 

We've removed some extra code execution by adding re-usable fixtures and removing arbitrary sleeps so the time required to execute the test has decreased. Also, we've disabled the feeds updates to avoid race conditions where the first test could fail due to vulnerability-detector not being able to generate the first alert in the expected time (because it is updating cve database). 


## Configuration options

The test uses a centos agent with redhat feed disabled and generate alerts using NVD. 


## Logs example

![image](https://user-images.githubusercontent.com/15269938/107790476-15c6df00-6d53-11eb-86c3-2c1412caa77c.png)

While the ignore time period is active, in the logs there should appear a message saying that a **partial** scan will be run against the agent 1, the first and the last scans are **full** scans and they are the ones that should generate an alert.

If one of the scans between the start and the end of the ignore time is full, it will generate an alert and make the check fail
![image](https://user-images.githubusercontent.com/15269938/107790665-4ad33180-6d53-11eb-9add-94a3e6342163.png)


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove this check if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`