### PR TITLE
Fix sqlite3.OperationalError: no such table: VULNERABILITIES error

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -28,6 +28,7 @@ DEFAULT_VULNERABILITY_ID = "WVE-000"
 CLIENT_KEYS_PATH = '/var/ossec/etc/client.keys'
 
 MOCKED_AGENT_NAME = 'mocked_agent'
+CVE_NUM_TABLES = 24
 
 REAL_NVD_FEED = 'real_nvd_feed.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -149,16 +149,36 @@ def load_db(db_path):
 
 def make_query(db_path, query_list):
     """
-    Makes a query to the database in db_path for each item in query_list
+    Run queries to the database in db_path for each item in query_list.
+
+    Args:
+        db_path (string): Path where is located the DB.
+        query_list (list): List with queries to run.
     """
     connect = sqlite3.connect(db_path)
 
     try:
-        with connect:
-            for item in query_list:
-                connect.execute(item)
+        _make_query(connect, query_list)
     finally:
         connect.close()
+
+
+def _make_query(connect, query_list):
+    """
+    Run queries to the database, retrying 5 times in case of operationalError exception.
+
+    Args:
+        connect (sqlite3.Connection): Database connection object.
+        query_list (list): List with queries to run.
+    """
+    for _ in range(5):
+        try:
+            with connect:
+                for item in query_list:
+                    connect.execute(item)
+                break
+        except sqlite3.OperationalError:
+            sleep(5)
 
 
 def get_query_result(db_path, query):
@@ -332,18 +352,9 @@ def insert_vulnerability(cveid=DEFAULT_VULNERABILITY_ID, target="RHEL7", target_
         VALUES
         ("{cveid}", "{ref_target}", "{advisory}")
         '''
-    try:
-        make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string,
-                                 query_references_info, query_bugzilla_info, query_advisories_info])
-    except sqlite3.OperationalError:
-        # Probably caused by missing tables on CVE DB. These tables are created by VD.
-        # Restart and wait a few seconds for VD to create the tables and then continue.
-        # We added this here because this restart is just necessary to be executed once
-        # for each group of tests when they firstly fail.
-        control_service('restart', daemon='wazuh-modulesd')
-        sleep(5)
-        make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string,
-                                 query_references_info, query_bugzilla_info, query_advisories_info])
+
+    make_query(CVE_DB_PATH, [vulnerabilities_query_string, query_vulnerabilities_info_query_string,
+                             query_references_info, query_bugzilla_info, query_advisories_info])
 
 
 def update_package(version, package, agent="000"):

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -150,7 +150,7 @@ def load_db(db_path):
 
 def make_query(db_path, query_list):
     """
-    Run queries to the database in db_path for each item in query_list.
+    Makes a query to the database in db_path for each item in query_list
 
     Args:
         db_path (string): Path where is located the DB.
@@ -159,27 +159,11 @@ def make_query(db_path, query_list):
     connect = sqlite3.connect(db_path)
 
     try:
-        _make_query(connect, query_list)
+        with connect:
+            for item in query_list:
+                connect.execute(item)
     finally:
         connect.close()
-
-
-def _make_query(connect, query_list):
-    """
-    Run queries to the database, retrying 5 times in case of operationalError exception.
-
-    Args:
-        connect (sqlite3.Connection): Database connection object.
-        query_list (list): List with queries to run.
-    """
-    for _ in range(5):
-        try:
-            with connect:
-                for item in query_list:
-                    connect.execute(item)
-                break
-        except sqlite3.OperationalError:
-            sleep(5)
 
 
 def get_query_result(db_path, query):

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -4,7 +4,10 @@
 
 from subprocess import CalledProcessError
 
+import os
+import time
 import pytest
+
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -49,6 +52,9 @@ def restart_modulesd_catching_ossec_conf_error(request):
 
 @pytest.fixture(scope='session')
 def mock_agent():
+    """
+    Fixture to create a mocked agent in wazuh databases
+    """
     control_service('stop', daemon='wazuh-db')
 
     agent_id = vd.create_mocked_agent(name="mocked_agent")
@@ -62,3 +68,27 @@ def mock_agent():
     vd.delete_mocked_agent(agent_id)
 
     control_service('start', daemon='wazuh-db')
+
+
+@pytest.fixture(scope='module')
+def check_cve_db():
+    """
+    Fixture to check if the CVE database exists and its tables are created
+    """
+    def cve_tables_created():
+        query_string = "SELECT count(*) FROM sqlite_master WHERE type='table'"
+        query_result = int(vd.get_query_result(vd.CVE_DB_PATH, query_string)[0])
+        return query_result == vd.CVE_NUM_TABLES
+
+    db_status_ok = False
+    attemps = 0
+
+    while not db_status_ok:
+        if os.path.exists(vd.CVE_DB_PATH) and cve_tables_created:
+            db_status_ok = True
+        attemps += 1
+
+        if attemps > 30:
+            raise Exception("Could not check that CVE database or its tables exist")
+
+        time.sleep(1)

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -84,7 +84,7 @@ def check_cve_db():
     attemps = 0
 
     while not db_status_ok:
-        if os.path.exists(vd.CVE_DB_PATH) and cve_tables_created:
+        if os.path.exists(vd.CVE_DB_PATH) and cve_tables_created():
             db_status_ok = True
         attemps += 1
 

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -89,6 +89,6 @@ def check_cve_db():
         attemps += 1
 
         if attemps > 30:
-            raise Exception("Could not check that CVE database or its tables exist")
+            raise AttributeError("Could not check that CVE database or its tables exist")
 
         time.sleep(1)

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -77,7 +77,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_debian_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_debian_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                        mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -51,7 +51,6 @@ def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
@@ -81,7 +81,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_macos_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_macos_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                       mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -118,7 +118,7 @@ def is_hotfix_installed(cve_patch, dependencies, hotfixes):
         return False, cve_patch
 
 
-def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """
     Check if a missing patch triggers a vulnerability(only windows).

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -76,7 +76,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_redhat_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_redhat_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                        mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
@@ -118,7 +118,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -132,7 +132,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
@@ -112,7 +112,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -50,6 +50,12 @@ def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
+    control_service('stop', daemon='wazuh-modulesd')
+    control_service('stop', daemon='wazuh-db')
+
+    # Clean tables
+    vd.clean_vd_tables(agent=mock_agent)
+
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -70,7 +70,7 @@ def mock_vulnerability_scan(request, mock_agent):
     vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
-def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
+def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                        mock_vulnerability_scan):
     """
     Check if inserted vulnerable packages are reported by vulnerability detector

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -50,12 +50,6 @@ def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)

--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -162,7 +162,7 @@ def mock_system(request):
     control_service('start', daemon='wazuh-db')
 
 
-def test_window_version_indexing(get_configuration, configure_environment, restart_modulesd, mock_system):
+def test_window_version_indexing(get_configuration, configure_environment, restart_modulesd, check_cve_db, mock_system):
     wazuh_log_monitor.start(
         timeout=50,
         update_position=False,


### PR DESCRIPTION
|Related issue|
|---|
|closes #1020 |

Hi,

This PR fixes the following error:

```
sqlite3.OperationalError: no such table: VULNERABILITIES
```
produced when launching a scan test on a clean installation of wazuh (by default cve.db does not exist until vuln detector is activated and wazuh-modulesd is restarted).

The fix has consisted of adding a new fixture that after applying the `ossec.conf` configuration and restarting `wazuh-modulesd` there is a wait (up to a maximum of 30 seconds) until the database and tables have been created.

This is done before doing any operation with the database (insert vulnerabilities ...)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`

Regards.

