### PR TITLE
Add integration tests for syslog

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import socket
+
+from wazuh_testing.tools import ARCHIVES_LOG_FILE_PATH
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import FileMonitor, make_callback, REMOTED_DETECTOR_PREFIX
+
+
+def callback_detect_remoted_started(port, protocol, connection_type="secure"):
+    """Creates a callback to detect if remoted was correctly started
+
+    wazuh-remoted logs if it has correctly started for each connection type, the port and
+    the protocol in the ossec.log
+
+    Args:
+        port (int): port configured for wazuh-remoted.
+        protocol (str): protocol configured for wazuh-remoted. It can be UDP, TCP or both options at the same time.
+        connection_type (str): it can be secure or syslog.
+
+    Returns:
+        callable: callback to detect this event
+    """
+    msg = fr"Started \(pid: \d+\). Listening on port {port}\/{protocol} \({connection_type}\)."
+
+    return make_callback(pattern=msg, prefix=REMOTED_DETECTOR_PREFIX)
+
+
+def callback_detect_syslog_event(message):
+    """Creates a callback to detect the syslog messages in the archives.log
+
+    Args:
+        message (str): syslog message sent through the socket
+
+    Returns:
+        callable: callback to detect this event
+    """
+    expr = fr".*->\d+\.\d+\.\d+\.\d+\s{message}"
+    return make_callback(pattern=expr, prefix=None)
+
+
+def send_syslog_message(message, port, protocol, manager_address="127.0.0.1"):
+    """This function sends the ping message to the manager
+
+    This message is the first of many between the manager and the agents. It is used to check if both of them are ready
+    to send and receive other messages
+
+    Args:
+        message (str): string to send as a syslog event.
+        protocol (str): it can be UDP or TCP.
+        port (int): port where the manager has bound the remoted port
+        manager_address (str): address of the manager.
+
+    Raises:
+        ConnectionRefusedError: if there's a problem while sending messages to the manager
+    """
+    if protocol == "UDP":
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    if not message.endswith("\n"):
+        message += "\n"
+
+    sock.connect((manager_address, port))
+    sock.send(message.encode())
+    sock.close()
+
+
+def create_archives_log_monitor():
+    """Creates a FileMonitor for the archives.log file
+
+    Returns:
+        FileMonitor: object to monitor the archives.log
+    """
+    # Reset ossec.log and start a new monitor
+    truncate_file(ARCHIVES_LOG_FILE_PATH)
+    wazuh_archives_log_monitor = FileMonitor(ARCHIVES_LOG_FILE_PATH)
+
+    return wazuh_archives_log_monitor
+
+
+def detect_archives_log_event(archives_monitor, callback, error_message, update_position=True, timeout=5):
+    archives_monitor.start(timeout=timeout, update_position=update_position, callback=callback,
+                           error_message=error_message)
+
+
+def check_syslog_event(wazuh_archives_log_monitor, message, port, protocol):
+    """Check if a syslog event is properly receive by the manager.
+
+    Args:
+        wazuh_archives_log_monitor (FileMonitor): FileMonitor object to monitor the archives.log.
+        message (str): Message sent for syslog that must appear in the archives.log.
+        protocol (str): it can be UDP or TCP.
+        port (int): port where the manager has bound the remoted port
+    """
+    send_syslog_message(message, port, protocol)
+    detect_archives_log_event(archives_monitor=wazuh_archives_log_monitor,
+                              callback=callback_detect_syslog_event(message),
+                              error_message="Syslog message wasn't received or took too much time.")

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -100,3 +100,37 @@ def check_syslog_event(wazuh_archives_log_monitor, message, port, protocol):
     detect_archives_log_event(archives_monitor=wazuh_archives_log_monitor,
                               callback=callback_detect_syslog_event(message),
                               error_message="Syslog message wasn't received or took too much time.")
