### PR TITLE
Add logcollector module to agent simulator 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -847,12 +847,12 @@ class Rootcheck:
 
 class Logcollector:
     def __init__(self):
-        self.name = 'syslog'
+        self.LOGCOLLECTOR = 'syslog'
         self.LOGCOLLECTOR_MQ = 'x'
 
     def generate_event(self):
         log = 'Mar 24 10:12:36 centos8 sshd[12249]: Invalid user random_user from 172.17.1.1 port 56550'
-        return f"{self.LOGCOLLECTOR_MQ}:{self.name}:{log}"
+        return f"{self.LOGCOLLECTOR_MQ}:{self.LOGCOLLECTOR}:{log}"
 
 
 class GeneratorIntegrityFIM:


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1172|

As part of https://github.com/wazuh/wazuh-qa/issues/1133

This PR adds a simple logcollector module to the agent simulator that generates sshd failed login attempts messages and sends them to the manager to stress out the "other messages" queue.

