### PR TITLE
Added test_basic_usage_db_inode_check to check false positives due to wrong inodes

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -973,57 +973,59 @@ def change_conf_param(param, value):
 def callback_detect_end_scan(line):
     msg = r'.*Sending FIM event: (.+)$'
     match = re.match(msg, line)
+    if not match:
+        return None
 
     try:
         if json.loads(match.group(1))['type'] == 'scan_end':
             return True
-    except (JSONDecodeError):
-        logger.warning("Couldn't load a log line into json object")
-    except (AttributeError, KeyError):
-        pass
+    except (JSONDecodeError, AttributeError, KeyError) as e:
+        logger.warning(f"Couldn't load a log line into json object. Reason {e}")
 
 
 def callback_detect_event(line):
     msg = r'.*Sending FIM event: (.+)$'
     match = re.match(msg, line)
+    if not match:
+        return None
 
     try:
         json_event = json.loads(match.group(1))
         if json_event['type'] == 'event':
             return json_event
-    except (JSONDecodeError):
-        logger.warning("Couldn't load a log line into json object")
-    except (AttributeError, KeyError):
-        pass
+    except (JSONDecodeError, AttributeError, KeyError) as e:
+        logger.warning(f"Couldn't load a log line into json object. Reason {e}")
 
 
 def callback_detect_modified_event(line):
     msg = r'.*Sending FIM event: (.+)$'
     match = re.match(msg, line)
+    if not match:
+        return None
 
     try:
         json_event = json.loads(match.group(1))
-        if (json_event['type'] == 'event') and (json_event['data']['type'] == 'modified'):
+        if json_event['type'] == 'event' and json_event['data']['type'] == 'modified':
             return json_event
-    except (JSONDecodeError):
-        logger.warning("Couldn't load a log line into json object")
-    except (AttributeError, KeyError):
-        pass
+    except (JSONDecodeError, AttributeError, KeyError) as e:
+        logger.warning(f"Couldn't load a log line into json object. Reason {e}")
 
 
 def callback_detect_modified_event_with_inode_mtime(line):
     msg = r'.*Sending FIM event: (.+)$'
     match = re.match(msg, line)
+    if not match:
+        return None
 
     try:
         json_event = json.loads(match.group(1))
-        if (json_event['type'] == 'event') and (json_event['data']['type'] == 'modified'):
+        if json_event['type'] == 'event' and json_event['data']['type'] == 'modified':
+            # If 'changed_attributes' are not exactly 'inode' and 'mtime', symmetric_difference
+            # will return a non-empty set, returning the event.
             if {'inode', 'mtime'}.symmetric_difference(set(json_event['data']['changed_attributes'])):
                 return json_event
-    except (JSONDecodeError):
-        logger.warning("Couldn't load a log line into json object")
-    except (AttributeError, KeyError):
-        pass
+    except (JSONDecodeError, AttributeError, KeyError) as e:
+        logger.warning(f"Couldn't load a log line into json object. Reason {e}")
 
 
 def callback_detect_integrity_event(line):

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -986,8 +986,38 @@ def callback_detect_event(line):
     match = re.match(msg, line)
 
     try:
-        if json.loads(match.group(1))['type'] == 'event':
-            return json.loads(match.group(1))
+        json_event = json.loads(match.group(1))
+        if json_event['type'] == 'event':
+            return json_event
+    except (AttributeError, JSONDecodeError, KeyError):
+        pass
+
+    return None
+
+
+def callback_detect_modified_event(line):
+    msg = r'.*Sending FIM event: (.+)$'
+    match = re.match(msg, line)
+
+    try:
+        json_event = json.loads(match.group(1))
+        if (json_event['type'] == 'event') and (json_event['data']['type'] == 'modified'):
+            return json_event
+    except (AttributeError, JSONDecodeError, KeyError):
+        pass
+
+    return None
+
+
+def callback_detect_modified_event_with_inode_mtime(line):
+    msg = r'.*Sending FIM event: (.+)$'
+    match = re.match(msg, line)
+
+    try:
+        json_event = json.loads(match.group(1))
+        if (json_event['type'] == 'event') and (json_event['data']['type'] == 'modified'):
+            if {'inode', 'mtime'}.symmetric_difference(set(json_event['data']['changed_attributes'])):
+                return json_event
     except (AttributeError, JSONDecodeError, KeyError):
         pass
 

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -977,7 +977,9 @@ def callback_detect_end_scan(line):
     try:
         if json.loads(match.group(1))['type'] == 'scan_end':
             return True
