### PR TITLE
Avoid duplicated scan's IDs in the agent simulator

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -747,6 +747,7 @@ class GeneratorSyscollector:
         self.batch_size = batch_size
         self.syscollector_tag = 'syscollector'
         self.syscollector_mq = 'd'
+        self.current_id = 1
 
     def format_event(self, message_type):
         """Format syscollector message of the specified type.
@@ -779,13 +780,15 @@ class GeneratorSyscollector:
         timestamp = today.strftime("%Y/%m/%d %H:%M:%S")
 
         fields_to_replace = [
-                        ('<agent_name>', self.agent_name), ('<random_int>', str(randint(1, 10 * 10))),
+                        ('<agent_name>', self.agent_name), ('<random_int>', f"{self.current_id}"),
                         ('<random_string>', get_random_string(10)),
                         ('<timestamp>', timestamp), ('<syscollector_type>', message_type)
                     ]
 
         for variable, value in fields_to_replace:
             message = message.replace(variable, value)
+
+        self.current_id += 1
 
         message = f"{self.syscollector_mq}:{self.syscollector_tag}:{message}"
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #1230 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes  #1230 by adding a new attribute to `GeneratorSyscollector` to store the scan ID. This ID will be incremented by one every time a new event gets generated.

## Configuration options

NA

## Logs example

- Manager:
```shellsession
[root@17f2038fbaf9 /]# tail -f /var/ossec/logs/ossec.log  | grep wazuh-db

```
- Agent:
```shellsession
[root@5803dff79ca4 wazuh_testing]# python3
Python 3.6.8 (default, Aug 24 2020, 17:57:11)
[GCC 8.3.1 20191121 (Red Hat 8.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import wazuh_testing.tools.agent_simulator as ag
>>> agent = ag.Agent(manager_address, "aes", os="debian8", version="4.2.0")
>>> agent.modules["fim"]["status"] = 'disabled'
>>> agent.modules["syscollector"]["status"] = 'enabled'
>>> sender = ag.Sender(manager_address, protocol='TCP')
>>> injector = ag.Injector(sender, agent)
>>> injector.run()
>>> d:syscollector:{"type":"network","ID":1,"timestamp":"2021/04/16 00:00:00","iface":{"name":"0HUVXO7EOQ","type":"ethernet","state":"up","MAC":"08:00:27:be:ce:3a","tx_packets":2135,"rx_packets":9091,"tx_bytes":210748,"rx_bytes":10134272,"tx_errors":0,"rx_errors":0,"tx_dropped":0,"rx_dropped":0,"MTU":1500,"IPv4":{"address":["10.0.2.15"],"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}
d:syscollector:{"type":"network","ID":2,"timestamp":"2021/04/16 00:00:00","iface":{"name":"OIH4M934O9","type":"ethernet","state":"up","MAC":"08:00:27:be:ce:3a","tx_packets":2135,"rx_packets":9091,"tx_bytes":210748,"rx_bytes":10134272,"tx_errors":0,"rx_errors":0,"tx_dropped":0,"rx_dropped":0,"MTU":1500,"IPv4":{"address":["10.0.2.15"],"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}
d:syscollector:{"type":"network","ID":3,"timestamp":"2021/04/16 00:00:00","iface":{"name":"QO3ROMKAU0","type":"ethernet","state":"up","MAC":"08:00:27:be:ce:3a","tx_packets":2135,"rx_packets":9091,"tx_bytes":210748,"rx_bytes":10134272,"tx_errors":0,"rx_errors":0,"tx_dropped":0,"rx_dropped":0,"MTU":1500,"IPv4":{"address":["10.0.2.15"],"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}
d:syscollector:{"type":"network","ID":4,"timestamp":"2021/04/16 00:00:00","iface":{"name":"IOSWFU7WJ1","type":"ethernet","state":"up","MAC":"08:00:27:be:ce:3a","tx_packets":2135,"rx_packets":9091,"tx_bytes":210748,"rx_bytes":10134272,"tx_errors":0,"rx_errors":0,"tx_dropped":0,"rx_dropped":0,"MTU":1500,"IPv4":{"address":["10.0.2.15"],"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}
d:syscollector:{"type":"network","ID":5,"timestamp":"2021/04/16 00:00:00","iface":{"name":"AWO0XU1PD4","type":"ethernet","state":"up","MAC":"08:00:27:be:ce:3a","tx_packets":2135,"rx_packets":9091,"tx_bytes":210748,"rx_bytes":10134272,"tx_errors":0,"rx_errors":0,"tx_dropped":0,"rx_dropped":0,"MTU":1500,"IPv4":{"address":["10.0.2.15"],"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}
d:syscollector:{"type":"network","ID":6,"timestamp":"2021/04/16 00:00:00","iface":{"name":"DSBA7DSI81","type":"ethernet","state":"up","MAC":"08:00:27:be:ce:3a","tx_packets":2135,"rx_packets":9091,"tx_bytes":210748,"rx_bytes":10134272,"tx_errors":0,"rx_errors":0,"tx_dropped":0,"rx_dropped":0,"MTU":1500,"IPv4":{"address":["10.0.2.15"],"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}
```

## Tests

<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.