### PR TITLE
Fix control_service for wazuh-clusterd and wazuh-apid

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -110,9 +110,12 @@ def control_service(action, daemon=None, debug_mode=False):
                 processes = []
 
                 for proc in psutil.process_iter():
-                    if daemon in proc.name():
                         try:
-                            processes.append(proc)
+                            if daemon in ['wazuh-clusterd', 'wazuh-apid']:
+                                if any(filter(lambda x: f"{daemon}.py" in x, proc.cmdline())):
+                                    processes.append(proc)
+                            elif daemon in proc.name():
+                                processes.append(proc)
                         except psutil.NoSuchProcess:
                             pass
                 try:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1221 

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Most of the processes in Wazuh run as `/var/ossec/bin/daemon-name`. However, wazuh-clusterd and wazuh-apid run as
```
/var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-clusterd.py
/var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh-apid.py
```
This wasn't being detected by `control_sevice` and it couldn't stop the processes.

We've changed how these processes are detected so it works correctly.

## Configuration options

NA

## Logs example

![image](https://user-images.githubusercontent.com/80041853/114547248-7e044500-9c5e-11eb-8a92-8017eb918067.png)


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.