### PR TITLE
Rename ossec.log to wazuh.log and ossec.json to wazuh.json in IT

### DIFF
--- a/.github/ISSUE_TEMPLATE/test--fim.md
+++ b/.github/ISSUE_TEMPLATE/test--fim.md
@@ -55,7 +55,7 @@ typedef struct fim_entry_data {
 Configure in local_internal_options.conf:
 >`syscheck.debug=2`
 
-During the test, check `ossec.log` looking for debug, error or warning messages that may be unnecessarily repetitive or useless.
+During the test, check `wazuh.log` looking for debug, error or warning messages that may be unnecessarily repetitive or useless.
 
 ### FIM start:
 - [ ] FIM should not report any alerts until the first scan has finished and generated a base line.
@@ -323,7 +323,7 @@ typedef struct fim_entry_data {
 Configure in local_internal_options.conf:
 >`syscheck.debug=2`
 
-During the test, check `ossec.log` looking for debug, error or warning messages that may be unnecessarily repetitive or useless.
+During the test, check `wazuh.log` looking for debug, error or warning messages that may be unnecessarily repetitive or useless.
 
 ### FIM start:
 - [ ] FIM should not report any alerts until the first scan has finished and generated a base line.
@@ -573,7 +573,7 @@ typedef struct fim_entry_data {
 Configure in local_internal_options.conf:
 >`syscheck.debug=2`
 
-During the test, check `ossec.log` looking for debug, error or warning messages that may be unnecessarily repetitive or useless.
+During the test, check `wazuh.log` looking for debug, error or warning messages that may be unnecessarily repetitive or useless.
 
 ### FIM start:
 - [ ] FIM should not report any alerts until the first scan has finished and generated a base line.

--- a/.github/ISSUE_TEMPLATE/test--gcp.md
+++ b/.github/ISSUE_TEMPLATE/test--gcp.md
@@ -111,7 +111,7 @@ GCP
 
 **Description**
 
-The accepted values for this option are debug, info, warning, error, critical. Depending on which is configured, the ossec.log file will show messages from this severities. In debug mode, other severity messages and events can be seen at this file.
+The accepted values for this option are debug, info, warning, error, critical. Depending on which is configured, the wazuh.log file will show messages from this severities. In debug mode, other severity messages and events can be seen at this file.
 
 **Compatible versions**
 

--- a/.github/ISSUE_TEMPLATE/test--installation.md
+++ b/.github/ISSUE_TEMPLATE/test--installation.md
@@ -21,7 +21,7 @@ assignees: ''
 - [ ] Service is running after installation
 - [ ] Service status
 - [ ] Running processes
-- [ ] No errors in ossec.log
+- [ ] No errors in wazuh.log
 - [ ] CentOS5
 - [ ] Check uninstall (services / files / users)
 - [ ] /opt
@@ -37,7 +37,7 @@ assignees: ''
 - [ ] Check apt-get remove
 - [ ] Check apt-get purge
 - [ ] Check uninstall (services / files / users)
-- [ ] No errors in ossec.log
+- [ ] No errors in wazuh.log
 
 
 ## Mac OS X
@@ -73,4 +73,4 @@ assignees: ''
 - [ ] Service is running after installation
 - [ ] Service status
 - [ ] Running processes
-- [ ] No errors in ossec.log
+- [ ] No errors in wazuh.log

--- a/.github/ISSUE_TEMPLATE/test--mitre.md
+++ b/.github/ISSUE_TEMPLATE/test--mitre.md
@@ -112,7 +112,7 @@ Then, install Manager
 **Expected logs**
 
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-analysisd[19213] mitre.c:71 at mitre_load(): DEBUG: Mitre info loading failed. Mitre's database response has 0 elements.
 
@@ -148,7 +148,7 @@ Then, install Manager
 **Expected logs**
 
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-analysisd[19213] mitre.c:71 at mitre_load(): DEBUG: Mitre info loading failed. Query's response has 0 elements.
 
@@ -799,7 +799,7 @@ wazuh-control restart
 }
 ```
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-db[7314] wdb_parser.c:348 at wdb_parse(): DEBUG: Mitre DB Cannot execute SQL query; err database var/db/mitre.db: no such table: has_phase
 
@@ -874,7 +874,7 @@ wazuh-control restart
 }
 ```
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-db[27581] wdb_parser.c:348 at wdb_parse(): DEBUG: Mitre DB Cannot execute SQL query; err database var/db/mitre.db: no such table: attack
 
@@ -947,7 +947,7 @@ Change  id for ids in sql_create_attack = """CREATE TABLE IF NOT EXISTS attack (
 }
 ```
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-db[28187] wdb_parser.c:358 at wdb_parse(): DEBUG: Mitre DB Cannot execute SQL query; err database var/db/mitre.db: no such column: id
 
@@ -1025,7 +1025,7 @@ Change phase_name for phase in sql_create_has_phase = """CREATE TABLE IF NOT EXI
 }
 ```
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-db[3303] wdb_parser.c:358 at wdb_parse(): DEBUG: Mitre DB Cannot execute SQL query; err database var/db/mitre.db: no such table: has_phase
 
@@ -1098,7 +1098,7 @@ wazuh-control restart
 }
 ```
 ```
-# cat ossec.log | grep Mitre
+# cat wazuh.log | grep Mitre
 ```
 > wazuh-db[14586] wdb.c:212 at wdb_open_mitre(): ERROR: Can't open SQLite database 'var/db/mitre.db': unable to open database file
 

--- a/.github/ISSUE_TEMPLATE/test--vuln-detector.md
+++ b/.github/ISSUE_TEMPLATE/test--vuln-detector.md
@@ -306,7 +306,7 @@ Vulnerability detection
 
 **Description**
 
-To evaluate if a package is vulnerable or not, the module performs a comparison between its version and the version where the vulnerability was fixed/disappeared. These checks are displayed en the `ossec.log` file if debug level of modulesd is level 2.
+To evaluate if a package is vulnerable or not, the module performs a comparison between its version and the version where the vulnerability was fixed/disappeared. These checks are displayed en the `wazuh.log` file if debug level of modulesd is level 2.
 
 You can verify that the result of those checks is correct by checking the messages whose ID is 5467, 5468, 5533 or 5456.
 
@@ -583,7 +583,7 @@ Doesn't matter.
 
 **Expected logs**
 
-Since this test is the reverse of `VUL009`, verify that the `ossec.log` file does not have a false positive of that test.
+Since this test is the reverse of `VUL009`, verify that the `wazuh.log` file does not have a false positive of that test.
 
 
 ## VUL011

--- a/.github/ISSUE_TEMPLATE/test--windows-msi.md
+++ b/.github/ISSUE_TEMPLATE/test--windows-msi.md
@@ -20,7 +20,7 @@ To check in every test:
 - Correct version.
 - WUI doesn't show any strange information.
 - Service is running correctly.
-- No errors in ossec.log.
+- No errors in wazuh.log.
 
 - [ ] Successful installation by UI
 - [ ] Unattended installation
@@ -73,7 +73,7 @@ To check in every test:
 - It does not overwrite the `client.keys`, `ossec.conf` and `local_internal_options.conf`.
 - WUI doesn't show any strange information.
 - Service is restarted correctly.
-- No errors in ossec.log.
+- No errors in wazuh.log.
 - No duplicated package when upgrading from the EXE.
 
 - [ ] Upgrade MSI from 3.X.X

--- a/deps/wazuh_testing/wazuh_testing/mitre.py
+++ b/deps/wazuh_testing/wazuh_testing/mitre.py
@@ -27,7 +27,7 @@ def callback_detect_mitre_event(line):
     """Callback to detect Mitre event
 
     Args:
-        line (str): text to be compared with alerts in ossec.log
+        line (str): text to be compared with alerts in wazuh.log
 
     Returns:
         dict: JSON object on success or None on fail

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -283,7 +283,7 @@ def callback_start_up(agent_name):
 def callback_detect_remoted_started(port, protocol, connection_type="secure"):
     """Create a callback to detect if remoted was correctly started.
 
-    wazuh-remoted logs if it has correctly started for each connection type, the port and the protocol in the ossec.log
+    wazuh-remoted logs if it has correctly started for each connection type, the port and the protocol in the wazuh.log
 
     Args:
         port (int): port configured for wazuh-remoted.
@@ -445,18 +445,18 @@ def send_ping_pong_messages(protocol, manager_address, port):
 
 def check_remoted_log_event(wazuh_log_monitor, callback_pattern, error_message='', update_position=False,
                             timeout=REMOTED_GLOBAL_TIMEOUT):
-    """Allow to monitor the ossec.log file and search for a remoted event.
+    """Allow to monitor the wazuh.log file and search for a remoted event.
 
     Args:
         wazuh_log_monitor (FileMonitor): FileMonitor object to monitor the Wazuh log.
-        callback_pattern (str): Regex pattern to search in ossec.log.
+        callback_pattern (str): Regex pattern to search in wazuh.log.
         error_message (str): Message error to show in case that the callback pattern is not found in the expected time.
         update_position (boolean): True to search from the last line of the log file, False to search in the complete
                                    log file.
         timeout (int): Maximum time in seconds for event search in log.
 
     Raises:
-        TimeoutError: if callback pattern is not found in ossec.log in the expected time.
+        TimeoutError: if callback pattern is not found in wazuh.log in the expected time.
     """
     wazuh_log_monitor.start(
         timeout=timeout,
@@ -467,7 +467,7 @@ def check_remoted_log_event(wazuh_log_monitor, callback_pattern, error_message='
 
 
 def check_tcp_connection_established_log(wazuh_log_monitor, update_position=False, ip_address='127.0.0.1'):
-    """Allow to detect events of new incoming TCP connections in the ossec.log.
+    """Allow to detect events of new incoming TCP connections in the wazuh.log.
 
     Args:
         wazuh_log_monitor (FileMonitor): FileMonitor object to monitor the Wazuh log.
@@ -476,7 +476,7 @@ def check_tcp_connection_established_log(wazuh_log_monitor, update_position=Fals
         ip_address (str): IP address of incoming connection.
 
     Raises:
-        TimeoutError: if callback pattern is not found in ossec.log in the expected time.
+        TimeoutError: if callback pattern is not found in wazuh.log in the expected time.
     """
     callback_pattern = f".*New TCP connection at {ip_address}.*"
     error_message = f"Could not find the log with the following pattern {callback_pattern}"

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -11,7 +11,7 @@ if sys.platform == 'win32':
     WAZUH_PATH = os.path.join("C:", os.sep, "Program Files (x86)", "ossec-agent")
     WAZUH_CONF = os.path.join(WAZUH_PATH, 'ossec.conf')
     WAZUH_SOURCES = os.path.join('/', 'wazuh')
-    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'ossec.log')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'wazuh.log')
     PREFIX = os.path.join('c:', os.sep)
     GEN_OSSEC = None
     WAZUH_API_CONF = None
