### PR TITLE
Add to the agent simulator the ability to register the agent in a different manager than the connection

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -65,6 +65,7 @@ class Agent:
                                  alert.
         fim_integrity_eps (int, optional): Set the maximum database synchronization message throughput.
         authd_password (str), optional: Password for registration if needed.
+        registration_address (str, optional): Manager registration IP address.
 
     Attributes:
         id (str): ID of the agent.
@@ -108,12 +109,14 @@ class Agent:
         keepalive_frequency (int): frequency to send keepalive messages. 0 to continuously send keepalive messages.
         sca_frequency (int): frequency to run sca_label scans. 0 to continuously send sca_label events.
         syscollector_batch_size (int): Size of the syscollector type batch events.
+        registration_address (str): Manager registration IP address.
     """
     def __init__(self, manager_address, cypher="aes", os=None, rootcheck_sample=None, id=None, name=None, key=None,
                  version="v3.12.0", fim_eps=100, fim_integrity_eps=100, sca_eps=100, syscollector_eps=100, labels=None,
                  rootcheck_eps=100, logcollector_eps=100, authd_password=None, disable_all_modules=False,
                  rootcheck_frequency=60.0, rcv_msg_limit=0, keepalive_frequency=10, sca_frequency=60,
-                 syscollector_frequency=60.0, syscollector_batch_size=10, hostinfo_eps=100, winevt_eps=100):
+                 syscollector_frequency=60.0, syscollector_batch_size=10, hostinfo_eps=100, winevt_eps=100,
+                 registration_address=None):
         self.id = id
         self.name = name
         self.key = key
@@ -138,6 +141,7 @@ class Agent:
         self.keepalive_frequency = keepalive_frequency
         self.syscollector_frequency = syscollector_frequency
         self.manager_address = manager_address
+        self.registration_address = manager_address if registration_address is None else registration_address
         self.encryption_key = ""
         self.keep_alive_event = ""
         self.keep_alive_raw_msg = ""
@@ -233,22 +237,26 @@ class Agent:
         context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
-        ssl_socket = context.wrap_socket(sock,
-                                         server_hostname=self.manager_address)
-        ssl_socket.connect((self.manager_address, 1515))
+
+        ssl_socket = context.wrap_socket(sock, server_hostname=self.registration_address)
+        ssl_socket.connect((self.registration_address, 1515))
+
         if self.authd_password is None:
-            event = "OSSEC A:'{}'\n".format(self.name).encode()
+            event = f"OSSEC A:'{self.name}'\n".encode()
         else:
-            event = "OSSEC PASS: {} OSSEC A:'{}'\n".format(self.authd_password,
-                                                           self.name).encode()
+            event = f"OSSEC PASS: {self.authd_password} OSSEC A:'{self.name}'\n".encode()
+
         ssl_socket.send(event)
         recv = ssl_socket.recv(4096)
         registration_info = recv.decode().split("'")[1].split(" ")
+
         self.id = registration_info[0]
         self.key = registration_info[3]
+
         ssl_socket.close()
         sock.close()
-        logging.debug("Registration - {}({})".format(self.name, self.id))
+
+        logging.debug(f"Registration - {self.name}({self.id}) in {self.registration_address}")
 
     @staticmethod
     def wazuh_padding(compressed_event):

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1318,6 +1318,7 @@ class GeneratorFIM:
         self.random_sha256()
         self.random_time()
         self.random_inode()
+        self._checksum = self.random_sha1()
 
     def check_changed_attributes(self, attributes, old_attributes):
         """Returns attributes that have changed. """
@@ -1373,7 +1374,7 @@ class GeneratorFIM:
             string: generated message with the required FIM header.
         """
         if self.agent_version >= "3.12":
-            formated_message = f"{self.syscheck_mq}:[{self.agent_id}] ({message})"
+            formated_message = f"{self.syscheck_mq}:({self.agent_id}) any->syscheck:{message}"
         else:
             # If first time generating. Send control message to simulate
             # end of FIM baseline.


### PR DESCRIPTION
|Related issue|
|---|
|#1139|

## Description

This PR makes the following changes:
- Add to the agent simulator the ability to register the agent in a different manager than the connection
- Add the FIM alerts fix (it was not merged in 4.2)

# Checks

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.

# Tests

- [x] Tested on a cluster environment. The agent was registered in the master node and then connected to the worker node. The worker node got all the expected events from the agent.
