### PR TITLE
Add a base name for the images

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -15,6 +15,8 @@ def get_script_arguments():
                         help='Generate data visualizations for a specific target. Default binary.')
     parser.add_argument('-d', '--destination', dest='destination', default=gettempdir(),
                         help=f'Directory to store the images. Default {gettempdir()}')
+    parser.add_argument('-n', '--name', dest='name', default=None,
+                        help=f'Base name for the images. Default {None}.')
 
     return parser.parse_args()
 
@@ -26,7 +28,7 @@ def main():
     if not exists(destination):
         makedirs(destination)
     dv = DataVisualizer(dataframes=options.csv_list, target=options.visualization_target,
-                        compare=False, store_path=options.destination)
+                        compare=False, store_path=options.destination, base_name=options.name)
     dv.plot()
 
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -11,7 +11,8 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent_version='v4.0.0',
-               agent_os='debian8', eps=1000, run_duration=20, active_modules=[], modules_eps=None, fixed_message_size=None):
+               agent_os='debian8', eps=1000, run_duration=20, active_modules=[], modules_eps=None,
+               fixed_message_size=None):
     """Run a batch of agents connected to a manager with the same parameters.
 
     Args:
@@ -24,6 +25,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
         run_duration (int): Agent life time.
         active_modules (list): list with active modules names.
         modules_eps (list): list with eps for each active modules.
+        fixed_message_size (int): size in bytes for the message.
     """
 
     logger = logging.getLogger(f"P{os.getpid()}")
@@ -40,11 +42,10 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
             if module not in available_modules:
                 raise ValueError(f"Selected module: '{module}' doesn't exist on agent simulator!")
 
-        index = 0
         for module in available_modules:
             if module in active_modules:
+                index = list(active_modules).index(module)
                 agent.modules[module]['status'] = 'enabled'
-
                 if modules_eps is not None and 'eps' in agent.modules[module]:
                     agent.modules[module]['eps'] = modules_eps[index]
                 else:
@@ -144,6 +145,8 @@ def main():
             agents, args.manager_addr, args.agent_protocol, args.version, args.os, args.eps, args.duration,
             args.modules, args.modules_eps, args.fixed_message_size
         )
+
+        print(args.modules_eps)
 
         processes.append(Process(target=run_agents, args=arguments))
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -158,17 +158,17 @@ class Agent:
         self.fim_integrity = None
         self.syscollector = None
         self.modules = {
-            "keepalive": {"status": "enabled", "frequency": self.keepalive_frequency},
-            "fim": {"status": "enabled", "eps": self.fim_eps},
-            "fim_integrity": {"status": "disabled", "eps": self.fim_integrity_eps},
-            "syscollector": {"status": "disabled", "frequency": self.syscollector_frequency,
-                             "eps": self.syscollector_eps},
-            "rootcheck": {"status": "disabled", "frequency": self.rootcheck_frequency, "eps": self.rootcheck_eps},
-            "sca": {"status": "disabled", "frequency": self.sca_frequency, "eps": self.sca_eps},
-            "hostinfo": {"status": "disabled", "eps": self.hostinfo_eps},
-            "winevt": {"status": "disabled", "eps": self.winevt_eps},
-            "logcollector": {"status": "disabled", "eps": self.logcollector_eps},
-            "receive_messages": {"status": "enabled"},
+            'keepalive': {'status': 'enabled', 'frequency': self.keepalive_frequency},
+            'fim': {'status': 'enabled', 'eps': self.fim_eps},
+            'fim_integrity': {'status': 'disabled', 'eps': self.fim_integrity_eps},
+            'syscollector': {'status': 'disabled', 'frequency': self.syscollector_frequency,
+                             'eps': self.syscollector_eps},
+            'rootcheck': {'status': 'disabled', 'frequency': self.rootcheck_frequency, 'eps': self.rootcheck_eps},
+            'sca': {'status': 'disabled', 'frequency': self.sca_frequency, 'eps': self.sca_eps},
+            'hostinfo': {'status': 'disabled', 'eps': self.hostinfo_eps},
+            'winevt': {'status': 'disabled', 'eps': self.winevt_eps},
+            'logcollector': {'status': 'disabled', 'eps': self.logcollector_eps},
+            'receive_messages': {'status': 'enabled'},
         }
         self.sha_key = None
         self.upgrade_exec_result = None
