### PR TITLE
Add API performance tests

### DIFF
--- a/tests/performance/test_api/README.md
+++ b/tests/performance/test_api/README.md
@@ -1,0 +1,74 @@
+# wazuh-qa
+
+Wazuh - System quality assurance automation templates
+
+## Setting up a test environment
+
+To run these tests we need to use a **Linux** machine with direct connection to another machine with Wazuh installed.
+
+### Dependencies
+
+In addition, we need the `wazuh-testing` package in addition to the default requirements from this repository.
+
+## Performance API tests
+
+These tests are designed to work on another machine to test our API endpoints on custom environments, such as a loaded Wazuh cluster.
+
+#### conftest
+
+The conftest is prepared to accept the `--html=report.html` option to generate an HTML report with useful information.
+
+#### data
+
+Folder which includes the configuration that will be applied to the test. This includes connection information in addition to the request template.
+
+##### configuration.yaml
+
+```yaml
+---
+configuration:
+  host: 'localhost'
+  port: 55000
+  restart_delay: 30
+
+test_cases:
+  - endpoint: /agents
+    method: post
+    parameters: {}
+    body:
+      name: "new_test_agent"
+      ip: "any"
+      
+  - endpoint: /cluster/restart
+    method: put
+    parameters: {}
+    body: {}
+    restart: True
+
+  ( ... )
+
+```
+
+**Configuration**
+- **host**: Host IP or name to make the requests to.
+- **port**: Wazuh API port.
+- **restart_delay**: Delay in seconds to apply after endpoints that may restart an agent or manager.
+
+**Test cases**
+- **endpoint**: API endpoint.
+- **method**: Method to apply to the request.
+- **parameters**: Parameters to add to the request (dict format).
+- **body**: Body to add to the request (dict format).
+- **restart (optional)**: On `PUT` endpoints, this option must be added to define if there will be a delay after that test passes.
+
+### Pytest
+
+These tests will be run with `pytest`. You can apply any of the pytest options, but it is recommended to add the following at least:
+- **--html=report.html**: Generate an HTML report with useful information about the tests.
+- **--disable-warnings**: Hide test warnings (`requests` module will generate some warnings as we are doing unverified requests).
+
+An example would be the following:
+
+```shell script
+root@wazuh-test-master:/wazuh-qa/tests/performance# python3 -m pytest test_api/test_api.py --self-contained-html --disable-warnings
+```

--- a/tests/performance/test_api/conftest.py
+++ b/tests/performance/test_api/conftest.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+from py.xml import html
+from wazuh_testing.api import get_api_details_dict
+
+results = dict()
+
+
+@pytest.fixture(scope='module')
+def set_api_test_environment(request):
+    kwargs = dict()
+    if hasattr(request.module, 'configuration'):
+        configuration = getattr(request.module, 'configuration')
+        kwargs.update({'host': configuration['host'], 'port': configuration['port']})
+
+    setattr(request.module, 'api_details', get_api_details_dict(**kwargs))
+
+
+def pytest_html_report_title(report):
+    report.title = 'Wazuh API integration tests'
+
+
+# HTML report
+class HTMLStyle(html):
+    class body(html.body):
+        style = html.Style(background_color='#F0F0EE')
+
+    class table(html.table):
+        style = html.Style(border='2px solid #005E8C', margin='16px 0px', color='#005E8C',
+                           font_size='15px')
+
+    class colored_td(html.td):
+        style = html.Style(color='#005E8C', padding='5px', border='2px solid #005E8C', text_align='center',
+                           white_space='pre-wrap', font_size='14px')
+
+    class td(html.td):
+        style = html.Style(padding='5px', border='2px solid #005E8C', text_align='left',
+                           white_space='pre-wrap', font_size='14px')
+
+    class th(html.th):
+        style = html.Style(color='#0094ce', padding='5px', border='2px solid #005E8C', text_align='center',
+                           font_weight='bold', font_size='15px')
+
+    class h1(html.h1):
+        style = html.Style(color='#0094ce')
+
+    class h2(html.h2):
+        style = html.Style(color='#0094ce')
+
+    class h3(html.h3):
+        style = html.Style(color='#0094ce')
+
+
+def pytest_html_results_table_header(cells):
+    cells[1] = html.th('Method')
+    cells.insert(2, html.th('Endpoint'))
+    cells.insert(3, html.th('Parameters'))
+    cells.insert(4, html.th('Body'))
+    cells.insert(5, html.th('Restart'))
+
+    # Remove links
+    cells.pop()
+
+
+def pytest_html_results_table_row(report, cells):
+    try:
+        # Replace test name for method
+        cells[1] = HTMLStyle.colored_td(report.user_properties[1][1].upper())
+        cells[2] = HTMLStyle.colored_td(report.user_properties[0][1])
+        cells[3] = HTMLStyle.colored_td(str(report.user_properties[2][1]))
+        cells.append(HTMLStyle.colored_td(str(report.user_properties[3][1])))
+        cells.append(HTMLStyle.colored_td(u'\u2713' if len(report.user_properties) > 4 and report.user_properties[4][1] else ''))
+        cells.append(HTMLStyle.colored_td(f'{report.duration:.3f} s'))
+
+    except AttributeError:
+        pass
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # Define HTML style
+    pytest_html = item.config.pluginmanager.getplugin('html')
+    pytest_html.html.body = HTMLStyle.body
+    pytest_html.html.table = HTMLStyle.table
+    pytest_html.html.th = HTMLStyle.th
+    pytest_html.html.td = HTMLStyle.td
+    pytest_html.html.h1 = HTMLStyle.h1
+    pytest_html.html.h2 = HTMLStyle.h2
+    pytest_html.html.h3 = HTMLStyle.h3
+
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.location[0] not in results:
+        results[report.location[0]] = {'passed': 0, 'failed': 0, 'skipped': 0, 'xfailed': 0, 'error': 0}
+
+    if report.when == 'call':
+        if report.longrepr is not None and report.longreprtext.split()[-1] == 'XFailed':
+            results[report.location[0]]['xfailed'] += 1
+        else:
+            results[report.location[0]][report.outcome] += 1
+
+    elif report.outcome == 'failed':
+        results[report.location[0]]['error'] += 1
+
+
+def pytest_html_results_summary(prefix, summary, postfix):
+    postfix.extend([HTMLStyle.table(
+        html.thead(
+            html.tr([
+                HTMLStyle.th("Tests"),
+                HTMLStyle.th("Success"),
+                HTMLStyle.th("Failed"),
+                HTMLStyle.th("XFail"),
+                HTMLStyle.th("Error")]
+            ),
+        ),
+        [html.tbody(
+            html.tr([
+                HTMLStyle.td(k),
+                HTMLStyle.td(v['passed']),
+                HTMLStyle.td(v['failed']),
+                HTMLStyle.td(v['xfailed']),
+                HTMLStyle.td(v['error']),
+            ])
+        ) for k, v in results.items()])])
+
+
+def pytest_collection_modifyitems(session, config, items):
+    # Add test configuration as metadata (environment table)
+    try:
+        config._metadata = items[0].callspec.params['test_configuration']
+    except IndexError:
+        pass
+
+    # Add each test_case metadata as user_properties for its item
+    for item in items:
+        item.user_properties.extend([(key, value) for key, value in item.callspec.params['test_case'].items()])

