### PR TITLE
 Fix some errors on integration tests 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -646,14 +646,14 @@ def check_push_shared_config(agent, sender):
 
         # Check up file (push start) message
         check_agent_received_message(agent.rcv_msg_queue, r'#!-up file \w+ merged.mg', timeout=10,
-                                        error_message="initial up file message not received")
+                                     error_message="initial up file message not received")
 
         # Check agent.conf message
         check_agent_received_message(agent.rcv_msg_queue, '#default', timeout=10,
-                                        error_message="agent.conf message not received")
+                                     error_message="agent.conf message not received")
         # Check close file (push end) message
         check_agent_received_message(agent.rcv_msg_queue, 'close', timeout=35,
-                                        error_message="initial close message not received")
+                                     error_message="initial close message not received")
 
         sender.send_event(agent.keep_alive_event)
 

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -652,7 +652,7 @@ def check_push_shared_config(agent, sender):
         check_agent_received_message(agent.rcv_msg_queue, '#default', timeout=10,
                                         error_message="agent.conf message not received")
         # Check close file (push end) message
-        check_agent_received_message(agent.rcv_msg_queue, 'close', timeout=10,
+        check_agent_received_message(agent.rcv_msg_queue, 'close', timeout=35,
                                         error_message="initial close message not received")
 
         sender.send_event(agent.keep_alive_event)

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -99,7 +99,7 @@ class Agent:
     """
     def __init__(self, manager_address, cypher="aes", os=None, inventory_sample=None, rootcheck_sample=None,
                  id=None, name=None, key=None, version="v3.12.0", fim_eps=None, fim_integrity_eps=None,
-                 authd_password=None, disable_all_modules=False, rcv_msg_limit=100):
+                 authd_password=None, disable_all_modules=False, rcv_msg_limit=999):
         self.id = id
         self.name = name
         self.key = key
@@ -590,7 +590,7 @@ class Agent:
         status = self.get_connection_status()
         if status == 'active':
             return
-        raise AttributeError("Agent is not active yet")
+        raise AttributeError(f"Agent is not active yet: {status}")
 
     def set_module_status(self, module_name, status):
         self.modules[module_name]['status'] = status

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1157,7 +1157,6 @@ def create_agents(agents_number, manager_address, cypher='aes', fim_eps=None, au
 
 def connect(agent,  manager_address='localhost', protocol=TCP, manager_port='1514'):
     """Connects an agent to the manager
-    
     Args:
         agent (Agent): agent to connect.
         manager_address (str): address of the manager. It can be an IP or a DNS.

--- a/docs/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
@@ -7,11 +7,14 @@ Check that manager-agent communication through remoted socket works as expected.
 Confirm that there are no problems when the manager tries to communicate with an agent to ask for configuration or
 state files using the remoted socket.
 
+As the test has nothing to do with shared configuration files, we removed those rootcheck txt files from default agent 
+group to reduce the time required by the test to make the checks.
+
 ## General info
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 0 | 1 | 3m |
+| 0 | 1 | 126.41s |
 
 ## Expected behavior
 

--- a/tests/integration/test_remoted/conftest.py
+++ b/tests/integration/test_remoted/conftest.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-import os
 import shutil
 import subprocess as sb
 import os

--- a/tests/integration/test_remoted/conftest.py
+++ b/tests/integration/test_remoted/conftest.py
@@ -2,11 +2,12 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+import shutil
 import subprocess as sb
-
+import os
 import pytest
 from wazuh_testing.remote import remove_agent_group, new_agent_group
-from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
@@ -36,3 +37,28 @@ def create_agent_group(group_name='testing_group'):
     yield
 
     remove_agent_group(group_name)
+
+
+@pytest.fixture(scope="module")
+def remove_shared_files():
+    """Temporary removes txt files from default agent group shared files"""
+
+    source_dir = os.path.join(WAZUH_PATH, 'etc', 'shared', 'default')
+    target_dir = os.path.join(WAZUH_PATH, 'etc', 'default.backup')
+
+    os.mkdir(target_dir)
+
+    file_names = os.listdir(source_dir)
+
+    for file_name in file_names:
+        if 'txt' in file_name:
+            shutil.move(os.path.join(source_dir, file_name), target_dir)
+
+    yield
+
+    for file_name in file_names:
+        if 'txt' in file_name:
+            shutil.move(os.path.join(target_dir, file_name), source_dir)
+
+    os.removedirs(target_dir)
+

--- a/tests/integration/test_remoted/conftest.py
+++ b/tests/integration/test_remoted/conftest.py
@@ -61,4 +61,3 @@ def remove_shared_files():
             shutil.move(os.path.join(target_dir, file_name), source_dir)
 
     os.removedirs(target_dir)
-

--- a/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
@@ -2,6 +2,8 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+import time
+
 import pytest
 
 import wazuh_testing.tools.agent_simulator as ag
@@ -55,7 +57,8 @@ def get_configuration(request):
 
 
 @pytest.mark.parametrize("command_request,expected_answer", test_case.values(), ids=list(test_case.keys()))
-def test_request(get_configuration, configure_environment, restart_remoted, command_request, expected_answer):
+def test_request(get_configuration, configure_environment, remove_shared_files,
+                 restart_remoted, command_request, expected_answer):
     """
     Writes (config/state) requests in $DIR/queue/ossec/request and check if remoted forwards it to the agent,
     collects the response, and writes it in the socket or returns an error message if the queried


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1142|

## Description

We've introduced a change in the agent request test to remove root check txt files from the default agent group to avoid long waits until those files are pushed from manager to agent and possible check failures caused by "race conditions" when that push takes too much time to be done.

Also, on the push shared configuration file tests, we've increased the timeout of the wait for shared configuration to be pushed because we've found that sometimes it takes more than 10 seconds (the current value). 


## Logs example

<!--
Paste here related logs and alerts
-->
![image](https://user-images.githubusercontent.com/15269938/111182215-fbc92800-85ae-11eb-9aaa-b55c4701caac.png)
![image](https://user-images.githubusercontent.com/15269938/111182247-04216300-85af-11eb-8d37-d5a1eb89432d.png)


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.