@@ -865,7 +865,7 @@ class SCA:
         Args:
             event_type (str): Event type `[summary, check]`.
         """
-        event_data = {}
+        event_data = dict()
         event_data['type'] = event_type
         event_data['scan_id'] = self.last_scan_id
         self.last_scan_id += 1
@@ -1139,16 +1139,16 @@ class GeneratorWinevt:
         self.next_event_key = cycle(self.winevent_sources.keys())
 
     def generate_event(self, winevt_type=None):
-        """Genereate winevt event.
+        """Generate Windows event.
 
-        Generate the desired type of winevt event. If no type of winvt message is provided, all winvt message types
-        will be generated sequentially.
+        Generate the desired type of Windows event (winevt). If no type of winvt message is provided,
+        all winvt message types will be generated sequentially.
 
         Args:
             winevt_type (str): Winevt type message `system, security, application, windows-defender, sysmon`.
 
         Returns:
-            string: an windows event generatted message.
+            string: an windows event generated message.
         """
         self.current_event_key = next(self.next_event_key)
 
@@ -1199,7 +1199,7 @@ class GeneratorFIM:
         self.event_type = None
 
     def random_file(self):
-        """ Initialize file attribute.
+        """Initialize file attribute.
 
         Returns:
             string: the new randomized file for the instance
@@ -1208,7 +1208,7 @@ class GeneratorFIM:
         return self._file
 
     def random_size(self):
-        """ Initialize file size with random value
+        """Initialize file size with random value
 
         Returns:
             string: the new randomized file size for the instance
@@ -1587,7 +1587,6 @@ class InjectorThread(threading.Thread):
                 self.agent.update_checksum(new_checksum)
                 if self.totalMessages % eps == 0:
                     sleep(1.0 - ((time() - start_time) % 1.0))
-
 
     def run_module(self, module):
         """Send a module message from the agent to the manager.

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -69,18 +69,19 @@ class DataVisualizer:
         store_path (str): path to store the CSV images. Defaults to the temp directory.
         x_ticks_granularity (string): granularity of the Timestamp. It is set by default to minutes.
         x_ticks_interval (int): interval of the x-label.
-
+        base_name (str, optional): base name used to store the images.
     Attributes:
-        dataframes_path (list): paths of the CSVs.
+        dataframes_paths (list): paths of the CSVs.
         dataframe (pandas.Dataframe): dataframe containing the info from all the CSVs.
         compare (bool): boolean to compare the different datasets.
         target (str): string to set the visualization type.
         store_path (str): path to store the CSV images. Defaults to the temp directory.
         x_ticks_granularity (string): granularity of the Timestamp. It is set by default to minutes.
         x_ticks_interval (int): interval of the x-label.
+        base_name (str, optional): base name used to store the images.
     """
     def __init__(self, dataframes, target, compare=False, store_path=gettempdir(), x_ticks_granularity='minutes',
-                 x_ticks_interval=1):
+                 x_ticks_interval=1, base_name=None):
         self.dataframes_paths = dataframes
         self.dataframe = None
         self.compare = compare
@@ -89,6 +90,7 @@ class DataVisualizer:
         self._load_dataframes()
         self.x_ticks_granularity = x_ticks_granularity
         self.x_ticks_interval = x_ticks_interval
+        self.base_name = base_name
         sns.set(rc={'figure.figsize': (26, 9)})
 
     def _load_dataframes(self):
@@ -138,6 +140,8 @@ class DataVisualizer:
         self._set_x_ticks_interval(ax)
         plt.xticks(rotation=rotation)
         svg_name = sub(pattern=r'\(.*\)', string=y_label, repl='')
+        if self.base_name is not None:
+            svg_name = f"{self.base_name}_{svg_name}"
         plt.savefig(join(self.store_path, f"{svg_name}.svg"), dpi=1200, format='svg')
 
     def _plot_data(self, elements, title=None, generic_label=None):


### PR DESCRIPTION
This PR adds the possibility to add a base name for the images generated with the `data-visualizer`. It can be used as follows:
```shellsession
# data-visualizer -s /path/to/data.csv -t type -d /path/for/images -n base_name_for_the_images
```

It also fixes some errors in the agent_simulator and improves the docstrings.