### PR TITLE
Changed test_execd yaml due to an error in AR configuration, added do…

### DIFF
--- a/docs/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.md
+++ b/docs/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.md
@@ -1,6 +1,18 @@
 # Test execd firewall drop
+This test check that Active Response script called 'firewall-drop' is executed correctly when configured.
 
+## General info
 
-## Code documentation   
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | Linux | 00:00:11 | [test_active_response/test_execd/test_execd_firewall_drop.py]|
+
+## Test logic
+
+- Check Active Response enabled in ossec logs and AR logs.
+- If expected success check if the IP was added/removed in iptables.
+- If not, check error log "Invalid input format"
+
+## Code documentation
 
 <!-- ::: tests.integration.test_active_response.test_execd.test_execd_firewall_drop -->

--- a/docs/tests/integration/test_active_response/test_execd/test_execd_restart.md
+++ b/docs/tests/integration/test_active_response/test_execd/test_execd_restart.md
@@ -1,6 +1,18 @@
 # Test execd restart
+This test check that Active Response script called 'restart-wazuh' is executed correctly when configured.
 
+## General info
 
-## Code documentation   
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | Linux/Windows | 00:00:10 | [test_active_response/test_execd/test_execd_restart.py]|
+
+## Test logic
+
+- Check Active Response enabled in ossec logs and AR logs.
+- If expected success check shutdown message.
+- If not, check error log "Invalid input format"
+
+## Code documentation
 
 <!-- ::: tests.integration.test_active_response.test_execd.test_execd_restart -->

--- a/tests/integration/test_active_response/test_execd/data/wazuh_conf.yaml
+++ b/tests/integration/test_active_response/test_execd/data/wazuh_conf.yaml
@@ -24,8 +24,6 @@
         - protocol:
             value: PROTOCOL
   - section: active-response
-    attributes:
-      - name: 'active-response'
     elements:
     - disabled:
         value: 'no'

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -183,6 +183,13 @@ def test_execd_firewall_drop(set_debug_mode, get_configuration, test_version, co
                              remove_ip_from_iptables, start_agent, set_ar_conf_mode):
     """
     Check if firewall-drop Active Response is executed correctly
+
+    Args:
+        set_debug_mode (fixture): Set execd daemon in debug mode.
+        test_version (fixture): Validate Wazuh version.
+        set_ar_conf_mode (fixture): Configure Active Responses used in tests.
+        start_agent (fixture): Create Remoted and Authd simulators, register agent and start it.
+        remove_ip_from_iptables (fixture): Remove the test IP from iptables if it exist
     """
     metadata = get_configuration['metadata']
     expected = metadata['results']

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -155,6 +155,12 @@ def build_message(metadata, expected):
 def test_execd_restart(set_debug_mode, get_configuration, test_version, configure_environment, start_agent, set_ar_conf_mode):
     """
     Check if restart-wazuh Active Response is executed correctly
+
+    Args:
+        set_debug_mode (fixture): Set execd daemon in debug mode.
+        test_version (fixture): Validate Wazuh version.
+        set_ar_conf_mode (fixture): Configure Active Responses used in tests.
+        start_agent (fixture): Create Remoted and Authd simulators, register agent and start it.
     """
     metadata = get_configuration['metadata']
     expected = metadata['results']


### PR DESCRIPTION
…cumentation for this tests

|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1060|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR solves an error in Active Response configuration due to yaml AR section:
```
- tags:
  - all
  apply_to_modules:
  - test_execd_restart
  - test_execd_firewall_drop
  - conftest
  sections:
  - section: client
    elements:
    - notify_time:
        value: 10
    - time-reconnect:
        value: 60
    - auto_restart:
        value: 'yes'
    - crypto_method:
        value: 'aes'
    - server:
        elements:
        - address:
            value: SERVER_ADDRESS
        - port:
            value: REMOTED_PORT
        - protocol:
            value: PROTOCOL
  - section: active-response
    attributes:
      - name: 'active-response'
    elements:
    - disabled:
        value: 'no'
```

## Logs example

Error due to a bad configuration:
`2021/02/12 09:02:30 wazuh-execd: INFO: (1350): Active response disabled.`


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