-    except (AttributeError, JSONDecodeError, KeyError):
+    except (JSONDecodeError):
+        logger.warning("Couldn't load a log line into json object")
+    except (AttributeError, KeyError):
         pass
 
 
@@ -989,10 +991,10 @@ def callback_detect_event(line):
         json_event = json.loads(match.group(1))
         if json_event['type'] == 'event':
             return json_event
-    except (AttributeError, JSONDecodeError, KeyError):
+    except (JSONDecodeError):
+        logger.warning("Couldn't load a log line into json object")
+    except (AttributeError, KeyError):
         pass
-
-    return None
 
 
 def callback_detect_modified_event(line):
@@ -1003,10 +1005,10 @@ def callback_detect_modified_event(line):
         json_event = json.loads(match.group(1))
         if (json_event['type'] == 'event') and (json_event['data']['type'] == 'modified'):
             return json_event
-    except (AttributeError, JSONDecodeError, KeyError):
+    except (JSONDecodeError):
+        logger.warning("Couldn't load a log line into json object")
+    except (AttributeError, KeyError):
         pass
-
-    return None
 
 
 def callback_detect_modified_event_with_inode_mtime(line):
@@ -1018,10 +1020,10 @@ def callback_detect_modified_event_with_inode_mtime(line):
         if (json_event['type'] == 'event') and (json_event['data']['type'] == 'modified'):
             if {'inode', 'mtime'}.symmetric_difference(set(json_event['data']['changed_attributes'])):
                 return json_event
-    except (AttributeError, JSONDecodeError, KeyError):
+    except (JSONDecodeError):
+        logger.warning("Couldn't load a log line into json object")
+    except (AttributeError, KeyError):
         pass
-
-    return None
 
 
 def callback_detect_integrity_event(line):

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.md
@@ -1,0 +1,42 @@
+# Test basic usage db inode check
+
+The test check for false positives due to possible inconsistencies with inodes in the database.
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | Linux | 00:00:37 | [test_basic_usage_db_inode_check.py](../../../../../../tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.)|
+
+## Test logic
+
+- The test will monitor a folder using `scheduled`.
+- The test will create ten files with some content and wait for scan.
+- Then, remove files, and create again (adding one more at the beginning, or deleting it) with different inodes.
+- Time travel to the next scan and check if there are any unexpected events in the log.
+
+## Checks
+
+- [x] Check that the FIM database does not become inconsistent due to the change of inodes, whether or not `check_mtime` and `check_inode` are enabled.
+
+## Execution result
+
+```
+python3 -m pytest --html=/vagrant/report.html tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+======================================= test session starts ========================================
+platform linux -- Python 3.8.5, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
+rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: html-2.0.1, testinfra-5.0.0, metadata-1.11.0
+collected 4 items
+
+tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py .. [ 50%]
+..                                                                                           [100%]
+
+------------------------- generated html file: file:///vagrant/report.html -------------------------
+======================================== 4 passed in 37.66s ========================================
+
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_basic_usage.test_basic_usage_db_inode_check

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.md
@@ -6,7 +6,7 @@ The test check for false positives due to possible inconsistencies with inodes i
 
 | Tier | Platforms | Time spent| Test file |
 |:--:|:--:|:--:|:--:|
-| 0 | Linux | 00:00:37 | [test_basic_usage_db_inode_check.py](../../../../../../tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.)|
+| 0 | Linux | 00:00:43 | [test_basic_usage_db_inode_check.py](../../../../../../tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.)|
 
 ## Test logic
 
@@ -23,17 +23,17 @@ The test check for false positives due to possible inconsistencies with inodes i
 
 ```
 python3 -m pytest --html=/vagrant/report.html tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
