### PR TITLE
Improve stop/start behavior of DB's related functions

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -122,11 +122,11 @@ def mock_cve_db(func):
 
         func(*args, **kwargs)
 
-        control_service('start', daemon='wazuh-modulesd')
-        control_service('start', daemon='wazuh-db')
-
         # Truncate ossec.log
         file.truncate_file(LOG_FILE_PATH)
+
+        control_service('start', daemon='wazuh-modulesd')
+        control_service('start', daemon='wazuh-db')
 
         yield kwargs['request'].param
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import datetime
+import functools
 import json
 import os
 import re
@@ -10,7 +11,7 @@ import sqlite3
 import random
 from time import time, sleep
 
-from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH
 from wazuh_testing.tools import file
 from wazuh_testing.tools.services import control_service, check_if_process_is_running
 
@@ -96,6 +97,42 @@ TEST_CHARACTERS = ['.', ':', '@', '#', '*', '-', '_', "'", '"', '/', '=', 'ñ', 
 
 CUSTOM_INPUT_TEST_VALUES = [None, "", "dummy value", 12345, ['1', '2', '3', '4', '5'], "ñ", "テスト", "ИСПЫТАНИЕ", "测试",
                             "اختبار"]
+
+
+def mock_cve_db(func):
+    """Decorator used in any function that needs to mock cve.db
+
+    This function will execute `func` after stopping wazuh-modulesd and wazuh-db and cleaning the db. After that,
+    it will start the daemons again, clean the logs, etc.
+
+    Args:
+         func (callable): function that will mock the cve.db
+
+    Example:
+        @vd.mock_cve_db
+        def mock_vulnerability_scan(request, mock_agent):
+    """
+    @functools.wraps(func)
+    def magic(*args, **kwargs):
+        control_service('stop', daemon='wazuh-modulesd')
+        control_service('stop', daemon='wazuh-db')
+
+        # Clean tables
+        clean_vd_tables(agent=kwargs['mock_agent'])
+
+        func(*args, **kwargs)
+
+        control_service('start', daemon='wazuh-modulesd')
+        control_service('start', daemon='wazuh-db')
+
+        # Truncate ossec.log
+        file.truncate_file(LOG_FILE_PATH)
+
+        yield kwargs['request'].param
+
+        clean_vuln_and_sys_programs_tables(agent=kwargs['mock_agent'])
+
+    return magic
 
 
 def callback_detect_vulnerability_scan_sleeping(line):

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -2,17 +2,14 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import json
 import os
-from time import sleep
-
 import pytest
+
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
 from wazuh_testing import vulnerability_detector as vd
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -47,17 +44,11 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=debian_vulnerabilities, ids=debian_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
@@ -67,15 +58,6 @@ def mock_vulnerability_scan(request, mock_agent):
         vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'])
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_debian_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
@@ -2,9 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import json
 import os
-from time import sleep
 
 import pytest
 import wazuh_testing.vulnerability_detector as vd
@@ -12,7 +10,6 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -47,16 +44,11 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=macos_vulnerabilities, ids=macos_systems)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME,
@@ -69,16 +61,6 @@ def mock_vulnerability_scan(request, mock_agent):
 
     for vulnerability in request.param['vulnerabilities']:
         vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    # Truncate ossec.log
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_macos_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -3,9 +3,8 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from time import sleep
-
 import pytest
+
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -60,17 +59,12 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom hotfixes, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    vd.clean_vd_tables(agent=mock_agent)
-
-    # Modify the necessary databases. The arch follows a special format rather than the
-    # usual x86_64.
+    # Modify the necessary databases. The arch follows a special format rather than the usual x86_64.
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
@@ -78,16 +72,6 @@ def mock_vulnerability_scan(request, mock_agent):
 
     for patch in request.param["hotfixes"]:
         vd.insert_hotfix(agent=mock_agent, hotfix=patch)
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    # Truncate ossec.log
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def is_hotfix_installed(cve_patch, dependencies, hotfixes):

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -10,7 +10,6 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -103,7 +102,7 @@ def is_hotfix_installed(cve_patch, dependencies, hotfixes):
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,
-                                mock_vulnerability_scan):
+                                mock_vulnerability_scan, mock_agent):
     """
     Check if a missing patch triggers a vulnerability(only windows).
     """
@@ -117,17 +116,16 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
                 timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
                 update_position=False,
                 callback=vd.make_vuln_callback(
-                    f"Agent '000' has installed '{hotfix}' that corrects the vulnerability '{cve}'"
+                    f"Agent '{mock_agent}' has installed '{hotfix}' that corrects the vulnerability '{cve}'"
                 ),
