### PR TITLE
Fix requirements in order to avoid google and grpcio dependencies for Solaris systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ configobj==5.0.6
 distro==1.3.0
 filetype==1.0.7
 freezegun==0.3.15
-grpcio==1.27.2
-google-cloud-pubsub==2.3.0
+grpcio==1.27.2; platform_system != "Solaris"
+google-cloud-pubsub==2.3.0; platform_system != "Solaris"
 jsonschema==3.2.0
 lockfile==0.12.2
 netifaces==0.10.9


### PR DESCRIPTION
The requirements file has been changed in order avoid `grpcio` and google `modules` for Solaris systems