+
+
+def send_ping_pong_messages(protocol, manager_address, port):
+    """This function sends the ping message to the manager
+
+    This message is the first of many between the manager and the agents. It is used to check if both of them are ready
+    to send and receive other messages
+
+    Args:
+        protocol (str): it can be UDP or TCP
+        manager_address (str): address of the manager. IP and hostname are valid options
+        port (int): port where the manager has bound the remoted port
+
+    Returns:
+        bytes: returns the #pong message from the manager
+
+    Raises:
+        ConnectionRefusedError: if there's a problem while sending messages to the manager
+    """
+    if protocol == "UDP":
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        ping_msg = b'#ping'
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        msg = '#ping'
+        msg_size = len(bytearray(msg, 'utf-8'))
+        # Since the message size's is represented as an uint32, you need to use 4 bytes to represent it
+        ping_msg = msg_size.to_bytes(4, 'little') + msg.encode()
+
+    sock.connect((manager_address, port))
+    sock.send(ping_msg)
+    response = sock.recv(len(ping_msg))
+    sock.close()
+    return response if protocol == "UDP" else response[-5:]

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -42,10 +42,7 @@ def callback_detect_syslog_event(message):
 
 
 def send_syslog_message(message, port, protocol, manager_address="127.0.0.1"):
-    """This function sends the ping message to the manager
-
-    This message is the first of many between the manager and the agents. It is used to check if both of them are ready
-    to send and receive other messages
+    """This function sends a message to the syslog server of wazuh-remoted
 
     Args:
         message (str): string to send as a syslog event.
@@ -83,6 +80,18 @@ def create_archives_log_monitor():
 
 
 def detect_archives_log_event(archives_monitor, callback, error_message, update_position=True, timeout=5):
+    """Monitors the archives.log to detect a certain event
+
+    Args:
+        archives_monitor (FileMonitor): FileMonitor bound to the archives.log.
+        callback (callable): lambda function used to detect the event.
+        error_message (str): String used as human readable error if the event is not found.
+        update_position (bool): bool value used to update the position of `archives_monitor`.
+        timeout (int): maximum time in seconds to expect the event.
+
+    Raises:
+        TimeoutError: if the event is not found in the file.
+    """
     archives_monitor.start(timeout=timeout, update_position=update_position, callback=callback,
                            error_message=error_message)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -36,6 +36,7 @@ else:
     WAZUH_SECURITY_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'security.yaml')
     LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