-======================================= test session starts ========================================
+============================================== test session starts ==============================================
 platform linux -- Python 3.8.5, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
 rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
 plugins: html-2.0.1, testinfra-5.0.0, metadata-1.11.0
-collected 4 items
+collected 6 items
 
-tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py .. [ 50%]
-..                                                                                           [100%]
+tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py ..x..x          [100%]
 
-------------------------- generated html file: file:///vagrant/report.html -------------------------
-======================================== 4 passed in 37.66s ========================================
+------------------------------- generated html file: file:///vagrant/report.html --------------------------------
+========================================= 4 passed, 2 xfailed in 43.88s =========================================
+
 
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,6 +179,7 @@ nav:
               - tests/integration/test_fim/test_files/test_basic_usage/index.md
               - Test basic usage baseline generation: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_baseline_generation.md
               - Test basic usage changes: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.md
+              - Test basic usage db inode check: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.md
               - Test basic usage create after delete dir: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_create_after_delete_dir.md
               - Test basic usage create rt wd: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_create_rt_wd.md
               - Test basic usage create scheduled: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_create_scheduled.md

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_inodes.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_inodes.yaml
@@ -1,0 +1,18 @@
+---
+# conf 1
+- tags:
+  - ossec_conf
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - FIM_MODE
+        - check_all: 'yes'
+        - check_mtime: CHECK_TYPE
+        - check_inode: CHECK_TYPE

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -1,0 +1,133 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import shutil
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import create_file, generate_params, check_time_travel, callback_detect_modified_event, \
+                              LOG_FILE_PATH, REGULAR, callback_detect_modified_event_with_inode_mtime, \
+                              detect_initial_scan
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import truncate_file
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# Variables
+
+monitored_folder = os.path.join(PREFIX, 'testdir1')
+test_directories = [monitored_folder]
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_check_inodes.yaml')
+file_list = ['file1', 'file2', 'file3', 'file4', 'file5', 'file6', 'file7', 'file8', 'file9', 'file10']
+
+# configurations
+
+monitoring_modes = ['scheduled']
+
+conf_params = {'TEST_DIRECTORIES': test_directories, 'MODULE_NAME': __name__}
+p, m = generate_params(extra_params=conf_params, modes=monitoring_modes,
+                       apply_to_all=({'CHECK_TYPE': check} for check in ['yes', 'no']))
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope='function')
+def restart_syscheck_function(get_configuration, request):
+    """
+    Reset ossec.log and start a new monitor.
+    """
+    control_service('stop', daemon='wazuh-syscheckd')
+    truncate_file(LOG_FILE_PATH)
+    file_monitor = FileMonitor(LOG_FILE_PATH)
+    setattr(request.module, 'wazuh_log_monitor', file_monitor)
+    control_service('start', daemon='wazuh-syscheckd')
+
+
+@pytest.fixture(scope='function')
+def wait_for_fim_start_function(get_configuration, request):
+    """
+    Wait for realtime start, whodata start or end of initial FIM scan.
+    """
+    file_monitor = getattr(request.module, 'wazuh_log_monitor')
+    detect_initial_scan(file_monitor)
+
+
+# tests
+
+@pytest.mark.parametrize('test_added', [
+    0,
+    1
+])
+def test_db_inode_check(test_added, get_configuration, configure_environment, restart_syscheck_function,
+                        wait_for_fim_start_function):
+    """Test to check for false positives due to possible inconsistencies with inodes in the database.
+
+    Args:
+      test_added: Boolean variable to set whether the test will add one more or one less file.
+      get_configuration: Function to access the configuration in use.
+      configure_environment: Fixture to prepare the environment to pass the test
+      restart_syscheck_function: Restart syscheck and truncate the log file with function scope.
+      wait_for_fim_start_function: Wait until the log 'scan end' appear, with function scope.
+
+    Returns: Test failed if an unexpected event is founded.
+
+    Cases:
+    - With check_mtime="no" and check_inode="no", no modification events should appear.
+    - With check_mtime="yes" and check_inode="yes", modification events should have:
+        '"changed_attributes":["mtime","inode"]'
+
+    """
+
+    check_apply_test({'ossec_conf'}, get_configuration['tags'])
+
+    aux_file_list = file_list.copy()
+
+    for file in aux_file_list:
+        create_file(REGULAR, monitored_folder, file, content=file)
+
+    # Time travel after create 10 files
+    check_time_travel(True, monitor=wazuh_log_monitor)
+
+    shutil.rmtree(monitored_folder, ignore_errors=True)
+
+    # Duplicate cases with one file more or one file less
+    if test_added:
+        aux_file_list.insert(0, "file0")
+    else:
+        aux_file_list.pop(0)
+
+    for file in aux_file_list:
+        create_file(REGULAR, monitored_folder, file, content=file)
+
+    # Time travel after delete and create again a different number of files
+    check_time_travel(True, monitor=wazuh_log_monitor)
+
+    if get_configuration['metadata']['check_type'] == 'yes':
+        callback_test = callback_detect_modified_event_with_inode_mtime
+    else:
+        callback_test = callback_detect_modified_event
+
+    shutil.rmtree(monitored_folder, ignore_errors=True)
+
+    # Check unexpected events
+    with pytest.raises(TimeoutError):
+        event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                        callback=callback_test).result()
+        raise AttributeError(f'Unexpected event {event}')

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -6,9 +6,7 @@ import os
 import shutil
 import pytest
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import create_file, generate_params, check_time_travel, callback_detect_modified_event, \
-                              LOG_FILE_PATH, REGULAR, callback_detect_modified_event_with_inode_mtime, \
-                              detect_initial_scan
+import wazuh_testing.fim as fim
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -24,7 +22,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
 monitored_folder = os.path.join(PREFIX, 'testdir')
 test_directories = [monitored_folder]
 
-wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_check_inodes.yaml')
 file_list = [f"file{i}" for i in range(10)]
@@ -34,8 +32,8 @@ file_list = [f"file{i}" for i in range(10)]
 monitoring_modes = ['scheduled']
 
 conf_params = {'TEST_DIRECTORIES': test_directories, 'MODULE_NAME': __name__}
-params, metadata = generate_params(extra_params=conf_params, modes=monitoring_modes,
-                       apply_to_all=({'CHECK_TYPE': check} for check in ['yes', 'no']))
+params, metadata = fim.generate_params(extra_params=conf_params, modes=monitoring_modes,
+                                       apply_to_all=({'CHECK_TYPE': check} for check in ['yes', 'no']))
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
@@ -54,8 +52,8 @@ def restart_syscheck_function(get_configuration, request):
     Reset ossec.log and start a new monitor.
     """
     control_service('stop', daemon='wazuh-syscheckd')
-    truncate_file(LOG_FILE_PATH)
-    file_monitor = FileMonitor(LOG_FILE_PATH)
+    truncate_file(fim.LOG_FILE_PATH)
+    file_monitor = FileMonitor(fim.LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
     control_service('start', daemon='wazuh-syscheckd')
 
@@ -66,33 +64,29 @@ def wait_for_fim_start_function(get_configuration, request):
     Wait for realtime start, whodata start or end of initial FIM scan.
     """
     file_monitor = getattr(request.module, 'wazuh_log_monitor')
-    detect_initial_scan(file_monitor)
+    fim.detect_initial_scan(file_monitor)
 
 
 # tests
 