-                error_message=f"Could not find the report which says that the patch {hotfix}" +
-                              f" solves {cve}"
+                error_message=f"Could not find the report which says that the patch {hotfix} solves {cve}"
             )
         else:
             wazuh_log_monitor.start(
                 timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
                 update_position=False,
                 callback=vd.make_vuln_callback(
-                    f"Agent '000' is vulnerable to '{cve}'. Condition: 'KB{hotfix} patch is not installed'"
+                    f"Agent '{mock_agent}' is vulnerable to '{cve}'. Condition: 'KB{hotfix} patch is not installed'"
                 ),
                 error_message=f"Could not find the report which says that the system" +
                               f" is vulnerable to {cve} due to missing {hotfix}"

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_duplicate_vulns.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_duplicate_vulns.py
@@ -3,8 +3,8 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-
 import pytest
+
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -48,7 +48,7 @@ def get_configuration(request):
 def test_redhat_duplicate_vulns(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
     """
     RedHat provider was duplicating vulnerabilities when it downloaded a feed to update the database.
-    This test check the vulnerabilites are not repeated in the database when it is update.
+    This test check the vulnerabilities are not repeated in the database when it is update.
     """
     feed = get_configuration['metadata']['feed']
     timestamp = '2020-10-31T20:46:48'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -3,15 +3,13 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from time import sleep
-
 import pytest
+
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
 from wazuh_testing import vulnerability_detector as vd
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -46,16 +44,11 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=redhat_vulnerabilities, ids=redhat_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
@@ -65,15 +58,6 @@ def mock_vulnerability_scan(request, mock_agent):
         vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'])
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_redhat_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
@@ -3,15 +3,13 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from time import sleep
-
 import pytest
+
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -83,16 +81,11 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
@@ -106,16 +99,6 @@ def mock_vulnerability_scan(request, mock_agent):
     for vulnerability in vulnerabilities_nvd:
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
                           format=request.param['format'], agent=mock_agent)
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    # Truncate ossec.log
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -5,16 +5,14 @@
 import os
 from datetime import timedelta
 from shutil import copy
-from time import sleep
 
 import pytest
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.fim import check_time_travel
 from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools import file
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools import file
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -97,20 +95,15 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME,
                      os_platform=request.param['os_platform'], version=request.param['version'])
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
 
     # Insert a vulnerability in table VULNERABILITIES
     vd.insert_vulnerability(cveid='CWE-000', operation='less than', operation_value='1.0.0',
@@ -120,16 +113,6 @@ def mock_vulnerability_scan(request, mock_agent):
     for vulnerability in nvd_vulnerabilities['vulnerabilities_nvd']:
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
                           format=request.param['format'], agent=mock_agent)
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    # Truncate ossec.log
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
@@ -4,7 +4,6 @@
 
 import os
 from datetime import timedelta
-from time import sleep
 
 import pytest
 import wazuh_testing.vulnerability_detector as vd
@@ -13,7 +12,6 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
-from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -78,16 +76,11 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
@@ -101,15 +94,6 @@ def mock_vulnerability_scan(request, mock_agent):
     for vulnerability in (vulnerabilities['vulnerabilities_nvd'] + vulnerabilities['vulnerabilities_provider']):
         vd.insert_package(**vulnerability['package'], source=vulnerability['package']['name'],
                           format=request.param['format'], agent=mock_agent)
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -46,16 +46,11 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module', params=ubuntu_vulnerabilities, ids=ubuntu_data_ids)
+@vd.mock_cve_db
 def mock_vulnerability_scan(request, mock_agent):
     """
     It allows to mock the vulnerability scan inserting custom packages, feeds and changing the host system
     """
-    control_service('stop', daemon='wazuh-modulesd')
-    control_service('stop', daemon='wazuh-db')
-
-    # Clean tables
-    vd.clean_vd_tables(agent=mock_agent)
-
     # Mock system
     vd.modify_system(agent_id=mock_agent, os_name=request.param['os_name'], os_major=request.param['os_major'],
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
@@ -65,15 +60,6 @@ def mock_vulnerability_scan(request, mock_agent):
         vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'])
-
-    control_service('start', daemon='wazuh-db')
-    control_service('start', daemon='wazuh-modulesd')
-
-    file.truncate_file(LOG_FILE_PATH)
-
-    yield request.param
-
-    vd.clean_vuln_and_sys_programs_tables(agent=mock_agent)
 
 
 def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd,


### PR DESCRIPTION
|Related issue|
|---|
|closes #1057|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a new decorator that simplifies the creation of mocking functions.

## Configuration options

NA

## Logs example

```shellsession
# python3 -m pytest test_scan_results/test_scan_*
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.6.8, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /tmp/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.9.0, html-2.0.1, testinfra-5.0.0
collected 31 items

test_scan_results/test_scan_different_cves.py .........                                                                                                                                                   [ 29%]
test_scan_results/test_scan_nvd_feed.py .............                                                                                                                                                     [ 70%]
test_scan_results/test_scan_providers_and_nvd_feed.py .........                                                                                                                                           [100%]

======================================================================================== 31 passed in 323.20s (0:05:23) =========================================================================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove this check if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`