### PR TITLE
Send syscollector events with a constant throughput 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -35,7 +35,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
 
     for _ in range(agents_number):
         agent = ag.Agent(manager_address, "aes", os=agent_os, version=agent_version, fim_eps=eps,
-                         fixed_message_size=fixed_message_size)
+                         fixed_message_size=fixed_message_size, syscollector_frequency=0)
         available_modules = agent.modules.keys()
 
         for module in active_modules:


### PR DESCRIPTION
|Related issue|
|---|
|closes #1238|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #1238 by setting the Syscollector's frequency in the `simulate-agents` tool to 0. These lines https://github.com/wazuh/wazuh-qa/blob/2f73335e4bf5a6008481a6401ef3a6689055303d/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py#L1606-L1609 control how the events are sent and the batch size. By setting the frequency to 0 we can send a constant throughput of events.

## Configuration options

NA
## Logs example

![image](https://user-images.githubusercontent.com/9081114/115260573-2c166000-a133-11eb-9ffb-d4b1a77f2426.png)

## Tests

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.