### PR TITLE
Remove cluster configuration for authd test

### DIFF
--- a/tests/integration/test_authd/data/wazuh_conf.yaml
+++ b/tests/integration/test_authd/data/wazuh_conf.yaml
@@ -32,10 +32,6 @@
             value: '/var/ossec/etc/sslmanager.key'
         - ssl_auto_negotiate:
             value: 'no'
-      - section: cluster
-        elements:
-        - disabled:
-            value: 'yes'
     - tags:
       - all
       apply_to_modules:

--- a/tests/integration/test_authd/test_authd.py
+++ b/tests/integration/test_authd/test_authd.py
@@ -20,10 +20,12 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 # Configurations
 
 def load_tests(path):
-    """ Loads a yaml file from a path
-    Returns
-    ----------
-    yaml structure
+    """Loads a yaml file from a path
+    Args:
+        path (str): path to the file.
+
+    Returns:
+        dict: dictionary containing the test info.
     """
     with open(path) as f:
         return yaml.safe_load(f)
@@ -83,14 +85,13 @@ def test_ossec_auth_messages(clean_client_keys_file, get_configuration, set_up_g
                              configure_sockets_environment, connect_to_sockets_module, wait_for_agentd_startup):
     """Check that every input message in authd port generates the adequate output
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys).
+    Raises:
+        ConnectionResetError: if wazuh-authd does not send the response to the agent through the socket.
+        AssertionError: if the response does not match the expected message.
     """
     test_case = set_up_groups['test_case']
     for stage in test_case:
-        # Reopen socket (socket is closed by maanger after sending message with client key)
+        # Reopen socket (socket is closed by manager after sending message with client key)
         receiver_sockets[0].open()
         expected = stage['output']
         message = stage['input']


### PR DESCRIPTION
|Related issue|
|---|
|closes #1212|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description


This PR closes #1212 issue by removing the cluster configuration block in `wazuh_conf.yaml`. Since the cluster is disabled by default, this configuration is not longer necessary.


## Configuration options

NA

## Logs example

<!--
Paste here related logs and alerts
-->

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.