### PR TITLE
 Dynamic hostinfo event generator for agent simulator

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -764,24 +764,22 @@ class GeneratorIntegrityFIM:
 
 class GeneratorHostinfo:
     def __init__(self, agent_id, agent_name):
-        self.HOSTINFO = 'hostinfo'
         self.HOSTINFO_MQ = 3
         self.hostinfo_basic_template = 'Host: <random_ip> (), open ports: '
-        self.avaible_protocols = ['udp', 'tcp']
+        self.protocols_list = ['udp', 'tcp']
         self.localfile = '/var/log/nmap.log'
         self.agent_name = agent_name
-        self.agent_id = agent_id
 
     def generate_event(self):
-        number_open_ports = randint(1,10)
+        number_open_ports = randint(1, 10)
         host_ip = random_ip()
         message_open_port_list = ''
         for i in range(number_open_ports):
-            message_open_port_list += fr"{randint(1,65535)} ({choice(self.avaible_protocols)}) "
+            message_open_port_list += fr"{randint(1,65535)} ({choice(self.protocols_list)}) "
 
         message = self.hostinfo_basic_template.replace('<random_ip>', host_ip)
         message += message_open_port_list
-        message = fr"{self.HOSTINFO_MQ}:{self.HOSTINFO}:{message}"
+        message = fr"{self.HOSTINFO_MQ}:{self.localfile}:{message}"
         return message
 
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1193,7 +1193,7 @@ class InjectorThread(threading.Thread):
                 sleep(frequency - ((time() - start_time) % frequency))
 
     def hostinfo(self):
-        """ """
+        """Send a hostinfo message from the agent to the manager."""
         sleep(10)
         start_time = time()
         self.agent.init_hostinfo()

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -606,7 +606,7 @@ class Agent:
 
     def init_hostinfo(self):
         if self.hostinfo is None:
-            self.hostinfo = GeneratorHostinfo(self.name, self.id)
+            self.hostinfo = GeneratorHostinfo()
 
     def get_connection_status(self):
         result = wdb.query_wdb(f"global get-agent-info {self.id}")
@@ -763,12 +763,11 @@ class GeneratorIntegrityFIM:
 
 
 class GeneratorHostinfo:
-    def __init__(self, agent_id, agent_name):
+    def __init__(self):
         self.HOSTINFO_MQ = 3
         self.hostinfo_basic_template = 'Host: <random_ip> (), open ports: '
         self.protocols_list = ['udp', 'tcp']
         self.localfile = '/var/log/nmap.log'
-        self.agent_name = agent_name
 
     def generate_event(self):
         number_open_ports = randint(1, 10)

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -19,10 +19,9 @@ import socket
 import ssl
 import threading
 import zlib
-import string
 from datetime import date
+from random import randint, sample, choice
 
-from random import randint, sample, choice, SystemRandom
 from stat import S_IFLNK, S_IFREG, S_IRWXU, S_IRWXG, S_IRWXO
 from string import ascii_letters, digits
 from struct import pack
@@ -35,7 +34,7 @@ from wazuh_testing import TCP
 from wazuh_testing import is_udp, is_tcp
 from wazuh_testing.tools.monitoring import wazuh_unpack, Queue
 from wazuh_testing.tools.remoted_sim import Cipher
-from wazuh_testing.tools.utils import retry
+from wazuh_testing.tools.utils import retry, random_ip, random_string
 
 _data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data')
 
@@ -668,8 +667,7 @@ class GeneratorSyscollector:
 
         event_map = [
                         ('<agent_name>', self.agent_name), ('<random_int>', str(randint(1, 10 * 10))),
-                        ('<random_string>', ''.join(SystemRandom().choice(string.ascii_uppercase + string.digits)
-                                            for _ in range(10))),
+                        ('<random_string>', random_string(10)),
                         ('<timestamp>', timestamp), ('<syscollector_type>', message_type)
                     ]
 
@@ -776,7 +774,7 @@ class GeneratorHostinfo:
 
     def generate_event(self):
         number_open_ports = randint(1,10)
-        host_ip = fr"{randint(1,255)}.{randint(1,255)}.{randint(1,255)}.{randint(1,255)}"
+        host_ip = random_ip()
         message_open_port_list = ''
         for i in range(number_open_ports):
             message_open_port_list += fr"{randint(1,65535)} ({choice(self.avaible_protocols)}) "

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -5,6 +5,7 @@ import logging
 import re
 from functools import wraps
 from time import sleep
+from random import randint
 
 
 def retry(exceptions, attempts=5, delay=1, delay_multiplier=2):
@@ -97,3 +98,7 @@ def replace_in_file(filename, to_replace, replacement):
 
     with open(filename, "w") as f:
         f.write(replace_content)
+
+
+def random_ip():
+    return fr"{randint(0,255)}.{randint(0,255)}.{randint(0,255)}.{randint(0,255)}"

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -5,7 +5,8 @@ import logging
 import re
 from functools import wraps
 from time import sleep
-from random import randint
+from random import randint, SystemRandom, choice
+import string
 
 
 def retry(exceptions, attempts=5, delay=1, delay_multiplier=2):
@@ -102,3 +103,9 @@ def replace_in_file(filename, to_replace, replacement):
 
 def random_ip():
     return fr"{randint(0,255)}.{randint(0,255)}.{randint(0,255)}.{randint(0,255)}"
+
+
+def random_string(string_length):
+    return ''.join(SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(string_length))
+
+


### PR DESCRIPTION
|Related issue|
|---|
|closes #1163  |

In this PR a new GeneratorHostinfo class has been added. It is in charge of generating hostinfo events dynamically. For this task, it uses the following basic hostinfo message template:

```
 'Host: <random_ip> (), open ports: '
```
To this message, a random list of ports for udp or tcp protocols are added to this basic message. Examples of generated messages:

```
2021 Mar 22 10:01:09 (b6085974) any->hostinfo Host: 69.243.203.68 (), open ports: 6550 (udp) 55716 (udp) 27127 (tcp) 52602 (udp) 38746 (tcp) 47201 (tcp) 7098 (udp) 
2021 Mar 22 10:01:09 (b6085974) any->hostinfo Host: 241.180.5.0 (), open ports: 38320 (udp) 30484 (udp) 43 (tcp) 21735 (udp) 12399 (tcp) 53948 (tcp) 
2021 Mar 22 10:01:09 (b6085974) any->hostinfo Host: 216.248.199.87 (), open ports: 32902 (tcp) 21780 (tcp) 36482 (udp) 59292 (udp) 14071 (tcp) 24712 (tcp) 58472 (udp) 45217 (tcp) 36069 (udp) 
2021 Mar 22 10:01:09 (b6085974) any->hostinfo Host: 94.39.40.202 (), open ports: 7364 (tcp) 60747 (udp) 55018 (udp) 
```

These events are sent to hostinfo queue, so,  `wazuh-analysisd.state` is updated and alerts are generated:
```
** Alert 1616407269.10516076: - ossec,hostinfo,pci_dss_10.2.7,gpg13_4.13,hipaa_164.312.b,nist_800_53_AU.14,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2021 Mar 22 10:01:09 (b6085974) any->hostinfo
Rule: 581 (level 8) -> 'Host information added.'
Host: 116.189.185.82 (), open ports: 5555 (tcp) 24141 (udp) 44849 (udp) 40642 (tcp) 37418 (udp) 51578 (tcp) 64985 (udp
```
