### PR TITLE
Fix outdated system tests

### DIFF
--- a/tests/system/test_jwt_invalidation/conftest.py
+++ b/tests/system/test_jwt_invalidation/conftest.py
@@ -39,10 +39,16 @@ def create_testing_api_user(request):
 
     # Create new user
     response = hm.make_api_call(test_hosts[0], method='POST', endpoint='/security/users',
-                                request_body={'username': username, 'password': password, 'allow_run_as': True},
+                                request_body={'username': username, 'password': password},
                                 token=token)
     assert response['status'] == 200, f'Failed to create testing user: {response}'
     username_id = response['json']['data']['affected_items'][0]['id']
+
+    # Edit allow_run_as
+    response = hm.make_api_call(test_hosts[0], method='PUT',
+                                endpoint=f'/security/users/{username_id}/run_as?allow_run_as=true',
+                                token=token)
+    assert response['status'] == 200, f'Failed to enable allow_run_as: {response}'
 
     # Assign administrator role
     response = hm.make_api_call(test_hosts[0], method='POST',


### PR DESCRIPTION
|Related issue|
|---|
| None |

## Description

Hi team!

This PR is the result of running the system tests and fixing those which were outdated or not passing right now.
- [Integrity tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/system/test_cluster/test_integrity_sync): They were run last week [here](https://github.com/wazuh/wazuh/pull/8175#issuecomment-821093040), everything ok.
- [Agent-info sync tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/system/test_cluster/test_agent_info_sync): They were updated last week [here](https://github.com/wazuh/wazuh-qa/pull/1232).
- [Agent enrollment tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/system/test_cluster/test_agent_enrollment): Run today, everything ok.
- [Agent key-polling](https://github.com/wazuh/wazuh-qa/tree/master/tests/system/test_cluster/test_agent_key_polling): Skipped.
- [JWT invalidation tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/system/test_jwt_invalidation): There were some errors after [this](https://github.com/wazuh/wazuh/pull/7588) refactor in wazuh/wazuh. It is corrected in this PR.

## Results
### JWT invalidation
```
python3 -m pytest .
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_jwt_invalidation
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 19 items                                                                                                                                                                                           

test_change_rbac_mode.py ....                                                                                                                                                                          [ 21%]
test_change_security_resources.py ....                                                                                                                                                                 [ 42%]
test_disconnected_nodes.py .                                                                                                                                                                           [ 47%]
test_revoke_endpoint.py ......                                                                                                                                                                         [ 78%]
test_update_password.py ....                                                                                                                                                                           [100%]

======================================================================================== 19 passed in 1216.35 seconds ========================================================================================
```

### Enrollment 
```
python3 -m pytest test_agent_enrollment
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                                                                                                                                                                                             

test_agent_enrollment/test_agent_enrollment.py .                                                                                                                                                       [100%]

========================================================================================= 1 passed in 80.59 seconds ==========================================================================================
```

Regards,
Selu.