### PR TITLE
Add a new integration test to check the registry sync responses.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1035,6 +1035,13 @@ def callback_detect_integrity_event(line):
     return None
 
 
+def callback_detect_registry_integrity_event(line):
+    match = re.match(r'.*Sending integrity control message: {"component":"fim_registry","type":"state","data":(.+)}', line)
+    if match:
+        return json.loads(match.group(1))
+    return None
+
+
 def callback_detect_integrity_state(line):
     event = callback_detect_integrity_event(line)
     if event:
@@ -1305,6 +1312,13 @@ def callback_detect_max_files_per_second(line):
     match = re.match(msg, line)
 
     return match is not None
+
+
+def callback_dbsync_no_data(line):
+    match = re.match(r'.*#!-fim_registry dbsync no_data (.+)', line)
+    if match:
+        return match.group(1)
+    return None
 
 
 def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None):

--- a/docs/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.md
+++ b/docs/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.md
@@ -1,0 +1,52 @@
+# Test registry responses win32
+
+This test performs several tests that check if the registry synchronization is performed properly.
+
+The first test checks that synchronization is performed after changes after the baseline scan.
+The second test checks that if a modification occurs when the Windows agent is down, the synchronization is triggered with the new values.
+
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 1 | Windows | 00:13:00 | [test_registry_responses.py](../../../../../../tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py)|
+
+## Test logic
+
+### test_registry_responses
+- The test waits for the baseline scan.
+- Then, the test will create several sub-keys inside a monitored key and values inside the monitored key and the sub-keys.
+- Finally, it will change the system clock and expect the synchronization event for the created keys/values.
+
+
+### test_registry_sync_after_restart
+- The test waits until the first synchronization is completed.
+- Then, the test stops the Windows agent and creates values inside a monitored key.
+- Finally, the test starts the agent and will check that the synchronization is performed with the new values.
+
+## Checks
+
+- [x] Check that FIM perform the registry synchronization after the baseline scan.
+- [x] Check that FIM perform the registry synchronization when changes occurs while the agent is down.
+- [x] Check that FIM perform properly the registry synchronization when using keys/values starting with `:`.
+- [x] Check that FIM perform properly the registry synchronization when using keys/values ending with `:`.
+- [x] Check that FIM perform properly the registry synchronization when using keys/values starting and ending with `:`.
+
+## Execution result
+
+```
+python -m pytest test_synchronization\test_registry_responses_win32.py
+=================================================================== test session starts ===================================================================
+platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
+rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
+plugins: html-2.0.1, metadata-1.11.0, testinfra-5.0.0
+collected 18 items
+test_synchronization\test_registry_responses_win32.py s.................                                                                             [100%]
+
+======================================================== 17 passed, 1 skipped in 808.74s (0:13:28) ========================================================
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_synchronization.test_registry_responses_win32

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -378,6 +378,7 @@ nav:
             - Test sync interval: tests/integration/test_fim/test_synchronization/test_sync_interval.md
             - Test synchronize integrity scan: tests/integration/test_fim/test_synchronization/test_synchronize_integrity_scan.md
             - Test synchronize integrity win32: tests/integration/test_fim/test_synchronization/test_synchronize_integrity_win32.md
+            - Test registry responses win32: tests/integration/test_fim/test_synchronization/test_registry_responses_win32.md
         - gCloud:
           - tests/integration/test_gcloud/index.md
           - Test configuration:

--- a/tests/integration/test_fim/test_synchronization/data/wazuh_conf_registry_responses_win32.yaml
+++ b/tests/integration/test_fim/test_synchronization/data/wazuh_conf_registry_responses_win32.yaml
@@ -1,0 +1,22 @@
+---
+# conf 1
+- tags:
+  - registry_sync_responses
+  apply_to_modules:
+  - test_registry_responses_win32
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_REGISTRY
+        attributes:
+        - check_mtime: 'no'
+        - arch: '64bit'
+    - synchronization:
+        elements:
+        - interval:
+            value: SYNC_INTERVAL
+        - max_interval:
+            value: SYNC_INTERVAL

--- a/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py
@@ -1,0 +1,208 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+from wazuh_testing import global_parameters
+import wazuh_testing.fim as fim
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# variables
+key = "HKEY_LOCAL_MACHINE"
+subkey = "SOFTWARE\\random_key"
+
+sync_interval = 20
+max_events = 20
+test_regs = [os.path.join(key, subkey)]
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_registry_responses_win32.yaml')
+conf_params = {'WINDOWS_REGISTRY': os.path.join(key, subkey), 'SYNC_INTERVAL': sync_interval}
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
+
+# configurations
+
+conf_params, conf_metadata = fim.generate_params(extra_params=conf_params,
+                                                 modes=['scheduled'])
+configurations = load_wazuh_configurations(configurations_path, __name__, params=conf_params, metadata=conf_metadata)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+def get_sync_msgs(tout, new_data=True):
+    """This function will look for as many synchronization events as possible (with a 'max_events' limit) and will
+       append all the json events in a list. If a Timeout is raised, the function will stop looking for events.
+    Params:
+        tout (int): Timeout that will be used to get the dbsync_no_data message.
+        new_data (bool): Specifies if the test will wait the event `dbsync_no_data`
+    Returns:
+        A list with all the events in json format.
+    """
+    events = []
+    if new_data:
+        wazuh_log_monitor.start(timeout=tout,
+                                callback=fim.callback_dbsync_no_data,
+                                error_message='Did not receive expected '
+                                              '"db sync no data" event')
+    for _ in range(0, max_events):
+        try:
+            js = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                         callback=fim.callback_detect_registry_integrity_event,
+                                         accum_results=1,
+                                         error_message='Did not receive expected '
+                                                       'Sending integrity control message"').result()
+        except TimeoutError:
+            break
+
+        events.append(js)
+
+    return events
+
+
+def find_path_in_event_list(path, event_list):
+    """Function that looks for a key path in a list of json events.
+    Params:
+        path (str): Path of the registry key.
+        event_list (list): List containing the events in JSON format.
+    Returns:
+        The event that matches the specified path. None if no event was found.
+    """
+    for event in event_list:
+        if event['path'] == path:
+            return event
+    return None
+
+
+def find_value_in_event_list(key_path, value_name, event_list):
+    """Function that looks for a key path and value_name in a list of json events.
+    Params:
+        path (str): Path of the registry key.
+        value_name (str): Name of the value
+        event_list (list): List containing the events in JSON format.
+    Returns:
+        The event that matches the specified path. None if no event was found.
+    """
+    for event in event_list:
+        if 'value_name' not in event.keys():
+            continue
+
+        if event['path'] == key_path and event['value_name'] == value_name:
+            return event
+
+    return None
+
+# tests
+
+
+@pytest.mark.parametrize('tags_to_apply', [{'registry_sync_responses'}])
+@pytest.mark.parametrize('key_name', [None, ':subkey1', 'subkey2:', ':subkey3:'])
+@pytest.mark.parametrize('value_name', [None, ':value1', 'value2:', ':value3:'])
+def test_registry_responses(key_name, value_name, tags_to_apply,
+                            get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """Test to check that the fields in synchronization events are decoded properly by the agent.
+    Params:
+        key_name (str): Name of the subkey that will be created in the test.
+        value_name (str): Name of the value that will be created in the test. If
+        tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+    Raises:
+        TimeoutError: If an expected event couldn't be captured.
+        ValueError: If a path or value are not in the sync event.
+    """
+    if key_name is None and value_name is None:
+        pytest.skip('key_name and value_name are None. Skipping')
+
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    # Wait for subkey sync messages only when it's expected
+    if key_name is not None:
+        fim.create_registry(fim.registry_parser[key], os.path.join(subkey, key_name), fim.KEY_WOW64_64KEY)
+        fim.check_time_travel(True, monitor=wazuh_log_monitor)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=fim.callback_detect_end_scan,
+                                error_message='Did not receive expected "end_scan" event').result()
+
+        events = get_sync_msgs(sync_interval + 15)
+        # Parent key sync event
+        assert find_path_in_event_list(test_regs[0], events) is not None, f"No sync event was found for {test_regs[0]}"
+
+        # Subkey sync event
+        subkey_path = os.path.join(test_regs[0], key_name)
+        assert find_path_in_event_list(subkey_path, events) is not None, f'No sync event was found for {subkey_path}'
+
+    if value_name is not None:
+        if key_name is not None:
+            key_path = os.path.join(subkey, key_name)
+        else:
+            key_path = subkey
+
+        v_path = os.path.join(key, key_path, value_name)
+
+        key_h = fim.RegOpenKeyEx(fim.registry_parser[key], key_path, 0, fim.KEY_ALL_ACCESS | fim.KEY_WOW64_64KEY)
+
+        fim.modify_registry_value(key_h, value_name, fim.REG_SZ, 'This is a test')
+        fim.check_time_travel(True, monitor=wazuh_log_monitor)
+
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=fim.callback_detect_end_scan,
+                                error_message='Did not receive expected "end_scan" event').result()
+
+        events = get_sync_msgs(sync_interval + 15)
+
+        assert find_value_in_event_list(
+               os.path.join(key, key_path), value_name, events) is not None, f"No sync event was found for {v_path}"
+
+
+@pytest.mark.parametrize('tags_to_apply', [{'registry_sync_responses'}])
+@pytest.mark.parametrize('key_name, value_name', [(':subkey1:', 'value1'),
+                                                  (':subkey2', ':value2')])
+def test_registry_sync_after_restart(key_name, value_name, tags_to_apply,
+                                     get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """
+    Test to check that FIM synchronizes the registry DB when a modification is performed while the agent is down.
+
+    Params:
+        key_name (str): Name of the subkey that will be created in the test.
+        value_name (str): Name of the value that will be created in the test. If
+        tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+    Raises:
+        TimeoutError: If an expected event couldn't be captured.
+        ValueError: If a path or value are not in the sync event.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    key_path = os.path.join(subkey, key_name)
+    v_path = os.path.join(key, key_path, value_name)
+
+    # wait until the sync is done.
+    get_sync_msgs(sync_interval)
+    # stops syscheckd
+    control_service('stop')
+
+    key_h = fim.create_registry(fim.registry_parser[key], key_path, fim.KEY_WOW64_64KEY)
+    fim.modify_registry_value(key_h, value_name, fim.REG_SZ, 'This is a test with syscheckd down.')
+    control_service('start')
+
+    events = get_sync_msgs(sync_interval + 15)
+
+    assert find_value_in_event_list(
+               os.path.join(key, key_path), value_name, events) is not None, f"No sync event was found for {v_path}"


### PR DESCRIPTION
|Related issue|
|---|
|#1210 |

Closes #1210
## Description
This PR adds a new integration test to check all the changes introduced in https://github.com/wazuh/wazuh/pull/8143

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail. If this test is executed in Windows agents with older versions, the agent will crash.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in wazuh-qa/docs.
- [X] `provision_documentation.sh` generate the docs without errors.