-@pytest.mark.parametrize('test_added', [
-    0,
-    1
-])
-def test_db_inode_check(test_added, get_configuration, configure_environment, restart_syscheck_function,
+@pytest.mark.parametrize('test_cases', [0, 1, 2])
+def test_db_inode_check(test_cases, get_configuration, configure_environment, restart_syscheck_function,
                         wait_for_fim_start_function):
-    """Test to check for false positives due to possible inconsistencies with inodes in the database.
+    """ Test to check for false positives due to possible inconsistencies with inodes in the database.
+        Cases:
+            - With check_mtime="no" and check_inode="no", no modification events should appear.
+            - With check_mtime="yes" and check_inode="yes", modification events should have:
+              "changed_attributes":["mtime","inode"]
 
     Args:
-      test_added (boolean): variable to set whether the test will add one more or one less file.
-      get_configuration (fixture): Function to access the configuration in use.
-      configure_environment (fixture): Fixture to prepare the environment to pass the test
-      restart_syscheck_function (fixture): Restart syscheck and truncate the log file with function scope.
-      wait_for_fim_start_function (fixture): Wait until the log 'scan end' appear, with function scope.
+        test_added (boolean): variable to set whether the test will add one more or one less file.
+        get_configuration (fixture): Function to access the configuration in use.
+        configure_environment (fixture): Fixture to prepare the environment to pass the test
+        restart_syscheck_function (fixture): Restart syscheck and truncate the log file with function scope.
+        wait_for_fim_start_function (fixture): Wait until the log 'scan end' appear, with function scope.
 
-    Returns: Test failed if an unexpected event is founded.
-
-    Cases:
-    - With check_mtime="no" and check_inode="no", no modification events should appear.
-    - With check_mtime="yes" and check_inode="yes", modification events should have:
-        '"changed_attributes":["mtime","inode"]'
-
+    Raises:
+        AttributeError: If an wrong or unexpected modified event appear
     """
 
     check_apply_test({'ossec_conf'}, get_configuration['tags'])
@@ -100,29 +94,34 @@ def test_db_inode_check(test_added, get_configuration, configure_environment, re
     aux_file_list = file_list.copy()
 
     for file in aux_file_list:
-        create_file(REGULAR, monitored_folder, file, content=file)
+        fim.create_file(fim.REGULAR, monitored_folder, file, content=file)
 
     # Time travel after creating the required files
-    check_time_travel(True, monitor=wazuh_log_monitor)
+    fim.check_time_travel(True, monitor=wazuh_log_monitor)
 
     shutil.rmtree(monitored_folder, ignore_errors=True)
 
-    # Duplicate cases with one file more or one file less
-    if test_added:
+    if test_cases == 0:
+        # First case, adding a file ahead
         aux_file_list.insert(0, "file")
-    else:
+    elif test_cases == 1:
+        # Second case, removing the first file
         aux_file_list.pop(0)
+    elif test_cases == 2:
+        # Third case, rotating files
+        aux_file_list.pop(-1)
+        aux_file_list.insert(0, "file9")
 
     for file in aux_file_list:
-        create_file(REGULAR, monitored_folder, file, content=file)
+        fim.create_file(fim.REGULAR, monitored_folder, file, content=file)
 
     # Time travel after delete and create again a different number of files
-    check_time_travel(True, monitor=wazuh_log_monitor)
+    fim.check_time_travel(True, monitor=wazuh_log_monitor)
 
     if get_configuration['metadata']['check_type'] == 'yes':
-        callback_test = callback_detect_modified_event_with_inode_mtime
+        callback_test = fim.callback_detect_modified_event_with_inode_mtime
     else:
-        callback_test = callback_detect_modified_event
+        callback_test = fim.callback_detect_modified_event
 
     shutil.rmtree(monitored_folder, ignore_errors=True)
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -17,7 +17,7 @@ from wazuh_testing.tools.file import truncate_file
 
 # Marks
 
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
 
 # Variables
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -21,23 +21,23 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
 
 # Variables
 
-monitored_folder = os.path.join(PREFIX, 'testdir1')
+monitored_folder = os.path.join(PREFIX, 'testdir')
 test_directories = [monitored_folder]
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_check_inodes.yaml')
-file_list = ['file1', 'file2', 'file3', 'file4', 'file5', 'file6', 'file7', 'file8', 'file9', 'file10']
+file_list = [f"file{i}" for i in range(10)]
 
 # configurations
 
 monitoring_modes = ['scheduled']
 
 conf_params = {'TEST_DIRECTORIES': test_directories, 'MODULE_NAME': __name__}
-p, m = generate_params(extra_params=conf_params, modes=monitoring_modes,
+params, metadata = generate_params(extra_params=conf_params, modes=monitoring_modes,
                        apply_to_all=({'CHECK_TYPE': check} for check in ['yes', 'no']))
 
-configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
 
 # fixtures
@@ -80,11 +80,11 @@ def test_db_inode_check(test_added, get_configuration, configure_environment, re
     """Test to check for false positives due to possible inconsistencies with inodes in the database.
 
     Args:
-      test_added: Boolean variable to set whether the test will add one more or one less file.
-      get_configuration: Function to access the configuration in use.
-      configure_environment: Fixture to prepare the environment to pass the test
-      restart_syscheck_function: Restart syscheck and truncate the log file with function scope.
-      wait_for_fim_start_function: Wait until the log 'scan end' appear, with function scope.
+      test_added (boolean): variable to set whether the test will add one more or one less file.
+      get_configuration (fixture): Function to access the configuration in use.
+      configure_environment (fixture): Fixture to prepare the environment to pass the test
+      restart_syscheck_function (fixture): Restart syscheck and truncate the log file with function scope.
+      wait_for_fim_start_function (fixture): Wait until the log 'scan end' appear, with function scope.
 
     Returns: Test failed if an unexpected event is founded.
 
@@ -102,14 +102,14 @@ def test_db_inode_check(test_added, get_configuration, configure_environment, re
     for file in aux_file_list:
         create_file(REGULAR, monitored_folder, file, content=file)
 
-    # Time travel after create 10 files
+    # Time travel after creating the required files
     check_time_travel(True, monitor=wazuh_log_monitor)
 
     shutil.rmtree(monitored_folder, ignore_errors=True)
 
     # Duplicate cases with one file more or one file less
     if test_added:
-        aux_file_list.insert(0, "file0")
+        aux_file_list.insert(0, "file")
     else:
         aux_file_list.pop(0)
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -129,4 +129,7 @@ def test_db_inode_check(test_cases, get_configuration, configure_environment, re
     with pytest.raises(TimeoutError):
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                         callback=callback_test).result()
+        if test_cases == 2:
+            pytest.xfail('Xfailing due to false positive in special case, issue related: \
+                          https://github.com/wazuh/wazuh/issues/7829')
         raise AttributeError(f'Unexpected event {event}')


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7829|


## Description
Hello team, this PR adds a new integrated test to the basic usage tests.

### test_basic_usage_db_inode_check
Test to check for false positives and wrong modified events due to possible inconsistencies in the database. It check that modified events appear correctly as expected.

Test creates 10 files, saves them in the database. then deletes them and creates those same files (removing or adding one), so that the files are the same but their inodes (and mtime) have changed.

The test will check for events according to the configuration of the inode and mtime checks.
Cases:
- With check_mtime="no" and check_inode="no", no modification events should appear.
- With check_mtime="yes" and check_inode="yes", modification events should have:
        '"changed_attributes":["mtime","inode"]'

## Result
Report using `master` branch 
[check_inodes_tests_failing.zip](https://github.com/wazuh/wazuh-qa/files/6172581/check_inodes_tests_failing.zip)

Report using `7829-test-db-inodes` branch
[check_inodes_tests_passing.zip](https://github.com/wazuh/wazuh-qa/files/6172580/check_inodes_tests_passing.zip)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.