### PR TITLE
Update system tests after changing cluster logs

### DIFF
--- a/tests/system/provisioning/agentless_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils

--- a/tests/system/provisioning/basic_cluster/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/agent-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils

--- a/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils
@@ -14,6 +15,8 @@
       - sqlite3
     force_apt_get: True
     state: present
+    update-cache: true
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils
@@ -15,6 +16,8 @@
       - sqlite3
     force_apt_get: True
     state: present
+    update-cache: true
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/enrollment_cluster/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/agent-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/tasks/main.yml
@@ -5,6 +5,7 @@
       - git
       - gcc
       - make
+      - cmake
       - libc6-dev
       - curl
       - policycoreutils

--- a/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
@@ -6,7 +6,7 @@ wazuh-master:
   - regex: '.*Received request:.*{"daemon_name":"authd","message":{"arguments":{"name":".*","ip":"any","force":0},"function":"add"}}'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
-  - regex: '.*Worker wazuh-worker1.*Finished integrity synchronization.*'
+  - regex: '.*Worker wazuh-worker1.*Integrity sync.*Finished in.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
 
@@ -24,7 +24,7 @@ wazuh-worker1:
   - regex: '.*Processing file etc\/client\.keys.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
-  - regex: '.*Updating files: End.*'
+  - regex: '.*Updating local files: End.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
 

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages.yml
@@ -3,19 +3,13 @@ wazuh-master:
   - regex: '.*Received request:.*{"daemon_name": "wazuh-db", "message": "global sync-agent-info-set.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
-  - regex: '.*wazuh-worker1.*Finished integrity synchronization.'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 15
-  - regex: '.*wazuh-worker2.*Finished integrity synchronization.'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 15
   - regex: '.*Received request: .*test_label.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
 
 
 wazuh-worker1:
-  - regex: ".*Starting agent-info sync process."
+  - regex: ".*Agent-info sync.*Starting."
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
   - regex: ".*Obtaining data to be sent to master's wazuh-db."
@@ -36,7 +30,7 @@ wazuh-worker1:
 
 
 wazuh-worker2:
-  - regex: ".*Starting agent-info sync process."
+  - regex: ".*Agent-info sync.*Starting."
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
   - regex: ".*Obtaining data to be sent to master's wazuh-db."

--- a/tests/system/test_cluster/test_agent_info_sync/data/messages_remove_agent.yml
+++ b/tests/system/test_cluster/test_agent_info_sync/data/messages_remove_agent.yml
@@ -6,7 +6,7 @@ wazuh-worker2:
   - regex: ".*Agent files removed"
     path: "/var/ossec/logs/cluster.log"
     timeout: 10
-  - regex: ".*Updating files: End"
+  - regex: ".*Updating local files: End"
     path: "/var/ossec/logs/cluster.log"
     timeout: 10
   - regex: ".*The master has verified that the integrity is right."


### PR DESCRIPTION
|Related issue|
|---|
| [#7860](https://github.com/wazuh/wazuh/issues/7860) |

## Description

Hi team!

This PR updates the system test where cluster logs where expected, since they were refactored in [#7860](https://github.com/wazuh/wazuh/issues/7860). Also, some dependencies like `cmake` had to be added to the provisioning of the environments. 

Regards,
Selu.
