### PR TITLE
Update test agent communication protocols

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -368,6 +368,8 @@ def send_agent_event(wazuh_log_monitor, message=EXAMPLE_MESSAGE_EVENT, protocol=
     # Wait until remoted has loaded the new agent key
     wait_to_remoted_key_update(wazuh_log_monitor)
 
+    sleep(1)
+
     # Build the event message and send it to the manager as an agent event
     event = agent.create_event(message)
 

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -8,7 +8,8 @@ import socket
 import wazuh_testing.tools.agent_simulator as ag
 import wazuh_testing.api as api
 
-from wazuh_testing.tools import ARCHIVES_LOG_FILE_PATH
+from time import sleep
+from wazuh_testing.tools import ARCHIVES_LOG_FILE_PATH, LOG_FILE_PATH
 from wazuh_testing.tools import file
 from wazuh_testing.tools import monitoring
 from wazuh_testing.tools.services import control_service
@@ -160,6 +161,15 @@ def callback_detect_syslog_event(message):
     return monitoring.make_callback(pattern=expr, prefix=None)
 
 
+def callback_detect_example_archives_event():
+    """Creates a callback to detect the example message in the archives.log
+
+    Returns:
+        callable: callback to detect this event
+    """
+    return monitoring.make_callback(pattern=fr".*{EXAMPLE_MESSAGE_PATTERN}.*", prefix=None)
+
+
 def send_syslog_message(message, port, protocol, manager_address="127.0.0.1"):
     """This function sends a message to the syslog server of wazuh-remoted
 
@@ -198,7 +208,7 @@ def create_archives_log_monitor():
     return wazuh_archives_log_monitor
 
 
-def detect_archives_log_event(archives_monitor, callback, error_message, update_position=True, timeout=5):
+def detect_archives_log_event(archives_monitor, callback, error_message=None, update_position=True, timeout=5):
     """Monitors the archives.log to detect a certain event
 
     Args:
@@ -211,6 +221,9 @@ def detect_archives_log_event(archives_monitor, callback, error_message, update_
     Raises:
         TimeoutError: if the event is not found in the file.
     """
+    if error_message is None:
+        error_message = 'Could not detect the expected event in archives.log'
+
     archives_monitor.start(timeout=timeout, update_position=update_position, callback=callback,
                            error_message=error_message)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -534,6 +534,11 @@ class Agent:
         self.keep_alive_msg = self.create_event(msg)
 
     def initialize_modules(self, disable_all_modules):
+        """Initialize and enable agent modules.
+
+        Args:
+            disable_all_modules (boolean): True to disable all modules, False to leave the default ones enabled.
+        """
         for module in ['syscollector', 'rootcheck', 'fim', 'fim_integrity', 'receive_messages', 'keepalive']:
             if disable_all_modules:
                 self.modules[module]['status'] = 'disabled'

--- a/deps/wazuh_testing/wazuh_testing/tools/thread_executor.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/thread_executor.py
@@ -20,11 +20,12 @@ class ThreadExecutor(threading.Thread):
         self.function = function
         self.exception = None
         self.parameters = parameters
+        self._return = None
 
 
     def _run(self):
         """Run the target function with its parameters in the thread"""
-        self.function(**self.parameters)
+        self._return = self.function(**self.parameters)
 
 
     def run(self):
@@ -49,3 +50,5 @@ class ThreadExecutor(threading.Thread):
         super(ThreadExecutor, self).join()
         if self.exception:
             raise self.exception
+
+        return self._return

--- a/docs/run-documentation.sh
+++ b/docs/run-documentation.sh
@@ -3,10 +3,11 @@
 cd /wazuh-qa/deps/wazuh_testing/
 python setup.py install
 
-mkdir -p /var/ossec/queue/vulnerabilities/dictionaries/  /var/ossec/etc/
+mkdir -p /var/ossec/queue/vulnerabilities/dictionaries/  /var/ossec/etc/ /var/ossec/logs/archives
 
 echo "" >>  /var/ossec/queue/vulnerabilities/dictionaries/cpe_helper.json
 echo "" >>  /var/ossec/etc/local_internal_options.conf
+echo "" >>  /var/ossec/logs/archives/archives.log
 
 cd /wazuh-qa
 mkdocs serve -a 0.0.0.0:8080

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
@@ -1,0 +1,53 @@
+# Test protocols communication
+
+## Overview
+
+These tests will check if there is a correct communication between the manager and the agent after establishing `TCP`,
+`UDP` or both as receiving and sending protocols.
+
+## Objective
+
+The objective is to check that the manager correctly receives information from the agent via TCP, UDP and both
+protocols simultaneously.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 8 | 60s |
+
+## Expected behavior
+
+Success if the event has been found in the manager's `archives.log` after sending it from the agent, using different
+protocols and ports. Failure otherwise
+
+## Testing
+
+The testing is based on configuring the manager to receive messages via `TCP`, `UDP`, `TCP-UDP` and `UDP-TCP` as well
+as using the default port and a custom port.
+
+After this, two jobs are launched:
+
+- A monitoring job that is based on monitoring the manager's  `archives.log` to see the events received.
+
+- A job that creates, registers an agent and sends a defined message to the manager.
+
+These jobs are launched in separate threads, launching first the monitoring and then the sending of the message with
+a difference of 2 seconds.
+
+### Checks
+
+**Block 1**
+- **TCP and port 1514**
+- **UDP and port 1514**
+- **TCP,UDP and port 1514**
+- **UDP,TCP and port 1514**
+
+**Block 2**
+- **TCP and port 56000**
+- **UDP and port 56000**
+- **TCP,UDP and port 56000**
+- **UDP,TCP and port 56000**
+
+## Code documentation
+::: tests.integration.test_remoted.test_agent_communication.test_protocols_communication

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
@@ -19,7 +19,7 @@ protocols simultaneously.
 ## Expected behavior
 
 Success if the event has been found in the manager's `archives.log` after sending it from the agent, using different
-protocols and ports. Failure otherwise
+protocols and ports. Failure otherwise.
 
 ## Testing
 
@@ -37,13 +37,10 @@ a difference of 2 seconds.
 
 ### Checks
 
-**Block 1**
 - **TCP and port 1514**
 - **UDP and port 1514**
 - **TCP,UDP and port 1514**
 - **UDP,TCP and port 1514**
-
-**Block 2**
 - **TCP and port 56000**
 - **UDP and port 56000**
 - **TCP,UDP and port 56000**

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
@@ -1,10 +1,10 @@
 # Test agent communication
-## Overview 
+## Overview
 Check that manager-agent communication through remoted socket works as expected.
 
 ## Objective
 
-Confirm that there are no problems when the manager tries to communicate with an agent to ask for configuration or 
+Confirm that there are no problems when the manager tries to communicate with an agent to ask for configuration or
 state files using the remoted socket.
 
 ## General info
@@ -27,4 +27,4 @@ state files using the remoted socket.
 - Test getconfig request for a disconnected agent
 
 ## Code documentation
-::: tests.integration.test_remoted.test_agent_communication.test_agent_communication
+::: tests.integration.test_remoted.test_agent_communication.test_request_agent_info

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,37 +20,37 @@ repo_url: https://github.com/wazuh/wazuh-qa
 edit_uri: ""
 nav:
     - Home: index.md
-    - Deps: 
+    - Deps:
       - Dependencies: deps/index.md
-      - Wazuh Testing: 
+      - Wazuh Testing:
         - Wazuh Testing: deps/wazuh-testing/wazuh_testing.md
         - Tools: deps/wazuh-testing/tools.md
-    - Tests: 
+    - Tests:
       - tests/index.md
-      - Integration: 
+      - Integration:
         - tests/integration/index.md
         - Integration tests structure: tests/integration/help.md
         - Setting up a test environment: tests/integration/setting_up_test_environment.md
-        - Vulnerability Detector:   
+        - Vulnerability Detector:
           - tests/integration/test_vulnerability_detector/index.md
-          - Tests feeds: 
+          - Tests feeds:
             - tests/integration/test_vulnerability_detector/test_feeds/index.md
-            - Debian: 
+            - Debian:
               - Test extra tags debian feed: tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.md
               - Test invalid syntax debian feed: tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.md
               - Test invalid values debian feed: tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.md
               - Test missing tags debian feed: tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.md
-            - RedHat: 
+            - RedHat:
               - Test extra fields redhat feed: tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.md
               - Test invalid syntax redhat feed: tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.md
               - Test invalid values redhat feed: tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.md
               - Test missing fileds redhat feed: tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.md
-            - MSU: 
+            - MSU:
               - Test extra fields feed: tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.md
               - Test invalid syntax msu feed: tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.md
               - Test invalid values msu feed: tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_values_msu_feed.md
               - Test missing fields msu feed: tests/integration/test_vulnerability_detector/test_feeds/msu/test_missing_fields_msu_feed.md
-            - Canonical: 
+            - Canonical:
               - Test missing tags canonical feed: tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.md
               - Test invalid values canonical feed: tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.md
               - Test invalid syntax canonical feed: tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.md
@@ -59,13 +59,13 @@ nav:
             - Test invalid type custom feeds: tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.md
             - Test invalid type url feeds: tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.md
             - Test validate feed content: tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.md
-          - Tests general settings: 
+          - Tests general settings:
             -  tests/integration/test_vulnerability_detector/test_general_settings/index.md
             - Test general settings enabled: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.md
             - Test general settings ignore time: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.md
             - Test general settings intervals: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.md
             - Test general settings run on start: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.md
-          - Tests providers: 
+          - Tests providers:
             - tests/integration/test_vulnerability_detector/test_providers/index.md
             - Test providers enabled: tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.md
             - Test providers update intervals: tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.md
@@ -73,7 +73,7 @@ nav:
             - Test providers OS: tests/integration/test_vulnerability_detector/test_providers/test_providers_os.md
             - Test providers no OS: tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.md
             - Test providers multiple providers: tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.md
-          - Tests SCAN results: 
+          - Tests SCAN results:
             - tests/integration/test_vulnerability_detector/test_scan_results/index.md
             - Test debian inventory with debian feed: tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.md
             - Test macos inventory: tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.md
@@ -83,31 +83,31 @@ nav:
             - Test scan different cves:  tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.md
             - Test scan nvd feed: tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.md
             - Test scan providers and nvd feed: tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.md
-          - Tests Windows: 
+          - Tests Windows:
             - tests/integration/test_vulnerability_detector/test_windows/index.md
             - Test CPE indexing: tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.md
-        - Active response:   
+        - Active response:
           - tests/integration/test_active_response/index.md
-          - Test analysisd: 
+          - Test analysisd:
             - tests/integration/test_active_response/test_analysisd/index.md
             - Test OS exec: tests/integration/test_active_response/test_analysisd/test_os_exec.md
           - Test execd:
             - tests/integration/test_active_response/test_execd/index.md
             - Test execd restart: tests/integration/test_active_response/test_execd/test_execd_restart.md
             - Test execd firewall drop: tests/integration/test_active_response/test_execd/test_execd_firewall_drop.md
-        - Agentd:   
+        - Agentd:
           - tests/integration/test_agentd/index.md
           - Test agentd reconnection: tests/integration/test_agentd/test_agentd_reconnection.md
           - Test agentd parametrized reconnection: tests/integration/test_agentd/test_agentd_parametrized_reconnections.md
           - Test agentd multi server: tests/integration/test_agentd/test_agentd_multi_server.md
           - Test agentd enrollment param: tests/integration/test_agentd/test_agentd_enrollment_params.md
           - Test agentd auth enrollment: tests/integration/test_agentd/test_agent_auth_enrollment.md
-        - Analysisd:   
+        - Analysisd:
           - tests/integration/test_analysisd/index.md
           - Test integrity messages: tests/integration/test_analysisd/test_integrity_messages/test_integrity_messages.md
           - Test event messages: tests/integration/test_analysisd/test_event_messages/test_event_messages.md
           - Test error messages: tests/integration/test_analysisd/test_error_messages/test_error_messages.md
-          - Test all syscheckd configurations: 
+          - Test all syscheckd configurations:
             - tests/integration/test_analysisd/test_all_syscheckd_configurations/index.md
             - Test validate win32 analysisd registry alerts: tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.md
             - Test validate win32 analysisd alerts: tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.md
@@ -117,7 +117,7 @@ nav:
             - Test check rare socket_responses: tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.md
           - Test mitre: tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.md
           - Test scan messages: tests/integration/test_analysisd/test_scan_messages/test_scan_messages.md
-        - API:   
+        - API:
           - tests/integration/test_api/index.md
           - Test config:
             - tests/integration/test_api/test_config/index.md
@@ -127,7 +127,7 @@ nav:
             - Test cors: tests/integration/test_api/test_config/test_cors/test_cors.md
             - Test DOS blocking system: tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.md
             - Test drop privileges:  tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.md
-            - Test experimental features:  tests/integration/test_api/test_config/test_experimental_features/test_experimental_features 
+            - Test experimental features:  tests/integration/test_api/test_config/test_experimental_features/test_experimental_features
             - Test host port:  tests/integration/test_api/test_config/test_host_port/test_host_port.md
             - Test https:  tests/integration/test_api/test_config/test_https/test_https.md
             - Test jwt token exp timeout:  tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.md
@@ -141,7 +141,7 @@ nav:
             - Test policy position: tests/integration/test_api/test_rbac/test_policy_position.md
             - Test remove relationship: tests/integration/test_api/test_rbac/test_remove_relationship.md
             - Test remove resource: tests/integration/test_api/test_rbac/test_remove_resource.md
-        - Authd:   
+        - Authd:
           - tests/integration/test_authd/index.md
           - Test authd: tests/integration/test_authd/test_authd.md
           - Test authd worker: tests/integration/test_authd/test_authd_worker.md
@@ -150,17 +150,17 @@ nav:
           - Test authd name ip pass:  tests/integration/test_authd/test_authd_name_ip_pass.md
           - Test authd local:  tests/integration/test_authd/test_authd_local.md
           - Test authd agents ctx:  tests/integration/test_authd/test_authd_agents_ctx.md
-        - Cluster:   
+        - Cluster:
           - tests/integration/test_cluster/index.md
           - Test key polling:
             - tests/integration/test_cluster/test_key_polling/index.md
             - Test key polling master: tests/integration/test_cluster/test_key_polling/test_key_polling_master.md
             - Test key polling worker: tests/integration/test_cluster/test_key_polling/test_key_polling_worker.md
-        - FIM:   
+        - FIM:
           - tests/integration/test_fim/index.md
           - Test files:
-            - tests/integration/test_fim/test_files/index.md    
-            - Test ambiguous conf: 
+            - tests/integration/test_fim/test_files/index.md
+            - Test ambiguous conf:
               - tests/integration/test_fim/test_files/test_ambiguous_confs/index.md
               - Test ambiguous complex: tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.md
               - Test ambiguous simple: tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.md
@@ -298,7 +298,7 @@ nav:
               - tests/integration/test_fim/test_files/test_tags/index.md
               - Test tags: tests/integration/test_fim/test_files/test_tags/test_tags.md
             - Test timezone changes:
-              - tests/integration/test_fim/test_files/test_timezone_changes/index.md  
+              - tests/integration/test_fim/test_files/test_timezone_changes/index.md
               - Test timezone changes: tests/integration/test_fim/test_files/test_timezone_changes/test_timezone_changes.md
             - Test windows audit interval:
               - tests/integration/test_fim/test_files/test_windows_audit_interval/index.md
@@ -344,7 +344,7 @@ nav:
             - Test registry recursion level:
               - tests/integration/test_fim/test_registry/test_registry_recursion_level/index.md
               - Test recursion level registry: tests/integration/test_fim/test_registry/test_registry_recursion_level/test_recursion_level_registry.md # This fails
-            - Test registry report changes: 
+            - Test registry report changes:
               - tests/integration/test_fim/test_registry/test_registry_report_changes/index.md
               - Test registry all limits disabled: tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_all_limits_disabled.md
               - Test registry diff size limit values: tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_diff_size_limit_values.md
@@ -357,7 +357,7 @@ nav:
               - Test registry report changes: tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes.md
               - Test registry restrict: tests/integration/test_fim/test_registry/test_registry_restrict
               - Test registry restrict: tests/integration/test_fim/test_registry/test_registry_restrict/test_registry_restrict.md
-            - Test registry tags: 
+            - Test registry tags:
               - tests/integration/test_fim/test_registry/test_registry_tags/index.md
               - Test registry tags: tests/integration/test_fim/test_registry/test_registry_tags/test_registry_tags.md
           - Test synchronization:
@@ -370,7 +370,7 @@ nav:
             - Test sync interval: tests/integration/test_fim/test_synchronization/test_sync_interval.md
             - Test synchronize integrity scan: tests/integration/test_fim/test_synchronization/test_synchronize_integrity_scan.md
             - Test synchronize integrity win32: tests/integration/test_fim/test_synchronization/test_synchronize_integrity_win32.md
-        - gCloud:   
+        - gCloud:
           - tests/integration/test_gcloud/index.md
           - Test configuration:
             - tests/integration/test_gcloud/test_configuration/test_invalid.md
@@ -391,13 +391,14 @@ nav:
                 - tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.md
                 - tests/integration/test_remoted/test_socket_communication/test_syslog_message.md
             - Test communications with agent:
-                - tests/integration/test_remoted/test_agent_communication/test_agent_communication.md
+                - tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
+                - tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
         - Logtest:
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md
           - Test rules and decoders load: tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.md
           - Test remove session: tests/integration/test_logtest/test_remove_session/test_remove_session.md
-          - Test remove old session: 
+          - Test remove old session:
             - Test remove old session: tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.md
             - Test remove old session for inactivity: tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.md
           - Test invalid socket input: tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.md
@@ -407,30 +408,30 @@ nav:
           - Test invalid rule decoders syntax:
             - Test invalid decoder syntax: tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.md
             - Test invalid rules syntax: tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.md
-        - RIDS:   
+        - RIDS:
           - tests/integration/test_rids/index.md
           - Test rids conf:  tests/integration/test_rids/test_rids.md
           - Test rids:  tests/integration/test_rids/test_rids_conf.md
-        - Rootcheck:   
+        - Rootcheck:
           - tests/integration/test_rootcheck/index.md
           - Test rootcheck: tests/integration/test_rootcheck/test_rootcheck.md
-        - WazuhDB: 
+        - WazuhDB:
           - tests/integration/test_wazuh_db/index.md
           - Test WazuhDB: tests/integration/test_wazuh_db/test_wazuh_db.md
-        - WPK:   
+        - WPK:
           - tests/integration/test_wpk/index.md
           - Test wpk manager:  tests/integration/test_wpk/test_wpk_manager.md
           - Test wpk manager task states:  tests/integration/test_wpk/test_wpk_manager_task_states.md
           - Test wpk agent: tests/integration/test_wpk/test_wpk_agent.md
       - System:
         - tests/system/index.md
-        - Test cluster: 
+        - Test cluster:
           - tests/system/test_cluster/index.md
           - Test agent info sync: tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.md
           - Test agent enrollment:  tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.md
           - Test agent key polling: tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.md
           - Test integrity sync: tests/system/test_cluster/test_integrity_sync/test_integrity_sync.md
-        - Test JWT invalidation: 
+        - Test JWT invalidation:
           - tests/system/test_jwt_invalidation/index.md
           - Test change RBAC mode: tests/system/test_jwt_invalidation/test_change_rbac_mode.md
           - Tet change security resources: tests/system/test_jwt_invalidation/test_change_security_resources.md
@@ -439,6 +440,3 @@ nav:
           - Test update password:  tests/system/test_jwt_invalidation/test_update_password.md
       - Legacy:
         - tests/legacy/index.md
-
-
-

--- a/tests/integration/test_remoted/test_agent_communication/data/wazuh_protocols_communication.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/wazuh_protocols_communication.yaml
@@ -1,7 +1,7 @@
 - tags:
-  - test_agent_connection_protocols
+  - test_protocols_communication
   apply_to_modules:
-  - test_agent_connection_protocols
+  - test_protocols_communication
   sections:
   - section: remote
     elements:

--- a/tests/integration/test_remoted/test_agent_communication/data/wazuh_request_agent_info.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/wazuh_request_agent_info.yaml
@@ -1,7 +1,7 @@
 - tags:
-  - test_agent_communication
+  - test_request_agent_info
   apply_to_modules:
-  - test_agent_communication
+  - test_request_agent_info
   sections:
   - section: remote
     elements:

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.tier(level=0)
 # Variables
 current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_agent_connection_protocols.yaml')
+configurations_path = os.path.join(test_data_path, 'wazuh_protocols_communication.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 wazuh_archives_monitor = rd.create_archives_log_monitor()
@@ -103,7 +103,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_agent_connection_protocols(get_configuration, configure_environment, restart_remoted):
+def test_protocols_communication(get_configuration, configure_environment, restart_remoted):
     protocol = get_configuration['metadata']['protocol']
     manager_port = get_configuration['metadata']['port']
 

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -93,7 +93,8 @@ def validate_agent_manager_protocol_communication(protocol, manager_port):
 
     # Wait until the threads end
     monitor_thread.join()
-    send_message_thread.join()
+    _, sender = send_message_thread.join()
+    sender.socket.close()
 
 
 # Fixtures

--- a/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.tier(level=0)
 
 # Configuration
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_agent_communication.yaml')
+configurations_path = os.path.join(test_data_path, 'wazuh_request_agent_info.yaml')
 
 parameters = [
     {'PROTOCOL': 'udp,tcp'},

--- a/tests/integration/test_remoted/test_socket_communication/test_agent_connection_protocols.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_agent_connection_protocols.py
@@ -4,8 +4,9 @@ import threading
 
 from wazuh_testing.tools.thread_executor import ThreadExecutor
 import wazuh_testing.tools.agent_simulator as ag
-from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools import LOG_FILE_PATH, ARCHIVES_LOG_FILE_PATH
 from wazuh_testing.tools import file
+from wazuh_testing.tools import monitoring
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing import remote as rd
@@ -20,6 +21,7 @@ test_data_path = os.path.join(current_test_path, 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_agent_connection_protocols.yaml')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_archives_monitor = rd.create_archives_log_monitor()
 
 # Set configuration
 parameters = [
@@ -58,20 +60,39 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 
 def validate_agent_manager_protocol_communication(protocol, manager_port):
-    file.truncate_file(LOG_FILE_PATH)
+    """ Allow to validate if the agent-manager communication using a certain protocol has been successfull.
 
-    socket_monitor_thread = ThreadExecutor(rd.check_queue_socket_event)
+    For this purpose, two jobs are launched concurrently. One for monitoring the archives.log and one for sending the
+    message.
+
+    Args:
+        protocol (str): Message sending protocol. It can be TCP or UDP.
+        manager_port (int): Manager port when remoted is listening.
+
+    Raises:
+        TimeoutError: If the expected event could not be found in archives.log after sending it.
+    """
+    file.truncate_file(LOG_FILE_PATH)
+    file.truncate_file(ARCHIVES_LOG_FILE_PATH)
+
+    monitor_thread = ThreadExecutor(
+        rd.detect_archives_log_event, {'archives_monitor': wazuh_archives_monitor, 'timeout': 20,
+                                       'callback': rd.callback_detect_example_archives_event(),
+                                       'update_position': False})
+
     send_message_thread = ThreadExecutor(rd.send_agent_event, {'wazuh_log_monitor': wazuh_log_monitor,
                                                                'protocol': protocol, 'manager_port': manager_port})
-    socket_monitor_thread.start()
+    # Start log monitoring
+    monitor_thread.start()
 
-    # Time to wait until starting the socket monitor
-    sleep(5)
+    # Time to wait until starting the log monitoring
+    sleep(2)
 
+    # Send agent message
     send_message_thread.start()
 
     # Wait until the threads end
-    socket_monitor_thread.join()
+    monitor_thread.join()
     send_message_thread.join()
 
 


### PR DESCRIPTION
|Related issue|
|---|
|close #1063|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR makes the following changes:

- Updated test agent connection protocols to instead of intercepting messages from `queue` socket, it monitors `archives.log` to validate the agent-manager communication. This has been done because when configuring `TCP,UDP`, and `UDP,TCP` the MITM monitoring was not successfull (we are investigating this issues, but while this workaround has been done).

- Renamed `test_agent_connection_protocols` to `test_protocols_communication`.
- Added `test_protocols_communication` documentation.
- Renamed `test_agent_communication` to `test_request_agent_info`.
- Improved some tools functions.

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs