### PR TITLE
Removed every cluster configuration block except in worker configuration

### DIFF
--- a/tests/integration/test_authd/data/wazuh_conf.yaml
+++ b/tests/integration/test_authd/data/wazuh_conf.yaml
@@ -65,10 +65,6 @@
             value: '/var/ossec/etc/sslmanager.key'
         - ssl_auto_negotiate:
             value: SSL_AUTO_NEGOTIATE
-      - section: cluster
-        elements:
-        - disabled:
-            value: 'yes'
     # conf 2
     - tags:
       - all
@@ -105,10 +101,6 @@
             value: 'no'
         - ssl_agent_ca:
             value: SSL_AGENT_CA
-      - section: cluster
-        elements:
-        - disabled:
-            value: 'yes'
     #local-server
     - tags:
       - all
@@ -121,10 +113,6 @@
             value: 'no'        
         - purge:
             value: 'no'
-      - section: cluster
-        elements:
-        - disabled:
-            value: 'yes'
     # conf 3
     - tags:
       - all
@@ -214,10 +202,6 @@
               value: '/var/ossec/etc/sslmanager.key'
           - ssl_auto_negotiate:
               value: 'no'
-      - section: cluster
-        elements:
-        - disabled:
-            value: 'yes'
     - tags:
       - all
       apply_to_modules:
@@ -251,7 +235,3 @@
             value: '/var/ossec/etc/sslmanager.key'
         - ssl_auto_negotiate:
             value: 'no'
-      - section: cluster
-        elements:
-        - disabled:
-            value: 'yes'


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1212 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #1212 issue by removing the cluster configuration block in wazuh_conf.yaml. Since the cluster is disabled by default, this configuration is not longer necessary.

## Configuration options

NA

## Logs example

https://ci.wazuh.info/view/Tests/job/test_integration/1596/console

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.