### PR TITLE
Update mock_vulnerability_scan fixture from vuln scan tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -27,6 +27,8 @@ DEFAULT_PACKAGE_NAME = "wazuhintegrationpackage"
 DEFAULT_VULNERABILITY_ID = "WVE-000"
 CLIENT_KEYS_PATH = '/var/ossec/etc/client.keys'
 
+MOCKED_AGENT_NAME = 'mocked_agent'
+
 REAL_NVD_FEED = 'real_nvd_feed.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'
 CUSTOM_REDHAT_JSON_FEED = 'custom_redhat_json_feed.json'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -47,36 +47,35 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=debian_vulnerabilities, ids=debian_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'])
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
     # Add custom vulnerabilities and feeds
     for vulnerability in request.param['vulnerabilities']:
-        vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'])
+        vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'])
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_debian_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
@@ -59,7 +59,7 @@ def mock_vulnerability_scan(request, mock_agent):
 
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name='mocked_agent',
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME,
                      os_platform=request.param['os_platform'], version=request.param['version'])
 
     # Insert data in sys_osinfo and sys_programs tables
@@ -68,7 +68,7 @@ def mock_vulnerability_scan(request, mock_agent):
                      release=request.param['release'])
 
     for vulnerability in request.param['vulnerabilities']:
-        vd.insert_package(**vulnerability['package'],agent=mock_agent, source=vulnerability['package']['name'])
+        vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
 
     control_service('start', daemon='wazuh-db')
     control_service('start', daemon='wazuh-modulesd')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -60,35 +60,34 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom hotfixes, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    sleep(4)
-
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Modify the necessary databases. The arch follows a special format rather than the
     # usual x86_64.
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'], os_arch="x64")
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
-    vd.insert_osinfo(os_name=request.param['os_name'], os_release=request.param['os_release'])
+    vd.insert_osinfo(agent=mock_agent, os_name=request.param['os_name'], os_release=request.param['os_release'])
 
     for patch in request.param["hotfixes"]:
-        vd.insert_hotfix(hotfix=patch)
+        vd.insert_hotfix(agent=mock_agent, hotfix=patch)
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     # Truncate ossec.log
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def is_hotfix_installed(cve_patch, dependencies, hotfixes):

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -46,37 +46,34 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=redhat_vulnerabilities, ids=redhat_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'])
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
     # Add custom vulnerabilities and feeds
     for vulnerability in request.param['vulnerabilities']:
-        vd.insert_package(**vulnerability['package'])
+        vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'])
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
-    # Truncate ossec.log
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_redhat_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
@@ -83,22 +83,19 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'])
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
     # Insert half vulnerabilities for provider feed
     for vulnerability in vulnerabilities_provider:
