### PR TITLE
Update agent_simulator.py

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1313,6 +1313,7 @@ class GeneratorFIM:
         self.random_sha256()
         self.random_time()
         self.random_inode()
+        self._checksum = self.random_sha1()
 
     def check_changed_attributes(self, attributes, old_attributes):
         """Returns attributes that have changed. """
@@ -1368,7 +1369,7 @@ class GeneratorFIM:
             string: generated message with the required FIM header.
         """
         if self.agent_version >= "3.12":
-            formated_message = f"{self.syscheck_mq}:[{self.agent_id}] ({message})"
+            formated_message = f"{self.syscheck_mq}:({self.agent_id}) any->syscheck:{message}"
         else:
             # If first time generating. Send control message to simulate
             # end of FIM baseline.


### PR DESCRIPTION
|Related issue|
|---|
|Close https://github.com/wazuh/wazuh-qa/issues/1205|

This Pr fix a bug with FIM random messages generated by agent simulator, which aren't being correctly decoded by Wazuh manager due to a failure in the message header format.

Also, we've noticed that the checksum of the random field is static and we've introduced a small change to make it random on each message.

Best regards. 