### PR TITLE
Adding new tests for write/erase Wazuh-DB commands in agents' CVEs table

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -4,15 +4,15 @@
   description: "Checks the commands insert and clear"
   test_case:
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}'
+    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}'
     output: "ok"
     stage: "agent vuln_cve insert test package"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves'
-    output: 'ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}]'
+    output: 'ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}]'
     stage: "agent vuln_cve checking test package"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}'
+    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}'
     output: "err Cannot execute vuln_cve insert command; SQL err: UNIQUE constraint failed: vuln_cves.name, vuln_cves.version, vuln_cves.architecture, vuln_cves.cve"
     stage: "agent vuln_cve insert duplicated entry"
   -
@@ -24,7 +24,7 @@
     output: 'ok []'
     stage: "agent vuln_cve checking empty table"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package","cve":"1001"}'
+    input: 'agent 000 vuln_cve insert {"name":"test_package","cve":"CVE-2021-1001"}'
     output: "err Invalid JSON data, missing required fields"
     stage: "agent vuln_cve insert incomplete package"
   -
@@ -36,28 +36,28 @@
     output: "err Invalid vuln_cve query syntax, near 'vuln_cve'"
     stage: "agent vuln_cve missing command "
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package2","version":"1.0","architecture":"x86","cve":"1001"}'
+    input: 'agent 000 vuln_cve insert {"name":"test_package2","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}'
     output: "ok"
     stage: "agent vuln_cve insert another package"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves'
-    output: 'ok [{"name":"test_package2","version":"1.0","architecture":"x86","cve":"1001"}]'
+    output: 'ok [{"name":"test_package2","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}]'
     stage: "agent vuln_cve checking another package"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"1001"}'
+    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1001"}'
     output: "ok"
     stage: "agent vuln_cve insert package with same CVE"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3"'
-    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"1001"}]'
+    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1001"}]'
     stage: "agent vuln_cve checking package insertion with same CVE"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"1002"}'
+    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1002"}'
     output: "ok"
     stage: "agent vuln_cve insert same package with different CVE"
   -
-    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3" AND cve = "1002"'
-    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"1002"}]'
+    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3" AND cve = "CVE-2021-1002"'
+    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1002"}]'
     stage: "agent vuln_cve checking package with different CVE"
   -
     input: 'agent 000 vuln_cve clear'

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -13,7 +13,7 @@
     stage: "agent vuln_cve checking test package"
   -
     input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}'
-    output: "err Cannot execute Global database query; UNIQUE constraint failed: vuln_cves.name, vuln_cves.version, vuln_cves.architecture, vuln_cves.cve"
+    output: "err Cannot execute vuln_cve insert command; SQL err: UNIQUE constraint failed: vuln_cves.name, vuln_cves.version, vuln_cves.architecture, vuln_cves.cve"
     stage: "agent vuln_cve insert duplicated entry"
   -
     input: 'agent 000 vuln_cve clear'
@@ -25,7 +25,7 @@
     stage: "agent vuln_cve checking empty table"
   -
     input: 'agent 000 vuln_cve insert {"name":"test_package","cve":"1001"}'
-    output: "err Invalid JSON data, near '{\"name\":\"test_package\",\"cve\":\"10'"
+    output: "err Invalid JSON data, missing required fields"
     stage: "agent vuln_cve insert incomplete package"
   -
     input: 'agent 000 vuln_cve insert {"name":"test_package",'

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -1,0 +1,69 @@
+---
+-
+  name: "Agents' CVEs table: vuln_cves "
+  description: "Checks the commands insert and clear"
+  test_case:
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}'
+    output: "ok"
+    stage: "agent vuln_cve insert test package"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves'
+    output: 'ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}]'
+    stage: "agent vuln_cve checking test package"
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"1001"}'
+    output: "err Cannot execute Global database query; UNIQUE constraint failed: vuln_cves.name, vuln_cves.version, vuln_cves.architecture, vuln_cves.cve"
+    stage: "agent vuln_cve insert duplicated entry"
+  -
+    input: 'agent 000 vuln_cve clear'
+    output: "ok"
+    stage: "agent vuln_cve clear table"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves'
+    output: 'ok []'
+    stage: "agent vuln_cve checking empty table"
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package","cve":"1001"}'
+    output: "err Invalid JSON data, near '{\"name\":\"test_package\",\"cve\":\"10'"
+    stage: "agent vuln_cve insert incomplete package"
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package",'
+    output: "err Invalid JSON syntax, near '{\"name\":\"test_package\",'"
+    stage: "agent vuln_cve insert invalid JSON "
+  -
+    input: 'agent 000 vuln_cve'
+    output: "err Invalid vuln_cve query syntax, near 'vuln_cve'"
+    stage: "agent vuln_cve missing command "
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package2","version":"1.0","architecture":"x86","cve":"1001"}'
+    output: "ok"
+    stage: "agent vuln_cve insert another package"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves'
+    output: 'ok [{"name":"test_package2","version":"1.0","architecture":"x86","cve":"1001"}]'
+    stage: "agent vuln_cve checking another package"
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"1001"}'
+    output: "ok"
+    stage: "agent vuln_cve insert package with same CVE"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3"'
+    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"1001"}]'
+    stage: "agent vuln_cve checking package insertion with same CVE"
+  -
+    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"1002"}'
+    output: "ok"
+    stage: "agent vuln_cve insert same package with different CVE"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3" AND cve = "1002"'
+    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"1002"}]'
+    stage: "agent vuln_cve checking package with different CVE"
+  -
+    input: 'agent 000 vuln_cve clear'
+    output: "ok"
+    stage: "agent vuln_cve clearing table again"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves'
+    output: 'ok []'
+    stage: "agent vuln_cve checking empty table again"


### PR DESCRIPTION
|Related issue|
|---|
|1069|


## Description

This PR adds a new `test_wazuh_db/data/agent_messages.yaml` tests file to verify the **agent XXX vuln_cve insert** and **agent XXX vuln_cve clear** commands.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.

The Wazuh-DB IT were tested locally and using Jenkins: 
https://ci.wazuh.info/job/test_integration/1323/console