### PR TITLE
Add new method to run queries to wazuh-db using wdb socket

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -83,6 +83,8 @@ QUEUE_SOCKETS_PATH = os.path.join(WAZUH_PATH, 'queue', 'sockets')
 QUEUE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
 CLUSTER_SOCKET_PATH = os.path.join(WAZUH_PATH, 'queue', 'cluster')
 
+WDB_SOCKET_PATH = os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb')
+
 WAZUH_SOCKETS = {
     'wazuh-agentd': [],
     'wazuh-analysisd': [os.path.join(QUEUE_SOCKETS_PATH, 'analysis'),

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -580,7 +580,7 @@ class Agent:
     def get_connection_status(self):
         result = wdb.query_wdb(f"global get-agent-info {self.id}")
 
-        if type(result) is list and len(result) > 0:
+        if len(result) > 0:
             result = result[0]['connection_status']
         else:
             result = "Not in global.db"

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -576,17 +576,18 @@ class Agent:
         if self.modules['fim_integrity']['status'] == 'enabled':
             self.fim_integrity = GeneratorIntegrityFIM(self.id, self.name, self.short_version)
 
+
     def get_connection_status(self):
-        numeric_id = int(self.id)
-        connection_status_query = f'select connection_status from agent where id={numeric_id} limit 1'
-        result = wdb.get_query_result(connection_status_query)
+        result = wdb.query_wdb(f"global get-agent-info {self.id}")
+
         if type(result) is list and len(result) > 0:
-            result = result[0]
+            result = result[0]['connection_status']
         else:
             result = "Not in global.db"
         return result
 
-    @retry(AttributeError, attempts=10, delay=5, delay_multiplier=1)
+
+    @retry(AttributeError, attempts=10, delay=2, delay_multiplier=1)
     def wait_status_active(self):
         status = self.get_connection_status()
         if status == 'active':

--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -2,15 +2,14 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import functools
-import sqlite3
+import json
 import logging
 import socket
-import struct
-import json
+import sqlite3
 
 from wazuh_testing.tools import WAZUH_PATH, WDB_SOCKET_PATH
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.tools.monitoring import wazuh_unpack
+from wazuh_testing.tools.monitoring import wazuh_pack, wazuh_unpack
 
 
 GLOBAL_DB_PATH = f"{WAZUH_PATH}/queue/db/global.db"
@@ -130,7 +129,7 @@ def get_query_result(query, db_path=GLOBAL_DB_PATH):
 
 
 def query_wdb(command):
-    """ Make queries to wazuh-db using the wdb socket.
+    """Make queries to wazuh-db using the wdb socket.
 
     Args:
         command (str): wazuh-db command alias. For example `global get-agent-info 000`.
@@ -141,11 +140,10 @@ def query_wdb(command):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(WDB_SOCKET_PATH)
 
-    length = struct.pack('<I', len(command))
     data = []
 
     try:
-        sock.send(length + command.encode())
+        sock.send(wazuh_pack(len(command)) + command.encode())
 
         rcv = sock.recv(4)
 


### PR DESCRIPTION
|Related issue|
|---|
|close #1122 |

## Description

This PR makes the following changes:

- Add a new method to run command alias queries to `wazuh-db` using `wdb` socket
- Update `get_connection_status` method to use `wdb` queries.
- Decreased the number of attempts to wait for active status in the agent simulator.


- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.

## Examples

**Running queries to wdb**

```
>>> query_wdb('global get-agent-info 000')
[
    {
        "id": 0,
        "name": "manager",
        "ip": "127.0.0.1",
        "register_ip": "127.0.0.1",
        "os_name": "Ubuntu",
        "os_version": "20.04 LTS",
        "os_major": "20",
        "os_minor": "04",
        "os_codename": "Focal Fossa",
        "os_platform": "ubuntu",
        "os_uname": "Linux |manager |5.4.0-66-generic |#74-Ubuntu SMP Wed Jan 27 22:54:38 UTC 2021 |x86_64",
        "os_arch": "x86_64",
        "version": "Wazuh v4.2.0",
        "manager_host": "manager",
        "node_name": "node01",
        "date_add": 1614680079,
        "last_keepalive": 253402300799,
        "sync_status": "synced",
        "connection_status": "active"
    }
]
```

**Checking agent connection status**

```
>>> agent.get_connection_status()
 'never_connected'

>>> sender.send_event(agent.startup_msg)

>>> agent.get_connection_status()
'pending'
```

Regards.