@@ -108,16 +105,17 @@ def mock_vulnerability_scan(request):
     # Insert vulnerable packages
     for vulnerability in vulnerabilities_nvd:
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
-                          format=request.param['format'], agent="000")
+                          format=request.param['format'], agent=mock_agent)
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     # Truncate ossec.log
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -97,23 +97,20 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'],
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME,
                      os_platform=request.param['os_platform'], version=request.param['version'])
 
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Insert a vulnerability in table VULNERABILITIES
     vd.insert_vulnerability(cveid='CWE-000', operation='less than', operation_value='1.0.0',
@@ -122,16 +119,17 @@ def mock_vulnerability_scan(request):
     # Add custom vulnerabilities and feeds
     for vulnerability in nvd_vulnerabilities['vulnerabilities_nvd']:
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
-                          format=request.param['format'], agent="000")
+                          format=request.param['format'], agent=mock_agent)
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     # Truncate ossec.log
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
@@ -141,13 +139,13 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
     """
     vulnerabilities_number = mock_vulnerability_scan["vulnerabilities_number"]
 
-    if mock_vulnerability_scan["format"] == "pkg" and mock_vulnerability_scan["version"] == "Wazuh v4.0":
-        version = mock_vulnerability_scan["version"]
+    if mock_vulnerability_scan['format'] == 'pkg' and mock_vulnerability_scan['version'] == 'Wazuh v4.0':
+        version = mock_vulnerability_scan['version']
         wazuh_log_monitor.start(
             timeout=SCAN_TIMEOUT,
             update_position=False,
-            callback=vd.make_vuln_callback(f"Agent '000' has an unsupported Wazuh version: '{version}'"),
-            error_message=f"The expected event 'Agent \'000\' has an unsupported Wazuh version' not found"
+            callback=vd.make_vuln_callback(fr"Agent .* has an unsupported Wazuh version: '{version}'"),
+            error_message="The expected event 'Agent .* has an unsupported Wazuh version' not found"
         )
 
         return

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
@@ -78,22 +78,19 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'])
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
     # Insert half vulnerabilities for provider feed
     for vulnerability in vulnerabilities['vulnerabilities_provider']:
@@ -103,15 +100,16 @@ def mock_vulnerability_scan(request):
     # Insert vulnerable packages
     for vulnerability in (vulnerabilities['vulnerabilities_nvd'] + vulnerabilities['vulnerabilities_provider']):
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
-                          format=request.param['format'], agent="000")
+                          format=request.param['format'], agent=mock_agent)
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -46,36 +46,34 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=ubuntu_vulnerabilities, ids=ubuntu_data_ids)
-def mock_vulnerability_scan(request):
+def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('restart', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
-    # Wait until modulesd is restarted to avoid overwriting the system
-    sleep(4)
-
     # Clean tables
-    vd.clean_vd_tables(agent='000')
+    vd.clean_vd_tables(agent=mock_agent)
 
     # Mock system
-    vd.modify_system(os_name=request.param['os_name'], os_major=request.param['os_major'],
-                     os_minor=request.param['os_minor'], name=request.param['name'])
+    vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
+                     os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
     # Add custom vulnerabilities and feeds
     for vulnerability in request.param['vulnerabilities']:
-        vd.insert_package(**vulnerability['package'])
+        vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'])
 
     control_service('start', daemon='wazuh-db')
+    control_service('start', daemon='wazuh-modulesd')
 
     file.truncate_file(LOG_FILE_PATH)
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,


### PR DESCRIPTION
|Related issue|
|---|
|closes #1050 |

Hi,

This PR makes the following changes:

- Improve `mock_vulnerability_scan_fixture` from vuln scan tests. Now it uses a mocked agent, and it has been removed a `sleep` due to it has not to wait to wazuh-modulesd updates the `global.db` since it is stopped. 

- Fix the following error

   ``` 
   test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py:104: in mock_vulnerability_scan
       control_service('stop', daemon='wazuh-modulesd')
   /usr/local/lib/python3.8/dist-packages/wazuh_testing-4.2.0-py3.8.egg/wazuh_testing/tools/services.py:124: in control_service
       processes = [proc for proc in psutil.process_iter() if daemon in proc.name()]
   /usr/local/lib/python3.8/dist-packages/wazuh_testing-4.2.0-py3.8.egg/wazuh_testing/tools/services.py:124: in <listcomp>
       processes = [proc for proc in psutil.process_iter() if daemon in proc.name()]
   /usr/local/lib/python3.8/dist-packages/psutil/__init__.py:630: in name
       name = self._proc.name()
   /usr/local/lib/python3.8/dist-packages/psutil/_pslinux.py:1516: in wrapper
       return fun(self, *args, **kwargs)
   /usr/local/lib/python3.8/dist-packages/psutil/_pslinux.py:1611: in name
       name = self._parse_stat_file()['name']
   /usr/local/lib/python3.8/dist-packages/psutil/_pslinux.py:1523: in wrapper
       raise NoSuchProcess(self.pid, self._name)
   E   psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=83691)
   ```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`

Regards.