### PR TITLE
Rename sockets directory according to the product

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -51,7 +51,7 @@ def delete_sockets(path=None):
     """
     try:
         if path is None:
-            path = os.path.join(WAZUH_PATH, 'queue', 'ossec')
+            path = os.path.join(WAZUH_PATH, 'queue', 'sockets')
             for file in os.listdir(path):
                 os.remove(os.path.join(path, file))
             if os.path.exists(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb')):

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -17,7 +17,7 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
-ANALYSISD_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue')
+ANALYSISD_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue')
 
 SERVER_ADDRESS = 'localhost'
 SERVER_NAME = 'vm-test'

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.py
@@ -26,7 +26,7 @@ with open(messages_path) as f:
 
 log_monitor_paths = [LOG_FILE_PATH]
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_socket_responses.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_socket_responses.py
@@ -26,7 +26,7 @@ with open(messages_path) as f:
 
 log_monitor_paths = [LOG_FILE_PATH]
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_linux_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_linux_analysisd_alerts.py
@@ -24,7 +24,7 @@ with open(messages_path) as f:
 # Variables
 
 log_monitor_paths = [LOG_FILE_PATH, ALERT_FILE_PATH]
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_rare_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_rare_analysisd_alerts.py
@@ -24,7 +24,7 @@ with open(messages_path) as f:
 # Variables
 
 log_monitor_paths = [LOG_FILE_PATH, ALERT_FILE_PATH]
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.py
@@ -24,7 +24,7 @@ with open(messages_path) as f:
 # Variables
 
 log_monitor_paths = [LOG_FILE_PATH, ALERT_FILE_PATH]
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py
@@ -25,7 +25,7 @@ with open(messages_path) as f:
 # Variables
 
 log_monitor_paths = [LOG_FILE_PATH, ALERT_FILE_PATH]
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_linux_yaml.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_linux_yaml.py
@@ -21,7 +21,7 @@ from wazuh_testing.tools.monitoring import ManInTheMiddle, QueueMonitor, FileMon
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_sockets
 
 alerts_json = os.path.join(WAZUH_LOGS_PATH, 'alerts', 'alerts.json')
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 # Syscheck variables
 n_directories = 0

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_windows_yaml.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_windows_yaml.py
@@ -18,7 +18,7 @@ from wazuh_testing.tools.monitoring import ManInTheMiddle, QueueMonitor
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_sockets
 
 alerts_json = os.path.join(WAZUH_LOGS_PATH, 'alerts', 'alerts.json')
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 # Syscheck variables
 n_directories = 0

--- a/tests/integration/test_analysisd/test_error_messages/test_error_messages.py
+++ b/tests/integration/test_analysisd/test_error_messages/test_error_messages.py
@@ -25,7 +25,7 @@ with open(messages_path) as f:
 # Variables
 
 log_monitor_paths = [LOG_FILE_PATH]
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_event_messages/test_event_messages.py
+++ b/tests/integration/test_analysisd/test_event_messages/test_event_messages.py
@@ -27,7 +27,7 @@ with open(messages_path) as f:
 
 log_monitor_paths = [LOG_FILE_PATH, ALERT_FILE_PATH]
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_integrity_messages/test_integrity_messages.py
+++ b/tests/integration/test_analysisd/test_integrity_messages/test_integrity_messages.py
@@ -27,7 +27,7 @@ with open(messages_path) as f:
 
 log_monitor_paths = [LOG_FILE_PATH]
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_analysisd/test_scan_messages/test_scan_messages.py
+++ b/tests/integration/test_analysisd/test_scan_messages/test_scan_messages.py
@@ -26,7 +26,7 @@ with open(messages_path) as f:
 
 log_monitor_paths = [LOG_FILE_PATH]
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'queue'))
+analysis_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue'))
 
 receiver_sockets_params = [(analysis_path, 'AF_UNIX', 'UDP')]
 

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -40,7 +40,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 # Variables
 log_monitor_paths = []
 
-ls_sock_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'auth'))
+ls_sock_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'auth'))
 receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2'), (ls_sock_path, 'AF_UNIX', 'TCP')]
 
 monitored_sockets_params = [('wazuh-modulesd', None, True), ('wazuh-db', None, True), ('wazuh-authd', None, True)]

--- a/tests/integration/test_authd/test_authd_local.py
+++ b/tests/integration/test_authd/test_authd_local.py
@@ -36,7 +36,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 # Variables
 log_monitor_paths = []
-ls_sock_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'auth'))
+ls_sock_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'auth'))
 receiver_sockets_params = [(ls_sock_path, 'AF_UNIX', 'TCP')]
 
 # TODO Replace or delete

--- a/tests/integration/test_cluster/test_key_polling/test_key_polling_master.py
+++ b/tests/integration/test_cluster/test_key_polling/test_key_polling_master.py
@@ -22,7 +22,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 # Variables
 
 log_monitor_paths = [CLUSTER_LOGS_PATH]
-modulesd_socket_path = os.path.join(WAZUH_PATH, 'queue', 'ossec', 'krequest')
+modulesd_socket_path = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'krequest')
 cluster_socket_address = ('localhost', 1516)
 
 receiver_sockets_params = [(cluster_socket_address, 'AF_INET', 'TCP')]  # SocketController items

--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -73,7 +73,7 @@ def get_configuration(request):
 # tests
 
 def get_remote_configuration(component_name, config):
-    socket_path = os.path.join(WAZUH_PATH, 'queue', 'ossec')
+    socket_path = os.path.join(WAZUH_PATH, 'queue', 'sockets')
     dest_socket = os.path.join(socket_path, component_name)
     command = f"getconfig {config}"
 

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -18,7 +18,7 @@ configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 configurations = load_wazuh_configurations(configurations_path, __name__)
 
 # Variables
-logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'analysis'))
+logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'analysis'))
 receiver_sockets_params = [(logtest_sock, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 msg_get_config = "getconfig rule_test"

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -23,7 +23,7 @@ with open(messages_path) as f:
 
 # Variables
 
-logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
 
 

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -23,7 +23,7 @@ with open(messages_path) as f:
 
 # Variables
 
-logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
 
 

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -19,7 +19,7 @@ with open(messages_path) as f:
     test_cases = yaml.safe_load(f)
 
 # Variables
-logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
 receiver_sockets = None  # Set in the fixtures
 

--- a/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
+++ b/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
@@ -25,7 +25,7 @@ with open(messages_path) as f:
 
 # Variables
 
-logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 
 
 # Functions used on the test

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
@@ -25,7 +25,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__)
 # Variables
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 receiver_sockets_params = [(logtest_sock, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
@@ -23,7 +23,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__)
 
 # Variables
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_sock = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 
 msg_create_session = """{"version":1, "command":"log_processing", "parameters":{
 "event": "Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928",

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -22,7 +22,7 @@ with open(messages_path) as f:
     test_cases = yaml.safe_load(f)
 
 # Variables
-logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 receiver_sockets_params = [(logtest_path, 'AF_UNIX', 'TCP')]
 receiver_sockets = None  # Set in the fixtures
 

--- a/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
+++ b/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
@@ -25,7 +25,7 @@ with open(messages_path) as f:
 
 # Variables
 
-logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'ossec', 'logtest'))
+logtest_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'sockets', 'logtest'))
 
 
 # Functions used on the test


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/6885 |

## Description

This pull request renames the sockets directory according to the issue https://github.com/wazuh/wazuh/issues/6885.

- **Old sockets directory:** `queue/ossec`
- **New sockets directory:** `queue/sockets`

## Configuration options

N/A

## Logs example

N/A

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests working with sockets pass