### PR TITLE
Updating Wazuh-DB IT documentation with agent's CVE table commands

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,9 @@ Wazuh solution consists of an endpoint security agent, deployed to the monitored
 In this repository you will find the tests used in the CI environment to test Wazuh's capabilities and daemons. This is the structure of the repository:
 
 - **[deps](deps/)**:  contains a Python's framework used to automatize tasks and interact with Wazuh.
-- **[tests](tests/integration/integration)**: directory containing the test suite. These are tests developed using Pytest.
-    -  **[integration](tests/integration/integration)**: integration tests of the different daemons/components.
-    -  **[system](tests/integration/system)**: system tests of Wazuh.
+- **[tests](tests/)**: directory containing the test suite. These are tests developed using Pytest.
+    -  **[integration](tests/integration/)**: integration tests of the different daemons/components.
+    -  **[system](tests/system)**: system tests of Wazuh.
 - **[docs](link/to/docs)**: contains the technical documentation about the code and documentation about the tests.
 
 ## Builds docs locally

--- a/docs/tests/integration/index.md
+++ b/docs/tests/integration/index.md
@@ -12,7 +12,7 @@ Our newest integration tests are located in `wazuh-qa/tests/integration/`. They 
 - _test_sca_
 - **[_test_remoted_](test_remoted#test_remoted)**
 - **[_test_vulnerability_detector_](test_vulnerability_detector#tests-vulnerability-detector)**
-- _test_wazuh_db_
+- **[_test_wazuh_db_](test_wazuh_db#test_wazuh_db)**
 
 ## How to setup the test environment
 

--- a/docs/tests/integration/test_wazuh_db/index.md
+++ b/docs/tests/integration/test_wazuh_db/index.md
@@ -1,6 +1,6 @@
 # Overview
 
-**Wazuh-db** is the daemon in charge of the databases with all the Wazuh persistent information, exposing a socket so receive requests and provide information.
+**Wazuh-db** is the daemon in charge of the databases with all the Wazuh persistent information, exposing a socket to receive requests and provide information.
 
 ## Tiers
 ### Tier 0
@@ -8,6 +8,6 @@
 
 These tests check the Wazuh-db commands syntax, valid responses and error messages in different circumstances. They are divided in **.yaml** configuration files:
 
-- **agent_messages.yaml**: tests for agents in general, currently only for Agents' CVEs table
-- **fim_messages.yaml**: tests for agents, but only for FIM module
-- **global_messages.yaml**: tests for the Global DB, using "global" commands
+- **agent_messages.yaml**: tests for agents DB, general commands
+- **fim_messages.yaml**: tests for agents DB, FIM module commands
+- **global_messages.yaml**: tests for the Global DB, using `global` commands

--- a/docs/tests/integration/test_wazuh_db/index.md
+++ b/docs/tests/integration/test_wazuh_db/index.md
@@ -1,3 +1,13 @@
 # Overview
 
+**Wazuh-db** is the daemon in charge of the databases with all the Wazuh persistent information, exposing a socket so receive requests and provide information.
 
+## Tiers
+### Tier 0
+#### Test wazuh_db
+
+These tests check the Wazuh-db commands syntax, valid responses and error messages in different circumstances. They are divided in **.yaml** configuration files:
+
+- **agent_messages.yaml**: tests for agents in general, currently only for Agents' CVEs table
+- **fim_messages.yaml**: tests for agents, but only for FIM module
+- **global_messages.yaml**: tests for the Global DB, using "global" commands

--- a/docs/tests/integration/test_wazuh_db/test_wazuh_db.md
+++ b/docs/tests/integration/test_wazuh_db/test_wazuh_db.md
@@ -1,6 +1,7 @@
 # Test Wazuh DB
 
-All these tests are meant to send a specific command to the socket (valid or not) and compare the resulting output with the expected result.
+All these tests are meant to send a specific command (valid or not) to the socket and compare the resulting output with the expected result.
+
 ## Overview
 
 Lets consider an example:
@@ -19,6 +20,7 @@ All similar test are grouped by a name, like `Update commands`. Then, every test
 - **input**: the command that will be sent to the socket
 - **output**: the expected result
 - **stage**: the name of that particular test
+
 ## Objective
 
 Confirm that `wazuh-db` is able to save, update and erase the necessary information into the corresponding databases, using the proper commands and response strings.
@@ -37,7 +39,7 @@ Confirm that `wazuh-db` is able to save, update and erase the necessary informat
 Tests description according to its classification
 ### Checks agent_messages
 
-Currently, only **insert** and **clear** commands for `vuln_cves` table are tested
+The **insert** and **clear** commands for `vuln_cves` table are tested:
 
 - Right insertion of a vulnerability that affects a package
 - Attempt to insert a duplicated vulnerability in the database, resulting in no error message

--- a/docs/tests/integration/test_wazuh_db/test_wazuh_db.md
+++ b/docs/tests/integration/test_wazuh_db/test_wazuh_db.md
@@ -1,0 +1,61 @@
+# Test Wazuh DB
+
+All these tests are meant to send a specific command to the socket (valid or not) and compare the resulting output with the expected result.
+## Overview
+
+Lets consider an example:
+```
+  name: "Update commands"
+  description: "Check success use cases for update commands on global DB"
+  test_case:
+  -
+    input: 'global update-agent-name {"id":1,"name":"TestName2"}'
+    output: "ok"
+    stage: "global update-agent-name success"
+```
+
+All similar test are grouped by a name, like `Update commands`. Then, every test has:
+
+- **input**: the command that will be sent to the socket
+- **output**: the expected result
+- **stage**: the name of that particular test
+## Objective
+
+Confirm that `wazuh-db` is able to save, update and erase the necessary information into the corresponding databases, using the proper commands and response strings.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 30 | 45s |
+
+## Expected behavior
+
+- Fail if `wazuh-db` response is different from output
+## Testing
+
+Tests description according to its classification
+### Checks agent_messages
+
+Currently, only **insert** and **clear** commands for `vuln_cves` table are tested
+
+- Right insertion of a vulnerability that affects a package
+- Attempt to insert a duplicated vulnerability in the database, resulting in no error message
+- Insertion of data that contains spaces
+- Attempt to insert incomplete data
+- Attempt to insert with an invalid JSON
+- Attempt to insert without sending data
+- Attempt to modify the database table that contains the vulnerabilities without specifying the action (insert or clear)
+- Clear vulnerabilities information from the database
+- Insert of data after clearing
+- Insert an entry with some fields repeated from other existing entries
+
+### Checks FIM
+
+### Checks global_messages
+
+### Checks chunks
+
+## Code documentation
+
+::: tests.integration.test_wazuh_db.test_wazuh_db


### PR DESCRIPTION
|Related issue|
|---|
|1116|

## Description

This PR creates the Wazuh-DB IT documentation section, but only adds the information related to the new file **test_wazuh_db/data/agent_messages.yaml**.

Also, some internal broken links were fixed. 

## Tests

- [x] The test is documented in wazuh-qa/docs