--- a/tests/performance/test_api/conftest.py
+++ b/tests/performance/test_api/conftest.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import pytest
+import requests
 from py.xml import html
 from wazuh_testing.api import get_api_details_dict
 
@@ -16,6 +17,16 @@ def set_api_test_environment(request):
         configuration = getattr(request.module, 'configuration')
         kwargs.update({'host': configuration['host'], 'port': configuration['port']})
 
+    api_details = get_api_details_dict(**kwargs)
+
+    # Set a longer token expiration timeout
+    token_time_endpoint = f"{api_details['base_url']}/security/config"
+    headers = api_details['auth_headers']
+    response = requests.put(token_time_endpoint, headers=headers, json={'auth_token_exp_timeout': 999999}, verify=False)
+
+    assert response.status_code == 200, f'Failed to set API token expiration timeout. Response: {response.json()}'
+
+    # Ask for a new token and set it
     setattr(request.module, 'api_details', get_api_details_dict(**kwargs))
 
 

--- a/tests/performance/test_api/data/configuration.yaml
+++ b/tests/performance/test_api/data/configuration.yaml
@@ -1,0 +1,319 @@
+configuration:
+  host: 'localhost'
+  port: 55000
+  restart_delay: 30
+
+test_cases:
+
+# SERVICE ENDPOINTS
+
+  # GET
+
+  - endpoint: /cluster/local/info
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /cluster/nodes
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /cluster/healthcheck
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /cluster/status
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /cluster/local/config
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /cluster/api/config
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /cluster/configuration/validation
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/status
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/info
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/configuration
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/stats
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/logs
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/api/config
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /manager/configuration/validation
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /mitre
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /overview/agents
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /tasks/status
+    method: get
+    parameters: {}
+    body: {}
+
+  # PUT
+
+  - endpoint: /active-response
+    method: put
+    parameters: {}
+    body:
+      command: custom
+      custom: True
+    restart: False
+
+  - endpoint: /cluster/restart
+    method: put
+    parameters: {}
+    body: {}
+    restart: True
+
+  - endpoint: /manager/restart
+    method: put
+    parameters: {}
+    body: {}
+    restart: True
+
+  - endpoint: /rootcheck
+    method: put
+    parameters: {}
+    body: {}
+    restart: False
+
+  - endpoint: /syscheck
+    method: put
+    parameters: {}
+    body: {}
+    restart: False
+
+  # DELETE
+
+  - endpoint: /rootcheck
+    method: delete
+    parameters: {}
+    body: {}
+
+# RESOURCE ENDPOINTS
+
+  # POST
+
+  - endpoint: /agents
+    method: post
+    parameters: {}
+    body:
+      name: "new_test_agent"
+      ip: "any"
+
+  - endpoint: /agents/insert
+    method: post
+    parameters: {}
+    body:
+      name: "new_test_agent_insert"
+      ip: "any"
+
+  - endpoint: /agents/insert/quick
+    method: post
+    parameters:
+      agent_name: "new_test_agent_insert_quick"
+    body: {}
+
+  - endpoint: /groups
+    method: post
+    parameters:
+      group_id: "new_test_group"
+    body: {}
+
+  - endpoint: /security/users
+    method: post
+    parameters: {}
+    body:
+      username: "new_test_user"
+      password: "Password1!"
+      allow_run_as: True
+
+  - endpoint: /security/roles
+    method: post
+    parameters: {}
+    body:
+      name: "new_test_role"
+
+  - endpoint: /security/policies
+    method: post
+    parameters: {}
+    body:
+      name: "new_test_policy"
+      policy:
+        actions:
+          - "agent:read"
+        resources:
+          - "agent:id:99"
+        effect: "allow"
+
+  - endpoint: /security/rules
+    method: post
+    parameters: {}
+    body:
+      name: "new_test_security_rule"
+      rule:
+        MATCH:
+          name: "test"
+
+  # PUT
+
+  - endpoint: /agents/group
+    method: put
+    parameters:
+      group_id: "new_test_group"
+    body: {}
+    restart: True
+
+  - endpoint: /agents/group/new_test_group/restart
+    method: put
+    parameters: {}
+    body: {}
+    restart: True
+
+  - endpoint: /agents/restart
+    method: put
+    parameters: {}
+    body: {}
+    restart: True
+
+  # GET
+
+  - endpoint: /agents
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /agents/no_group
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /agents/outdated
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /decoders
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /groups
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /lists
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /rules
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /security/users
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /security/roles
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /security/policies
+    method: get
+    parameters: {}
+    body: {}
+
+  - endpoint: /security/rules
+    method: get
+    parameters: {}
+    body: {}
+
+  # DELETE
+
+  - endpoint: /agents
+    method: delete
+    parameters:
+      agents_list: "all"
+      status: "all"
+      older_than: "0s"
+    body: {}
+
+  - endpoint: /groups
+    method: delete
+    parameters:
+      groups_list: "all"
+    body: {}
+
+  - endpoint: /security/users
+    method: delete
+    parameters:
+      user_ids: "all"
+    body: {}
+
+  - endpoint: /security/roles
+    method: delete
+    parameters:
+      role_ids: "all"
+    body: {}
+
+  - endpoint: /security/policies
+    method: delete
+    parameters:
+      policy_ids: "all"
+    body: {}
+
+  - endpoint: /security/rules
+    method: delete
+    parameters:
+      rule_ids: "all"
+    body: {}