@@ -40,7 +40,7 @@ else:
     WAZUH_CONF = os.path.join(WAZUH_PATH, WAZUH_CONF_RELATIVE)
     WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')
     WAZUH_SECURITY_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'security.yaml')
-    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'wazuh.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
     ARCHIVES_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'archives', 'archives.log')
     AGENT_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-agentd.state')

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -41,6 +41,7 @@ else:
     WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')
     WAZUH_SECURITY_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'security.yaml')
     LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'wazuh.log')
+    CLUSTER_LOG_PATH = os.path.join(WAZUH_PATH, 'logs', 'cluster.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
     ARCHIVES_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'archives', 'archives.log')
     AGENT_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-agentd.state')

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -123,7 +123,7 @@ def mock_cve_db(func):
 
         func(*args, **kwargs)
 
-        # Truncate ossec.log
+        # Truncate wazuh.log
         file.truncate_file(LOG_FILE_PATH)
 
         control_service('start', daemon='wazuh-modulesd')
@@ -627,7 +627,7 @@ def check_log_event(wazuh_log_monitor, log_event, update_position=False, timeout
     wazuh_log_monitor: FileMonitor
         FileMonitor object to monitor the Wazuh log
     log_event: str
-        Log event to find in ossec.log
+        Log event to find in wazuh.log
     update_position : boolean
         Filter configuration parameter to search in Wazuh log
     timeout: str
@@ -648,7 +648,7 @@ def check_feed_imported_successfully(wazuh_log_monitor, log_system_name, expecte
 
     Args:
         wazuh_log_monitor (FileMonitor): FileMonitor object to monitor the Wazuh log
-        log_system_name (str): system name in ossec.log. For instance 'Red Hat Enterprise Linux'
+        log_system_name (str): system name in wazuh.log. For instance 'Red Hat Enterprise Linux'
         expected_vulnerabilities_number (int): number of expected vulnerabilities imported in the BD
         update_position (boolean): filter configuration parameter to search in Wazuh log
         timeout (str): timeout to check the event in Wazuh log

--- a/docs/tests/integration/test_vulnerability_detector/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/index.md
@@ -38,16 +38,16 @@ The following section shows the classification of tests in the different tiers.
 #### Test general settings
 
 - **[test_general_settings_enabled](test_general_settings/test_general_settings_enabled.md#test-general-settings-enabled)**:
-Tests that modify the value of `enabled` tag in `ossec.conf` and check the result in `ossec.log`.
+Tests that modify the value of `enabled` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 - **[test_general_settings_ignore_time](test_general_settings/test_general_settings_ignore_time.md#test-general-settings-ignore-time)**:
-Tests that modify the value of `ignore_time` tag in `ossec.conf`, set different times and check the result in `ossec.log`.
+Tests that modify the value of `ignore_time` tag in `ossec.conf`, set different times and check the result in `wazuh.log`.
 
 - **[test_general_settings_interval](test_general_settings/test_general_settings_interval.md#test-general-settings-interval)**:
-Tests that modify the value of `interval` tag in `ossec.conf`, set different times and check the result in `ossec.log`.
+Tests that modify the value of `interval` tag in `ossec.conf`, set different times and check the result in `wazuh.log`.
 
 - **[test_general_settings_run_on_start](test_general_settings/test_general_settings_run_on_start.md#test-general-settings-run-on-start)**:
-Tests that modify the value of `run_on_start` tag in `ossec.conf` and check the result in `ossec.log`.
+Tests that modify the value of `run_on_start` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 #### Test scan results
 
@@ -84,18 +84,18 @@ in the logs.
 #### Test providers
 
 - **[test_providers_enabled](test_providers/test_providers_enabled.md#test-providers-enabled)**: Tests that
-modify the value of `enabled` tag in `ossec.conf` and check the result in `ossec.log`.
+modify the value of `enabled` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 - **[test_providers_os](test_providers/test_providers_os.md#test-providers-os)**: Tests that modify the value of
-`os` tag in `ossec.conf`, set different `os` for Canonical and Debian, and check the result in `ossec.log`.
+`os` tag in `ossec.conf`, set different `os` for Canonical and Debian, and check the result in `wazuh.log`.
 
 - **[test_providers_update_from_year](test_providers/test_providers_update_from_year.md#test-providers-update-from-year)**:
 Tests modify the value of `update_from_year` tag in `ossec.conf`, set different years and check the result in
-`ossec.log`.
+`wazuh.log`.
 
 - **[test_providers_update_interval](test_providers/test_providers_update_interval.md#test-providers-update-interval)**:
 Tests that modify the value of `interval` tag in `ossec.conf`, set different time intervals and units, and check the
-result in `ossec.log`.
+result in `wazuh.log`.
 
 ---
 

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.md
@@ -31,7 +31,7 @@ For instance:
 
 - [x] Feed is imported successfully with the original feed.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.md
@@ -45,7 +45,7 @@ In this case, for each of the following characters, a test is performed in which
 
 - [x] Feed is imported successfully with the original feed.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.md
@@ -47,7 +47,7 @@ For example:
 
 - [x] Feed is imported successfully with the original feed.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `Modulesd` is running after the test (don't crash).
 
 ## Observed behavior
@@ -65,7 +65,7 @@ For other cases, the feed will be imported successfully.
 **Comments**
 
 Marked as **expected fail** when `dpkginfo_test` is modified due to feed is not imported but the opposite is shown in
-`ossec.log`. Related issue https://github.com/wazuh/wazuh/issues/5275
+`wazuh.log`. Related issue https://github.com/wazuh/wazuh/issues/5275
 
 > Note: **expected fail** means that you expect a test to fail for some reason. A common example is a test for a feature
 not yet implemented, or a bug not yet fixed.

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.md
@@ -30,7 +30,7 @@ Each test consists of removing one of the following tags from the feed:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior
@@ -55,7 +55,7 @@ Marked as **expected fail** when there is one of the following tags missing:
 xfail_tags = ['definitions', 'metadata', 'reference', 'criteria', 'tests']
 ```
 
-due to vulnerabilities are not imported even though the opposite is logged in `ossec.log`. Related issue
+due to vulnerabilities are not imported even though the opposite is logged in `wazuh.log`. Related issue
 https://github.com/wazuh/wazuh/issues/5275
 
 > Note: **expected fail** means that you expect a test to fail for some reason. A common example is a test for a feature

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.md
@@ -32,7 +32,7 @@ For instance:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.md
@@ -45,7 +45,7 @@ For each of those characters, these tests will be executed:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.md
@@ -43,7 +43,7 @@ For example:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.md
@@ -32,7 +32,7 @@ Each test consists of removing one of the following tags from the feed:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.md
@@ -31,7 +31,7 @@ For instance:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] Check log event: `Unexpected JSON key`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.md
@@ -50,7 +50,7 @@ A test is performed for each of the following cases:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.md
@@ -41,7 +41,7 @@ For example:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior
@@ -61,7 +61,7 @@ For other cases, the feed will be imported successfully.
 **Comments**
 
 Marked as **expected fail** when `affected_packages` is modified due to vulnerabilities have not been imported but the
-opposite is shown in `ossec.log`. Related issue https://github.com/wazuh/wazuh/issues/5272
+opposite is shown in `wazuh.log`. Related issue https://github.com/wazuh/wazuh/issues/5272
 
 > Note: **expected fail** means that you expect a test to fail for some reason. A common example is a test for a feature
 not yet implemented, or a bug not yet fixed.

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.md
@@ -28,7 +28,7 @@ Each test consists of removing one of the following fields from the feed:
 
 - [x] The original feed is successfully imported.
 - [x] Vulnerabilities are inserted into the `vulnerabilities` database.
-- [x] Action status message displayed in `ossec.log`.
+- [x] Action status message displayed in `wazuh.log`.
 - [x] `wazuh-modulesd` is still running once the test has finished (it didn't crash).
 
 ## Observed behavior
@@ -46,7 +46,7 @@ For other cases, the feed will be imported successfully.
 **Comments**
 
 Marked as **expected fail** when `affected_packages` is missing due to vulnerabilities have not been imported but the
-opposite is shown in `ossec.log`. Related issue https://github.com/wazuh/wazuh/issues/5272
+opposite is shown in `wazuh.log`. Related issue https://github.com/wazuh/wazuh/issues/5272
 
 > Note: **expected fail** means that you expect a test to fail for some reason. A common example is a test for a feature
 not yet implemented, or a bug not yet fixed.

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/index.md
@@ -29,15 +29,15 @@ process gets started.
 ### Generic tests
 
 - **[test_general_settings_enabled](test_general_settings/test_general_settings_enabled.md#test-general-settings-enabled)**:
-Tests that modify the value of `enabled` tag in `ossec.conf` and check the result in `ossec.log`.
+Tests that modify the value of `enabled` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 - **[test_general_settings_ignore_time](test_general_settings/test_general_settings_ignore_time.md#test-general-settings-ignore-time)**:
 Tests that modify the value of `ignore_time` tag in `ossec.conf`, set different times and checking the result in
-`ossec.log`.
+`wazuh.log`.
 
 - **[test_general_settings_interval](test_general_settings/test_general_settings_interval.md#test-general-settings-interval)**:
 Tests that modify the value of `interval` tag in `ossec.conf`, set different times and checking the result in
-`ossec.log`.
+`wazuh.log`.
 
 - **[test_general_settings_run_on_start](test_general_settings/test_general_settings_run_on_start.md#test-general-settings-run-on-start)**:
-Tests that modify the value of `run_on_start` tag in `ossec.conf` and check the result in `ossec.log`.
+Tests that modify the value of `run_on_start` tag in `ossec.conf` and check the result in `wazuh.log`.

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.md
@@ -1,6 +1,6 @@
 # Test general settings enabled
 
-The tests will modify the value of `enabled` tag in `ossec.conf` and check the result in `ossec.log`.
+The tests will modify the value of `enabled` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 ## General info
 
@@ -10,7 +10,7 @@ The tests will modify the value of `enabled` tag in `ossec.conf` and check the r
 
 ## Test logic
 
-If `enabled` is set to `yes` then, the test will check the following pattern in `ossec.log`:
+If `enabled` is set to `yes` then, the test will check the following pattern in `wazuh.log`:
 
 ```
 (.*)wazuh-modulesd:vulnerability-detector(.*)
@@ -22,7 +22,7 @@ and not
 (.*)DEBUG: Module disabled. Exiting...(.*)
 ```
 
-If `enabled` is set to `no` then, the test will check the following pattern in `ossec.log`:
+If `enabled` is set to `no` then, the test will check the following pattern in `wazuh.log`:
 
 ```
 (.*)DEBUG: Module disabled. Exiting...(.*)

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.md
@@ -1,7 +1,7 @@
 # Test general settings ignore time
 
 The tests will modify the value of `ignore_time` tag in `ossec.conf`, set different times and check the result in
-`ossec.log`.
+`wazuh.log`.
 
 ## General info
 

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.md
@@ -1,6 +1,6 @@
 # Test general settings interval
 
-The tests will modify the value of `interval` tag in `ossec.conf`, set different times and check the result in `ossec.log`.
+The tests will modify the value of `interval` tag in `ossec.conf`, set different times and check the result in `wazuh.log`.
 
 ## General info
 
@@ -22,7 +22,7 @@ and time values:
 [1,2,5]
 ```
 
-The test will check in `ossec.log` if the following message appears:
+The test will check in `wazuh.log` if the following message appears:
 
 ```
 <vulnerability_detector_prefix> Sleeping for (.*)...
@@ -30,7 +30,7 @@ The test will check in `ossec.log` if the following message appears:
 
 ## Checks
 
-- [x] Vulnerability Detector process thread sleeps the time set, checking `ossec.log` message.
+- [x] Vulnerability Detector process thread sleeps the time set, checking `wazuh.log` message.
 
 ## Observed behavior
 

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.md
@@ -1,7 +1,7 @@
 ::: tests.integration.test_vulnerability_detector.test_general_settings.test_general_settings_run_on_start
 # Test general settings run on start
 
-The tests will modify the value of `run_on_start` tag in `ossec.conf` and check the result in `ossec.log`.
+The tests will modify the value of `run_on_start` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 ## General info
 
@@ -12,14 +12,14 @@ The tests will modify the value of `run_on_start` tag in `ossec.conf` and check 
 ## Test logic
 
 If `run_on_start` is set to `yes`, the test will check if the scan begins after `wazuh-modulesd` gets started by
-checking the following pattern in `ossec.log`:
+checking the following pattern in `wazuh.log`:
 
 ```
 (.*)Starting vulnerability scan(.*)
 ```
 
 If `run_on_start` is set to `no`, the test will check if the scan doesn't begin after `wazuh-modulesd` gets started.
-This is done by checking if the following pattern doesn't exist in `ossec.log`:
+This is done by checking if the following pattern doesn't exist in `wazuh.log`:
 
 ```
 (.*)Starting vulnerability scan(.*)
@@ -28,9 +28,9 @@ This is done by checking if the following pattern doesn't exist in `ossec.log`:
 ## Checks
 
 - [x] Vulnerability scan starts after restarting `wazuh-modulesd` when `run_on_start` is set to `yes`, checking
-`ossec.log` message.
+`wazuh.log` message.
 - [x] Vulnerability scan does not start after restarting `wazuh-modulesd` when `run_on_start` is set to `no`, checking
-`ossec.log` message.
+`wazuh.log` message.
 
 ## Observed behavior
 

--- a/docs/tests/integration/test_vulnerability_detector/test_providers/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_providers/index.md
@@ -28,15 +28,15 @@ working as expected. These general options are:
 ### Generic tests
 
 - **[test_providers_enabled](test_providers/test_providers_enabled.md#test-providers-enabled)**: Tests that
-modify the value of `enabled` tag in `ossec.conf` and checking the result in `ossec.log`.
+modify the value of `enabled` tag in `ossec.conf` and checking the result in `wazuh.log`.
 
 - **[test_providers_os](test_providers/test_providers_os.md#test-providers-os)**: Tests that modify the value
-of `os` tag in `ossec.conf`, set different os for Canonical and Debian and check the result in `ossec.log`.
+of `os` tag in `ossec.conf`, set different os for Canonical and Debian and check the result in `wazuh.log`.
 
 - **[test_providers_update_from_year](test_providers/test_providers_update_from_year.md#test-providers-update-from-year)**:
 Tests that modify the value of `update_from_year` tag in `ossec.conf`, set different years and check the result in
-`ossec.log`.
+`wazuh.log`.
 
 - **[test_providers_update_interval](test_providers/test_providers_update_interval.md#test-providers-update-interval)**:
 Tests that modify the value of `interval` tag in `ossec.conf`, set different time intervals and units, and check the
-result in `ossec.log`.
+result in `wazuh.log`.

--- a/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.md
@@ -1,6 +1,6 @@
 # Test providers enabled
 
-The tests will modify the value of `enabled` tag in `ossec.conf` and check the result in `ossec.log`.
+The tests will modify the value of `enabled` tag in `ossec.conf` and check the result in `wazuh.log`.
 
 ## General info
 
@@ -10,13 +10,13 @@ The tests will modify the value of `enabled` tag in `ossec.conf` and check the r
 
 ## Test logic
 
-If `enabled` is set to `yes` then, the test will check this pattern in `ossec.log`:
+If `enabled` is set to `yes` then, the test will check this pattern in `wazuh.log`:
 
 ```
 (.*)Starting '<provider_name>' database update
 ```
 
-If `enabled` is set to `no` then, the test will check if this pattern does not appear in `ossec.log`:
+If `enabled` is set to `no` then, the test will check if this pattern does not appear in `wazuh.log`:
 
 ```
 (.*)Starting '<provider_name>' database update

--- a/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.md
@@ -1,7 +1,7 @@
 # Test providers os
 
 The tests will modify the value of `os` tag in `ossec.conf`, set different os for Canonical and Debian and check the
-result in `ossec.log`.
+result in `wazuh.log`.
 
 ## General info
 
@@ -27,13 +27,13 @@ Each of these elements will modify the `os` provider setting in the `ossec.conf`
 
 Then, it will run the following checks:
 
-- If `os` provider has value (Canonical and Debian), then check this pattern in `ossec.log`
+- If `os` provider has value (Canonical and Debian), then check this pattern in `wazuh.log`
 
 ```
 (.*)Starting '<provider_name>' database update
 ```
 
-- If `os` provider has not any value (Red Hat and NVD), then check this pattern in `ossec.log`:
+- If `os` provider has not any value (Red Hat and NVD), then check this pattern in `wazuh.log`:
 
 ```
 (.*)Could not find: warning 'os' option can only be used in a single-provider

--- a/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.md
@@ -1,7 +1,7 @@
 # Test providers update from year
 
 Tests that are based on modifying the value of `update_from_year` tag in `ossec.conf`, setting different years and
-checking the result in `ossec.log`.
+checking the result in `wazuh.log`.
 
 ## General info
 

--- a/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.md
@@ -1,7 +1,7 @@
 # Test providers update interval
 
 The tests will modify the value of `interval` tag in `ossec.conf`, set different time intervals and units, and check
-the result in `ossec.log`.
+the result in `wazuh.log`.
 
 ## General info
 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.md
@@ -22,14 +22,14 @@ The test will run these actions:
 - Mock the system.
 - Insert [debian custom feed and vulnerable packages](../../test_scan_results/data/debian_vulnerabilities.json).
 - Import NVD vulnerabilities from [custom NVD feed](../../test_scan_results/data/real_nvd_feed.json).
-- Check this event in `ossec.log`:
+- Check this event in `wazuh.log`:
   ```
   The '{package}' package .* from agent .* is vulnerable to '{cve}'
   ```
 
 ## Checks
 
-- [x] A report of the corresponding vulnerabilities is generated in the `ossec.log`.
+- [x] A report of the corresponding vulnerabilities is generated in the `wazuh.log`.
 
 ## Observed behavior
 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.md
@@ -22,14 +22,14 @@ The tests will execute these actions:
 - Mock the system.
 - Insert [Red Hat custom feed and vulnerable packages](../../test_scan_results/data/redhat_vulnerabilities.json).
 - Import NVD vulnerabilities from [custom NVD feed](../../test_scan_results/data/real_nvd_feed.json).
-- Check this event in `ossec.log`:
+- Check this event in `wazuh.log`:
   ```
   The '{package}' package .* from agent .* is vulnerable to '{cve}'
   ```
 
 ## Checks
 
-- [x] A report of the corresponding vulnerabilities is generated in the `ossec.log`.
+- [x] A report of the corresponding vulnerabilities is generated in the `wazuh.log`.
 
 ## Observed behavior
 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.md
@@ -29,7 +29,7 @@ The test will run these actions
 - Insert a dummy vulnerability in the `vulnerabilities` table and mock an imported feed from a provider.
 - Insert **simulated** NVD [vulnerable packages](../../test_scan_results/data/vulnerabilities.json)
 - Import **simulated** NVD vulnerabilities from [custom NVD feed](../../test_scan_results/data/custom_nvd_feed.json).
-- Check these events in `ossec.log`:
+- Check these events in `wazuh.log`:
 
   - If *Windows*:
 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.md
@@ -27,7 +27,7 @@ The following actions are done:
 - Insert **simulated** NVD [vulnerable packages](../../test_scan_results/data/vulnerabilities.json) and provider
   **simulated** [vulnerable packages](../../test_scan_results/data/vulnerabilities.json)
 - Import **simulated** NVD vulnerabilities from [custom NVD feed](../../test_scan_results/data/custom_nvd_feed.json).
-- Check these events in `ossec.log`:
+- Check these events in `wazuh.log`:
 
   - For each provider, check:
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -61,7 +61,7 @@ def restart_wazuh(get_configuration, request):
     # Stop Wazuh
     control_service('stop')
 
-    # Reset ossec.log and start a new monitor
+    # Reset wazuh.log and start a new monitor
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
@@ -72,7 +72,7 @@ def restart_wazuh(get_configuration, request):
 
 @pytest.fixture(scope='module')
 def reset_ossec_log(get_configuration, request):
-    # Reset ossec.log and start a new monitor
+    # Reset wazuh.log and start a new monitor
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -37,7 +37,7 @@ with open(test_data_file) as f:
 
 # Global RemotedSimulator variable
 remoted_server = None
-# Global FileMonitor variable to watch ossec.log
+# Global FileMonitor variable to watch wazuh.log
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Variables
@@ -93,7 +93,7 @@ def test_agentd_state(configure_environment, test_case: list):
     else:
         set_state_interval(1, internal_options)
 
-    # Truncate ossec.log in order to watch it correctly
+    # Truncate wazuh.log in order to watch it correctly
     truncate_file(LOG_FILE_PATH)
 
     # Remove state file to check if agent behavior is as expected

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -42,7 +42,7 @@ else:
     state_file_path = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-agentd.state')
     internal_options = os.path.join(WAZUH_PATH, 'etc', 'internal_options.conf')
 
-# ossec.log watch callbacks
+# wazuh.log watch callbacks
 callbacks = {
     'interval_not_valid': callback_state_interval_not_valid,
     'interval_not_found': callback_state_interval_not_found,
@@ -76,7 +76,7 @@ def test_agentd_state_config(configure_environment, test_case: list):
 
     control_service('stop', 'wazuh-agentd')
 
-    # Truncate ossec.log in order to watch it correctly
+    # Truncate wazuh.log in order to watch it correctly
     truncate_file(LOG_FILE_PATH)
 
     # Remove state file to check if agent behavior is as expected
@@ -94,7 +94,7 @@ def test_agentd_state_config(configure_environment, test_case: list):
             time.sleep(test_case['interval'])
         assert test_case['state_file_exist'] == os.path.exists(state_file_path)
 
-    # Follow ossec.log to find desired messages by a callback
+    # Follow wazuh.log to find desired messages by a callback
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             callback=callbacks.get(test_case['log_expect']),

--- a/tests/integration/test_authd/test_authd_name_ip_pass.py
+++ b/tests/integration/test_authd/test_authd_name_ip_pass.py
@@ -89,7 +89,7 @@ def clean_client_keys_file():
 
 
 def read_random_pass():
-    osseclog_path = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
+    osseclog_path = os.path.join(WAZUH_PATH, 'logs', 'wazuh.log')
     passw = None
     try:
         with open(osseclog_path, 'r') as log_file:

--- a/tests/integration/test_fim/test_files/conftest.py
+++ b/tests/integration/test_fim/test_files/conftest.py
@@ -13,7 +13,7 @@ from wazuh_testing.tools.services import control_service
 @pytest.fixture(scope='module')
 def restart_syscheckd(get_configuration, request):
     """
-    Reset ossec.log and start a new monitor.
+    Reset wazuh.log and start a new monitor.
     """
     control_service('stop', daemon='wazuh-syscheckd')
     truncate_file(LOG_FILE_PATH)

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
@@ -129,7 +129,7 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
 
     /testdir -> has a restrict configuration
     /testdir/subdir -> has no restrict configuration
-    Only /testdir/subdir events should appear in ossec.log
+    Only /testdir/subdir events should appear in wazuh.log
 
     This test is intended to be used with valid configurations files. Each execution of this test will configure
     the environment properly, restart the service and wait for the initial scan.

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_create_after_delete_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_create_after_delete_dir.py
@@ -56,7 +56,7 @@ def test_create_after_delete(tags_to_apply, get_configuration, configure_environ
 
     This test performs the following steps:
     - Monitor a directory that exist.
-    - Create some files inside. Check that it does produce events in ossec.log.
+    - Create some files inside. Check that it does produce events in wazuh.log.
     - Delete the directory and wait for a second.
     - Create the directory again and wait for a second.
     - Check that creating files within the directory do generate events again.

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -49,7 +49,7 @@ def get_configuration(request):
 @pytest.fixture(scope='function')
 def restart_syscheck_function(get_configuration, request):
     """
-    Reset ossec.log and start a new monitor.
+    Reset wazuh.log and start a new monitor.
     """
     control_service('stop', daemon='wazuh-syscheckd')
     truncate_file(fim.LOG_FILE_PATH)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_new_dirs.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_new_dirs.py
@@ -68,7 +68,7 @@ def test_new_directory(tags_to_apply, get_configuration, configure_environment, 
 
     This test performs the following steps:
     - Monitor a directory that does not exist.
-    - Create the directory with files inside. Check that this does not produce events in ossec.log.
+    - Create the directory with files inside. Check that this does not produce events in wazuh.log.
     - Move time forward to the next scheduled scan.
     - Check that now creating files within the directory do generate events.
 

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -231,14 +231,14 @@ def create_long_path(length, path_name):
 
 
 def find_ossec_log(regex=None, strlog=None):
-    """Find in the ossec.log the specified strlog and return the first group if match with the regex.
+    """Find in the wazuh.log the specified strlog and return the first group if match with the regex.
 
     Parameters
     ----------
     regex : str
         Regular expression to be matched.
     strlog : str
-        String to be found in the ossec.log.
+        String to be found in the wazuh.log.
 
     Returns
     -------

--- a/tests/integration/test_fim/test_registry/conftest.py
+++ b/tests/integration/test_fim/test_registry/conftest.py
@@ -13,7 +13,7 @@ from wazuh_testing.tools.services import control_service
 @pytest.fixture(scope='module')
 def restart_syscheckd(get_configuration, request):
     """
-    Reset ossec.log and start a new monitor.
+    Reset wazuh.log and start a new monitor.
     """
     control_service('stop', daemon='wazuh-syscheckd')
     truncate_file(LOG_FILE_PATH)

--- a/tests/integration/test_fim/test_synchronization/conftest.py
+++ b/tests/integration/test_fim/test_synchronization/conftest.py
@@ -13,7 +13,7 @@ from wazuh_testing.tools.services import control_service
 @pytest.fixture(scope='module')
 def restart_syscheckd(get_configuration, request):
     """
-    Reset ossec.log and start a new monitor.
+    Reset wazuh.log and start a new monitor.
     """
     control_service('stop', daemon='wazuh-syscheckd')
     truncate_file(LOG_FILE_PATH)

--- a/tests/integration/test_fim/test_synchronization/test_response_timeout.py
+++ b/tests/integration/test_fim/test_synchronization/test_response_timeout.py
@@ -78,11 +78,11 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
         truncate_agent_log()
         start_time = datetime.now()
         while datetime.now() < start_time + timedelta(seconds=time_out):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/ossec.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if callback_detect_end_scan(line):
                     return
-        pytest.fail("No 'File integrity monitoring scan ended.' was found on ossec.log.")
+        pytest.fail("No 'File integrity monitoring scan ended.' was found on wazuh.log.")
 
     def create_files_in_agent():
         ssh.exec_command("sudo systemctl stop wazuh-agent")
@@ -105,7 +105,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     def detect_synchronization_start(time_out=1):
         start_time = datetime.now()
         while datetime.now() < start_time + timedelta(seconds=time_out):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/ossec.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if callback_detect_synchronization(line):
                     return extract_datetime(str(line))
@@ -114,7 +114,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     def wait_agent_dbsync_finish():
         previous_time = datetime.now()
         while datetime.now() - previous_time < timedelta(seconds=3):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/ossec.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if "syscheck dbsync" in line:
                     previous_time = datetime.now()
@@ -124,7 +124,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     def wait_agent_integrity_control():
         previous_time = datetime.now()
         while datetime.now() - previous_time < timedelta(seconds=1):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/ossec.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if "Sending integrity control message" in line:
                     previous_time = datetime.now()
@@ -154,7 +154,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     check_apply_test({'response_timeout'}, get_configuration['tags'])
 
     # Variables
-    LOG_PATH = "/var/ossec/logs/ossec.log"
+    LOG_PATH = "/var/ossec/logs/wazuh.log"
     DIR_NAME = "/testdir1"
     AGENT_IP = "172.19.0.201"
     USERNAME = "vagrant"

--- a/tests/integration/test_fim/test_synchronization/test_response_timeout.py
+++ b/tests/integration/test_fim/test_synchronization/test_response_timeout.py
@@ -78,7 +78,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
         truncate_agent_log()
         start_time = datetime.now()
         while datetime.now() < start_time + timedelta(seconds=time_out):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command (f"sudo cat {LOG_FILE_PATH}")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if callback_detect_end_scan(line):
                     return
@@ -105,7 +105,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     def detect_synchronization_start(time_out=1):
         start_time = datetime.now()
         while datetime.now() < start_time + timedelta(seconds=time_out):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command(f"sudo cat {LOG_FILE_PATH}")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if callback_detect_synchronization(line):
                     return extract_datetime(str(line))
@@ -114,7 +114,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     def wait_agent_dbsync_finish():
         previous_time = datetime.now()
         while datetime.now() - previous_time < timedelta(seconds=3):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command(f"sudo cat {LOG_FILE_PATH}")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if "syscheck dbsync" in line:
                     previous_time = datetime.now()
@@ -124,7 +124,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     def wait_agent_integrity_control():
         previous_time = datetime.now()
         while datetime.now() - previous_time < timedelta(seconds=1):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command("sudo cat /var/ossec/logs/wazuh.log")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command(f"sudo cat {LOG_FILE_PATH}")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if "Sending integrity control message" in line:
                     previous_time = datetime.now()
@@ -133,7 +133,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
             truncate_agent_log()
 
     def truncate_agent_log():
-        ssh.exec_command("sudo truncate -s 0 " + LOG_PATH)
+        ssh.exec_command("sudo truncate -s 0 " + LOG_FILE_PATH)
 
     def extract_datetime(line):
         return datetime.strptime(line[0:19], '%Y/%m/%d %H:%M:%S')
@@ -154,7 +154,6 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
     check_apply_test({'response_timeout'}, get_configuration['tags'])
 
     # Variables
-    LOG_PATH = "/var/ossec/logs/wazuh.log"
     DIR_NAME = "/testdir1"
     AGENT_IP = "172.19.0.201"
     USERNAME = "vagrant"

--- a/tests/integration/test_remoted/conftest.py
+++ b/tests/integration/test_remoted/conftest.py
@@ -16,7 +16,7 @@ DAEMON_NAME = "wazuh-remoted"
 
 @pytest.fixture(scope='module')
 def restart_remoted(get_configuration, request):
-    # Reset ossec.log and start a new monitor
+    # Reset wazuh.log and start a new monitor
     control_service('stop', daemon=DAEMON_NAME)
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
@@ -86,12 +86,12 @@ def test_active_response_ar_sending(get_configuration, configure_environment, re
 
             log_callback = remote.callback_active_response_received(active_response_message)
             wazuh_log_monitor.start(timeout=10, callback=log_callback,
-                                    error_message='The expected event has not been found in ossec.log')
+                                    error_message='The expected event has not been found in wazuh.log')
 
             log_callback = remote.callback_active_response_sent(active_response_message)
 
             wazuh_log_monitor.start(timeout=10, callback=log_callback,
-                                    error_message='The expected event has not been found in ossec.log')
+                                    error_message='The expected event has not been found in wazuh.log')
 
             remote.check_agent_received_message(agent.rcv_msg_queue, f"#!-execd {remote.ACTIVE_RESPONSE_EXAMPLE_COMMAND}",
                                                                      escape=True)

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_connection.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_connection.py
@@ -38,7 +38,7 @@ def test_invalid_connection(get_configuration, configure_environment, restart_re
     """Test if `wazuh-remoted` fails when invalid configuration for `connection` label is set.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message.
     """
     cfg = get_configuration['metadata']
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_port.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_port.py
@@ -38,7 +38,7 @@ def test_invalid_port(get_configuration, configure_environment, restart_remoted)
     """Test if `wazuh-remoted` fails when invalid configuration for `port` label is set.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message.
     """
     cfg = get_configuration['metadata']
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
@@ -57,7 +57,7 @@ def test_invalid_protocol(get_configuration, configure_environment, restart_remo
     For a syslog connection if more than one protocol is provided only TCP should be used.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected warning messages or does not
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected warning messages or does not
         set properly protocol values.
     """
     cfg = get_configuration['metadata']

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
@@ -43,7 +43,7 @@ def test_ipv6_secure(get_configuration, configure_environment, restart_remoted):
     manager connection coincides with the option selected on `ossec.conf`.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected warning message or
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected warning message or
         if API answer is different of expected configuration."""
     cfg = get_configuration['metadata']
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_invalid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_invalid.py
@@ -46,7 +46,7 @@ def test_local_ip_invalid(get_configuration, configure_environment, restart_remo
     """Test if `wazuh-remoted` fails when invalid `local_ip` values are configured.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error messages.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error messages.
     """
     log_callback = remote.callback_error_bind_port()
     wazuh_log_monitor.start(timeout=5, callback=log_callback,

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
@@ -44,7 +44,7 @@ def test_big_queue_size(get_configuration, configure_environment, restart_remote
     Check that the API answer for manager connection coincides with the option selected on `ossec.conf`.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected warning messages or if API answer is
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected warning messages or if API answer is
         different of expected configuration.
     """
     cfg = get_configuration['metadata']

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
@@ -45,7 +45,7 @@ def test_queue_size_valid(get_configuration, configure_environment, restart_remo
     errors.
 
     Check if the API answer for manager connection coincides with the option selected on `ossec.conf` and expected
-    warning message is shown in `ossec.log`.
+    warning message is shown in `wazuh.log`.
 
     Raises:
         AssertionError: if API answer is different of expected configuration.

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_invalid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_invalid.py
@@ -42,7 +42,7 @@ def test_rids_closing_time_invalid(get_configuration, configure_environment, res
     """Test if `wazuh-remoted` fails when invalid `rids_closing_time` values are configured.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error messages.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error messages.
     """
     log_callback = remote.callback_error_invalid_value_for('rids_closing_time')
     wazuh_log_monitor.start(timeout=5, callback=log_callback,

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
@@ -47,7 +47,7 @@ def test_allowed_denied_ips_syslog(get_configuration, configure_environment, res
     """Check that "allowed-ips" and "denied-ips" could be configured without errors for syslog connection.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message.
     """
     cfg = get_configuration['metadata']
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_ips_invalid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_ips_invalid.py
@@ -45,7 +45,7 @@ def test_allowed_ips_invalid(get_configuration, configure_environment, restart_r
     """Test if `wazuh-remoted` fails when invalid `allowed-ips` label value is set.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message.
     """
     cfg = get_configuration['metadata']
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
@@ -40,7 +40,7 @@ def test_denied_ips_syslog(get_configuration, configure_environment, restart_rem
     Check if the API answer for manager connection coincides with the option selected on `ossec.conf`.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message or API answer different
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message or API answer different
         of expected configuration.
     """
     cfg = get_configuration['metadata']

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips_invalid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips_invalid.py
@@ -43,7 +43,7 @@ def test_denied_ips_syslog_invalid(get_configuration, configure_environment, res
     """Test if `wazuh-remoted` fails when invalid `denied-ips` label value is set.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message.
     """
     cfg = get_configuration['metadata']
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_no_allowed_ips.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_no_allowed_ips.py
@@ -37,7 +37,7 @@ def test_allowed_denied_ips_syslog(get_configuration, configure_environment, res
     """Test if `wazuh-remoted` fails when `syslog` connection is configured without `allowed-ips` value.
 
     Raises:
-        AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
+        AssertionError: if `wazuh-remoted` does not show in `wazuh.log` expected error message.
     """
     log_callback = remote.callback_info_no_allowed_ips()
     wazuh_log_monitor.start(timeout=5, callback=log_callback,

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -17,7 +17,7 @@ from wazuh_testing import vulnerability_detector as vd
 
 @pytest.fixture(scope='module')
 def restart_modulesd(get_configuration, request):
-    # Reset ossec.log and start a new monitor
+    # Reset wazuh.log and start a new monitor
     control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/legacy/test_sca/README.md
+++ b/tests/legacy/test_sca/README.md
@@ -54,7 +54,7 @@ evaluation.
 ## Results
 ----------
 
-The agent will log to __ossec.log__ these type of messages
+The agent will log to __wazuh.log__ these type of messages
 
 ```
  sca: INFO: Starting evaluation of policy: 'policy.yml'

--- a/tests/legacy/test_sca/test_basic_usage/data/sca_condition_test_suite.yml
+++ b/tests/legacy/test_sca/test_basic_usage/data/sca_condition_test_suite.yml
@@ -31,7 +31,7 @@ checks:
    condition: any
    rules:
      - f:/var/ossec/etc/ossec.conf
-     - f:/var/ossec/logs/ossec.log
+     - f:/var/ossec/logs/wazuh.log
      - f:/var/ossec/etc/client.keys
 
  - id: 800101
@@ -100,7 +100,7 @@ checks:
    rules:
      - f:/var/ossec/etc/ossec.conf
      - f:/var/ossec/etc/client.keys
-     - f:/var/ossec/logs/ossec.log 
+     - f:/var/ossec/logs/wazuh.log
 
  - id: 800201
    title: FAIL -- ALL on a list [TRUE, TRUE, FALSE]
@@ -170,7 +170,7 @@ checks:
    rules:
      - f:/var/ossec/etc/ossec.conf
      - f:/var/ossec/etc/client.keys
-     - f:/var/ossec/logs/ossec.log
+     - f:/var/ossec/logs/wazuh.log
 
  - id: 800301
    title: FAIL -- NONE on a list [TRUE, FALSE, FALSE]

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -147,7 +147,7 @@ specify which messages are expected in each of the nodes.
 # sample messages
 node_name:
   - regex: ".*wazuh-master restarted.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
 ```
 
@@ -315,17 +315,17 @@ rootdir: /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster
 plugins: html-2.0.1, tavern-0.34.0, testinfra-5.0.0, metadata-1.8.0
 collected 1 item                                                                                                                                                          
 
-test_agent_key_polling/test_agent_key_polling.py::test_agent_key_polling 2020-03-31 09:42:46,087 - wazuh_testing - DEBUG - Add new file composer process for wazuh-master and path: /var/ossec/logs/ossec.log
-2020-03-31 09:42:46,089 - wazuh_testing - DEBUG - Add new file monitor process for wazuh-master and path: /var/ossec/logs/ossec.log
-2020-03-31 09:42:46,089 - wazuh_testing - DEBUG - Starting file composer for wazuh-master and path: /var/ossec/logs/ossec.log. Composite file in /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster/test_agent_key_polling/tmp/wazuh-master_ossec.log.tmp
-2020-03-31 09:42:46,091 - wazuh_testing - DEBUG - Add new file composer process for wazuh-worker1 and path: /var/ossec/logs/ossec.log
+test_agent_key_polling/test_agent_key_polling.py::test_agent_key_polling 2020-03-31 09:42:46,087 - wazuh_testing - DEBUG - Add new file composer process for wazuh-master and path: /var/ossec/logs/wazuh.log
+2020-03-31 09:42:46,089 - wazuh_testing - DEBUG - Add new file monitor process for wazuh-master and path: /var/ossec/logs/wazuh.log
+2020-03-31 09:42:46,089 - wazuh_testing - DEBUG - Starting file composer for wazuh-master and path: /var/ossec/logs/wazuh.log. Composite file in /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster/test_agent_key_polling/tmp/wazuh-master_wazuh.log.tmp
+2020-03-31 09:42:46,091 - wazuh_testing - DEBUG - Add new file composer process for wazuh-worker1 and path: /var/ossec/logs/wazuh.log
 2020-03-31 09:42:46,092 - wazuh_testing - DEBUG - Starting QueueMonitor for wazuh-master and message: .*Agent key generated for agent 'wazuh-agent2'.*
-2020-03-31 09:42:46,092 - wazuh_testing - DEBUG - Add new file monitor process for wazuh-worker1 and path: /var/ossec/logs/ossec.log
-2020-03-31 09:42:46,093 - wazuh_testing - DEBUG - Starting file composer for wazuh-worker1 and path: /var/ossec/logs/ossec.log. Composite file in /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster/test_agent_key_polling/tmp/wazuh-worker1_ossec.log.tmp
-2020-03-31 09:42:46,094 - wazuh_testing - DEBUG - Add new file composer process for wazuh-agent2 and path: /var/ossec/logs/ossec.log
+2020-03-31 09:42:46,092 - wazuh_testing - DEBUG - Add new file monitor process for wazuh-worker1 and path: /var/ossec/logs/wazuh.log
+2020-03-31 09:42:46,093 - wazuh_testing - DEBUG - Starting file composer for wazuh-worker1 and path: /var/ossec/logs/wazuh.log. Composite file in /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster/test_agent_key_polling/tmp/wazuh-worker1_wazuh.log.tmp
+2020-03-31 09:42:46,094 - wazuh_testing - DEBUG - Add new file composer process for wazuh-agent2 and path: /var/ossec/logs/wazuh.log
 2020-03-31 09:42:46,095 - wazuh_testing - DEBUG - Starting QueueMonitor for wazuh-worker1 and message: .*Authentication error. Wrong key or corrupt payload. Message received from agent '002'.*
-2020-03-31 09:42:46,096 - wazuh_testing - DEBUG - Add new file monitor process for wazuh-agent2 and path: /var/ossec/logs/ossec.log
-2020-03-31 09:42:46,097 - wazuh_testing - DEBUG - Starting file composer for wazuh-agent2 and path: /var/ossec/logs/ossec.log. Composite file in /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster/test_agent_key_polling/tmp/wazuh-agent2_ossec.log.tmp
+2020-03-31 09:42:46,096 - wazuh_testing - DEBUG - Add new file monitor process for wazuh-agent2 and path: /var/ossec/logs/wazuh.log
+2020-03-31 09:42:46,097 - wazuh_testing - DEBUG - Starting file composer for wazuh-agent2 and path: /var/ossec/logs/wazuh.log. Composite file in /home/adriiiprodri/Desktop/git/wazuh-qa/tests/system/cluster/test_agent_key_polling/tmp/wazuh-agent2_wazuh.log.tmp
 2020-03-31 09:42:46,099 - wazuh_testing - DEBUG - Starting QueueMonitor for wazuh-agent2 and message: .*Lost connection with manager. Setting lock.*
 2020-03-31 09:42:49,100 - wazuh_testing - DEBUG - Finishing QueueMonitor for wazuh-master and message: .*Agent key generated for agent 'wazuh-agent2'.*
 2020-03-31 09:42:49,101 - wazuh_testing - DEBUG - Finishing QueueMonitor for wazuh-worker1 and message: .*Authentication error. Wrong key or corrupt payload. Message received from agent '002'.*

--- a/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
@@ -1,7 +1,7 @@
 ---
 wazuh-master:
   - regex: ".*Agent key generated for agent.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: '.*Received request:.*{"daemon_name":"authd","message":{"arguments":{"name":".*","ip":"any","force":0},"function":"add"}}'
     path: "/var/ossec/logs/cluster.log"
@@ -13,13 +13,13 @@ wazuh-master:
 
 wazuh-worker1:
   - regex: ".*Received request for a new agent.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Dispatching request to master node.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Agent key generated for.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: '.*Processing file etc\/client\.keys.*'
     path: "/var/ossec/logs/cluster.log"
@@ -31,20 +31,20 @@ wazuh-worker1:
 
 wazuh-agent1:
   - regex: ".*Requesting a key from server:.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Registering agent to unverified manager"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Using agent name as:*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Waiting for server reply"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Valid key received"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Waiting .* seconds before server connection"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60

--- a/tests/system/test_cluster/test_agent_enrollment/data/messages_ossec.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages_ossec.yml
@@ -1,30 +1,30 @@
 ---
 wazuh-master:
   - regex: ".*Agent key generated for agent.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
 
 wazuh-worker1:
   - regex: ".*Received request for a new agent.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Dispatching request to master node.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Agent key generated for.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
 
 wazuh-agent1:
   - regex: ".*Starting enrollment process to server.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Received response with agent key.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Valid key created. Finished.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
   - regex: ".*Connection closed.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60

--- a/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
+++ b/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
@@ -34,10 +34,10 @@ def clean_environment():
 def test_agent_enrollment(clean_environment):
     """Check agent enrollment process works as expected. An agent pointing to a worker should be able to register itself
     into the master by starting Wazuh-agent process."""
-    # Clean ossec.log and cluster.log
-    host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
-    host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
-    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
+    # Clean wazuh.log and cluster.log
+    host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
+    host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
+    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
     host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
     host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
 
@@ -46,7 +46,7 @@ def test_agent_enrollment(clean_environment):
     host_manager.control_service(host='wazuh-worker1', service='wazuh', state="restarted")
     host_manager.get_host('wazuh-agent1').ansible('command', f'service wazuh-agent restart', check=False)
 
-    # Run the callback checks for the ossec.log and the cluster.log
+    # Run the callback checks for the wazuh.log and the cluster.log
     HostMonitor(inventory_path=inventory_path,
                 messages_path=messages_path,
                 tmp_path=tmp_path).run()

--- a/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
+++ b/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
@@ -5,7 +5,7 @@
 import os
 
 import pytest
-from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, CLUSTER_LOG_PATH
 from wazuh_testing.tools.monitoring import HostMonitor
 from wazuh_testing.tools.system import HostManager
 
@@ -35,11 +35,11 @@ def test_agent_enrollment(clean_environment):
     """Check agent enrollment process works as expected. An agent pointing to a worker should be able to register itself
     into the master by starting Wazuh-agent process."""
     # Clean wazuh.log and cluster.log
-    host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
-    host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
-    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
-    host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
-    host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
+    host_manager.clear_file(host='wazuh-master', file_path=LOG_FILE_PATH)
+    host_manager.clear_file(host='wazuh-worker1', file_path=LOG_FILE_PATH)
+    host_manager.clear_file(host='wazuh-agent1', file_path=LOG_FILE_PATH)
+    host_manager.clear_file(host='wazuh-master', file_path=CLUSTER_LOG_PATH)
+    host_manager.clear_file(host='wazuh-worker1', file_path=CLUSTER_LOG_PATH)
 
     # Start the agent enrollment process by restarting the wazuh-agent
     host_manager.control_service(host='wazuh-master', service='wazuh', state="restarted")

--- a/tests/system/test_cluster/test_agent_key_polling/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_key_polling/data/messages.yml
@@ -1,21 +1,21 @@
 ---
 wazuh-master:
   - regex: ".*Agent key generated for agent 'wazuh-agent2'.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
 
 wazuh-worker1:
   - regex: ".*Authentication error. Wrong key or corrupt payload. Message received from agent '002'.*"
-    path: "/var/ossec/logs/ossec.log"
+    path: "/var/ossec/logs/wazuh.log"
     timeout: 60
 
 wazuh-agent2:
   - regex: '.*Lost connection with manager. Setting lock.*'
-    path: '/var/ossec/logs/ossec.log'
+    path: '/var/ossec/logs/wazuh.log'
     timeout: 60
   - regex: '.*Trying to connect to server \(wazuh-worker1.*'
-    path: '/var/ossec/logs/ossec.log'
+    path: '/var/ossec/logs/wazuh.log'
     timeout: 60
   - regex: '.*Connected to the server \(wazuh-worker1.*'
-    path: '/var/ossec/logs/ossec.log'
+    path: '/var/ossec/logs/wazuh.log'
     timeout: 60

--- a/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
+++ b/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
@@ -26,11 +26,11 @@ def configure_environment(host_manager):
                            src_path=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files/fetch_keys.py'),
                            dest_path='/tmp/fetch_keys.py')
     host_manager.apply_config(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/config.yml'),
-                              clear_files=[os.path.join(WAZUH_LOGS_PATH, 'ossec.log')],
+                              clear_files=[os.path.join(WAZUH_LOGS_PATH, 'wazuh.log')],
                               restart_services=['wazuh'])
     host_manager.add_block_to_file(host='wazuh-master', path='/var/ossec/etc/client.keys', replace='NOTVALIDKEY',
                                    after='wazuh-agent2 any ', before='2\n')
-    host_manager.clear_file(host='wazuh-agent2', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
+    host_manager.clear_file(host='wazuh-agent2', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
 
 
 @pytest.mark.skip(reason='Development in progress: https://github.com/wazuh/wazuh/issues/4387')

--- a/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
+++ b/tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.py
@@ -5,7 +5,7 @@
 import os
 
 import pytest
-from wazuh_testing.tools import WAZUH_LOGS_PATH
+from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.monitoring import HostMonitor
 from wazuh_testing.tools.system import HostManager
 
@@ -26,11 +26,11 @@ def configure_environment(host_manager):
                            src_path=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files/fetch_keys.py'),
                            dest_path='/tmp/fetch_keys.py')
     host_manager.apply_config(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/config.yml'),
-                              clear_files=[os.path.join(WAZUH_LOGS_PATH, 'wazuh.log')],
+                              clear_files=[LOG_FILE_PATH],
                               restart_services=['wazuh'])
     host_manager.add_block_to_file(host='wazuh-master', path='/var/ossec/etc/client.keys', replace='NOTVALIDKEY',
                                    after='wazuh-agent2 any ', before='2\n')
-    host_manager.clear_file(host='wazuh-agent2', file_path=os.path.join(WAZUH_LOGS_PATH, 'wazuh.log'))
+    host_manager.clear_file(host='wazuh-agent2', file_path=LOG_FILE_PATH)
 
 
 @pytest.mark.skip(reason='Development in progress: https://github.com/wazuh/wazuh/issues/4387')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1195|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

We've renamed ossec.log to wazuh.log in Wazuh integration tests according to wazuh/wazuh#8086.

## Configuration options

NA

## Logs example

To see the logs that show that the new configuration is correct, visit issue #1195.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.