### PR TITLE
Update validation method of protocols communication test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -337,6 +337,8 @@ def wait_to_remoted_key_update(wazuh_log_monitor):
     Raises:
         TimeoutError: if could not find the remoted key loading log.
     """
+    # We have to make sure that remoted has correctly loaded the client key agent info. The log is truncated to
+    # ensure that the information has been loaded after the agent has been registered.
     file.truncate_file(LOG_FILE_PATH)
 
     callback_pattern = '.*rem_keyupdate_main().*Checking for keys file changes.'

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -8,7 +8,6 @@ import socket
 import wazuh_testing.tools.agent_simulator as ag
 import wazuh_testing.api as api
 
-from time import sleep
 from wazuh_testing.tools import ARCHIVES_LOG_FILE_PATH, LOG_FILE_PATH
 from wazuh_testing.tools import file
 from wazuh_testing.tools import monitoring
@@ -338,6 +337,8 @@ def wait_to_remoted_key_update(wazuh_log_monitor):
     Raises:
         TimeoutError: if could not find the remoted key loading log.
     """
+    file.truncate_file(LOG_FILE_PATH)
+
     callback_pattern = '.*rem_keyupdate_main().*Checking for keys file changes.'
     error_message = 'Could not find the remoted key loading log'
 
@@ -367,8 +368,6 @@ def send_agent_event(wazuh_log_monitor, message=EXAMPLE_MESSAGE_EVENT, protocol=
 
     # Wait until remoted has loaded the new agent key
     wait_to_remoted_key_update(wazuh_log_monitor)
-
-    sleep(1)
 
     # Build the event message and send it to the manager as an agent event
     event = agent.create_event(message)

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
@@ -14,7 +14,7 @@ protocols simultaneously.
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 0 | 8 | 60s |
+| 0 | 8 | 2m 23s |
 
 ## Expected behavior
 
@@ -45,6 +45,19 @@ a difference of 2 seconds.
 - **UDP and port 56000**
 - **TCP,UDP and port 56000**
 - **UDP,TCP and port 56000**
+
+## Comments
+
+An important aspect to take into account is the time in which remoted makes a reload of the `client.keys` info.
+By default it is **10 seconds**, but this option is configurable in the `internal_options.conf`, using the
+following directive:
+
+```
+remoted.keyupdate_interval=2
+```
+
+The test itself waits until the info is loaded, so reducing this time will also reduce the test time.
+It is recommended to set this time between 2 and 5 seconds.
 
 ## Code documentation
 ::: tests.integration.test_remoted.test_agent_communication.test_protocols_communication

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
@@ -18,7 +18,7 @@ protocols simultaneously.
 
 ## Expected behavior
 
-Success if the event has been found in the manager's `archives.log` after sending it from the agent, using different
+Success if the event has been found in the manager's `queue` socket after sending it from the agent, using different
 protocols and ports. Failure otherwise.
 
 ## Testing
@@ -28,7 +28,7 @@ as using the default port and a custom port.
 
 After this, two jobs are launched:
 
-- A monitoring job that is based on monitoring the manager's  `archives.log` to see the events received.
+- A monitoring job that is based on monitoring the manager's  `queue` socket to see the events received.
 
 - A job that creates, registers an agent and sends a defined message to the manager.
 

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.md
@@ -48,7 +48,7 @@ a difference of 2 seconds.
 
 ## Comments
 
-An important aspect to take into account is the time in which remoted makes a reload of the `client.keys` info.
+An important aspect to take into account is the time needed by wazuh-remoted to reload the `client.keys`.
 By default it is **10 seconds**, but this option is configurable in the `internal_options.conf`, using the
 following directive:
 

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -1,16 +1,14 @@
 import pytest
 import os
-import threading
 
+from time import sleep
 from wazuh_testing.tools.thread_executor import ThreadExecutor
-import wazuh_testing.tools.agent_simulator as ag
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools import file
-from wazuh_testing.tools import monitoring
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing import remote as rd
-from time import sleep
+
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -59,13 +57,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 
 def validate_agent_manager_protocol_communication(protocol, manager_port):
-    """
+    """Allow to validate if the agent-manager communication using a certain protocol has been successfull.
+
+    For this purpose, two jobs are launched concurrently. One for monitoring the queue socket and other for sending the
+    message.
+
     Args:
         protocol (str): Message sending protocol. It can be TCP or UDP.
         manager_port (int): Manager port when remoted is listening.
 
     Raises:
-        TimeoutError: If the expected event could not be found in
+        TimeoutError: If the expected event could not be found in queue socket.
     """
     file.truncate_file(LOG_FILE_PATH)
 
@@ -98,6 +100,7 @@ def get_configuration(request):
 
 
 def test_protocols_communication(get_configuration, configure_environment, restart_remoted):
+    """Validate agent-manager communication using different protocols and ports"""
     protocol = get_configuration['metadata']['protocol']
     manager_port = get_configuration['metadata']['port']
 


### PR DESCRIPTION
|Related issue|
|---|
|#1063|

## Description

This PR changes the way of validating the agent-manager communication in test agent protocols communication. Now, instead of checking `archives.log` it is checked the `queue` socket. This change allows us to more accurately validate that the message has reached the manager, has been decoded correctly and has been written to the socket queue for `analysisd` to read later. Previously, when monitoring the archives.log we were checking one step further.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs