### PR TITLE
Fix random failures in test_max_files_per_second.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -20,7 +20,7 @@ class Parameters:
         self._gcp_subscription_name = None
         self._gcp_credentials_file = None
         self._gcp_topic_name = None
-        self._fim_mode = None
+        self._fim_mode = list()
 
     @property
     def default_timeout(self):

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -20,7 +20,7 @@ class Parameters:
         self._gcp_subscription_name = None
         self._gcp_credentials_file = None
         self._gcp_topic_name = None
-        self._fim_mode = list()
+        self._fim_mode = []
 
     @property
     def default_timeout(self):

--- a/docs/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
+++ b/docs/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
@@ -1,0 +1,36 @@
+# Test max files per second
+
+This test checks the FIM behavior when the option `max_files_per_second` is enabled/disabled.
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 1 | Linux, Windows, MacOS, Solaris | 00:00:40 | [test_max_files_per_second.py](../../../../../../tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py)|
+
+## Test logic
+- After the baseline is generated, the test will create files inside a monitored folder.
+- Finally, if the option `max_files_per_second` is configured, the test will check that FIM sleeps for one second.
+## Checks
+
+- [x] Checks that FIM sleeps once the maximum files per second is reached.
+- [x] Checks that FIM doesn't sleeps if `max_files_per_second` is not enabled.
+
+## Execution result
+
+```
+python3 -m pytest test_max_files_per_second/
+============================= test session starts ==============================
+platform linux -- Python 3.8.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
+rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: html-2.0.1, testinfra-5.0.0, metadata-1.11.0
+collected 6 items
+
+test_max_files_per_second/test_max_files_per_second.py ......                                                                                                                                                                         [100%]
+
+============================================================================================================ 6 passed in 42.96s =============================================================================================================
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_max_files_per_second.test_max_files_per_second

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -248,7 +248,7 @@ nav:
               - Test max eps synchronization:  tests/integration/test_fim/test_files/test_max_eps/test_max_eps_synchronization.md
               - Test max eps: tests/integration/test_fim/test_files/test_max_eps/test_max_eps.md
             - Test max files per second:
-              - test max files per second: tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
+              - tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
             - Test multiple dirs:
               - tests/integration/test_fim/test_files/test_multiple_dirs/index.md
               - Test multiple dirs: tests/integration/test_fim/test_files/test_multiple_dirs/test_multiple_dirs.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,6 +247,8 @@ nav:
               - tests/integration/test_fim/test_files/test_max_eps/index.md
               - Test max eps synchronization:  tests/integration/test_fim/test_files/test_max_eps/test_max_eps_synchronization.md
               - Test max eps: tests/integration/test_fim/test_files/test_max_eps/test_max_eps.md
+            - Test max files per second:
+              - test max files per second: tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
             - Test multiple dirs:
               - tests/integration/test_fim/test_files/test_multiple_dirs/index.md
               - Test multiple dirs: tests/integration/test_fim/test_files/test_multiple_dirs/test_multiple_dirs.md

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -168,7 +168,7 @@ def pytest_addoption(parser):
         "--fim_mode",
         action="append",
         metavar="fim_mode",
-        default=None,
+        default=list(),
         type=str,
         help="run tests using a specific FIM mode"
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -261,7 +261,7 @@ def create_asset(
     if not os.path.exists(os.path.dirname(asset_path)):
         os.makedirs(os.path.dirname(asset_path))
 
-    relative_path = f"assets/{asset_file_name}"
+    relative_path = os.path.join("assets", asset_file_name)
 
     kwargs = {"encoding": "utf-8"} if "b" not in mode else {}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -168,7 +168,7 @@ def pytest_addoption(parser):
         "--fim_mode",
         action="append",
         metavar="fim_mode",
-        default=list(),
+        default=[],
         type=str,
         help="run tests using a specific FIM mode"
     )

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -46,7 +46,7 @@ def get_configuration(request):
 def test_max_files_per_second(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """ Check that FIM sleeps for one second when the option max_files_per_second is enabled
 
-    Args
+    Args:
         tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
         get_configuration (fixture): Gets the current configuration of the test.
         configure_environment (fixture): Configure the environment for the execution of the test.

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -52,10 +52,12 @@ def test_max_files_per_second(get_configuration, configure_environment, restart_
     for i in range(n_files_to_create):
         create_file(REGULAR, test_directories[0], f'test_{i}', content='')
 
+    extra_timeout = n_files_to_create / max_files_per_second
+
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
-    check_time_travel(scheduled, monitor=wazuh_log_monitor)
+    check_time_travel(scheduled)
     try:
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 2,
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout + extra_timeout,
                                 callback=callback_detect_max_files_per_second)
     except TimeoutError as e:
         if get_configuration['metadata']['max_files_per_sec'] == 0:

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -4,10 +4,9 @@
 
 import os
 import pytest
+import wazuh_testing.fim as fim
 
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_file, REGULAR, \
-    callback_detect_max_files_per_second, check_time_travel
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -20,7 +19,7 @@ pytestmark = pytest.mark.tier(level=1)
 
 test_directories = [os.path.join(PREFIX, 'testdir1')]
 max_files_per_second = 10
-wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 # Values for max_files_per_second option
@@ -29,7 +28,7 @@ n_files_to_create = 50
 # Configurations
 
 conf_params = {'TEST_DIRECTORIES': test_directories[0]}
-p, m = generate_params(extra_params=conf_params, apply_to_all=({'MAX_FILES_PER_SEC': value} for value in values))
+p, m = fim.generate_params(extra_params=conf_params, apply_to_all=({'MAX_FILES_PER_SEC': value} for value in values))
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
 
@@ -45,20 +44,28 @@ def get_configuration(request):
 
 
 def test_max_files_per_second(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check that FIM sleeps for one second when the option max_files_per_second is enabled
+    """ Check that FIM sleeps for one second when the option max_files_per_second is enabled
+
+    Args
+        tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+    Raises:
+        TimeoutError: If an expected event couldn't be captured.
     """
     # Create the files in an empty folder to check realtime and whodata.
     for i in range(n_files_to_create):
-        create_file(REGULAR, test_directories[0], f'test_{i}', content='')
+        fim.create_file(fim.REGULAR, test_directories[0], f'test_{i}', content='')
 
     extra_timeout = n_files_to_create / max_files_per_second
 
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
-    check_time_travel(scheduled)
+    fim.check_time_travel(scheduled)
     try:
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout + extra_timeout,
-                                callback=callback_detect_max_files_per_second)
+                                callback=fim.callback_detect_max_files_per_second)
     except TimeoutError as e:
         if get_configuration['metadata']['max_files_per_sec'] == 0:
             pass


### PR DESCRIPTION
- This commit also fixes the path generation of the assets directory in
  Windows systems.

|Related issue|
|---|
|#1098|

## Description

As described in #1098, this PR aims to fix the random failures in the test `test_max_files_per_second`.
This PR also fixes the path generation of the `assets` directory in Windows.

Closes #1098 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs example

```
root@ubuntu1:/vagrant/wazuh-qa/tests/integration/test_fim# python3 -m pytest --html=../../../../reportes/reporte1/report.html test_files/test_max_files_per_second/
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, testinfra-5.0.0, metadata-1.11.0
collected 6 items                                                                                                                                           

test_files/test_max_files_per_second/test_max_files_per_second.py ......                                                                              [100%]

-------------------------------------------- generated html file: file:///vagrant/reportes/reporte1/report.html ---------------------------------------------
==================================================================== 6 passed in 43.21s =====================================================================
root@ubuntu1:/vagrant/wazuh-qa/tests/integration/test_fim# 

```

<!--
Paste here related logs and alerts
-->

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs