### PR TITLE
Revised and implemented new test cases for Wazuh DB commands

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -105,7 +105,7 @@
                                         "status":"VALID",
                                         "check_pkg_existence":false}'
     output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert same package with different CVE without checking if the package is present in sys_program"
+    stage: "agent vuln_cves insert same package with different CVE without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2" AND cve = "CVE-2021-1002"'
     output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1002","reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
@@ -123,11 +123,29 @@
     input: 'agent 000 vuln_cves update_status {"new_status":"PENDING",
                                                "type":"OS"}'
     output: 'ok'
-    stage: "agent vuln_cves update status by type"
+    stage: 'agent vuln_cves update status by type "OS"'
   -
-    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
-    output: 'ok [{"status":"PENDING"},{"status":"VALID"}]'
-    stage: 'agent vuln_cves checking update status by type'
+    input: 'agent 000 sql SELECT count(status) FROM vuln_cves WHERE type = "OS"'
+    output: 'ok [{"count(status)":1}]'
+    stage: 'agent vuln_cves checking update status by type "OS"'
+  -
+    input: 'agent 000 vuln_cves update_status {"new_status":"PENDING",
+                                               "type":"PACKAGE"}'
+    output: 'ok'
+    stage: 'agent vuln_cves update status by type "PACKAGE"'
+  -
+    input: 'agent 000 sql SELECT count(status) FROM vuln_cves WHERE type = "PACKAGE"'
+    output: 'ok [{"count(status)":3}]'
+    stage: 'agent vuln_cves checking update status by type "PACKAGE"'
+  -
+    input: 'agent 000 vuln_cves update_status {"new_status":"VALID",
+                                               "type":"PACKAGE"}'
+    output: 'ok'
+    stage: 'agent vuln_cves update status by type "PACKAGE" again'
+  -
+    input: 'agent 000 sql SELECT count(status) FROM vuln_cves WHERE type = "PACKAGE"'
+    output: 'ok [{"count(status)":3}]'
+    stage: 'agent vuln_cves checking update status by type "PACKAGE" again'
   -
     input: 'agent 000 vuln_cves remove {"cve":"CVE-2021-1001",
                                         "reference":"03c06c4f118618400772367b1cf7e73ce0178e02"}'

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -42,12 +42,12 @@
     stage: "agent vuln_cves update already inserted entry"
   -
     input: 'agent 000 sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,checksum,item_id)
-                                             VALUES(0,"2021/04/0722:00:00","deb","test package","optional","utils","7490","Core Bugman corebugman@wazuh.com",NULL,"1.0.0","amd64",NULL,NULL,"Test package",NULL,0,NULL,NULL,"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","777fef8cc434b597769d102361af718d29ef72c1")'
+                                             VALUES(0,"2021/04/0722:00:00","deb","test package","optional","utils","7490","Wazuh wazuh@wazuh.com",NULL,"1.0.0","amd64",NULL,NULL,"Test package",NULL,0,NULL,NULL,"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","777fef8cc434b597769d102361af718d29ef72c1")'
     output: 'ok []'
     stage: "agent vuln_cves adding dummy test package to sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM sys_programs WHERE name = "test package"'
-    output: 'ok [{"scan_id":0,"scan_time":"2021/04/0722:00:00","format":"deb","name":"test package","priority":"optional","section":"utils","size":7490,"vendor":"Core Bugman corebugman@wazuh.com","version":"1.0.0","architecture":"amd64","description":"Test package","triaged":0,"checksum":"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","item_id":"777fef8cc434b597769d102361af718d29ef72c1"}]'
+    output: 'ok [{"scan_id":0,"scan_time":"2021/04/0722:00:00","format":"deb","name":"test package","priority":"optional","section":"utils","size":7490,"vendor":"Wazuh wazuh@wazuh.com","version":"1.0.0","architecture":"amd64","description":"Test package","triaged":0,"checksum":"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","item_id":"777fef8cc434b597769d102361af718d29ef72c1"}]'
     stage: "agent vuln_cves checking test package in sys_programs"
   -
     input: 'agent 000 vuln_cves insert {"name":"test package",

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -1,77 +1,199 @@
 ---
 -
   name: "Agents' CVEs table: vuln_cves"
-  description: "Checks the commands insert and clear"
+  description: "It checks the commands insert/update, update_status, remove and clear"
   test_case:
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}'
-    output: "ok"
-    stage: "agent vuln_cve insert test package"
+    input: 'agent 000 vuln_cves insert {"name":"test_package",
+                                        "version":"1.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1001",
+                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
+                                        "type":"PACKAGE",
+                                        "status":"VALID",
+                                        "check_pkg_existence":true}'
+    output: 'ok {"action":"INSERT","status":"PKG_NOT_FOUND"}'
+    stage: "agent vuln_cves insert test_package when it does not exist in sys_programs"
+  -
+    input: 'agent 000 vuln_cves insert {"name":"test_package",
+                                        "version":"1.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1001",
+                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
+                                        "type":"PACKAGE",
+                                        "status":"VALID",
+                                        "check_pkg_existence":false}'
+    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
+    stage: "agent vuln_cves insert test_package without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves'
-    output: 'ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}]'
-    stage: "agent vuln_cve checking test package"
+    output: 'ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001","reference":"03c06c4f118618400772367b1cf7e73ce0178e02","type":"PACKAGE","status":"VALID"}]'
+    stage: "agent vuln_cves checking test_package"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}'
-    output: "ok"
-    stage: "agent vuln_cve insert duplicated entry"
+    input: 'agent 000 vuln_cves insert {"name":"test_package",
+                                        "version":"1.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1001",
+                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
+                                        "type":"PACKAGE",
+                                        "status":"VALID",
+                                        "check_pkg_existence":false}'
+    output: 'ok {"action":"UPDATE","status":"SUCCESS"}'
+    stage: "agent vuln_cves update already inserted entry"
   -
-    input: 'agent 001 vuln_cve insert {"name":"test package","version":"1.0","architecture":"x86","cve":"1001"}'
-    output: "ok"
-    stage: "agent vuln_cve insert with spaces in json payload"
-  -
-    input: 'agent 000 vuln_cve clear'
-    output: "ok"
-    stage: "agent vuln_cve clear table"
-  -
-    input: 'agent 000 sql SELECT * FROM vuln_cves'
+    input: 'agent 000 sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,checksum,item_id)
+                                             VALUES(0,"2021/04/0722:00:00","deb","test package","optional","utils","7490","Core Bugman corebugman@wazuh.com",NULL,"1.0.0","amd64",NULL,NULL,"Test package",NULL,0,NULL,NULL,"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","777fef8cc434b597769d102361af718d29ef72c1")'
     output: 'ok []'
-    stage: "agent vuln_cve checking empty table"
+    stage: "agent vuln_cves adding dummy test package to sys_programs"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package","cve":"CVE-2021-1001"}'
+    input: 'agent 000 sql SELECT * FROM sys_programs WHERE name = "test package"'
+    output: 'ok [{"scan_id":0,"scan_time":"2021/04/0722:00:00","format":"deb","name":"test package","priority":"optional","section":"utils","size":7490,"vendor":"Core Bugman corebugman@wazuh.com","version":"1.0.0","architecture":"amd64","description":"Test package","triaged":0,"checksum":"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","item_id":"777fef8cc434b597769d102361af718d29ef72c1"}]'
+    stage: "agent vuln_cves checking test package in sys_programs"
+  -
+    input: 'agent 000 vuln_cves insert {"name":"test package",
+                                        "version":"1.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1002",
+                                        "reference":"777fef8cc434b597769d102361af718d29ef72c1",
+                                        "type":"OS",
+                                        "status":"PENDING",
+                                        "check_pkg_existence":true}'
+    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
+    stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs"
+  -
+    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test package"'
+    output: 'ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]'
+    stage: "agent vuln_cves checking test package"
+  -
+    input: 'agent 000 vuln_cves insert {"name":"test_package","cve":"CVE-2021-1001"}'
     output: "err Invalid JSON data, missing required fields"
-    stage: "agent vuln_cve insert incomplete package"
+    stage: "agent vuln_cves insert incomplete package"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package",'
+    input: 'agent 000 vuln_cves insert {"name":"test_package",'
     output: "err Invalid JSON syntax, near '{\"name\":\"test_package\",'"
-    stage: "agent vuln_cve insert invalid JSON"
+    stage: "agent vuln_cves insert invalid JSON"
   -
-    input: 'agent 000 vuln_cve'
-    output: "err Invalid vuln_cve query syntax, near 'vuln_cve'"
-    stage: "agent vuln_cve missing command"
+    input: 'agent 000 vuln_cves'
+    output: "err Invalid vuln_cves query syntax, near 'vuln_cves'"
+    stage: "agent vuln_cves missing command"
   -
-    input: 'agent 000 vuln_cve insert'
+    input: 'agent 000 vuln_cves insert'
     output: "err Invalid JSON syntax, near ''"
-    stage: "agent vuln_cve missing payload"
+    stage: "agent vuln_cves missing payload"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package2","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}'
-    output: "ok"
-    stage: "agent vuln_cve insert another package"
+    input: 'agent 000 vuln_cves insert {"name":"test_package2",
+                                        "version":"3.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1001",
+                                        "reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa",
+                                        "type":"PACKAGE",
+                                        "status":"VALID",
+                                        "check_pkg_existence":false}'
+    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
+    stage: "agent vuln_cves insert package with same CVE without checking if the package is present in sys_programs"
   -
-    input: 'agent 000 sql SELECT * FROM vuln_cves'
-    output: 'ok [{"name":"test_package2","version":"1.0","architecture":"x86","cve":"CVE-2021-1001"}]'
-    stage: "agent vuln_cve checking another package"
+    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2"'
+    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
+    stage: "agent vuln_cves checking package insertion with same CVE"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1001"}'
-    output: "ok"
-    stage: "agent vuln_cve insert package with same CVE"
+    input: 'agent 000 vuln_cves insert {"name":"test_package2",
+                                        "version":"3.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1002",
+                                        "reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa",
+                                        "type":"PACKAGE",
+                                        "status":"VALID",
+                                        "check_pkg_existence":false}'
+    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
+    stage: "agent vuln_cves insert same package with different CVE without checking if the package is present in sys_program"
   -
-    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3"'
-    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1001"}]'
-    stage: "agent vuln_cve checking package insertion with same CVE"
+    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2" AND cve = "CVE-2021-1002"'
+    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1002","reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
+    stage: "agent vuln_cves checking package with different CVE"
   -
-    input: 'agent 000 vuln_cve insert {"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1002"}'
-    output: "ok"
-    stage: "agent vuln_cve insert same package with different CVE"
+    input: 'agent 000 vuln_cves update_status {"old_status":"PENDING",
+                                               "new_status":"OBSOLETE"}'
+    output: 'ok'
+    stage: "agent vuln_cves update specific status to another one"
   -
-    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package3" AND cve = "CVE-2021-1002"'
-    output: 'ok [{"name":"test_package3","version":"3.0","architecture":"x86","cve":"CVE-2021-1002"}]'
-    stage: "agent vuln_cve checking package with different CVE"
+    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
+    output: 'ok [{"status":"OBSOLETE"},{"status":"VALID"}]'
+    stage: 'agent vuln_cves checking change specific status by another one'
   -
-    input: 'agent 000 vuln_cve clear'
-    output: "ok"
-    stage: "agent vuln_cve clearing table again"
+    input: 'agent 000 vuln_cves update_status {"new_status":"PENDING",
+                                               "type":"OS"}'
+    output: 'ok'
+    stage: "agent vuln_cves update status by type"
+  -
+    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
+    output: 'ok [{"status":"PENDING"},{"status":"VALID"}]'
+    stage: 'agent vuln_cves checking update status by type'
+  -
+    input: 'agent 000 vuln_cves remove {"cve":"CVE-2021-1001",
+                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02"}'
+    output: 'ok'
+    stage: "agent vuln_cves remove cve"
+  -
+    input: 'agent 000 sql SELECT count(*) FROM vuln_cves WHERE cve = "CVE-2021-1001" AND reference = "03c06c4f118618400772367b1cf7e73ce0178e02"'
+    output: 'ok [{"count(*)":0}]'
+    stage: 'agent vuln_cves checking remove cve'
+  -
+    input: 'agent 000 vuln_cves remove {"status":"PENDING"}'
+    output: 'ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]'
+    stage: 'agent vuln_cves remove by status'
+  -
+    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
+    output: 'ok [{"status":"VALID"}]'
+    stage: 'agent vuln_cves checking remove by status'
+  -
+    input: 'agent 000 vuln_cves insert {"name":"test package",
+                                        "version":"1.0",
+                                        "architecture":"x86",
+                                        "cve":"CVE-2021-1002",
+                                        "reference":"777fef8cc434b597769d102361af718d29ef72c1",
+                                        "type":"OS",
+                                        "status":"PENDING",
+                                        "check_pkg_existence":true}'
+    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
+    stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs again"
+  -
+    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
+    output: 'ok [{"status":"PENDING"},{"status":"VALID"}]'
+    stage: "agent vuln_cves checking status"
+  -
+    input: 'agent 000 vuln_cves update_status {"old_status":"*",
+                                               "new_status":"OBSOLETE"}'
+    output: 'ok'
+    stage: "agent vuln_cves update all status"
+  -
+    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
+    output: 'ok [{"status":"OBSOLETE"}]'
+    stage: 'agent vuln_cves checking update all status'
+  -
+    input: 'agent 000 vuln_cves clear'
+    output: 'ok'
+    stage: "agent vuln_cves clear table"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves'
     output: 'ok []'
-    stage: "agent vuln_cve checking empty table again"
+    stage: "agent vuln_cves checking empty table"
+-
+  name: "Agents' OS table: os_info"
+  description: "It checks the commands get and set"
+  test_case:
+  - 
+    input: 'agent 000 sql DELETE FROM sys_osinfo'
+    output: "ok []"
+    stage: agent sys_osinfo cleaning sys_osinfo table
+  -
+    input: 'agent 000 osinfo get'
+    output: "ok []"
+    stage: "agent sys_osinfo checking table is empty"
+  -
+    input: 'agent 000 osinfo set 0|2021/04/08 10:00:00|focal|x86_64|Ubuntu|20.04.2 LTS (Focal Fossa)|focal|20|04|1|ubuntu|Linux|5.4.0-70-generic|#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021|1|2'
+    output: 'ok'
+    stage: "agent sys_osinfo set information"
+  -
+    input: 'agent 000 osinfo get'
+    output: 'ok [{"scan_id":0,"scan_time":"2021/04/08 10:00:00","hostname":"focal","architecture":"x86_64","os_name":"Ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","os_codename":"focal","os_major":"20","os_minor":"04","os_patch":"2","os_build":"1","os_platform":"ubuntu","sysname":"Linux","release":"5.4.0-70-generic","version":"#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021","os_release":"1","checksum":"legacy","triaged":0,"reference":"54d5344c8f49eae38d81651495227c5080755b45"}]'
+    stage: "agent sys_osinfo getting information"

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -198,6 +198,14 @@
     output: 'ok [{"scan_id":0,"scan_time":"2021/04/08 10:00:00","hostname":"focal","architecture":"x86_64","os_name":"Ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","os_codename":"focal","os_major":"20","os_minor":"04","os_patch":"2","os_build":"1","os_platform":"ubuntu","sysname":"Linux","release":"5.4.0-70-generic","version":"#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021","os_release":"1","checksum":"legacy","triaged":0,"reference":"54d5344c8f49eae38d81651495227c5080755b45"}]'
     stage: "agent sys_osinfo getting information"
   -
+    input: 'agent 000 osinfo set_triaged'
+    output: 'ok'
+    stage: "agent sys_osinfo set triaged"
+  -
+    input: 'agent 000 sql SELECT triaged FROM sys_osinfo WHERE triaged = 1'
+    output: 'ok [{"triaged":1}]'
+    stage: "agent sys_osinfo checking triaged"
+  -
     input: 'agent 000 sql DELETE FROM sys_osinfo'
     output: "ok []"
     stage: "agent sys_osinfo cleaning sys_osinfo table"

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -184,7 +184,7 @@
   - 
     input: 'agent 000 sql DELETE FROM sys_osinfo'
     output: "ok []"
-    stage: agent sys_osinfo cleaning sys_osinfo table
+    stage: "agent sys_osinfo cleaning sys_osinfo table"
   -
     input: 'agent 000 osinfo get'
     output: "ok []"
@@ -197,3 +197,11 @@
     input: 'agent 000 osinfo get'
     output: 'ok [{"scan_id":0,"scan_time":"2021/04/08 10:00:00","hostname":"focal","architecture":"x86_64","os_name":"Ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","os_codename":"focal","os_major":"20","os_minor":"04","os_patch":"2","os_build":"1","os_platform":"ubuntu","sysname":"Linux","release":"5.4.0-70-generic","version":"#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021","os_release":"1","checksum":"legacy","triaged":0,"reference":"54d5344c8f49eae38d81651495227c5080755b45"}]'
     stage: "agent sys_osinfo getting information"
+  -
+    input: 'agent 000 sql DELETE FROM sys_osinfo'
+    output: "ok []"
+    stage: "agent sys_osinfo cleaning sys_osinfo table"
+  -
+    input: 'agent 000 osinfo get'
+    output: "ok []"
+    stage: "agent sys_osinfo checking table is empty"


### PR DESCRIPTION
|Related issue|
|---|
|#1158|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As part of the changes that affect the vulnerability detector behavior detailed here [#7749](https://github.com/wazuh/wazuh/issues/7749) the existent wazuh db commands were modified and new ones were implemented, due to that multiple test cases started to fail and also lacking of coverage. This PR fixes that in `Agents' CVEs table: vuln_cves` and `Agents' OS table: os_info`
<!--
Add a clear description of how the problem has been solved.
-->
## Logs example
![image](https://user-images.githubusercontent.com/13010397/114227124-f27f7100-994a-11eb-803c-04d5a9488223.png)
<!--
Paste here related logs and alerts
-->

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] The test is documented in wazuh-qa/docs.