--- a/tests/performance/test_api/test_api.py
+++ b/tests/performance/test_api/test_api.py
@@ -1,0 +1,32 @@
+from json import dumps
+from os.path import join, dirname, realpath
+from time import sleep
+
+import pytest
+import requests
+from yaml import safe_load
+
+test_data = safe_load(open(join(dirname(realpath(__file__)), 'data', 'configuration.yaml')))
+configuration = test_data['configuration']
+api_details = dict()
+
+
+# Tests
+@pytest.mark.parametrize('test_configuration', [configuration])
+@pytest.mark.parametrize('test_case', test_data['test_cases'])
+def test_api_endpoints(test_case, test_configuration, set_api_test_environment):
+    """Make an API request for each `test_case`. `test_configuration` fixture is only used to add metadata to the
+    HTML report."""
+    base_url = api_details['base_url']
+    headers = api_details['auth_headers']
+    response = getattr(requests, test_case['method'])(f"{base_url}{test_case['endpoint']}", headers=headers,
+                                                      params=test_case['parameters'], json=test_case['body'],
+                                                      verify=False)
+
+    # Add useful information to report as stdout
+    print(f'Request elapsed time: {response.elapsed.total_seconds():.3f}s\n')
+    print(f'Status code: {response.status_code}\n')
+    print(f'Full response:\n{dumps(response.json(), indent=2)}')
+
+    assert response.status_code == 200
+    test_case['method'] == 'put' and test_case['restart'] and sleep(configuration['restart_delay'])


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7940 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team, 

We added a new set of tests for performance. As for the moment, we only have the API tests. These will test a bunch of Wazuh API endpoints on another machine to obtain certain metrics and results to see which endpoints are scalable and make the necessary improvements.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

These tests are configurable through the `data/configuration.yaml` file. This includes the following options:

```yaml
configuration:
  host: 'localhost'
  port: 55000
  restart_delay: 30

test_cases:
  - endpoint: /active-response
    method: put
    parameters: {}
    body:
      command: custom
      custom: True
    restart: False

  - endpoint: /agents
    method: get
    parameters: {}
    body: {}
```

More information about this file can be found in the README.

<!--
When proceed, this section should include new configuration parameters.
-->

## Report example

These tests are designed to use the `--html=report.html --self-contained-html` options, as we want to see certain metadata that is only accessible through this. This would be an example of the report:

![image](https://user-images.githubusercontent.com/37274979/114358869-b418ca80-9b73-11eb-8d51-d6921d7369b8.png)


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.

Regards,
Víctor Fernández