+    ARCHIVES_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'archives', 'archives.log')
 
     try:
         import grp

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1050,37 +1050,3 @@ def create_agents(agents_number, manager_address, cypher, fim_eps=None, authd_pa
         agent_count = agent_count + 1
 
     return agents
-
-
-def send_ping_pong_messages(protocol, manager_address, port):
-    """This function sends the ping message to the manager
-
-    This message is the first of many between the manager and the agents. It is used to check if both of them are ready
-    to send and receive other messages
-
-    Args:
-        protocol (str): it can be UDP or TCP
-        manager_address (str): address of the manager. IP and hostname are valid options
-        port (int): port where the manager has bound the remoted port
-
-    Returns:
-        bytes: returns the #pong message from the manager
-
-    Raises:
-        ConnectionRefusedError: if there's a problem while sending messages to the manager
-    """
-    if protocol == "UDP":
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        ping_msg = b'#ping'
-    else:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        msg = '#ping'
-        msg_size = len(bytearray(msg, 'utf-8'))
-        # Since the message size's is represented as an uint32, you need to use 4 bytes to represent it
-        ping_msg = msg_size.to_bytes(4, 'little') + msg.encode()
-
-    sock.connect((manager_address, port))
-    sock.send(ping_msg)
-    response = sock.recv(len(ping_msg))
-    sock.close()
-    return response if protocol == "UDP" else response[-5:]

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -279,11 +279,9 @@ class Agent:
         """
         encrypted_event = None
         if self.cypher == "aes":
-            encrypted_event = Cipher(padded_event,
-                                     self.encryption_key).encrypt_aes()
+            encrypted_event = Cipher(padded_event, self.encryption_key).encrypt_aes()
         if self.cypher == "blowfish":
-            encrypted_event = Cipher(padded_event,
-                                     self.encryption_key).encrypt_blowfish()
+            encrypted_event = Cipher(padded_event, self.encryption_key).encrypt_blowfish()
         return encrypted_event
 
     def headers(self, agent_id, encrypted_event):
@@ -313,7 +311,7 @@ class Agent:
             bytes: Built event (compressed, padded, enceypted and with headers).
 
         Examples:
-            >>> create_event('test message)
+            >>> create_event('test message')
             b'!005!#AES:\\xab\\xfa\\xcc2;\\x87\\xab\\x7fUH\\x03>_J\\xda=I\\x96\\xb5\\xa4\\x89\\xbe\\xbf`\\xd0\\xad
             \\x03\\x06\\x1aN\\x86 \\xc2\\x98\\x93U\\xcc\\xf5\\xe3@%\\xabS!\\xd3\\x9d!\\xea\\xabR\\xf9\\xd3\\x0b\\
             xcc\\xe8Y\\xe31*c\\x17g\\xa6M\\x0b&\\xc0>\\xc64\\x815\\xae\\xb8[bg\\xe3\\x83\\x0e'
@@ -360,12 +358,10 @@ class Agent:
                 buffer_array = buffer_array[index + 2:]
             if self.cypher == "aes":
                 msg_remove_header = bytes(buffer_array[5:])
-                msg_decrypted = Cipher(msg_remove_header, self.encryption_key) \
-                    .decrypt_aes()
+                msg_decrypted = Cipher(msg_remove_header, self.encryption_key).decrypt_aes()
             else:
                 msg_remove_header = bytes(buffer_array[1:])
-                msg_decrypted = Cipher(msg_remove_header, self.encryption_key) \
-                    .decrypt_blowfish()
+                msg_decrypted = Cipher(msg_remove_header, self.encryption_key).decrypt_blowfish()
 
             padding = 0
             while msg_decrypted:
@@ -385,7 +381,7 @@ class Agent:
     def process_message(self, sender, message):
         """Process agent received messages.
 
-        If the message cointains reserved words, then it will be proceed as command.
+        If the message contains reserved words, then it will be proceed as command.
 
         Args:
             sender (Sender): Object to establish connection with the manager socket and receive/send information.
@@ -414,10 +410,9 @@ class Agent:
             com_index = message_list.index('upgrade')
             json_command = json.loads(message_list[com_index + 1])
             command = json_command['command']
-        if command in ['lock_restart', 'open', 'write', 'close',
-                       'clear_upgrade_result']:
-            if command == 'lock_restart' and \
-                    self.stage_disconnect == 'lock_restart':
+
+        if command in ['lock_restart', 'open', 'write', 'close', 'clear_upgrade_result']:
+            if command == 'lock_restart' and self.stage_disconnect == 'lock_restart':
                 self.stop_receive = 1
             elif command == 'open' and self.stage_disconnect == 'open':
                 self.stop_receive = 1
@@ -425,8 +420,7 @@ class Agent:
                 self.stop_receive = 1
             elif command == 'close' and self.stage_disconnect == 'close':
                 self.stop_receive = 1
-            elif command == 'clear_upgrade_result' and \
-                    self.stage_disconnect == 'clear_upgrade_result':
+            elif command == 'clear_upgrade_result' and self.stage_disconnect == 'clear_upgrade_result':
                 self.stop_receive = 1
             else:
                 if self.short_version < "4.1" or command == 'lock_restart':
@@ -508,6 +502,7 @@ class Agent:
             self.fim = GeneratorFIM(self.id, self.name, self.short_version)
         if self.modules["fim_integrity"]["status"] == "enabled":
             self.fim_integrity = GeneratorIntegrityFIM(self.id, self.name, self.short_version)
+
 
 class Inventory:
     def __init__(self, os, inventory_sample=None):
@@ -1081,6 +1076,7 @@ def send_ping_pong_messages(protocol, manager_address, port):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         msg = '#ping'
         msg_size = len(bytearray(msg, 'utf-8'))
+        # Since the message size's is represented as an uint32, you need to use 4 bytes to represent it
         ping_msg = msg_size.to_bytes(4, 'little') + msg.encode()
 
     sock.connect((manager_address, port))

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -162,7 +162,8 @@ def make_callback(pattern, prefix="wazuh"):
     """
 
     pattern = r'\s+'.join(pattern.split())
-    regex = re.compile(r'{}{}'.format(prefix, pattern))
+    full_pattern = pattern if prefix is None else fr'{prefix}{pattern}'
+    regex = re.compile(full_pattern)
 
     return lambda line: regex.match(line) is not None
 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -363,7 +363,7 @@ class QueueMonitor:
 
         Args:
             queue_item (queue): Queue to monitor
-            time_step (float,optiona) : Fraction of time to wait in every get. Default `0.5`
+            time_step (float,optional) : Fraction of time to wait in every get. Default `0.5`
         """
         self._queue = queue_item
         self._continue = False

--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -156,7 +156,7 @@ class RemotedSimulator:
         if extra > 0:
             padded_sec_message = (b'!' * (padding - extra)) + compressed_sec_message
         else:
-            padded_sec_message = (b'!' * (padding)) + compressed_sec_message
+            padded_sec_message = (b'!' * padding) + compressed_sec_message
         return padded_sec_message
 
     def encrypt(self, padded_sec_message, crypto_method):

--- a/deps/wazuh_testing/wazuh_testing/tools/security.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/security.py
@@ -125,7 +125,7 @@ class CertificateController(object):
 
         Args:
             key (PKey): Keys to be stored
-            rivate_key_path (str): Path to store the private key
+            private_key_path (str): Path to store the private key
         """
         if os.path.exists(private_key_path):
             if platform.system() == 'Windows':

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -217,10 +217,10 @@ def delete_dbs():
 
 def check_if_process_is_running(process_name):
     """
-    Check if proccess is running
+    Check if process is running
 
     Args:
-        proccess_name (str): Name of process
+        process_name (str): Name of process
 
     Returns
         boolean: True if process is running, False otherwise

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -166,6 +166,10 @@ def make_vuln_callback(pattern, prefix=VULNERABILITY_DETECTOR_PREFIX):
 
     Args:
         pattern (str): String to match on the log
+        prefix (str): regular expression used as prefix before the pattern.
+
+    Returns:
+        lambda: function that returns if there's a match in the file
 
     Examples:
         >>> callback_bionic_update_started = make_vuln_callback("Starting Ubuntu Bionic database update")
@@ -298,6 +302,7 @@ def insert_hotfix(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
         scan_id (int): id of the last scan
         scan_time (str): date of the scan with this format "%Y/%m/%d %H:%M:%S"
         hotfix (str): id representing the hotfix value
+        checksum (str): checksum of the hotfix
     """
     path = os.path.join(DB_PATH, f"{agent}.db")
     query_string = f'''INSERT INTO sys_hotfixes
@@ -647,6 +652,8 @@ def check_feed_imported_successfully(wazuh_log_monitor, log_system_name, expecte
         expected_vulnerabilities_number (int): number of expected vulnerabilities imported in the BD
         update_position (boolean): filter configuration parameter to search in Wazuh log
         timeout (str): timeout to check the event in Wazuh log
+        check_vuln_number (bool): boolean to enable the check that compares the number of generated alerts with
+            the number of expected alerts
     """
     check_vuln_detector_event(
         wazuh_log_monitor=wazuh_log_monitor, update_position=update_position, timeout=timeout,

--- a/docs/tests/integration/test_remoted/test_configuration/test_basic_configuration.md
+++ b/docs/tests/integration/test_remoted/test_configuration/test_basic_configuration.md
@@ -1,5 +1,5 @@
-# Overview
-
+# Test basic configuration
+## Overview 
 Configuration tests check that the introduced configuration on ossec.conf works as expected and no valid option generates errors. 
 Also, it checks that the API answer for configuration requests coincides with the configuration introduced in ossec.conf
 

--- a/docs/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.md
+++ b/docs/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.md
@@ -1,5 +1,5 @@
-# Overview
-
+# Test ping-pong messages
+## Overview
 These tests will check if `wazuh-remoted` sends the message `#pong` through the socket after receiving the `#ping` message.
 
 This message will be received in the port configured in the `remote` section, using the `secure` connection. Also, depending on the protocol used, these messages may vary:

--- a/docs/tests/integration/test_remoted/test_socket_communication/test_syslog_message.md
+++ b/docs/tests/integration/test_remoted/test_socket_communication/test_syslog_message.md
@@ -1,0 +1,41 @@
+# Test syslog messages
+## Overview
+These tests will check if `wazuh-remoted` can receive messages to its syslog server. This message will be received in the port configured in the `remote` section, using the `syslog` connection. The `syslog` functionality accepts these protocols `UDP` and `TCP` connections, but not at the same time.
+
+For `syslog`, you can send messages to the socket using any protocol without needing to add any header to the message but, any message must end with a `\n`. Otherwise, the event will remain in the socket until a message with the EOL character arrives.
+
+Finally, `wazuh-remoted` doesn't log anywhere the events received in its syslog server unless the `logall` option is set to `yes`. If it is enabled, `wazuh-remoted` will log in `/var/ossec/logs/archives/archives.log` any syslog event using this format:
+```buildoutcfg
+Year Month Day HH:MM:SS hostname->address syslog message
+```
+
+For example:
+```buildoutcfg
+2021 Feb 24 10:30:10 centos-8->127.0.0.1 Syslog message sent by wazuh-qa to test remoted syslog with UDP at 514
+```
+
+## Objective
+
+Confirm `wazuh-remoted` can receive messages to its syslog server. This confirmation is done by searching the syslog messages in the `archives.log`. 
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 4 | 95s |
+
+## Expected behavior
+
+- Fail if `wazuh-remoted` doesn't start with a valid configuration.
+- Fail if `wazuh-remoted` doesn't receive the syslog message.
+
+## Testing
+Checks executed in this test
+### Checks
+- **UDP and port 514**: `wazuh-remoted` must log a line similar to this: `2021 Feb 24 10:30:10 centos-8->127.0.0.1 Syslog message sent by wazuh-qa to test remoted syslog with UDP at 514`.
+- **UDP and port 51000**: `wazuh-remoted` must log a line similar to this: `2021 Feb 24 10:30:10 centos-8->127.0.0.1 Syslog message sent by wazuh-qa to test remoted syslog with UDP at 51000`. 
+- **TCP and port 514**: `wazuh-remoted` must log a line similar to this: `2021 Feb 24 10:30:10 centos-8->127.0.0.1 Syslog message sent by wazuh-qa to test remoted syslog with TCP at 514`.
+- **TCP and port 51000**: `wazuh-remoted` must log a line similar to this: `2021 Feb 24 10:30:10 centos-8->127.0.0.1 Syslog message sent by wazuh-qa to test remoted syslog with TCP at 51000`.
+
+## Code documentation
+::: tests.integration.test_remoted.test_socket_communication.test_syslog_message

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -389,6 +389,7 @@ nav:
                 - tests/integration/test_remoted/test_configuration/test_basic_configuration.md
             - Test communications through the sockets:
                 - tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.md
+                - tests/integration/test_remoted/test_socket_communication/test_syslog_message.md
         - Logtest:   
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration.py
@@ -6,8 +6,8 @@ import os
 import pytest
 import wazuh_testing.api as api
 
+from wazuh_testing.remote import callback_detect_remoted_started
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import FileMonitor, make_callback, REMOTED_DETECTOR_PREFIX
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -58,10 +58,8 @@ def test_connection(get_configuration, configure_environment, restart_remoted):
     """
     cfg = get_configuration['metadata']
 
-    log_callback = make_callback(
-        fr"Started \(pid: \d+\). Listening on port {cfg['port']}\/{cfg['protocol']} \({cfg['connection']}\).",
-        REMOTED_DETECTOR_PREFIX
-    )
+    log_callback = callback_detect_remoted_started(port=cfg['port'], protocol=cfg['protocol'],
+                                                   connection_type=cfg['connection'])
 
     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message="Wazuh remoted didn't start as expected.")
 

--- a/tests/integration/test_remoted/test_socket_communication/data/wazuh_syslog.yaml
+++ b/tests/integration/test_remoted/test_socket_communication/data/wazuh_syslog.yaml
@@ -1,0 +1,22 @@
+- tags:
+  - test_syslog_message
+  apply_to_modules:
+  - test_syslog_message
+  sections:
+  - section: remote
+    elements:
+    - connection:
+        value: syslog
+    -  allowed-ips:
+         value: "127.0.0.1"
+    - port:
+        value: PORT
+    - protocol:
+        value: PROTOCOL
+
+  # This is needed for syslog test. The messages received in the syslog socket are logged only if
+  # the logall option is set to yes.
+  - section: global
+    elements:
+      - logall:
+          value: "yes"

--- a/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
@@ -5,8 +5,8 @@
 import os
 import pytest
 
+from wazuh_testing.remote import callback_detect_remoted_started
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import make_callback, REMOTED_DETECTOR_PREFIX
 from wazuh_testing.tools.agent_simulator import send_ping_pong_messages
 
 
@@ -74,9 +74,8 @@ def test_ping_pong_message(get_configuration, configure_environment, restart_rem
         protocol = config['protocol'].split(',')[0]
     else:
         protocol = config['protocol']
-    callback = fr"Started \(pid: \d+\). Listening on port {config['port']}\/{protocol} \(secure\)."
 
-    log_callback = make_callback(callback, REMOTED_DETECTOR_PREFIX)
+    log_callback = callback_detect_remoted_started(port=config['port'], protocol=protocol)
 
     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message="Wazuh remoted didn't start as expected.")
 

--- a/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
@@ -5,7 +5,7 @@
 import os
 import pytest
 
-from wazuh_testing.remote import callback_detect_remoted_started, send_ping_pong_messages
+import wazuh_testing.remote as rm
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 
 
@@ -29,6 +29,18 @@ parameters = [
     {'PROTOCOL': 'UDP,UDP', 'PORT': 1514},
     {'PROTOCOL': 'TCP,TCP', 'PORT': 56000},
     {'PROTOCOL': 'UDP,UDP', 'PORT': 56000},
+    {'PROTOCOL': 'udp', 'PORT': 1514},
+    {'PROTOCOL': 'udp', 'PORT': 56000},
+    {'PROTOCOL': 'tcp', 'PORT': 1514},
+    {'PROTOCOL': 'tcp', 'PORT': 56000},
+    {'PROTOCOL': 'udp,tcp', 'PORT': 1514},
+    {'PROTOCOL': 'udp,tcp', 'PORT': 56000},
+    {'PROTOCOL': 'tcp,udp', 'PORT': 1514},
+    {'PROTOCOL': 'tcp,udp', 'PORT': 56000},
+    {'PROTOCOL': 'tcp,tcp', 'PORT': 1514},
+    {'PROTOCOL': 'udp,udp', 'PORT': 1514},
+    {'PROTOCOL': 'tcp,tcp', 'PORT': 56000},
+    {'PROTOCOL': 'udp,udp', 'PORT': 56000},
 ]
 
 metadata = [
@@ -44,6 +56,18 @@ metadata = [
     {'protocol': 'UDP,UDP', 'port': 1514},
     {'protocol': 'TCP,TCP', 'port': 56000},
     {'protocol': 'UDP,UDP', 'port': 56000},
+    {'protocol': 'udp', 'port': 1514},
+    {'protocol': 'udp', 'port': 56000},
+    {'protocol': 'tcp', 'port': 1514},
+    {'protocol': 'tcp', 'port': 56000},
+    {'protocol': 'udp,tcp', 'port': 1514},
+    {'protocol': 'udp,tcp', 'port': 56000},
+    {'protocol': 'tcp,udp', 'port': 1514},
+    {'protocol': 'tcp,udp', 'port': 56000},
+    {'protocol': 'tcp,tcp', 'port': 1514},
+    {'protocol': 'udp,udp', 'port': 1514},
+    {'protocol': 'tcp,tcp', 'port': 56000},
+    {'protocol': 'udp,udp', 'port': 56000},
 ]
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -67,20 +91,21 @@ def test_ping_pong_message(get_configuration, configure_environment, restart_rem
 
     test_multiple_pings = False
 
-    if config['protocol'] in ['TCP,UDP', 'UDP,TCP']:
-        protocol, test_multiple_pings = "TCP,UDP", True
-    elif config['protocol'] in ['TCP,TCP', 'UDP,UDP']:
+    if config['protocol'] in ['TCP,UDP', 'UDP,TCP', 'tcp,udp', 'udp,tcp']:
+        protocol, test_multiple_pings = rm.TCP_UDP, True
+    elif config['protocol'] in ['TCP,TCP', 'UDP,UDP', 'tcp,tcp', 'udp,udp']:
         protocol = config['protocol'].split(',')[0]
     else:
         protocol = config['protocol']
 
-    log_callback = callback_detect_remoted_started(port=config['port'], protocol=protocol)
+    log_callback = rm.callback_detect_remoted_started(port=config['port'], protocol=protocol)
 
     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message="Wazuh remoted didn't start as expected.")
 
     if test_multiple_pings:
-        assert b'#pong' == send_ping_pong_messages(manager_address="localhost", protocol='UDP', port=config['port'])
-        assert b'#pong' == send_ping_pong_messages(manager_address="localhost", protocol='TCP', port=config['port'])
+        assert b'#pong' == rm.send_ping_pong_messages(manager_address="localhost", protocol=rm.UDP, port=config['port'])
+        assert b'#pong' == rm.send_ping_pong_messages(manager_address="localhost", protocol=rm.TCP, port=config['port'])
     else:
-        assert b'#pong' == send_ping_pong_messages(manager_address="localhost", protocol=protocol, port=config['port'])
+        assert b'#pong' == rm.send_ping_pong_messages(manager_address="localhost", protocol=protocol,
+                                                      port=config['port'])
 

--- a/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
@@ -5,9 +5,8 @@
 import os
 import pytest
 
-from wazuh_testing.remote import callback_detect_remoted_started
+from wazuh_testing.remote import callback_detect_remoted_started, send_ping_pong_messages
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.agent_simulator import send_ping_pong_messages
 
 
 # Marks

--- a/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+
+import wazuh_testing.remote as remote
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_syslog.yaml')
+
+parameters = [
+    {'PROTOCOL': 'UDP', 'PORT': 514},
+    {'PROTOCOL': 'UDP', 'PORT': 51000},
+    {'PROTOCOL': 'TCP', 'PORT': 514},
+    {'PROTOCOL': 'TCP', 'PORT': 51000}
+]
+
+metadata = [
+    {'protocol': 'UDP', 'port': 514},
+    {'protocol': 'UDP', 'port': 51000},
+    {'protocol': 'TCP', 'port': 514},
+    {'protocol': 'TCP', 'port': 51000}
+]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"syslog_{x['PROTOCOL']}_{x['PORT']}" for x in parameters]
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+def test_syslog_message(get_configuration, configure_environment, restart_wazuh):
+    """Test if remoted can receive syslog messages through the socket
+
+    Raises:
+        TimeoutError: if `wazuh-remoted` doesn't show the log message for syslog
+        AssertionError: if `wazuh-remoted` doesn't respond `#pong`
+    """
+    config = get_configuration['metadata']
+    port, protocol = config['port'], config['protocol']
+
+    # Monitor the archives.log
+    wazuh_archives_log_monitor = remote.create_archives_log_monitor()
+
+    # Check if remoted correctly started with the new conf
+    log_callback = remote.callback_detect_remoted_started(port=port, protocol=protocol, connection_type='syslog')
+    wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message="Wazuh remoted didn't start as expected.")
+
+    # Check if wazuh-remoted receives syslog messages
+    syslog_message = f"Syslog message sent by wazuh-qa to test remoted syslog with {protocol} at {port}"
+    remote.check_syslog_event(wazuh_archives_log_monitor, syslog_message, port, protocol)

--- a/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
@@ -46,7 +46,6 @@ def test_syslog_message(get_configuration, configure_environment, restart_wazuh)
 
     Raises:
         TimeoutError: if `wazuh-remoted` doesn't show the log message for syslog
-        AssertionError: if `wazuh-remoted` doesn't respond `#pong`
     """
     config = get_configuration['metadata']
     port, protocol = config['port'], config['protocol']

--- a/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
@@ -20,14 +20,22 @@ parameters = [
     {'PROTOCOL': 'UDP', 'PORT': 514},
     {'PROTOCOL': 'UDP', 'PORT': 51000},
     {'PROTOCOL': 'TCP', 'PORT': 514},
-    {'PROTOCOL': 'TCP', 'PORT': 51000}
+    {'PROTOCOL': 'TCP', 'PORT': 51000},
+    {'PROTOCOL': 'udp', 'PORT': 514},
+    {'PROTOCOL': 'udp', 'PORT': 51000},
+    {'PROTOCOL': 'tcp', 'PORT': 514},
+    {'PROTOCOL': 'tcp', 'PORT': 51000}
 ]
 
 metadata = [
     {'protocol': 'UDP', 'port': 514},
     {'protocol': 'UDP', 'port': 51000},
     {'protocol': 'TCP', 'port': 514},
-    {'protocol': 'TCP', 'port': 51000}
+    {'protocol': 'TCP', 'port': 51000},
+    {'protocol': 'udp', 'port': 514},
+    {'protocol': 'udp', 'port': 51000},
+    {'protocol': 'tcp', 'port': 514},
+    {'protocol': 'tcp', 'port': 51000}
 ]
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)


### PR DESCRIPTION
|Related issue|
|---|
|closes #1083 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds new integration tests for the `syslog` option of remoted. These checks test if `remoted` is able to receive messages to its Syslog server and log them in the `archives.log`.

## Configuration options

NA

## Logs example
![image](https://user-images.githubusercontent.com/9081114/109031160-bc509f80-76c4-11eb-8a40-7cedaeb5dfd6.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs