### PR TITLE
Fixed yaml in test_basic_usage to set module of conf2 property

### DIFF
--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf.yaml
@@ -19,7 +19,7 @@
 - tags:
   - ossec_conf_wildcards
   apply_to_modules:
-  - MODULE_NAME
+  - test_regular_file_changes
   sections:
   - section: syscheck
     elements:


### PR DESCRIPTION
# Description
This PR is to avoid a series of logs that were produced in the **test_basic_usage** due to the yaml used by most of these tests, a new section had been added to test wildcards. 

But these were only used in the **test_basic_usage_changes**, in the rest of the tests, thanks to the **check_apply_test** was not generating any error, however, the configuration was being loaded with not properly set TEST_WILDCARDS, then those wrong behaviour logs appeared:

```
2021/03/16 09:49:39 wazuh-syscheckd[28359] syscheck-config.c:1216 at read_attr(): DEBUG: Could not check the real path of 'TEST_WILDCARDS' due to [(2)-(No such file or directory)].
2021/03/16 09:49:39 wazuh-syscheckd[28359] main.c:189 at main(): INFO: (6003): Monitoring path: 'TEST_WILDCARDS', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
...
2021/03/16 09:49:41 wazuh-syscheckd[28407] syscheck-config.c:1216 at read_attr(): DEBUG: Could not check the real path of 'TEST_WILDCARDS' due to [(2)-(No such file or directory)].
2021/03/16 09:49:41 wazuh-syscheckd[28407] main.c:189 at main(): INFO: (6003): Monitoring path: 'TEST_WILDCARDS', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | realtime'.
2021/03/16 09:49:41 wazuh-syscheckd[28407] main.c:241 at main(): INFO: (6016): Directory set for real time monitoring: 'TEST_WILDCARDS'.
2021/03/16 09:49:41 wazuh-syscheckd[28407] run_realtime.c:79 at realtime_adddir(): DEBUG: (6272): Unable to add inotify watch to real time monitoring: 'TEST_WILDCARDS'. '-1' '2':'No such file or directory'
```