### PR TITLE
Add registration-address parameter to agent simulator tool and script

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent_version='v4.0.0',
                agent_os='debian8', eps=1000, run_duration=20, active_modules=[], modules_eps=None,
-               fixed_message_size=None):
+               fixed_message_size=None, registration_address=None):
     """Run a batch of agents connected to a manager with the same parameters.
 
     Args:
@@ -26,6 +26,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
         active_modules (list): list with active modules names.
         modules_eps (list): list with eps for each active modules.
         fixed_message_size (int): size in bytes for the message.
+        registration_address (str): Manager IP address where the agent will be registered.
     """
 
     logger = logging.getLogger(f"P{os.getpid()}")
@@ -35,7 +36,8 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
 
     for _ in range(agents_number):
         agent = ag.Agent(manager_address, "aes", os=agent_os, version=agent_version, fim_eps=eps,
-                         fixed_message_size=fixed_message_size, syscollector_frequency=0)
+                         fixed_message_size=fixed_message_size, syscollector_frequency=0,
+                         registration_address=registration_address)
         available_modules = agent.modules.keys()
 
         for module in active_modules:
@@ -50,7 +52,6 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
                     agent.modules[module]['eps'] = modules_eps[index]
                 else:
                     agent.modules[module]['eps'] = eps
-                index += 1
             else:
                 agent.modules[module]['status'] = 'disabled'
                 agent.modules[module]['eps'] = 0
@@ -101,6 +102,10 @@ def main():
     arg_parser.add_argument('-p', '--protocol', metavar='<protocol>', dest='agent_protocol',
                             type=str, required=False, default=TCP, help='Communication protocol')
 
+    arg_parser.add_argument('-r', '--registration-address', metavar='<manager_registration_ip_address>', type=str,
+                            required=False, default=None, help='Manager IP address where the agent will be registered',
+                            dest='manager_registration_address')
+
     arg_parser.add_argument('-t', '--time', metavar='<monitoring_time>', dest='duration',
                             type=int, required=False, default=20, help='Time in seconds for monitoring')
 
@@ -143,7 +148,7 @@ def main():
 
         arguments = (
             agents, args.manager_addr, args.agent_protocol, args.version, args.os, args.eps, args.duration,
-            args.modules, args.modules_eps, args.fixed_message_size
+            args.modules, args.modules_eps, args.fixed_message_size, args.manager_registration_address
         )
 
         print(args.modules_eps)


### PR DESCRIPTION
|Related issue|
|---|
|#1139|

## Description

This PR adds the capability of registering agents in a custom node. This is useful in the cluster environments since all the agents must be registered on the master node. To do this, I have updated the agent simulator tool and the `simulate-agents` script.

## Logs example

Before the changes, when trying to register the agents in one of the workers nodes, the following error was obtained:

```
self.register()
File "/usr/local/lib/python3.9/site-packages/wazuh_testing-4.2.0-py3.9.egg/wazuh_testing/tools/agent_simu
ssl_socket.connect((self.registration_address, 1515))
File "/usr/local/lib/python3.9/ssl.py", line 1342, in connect
self._real_connect(addr, False)
File "/usr/local/lib/python3.9/ssl.py", line 1329, in _real_connect
super().connect(addr)
ConnectionRefusedError: [Errno 111] Connection refused
```

Now we can see how the agents have registered in the master node and have connected correctly in each of the different nodes.

```
[root@ip-172-31-15-151 ec2-user]# /var/ossec/bin/cluster_control -a
ID   NAME                           IP         STATUS  VERSION       NODE NAME                                       
000  ip-172-31-15-151.ec2.internal  127.0.0.1  active  Wazuh v4.2.0  master                                          
001  1-db6873f1-debian10            10.0.2.15  active  Wazuh 4.2.0   Test_cluster_performance_sprint2_B89_manager_1  
002  1-26cf3108-debian10            10.0.2.15  active  Wazuh 4.2.0   Test_cluster_performance_sprint2_B89_manager_2  
003  1-ed742f0a-debian10            10.0.2.15  active  Wazuh 4.2.0   Test_cluster_performance_sprint2_B89_manager_3  
004  1-0b8047a6-debian10            10.0.2.15  active  Wazuh 4.2.0   Test_cluster_performance_sprint2_B89_manager_1  
005  1-42d49a73-debian10            10.0.2.15  active  Wazuh 4.2.0   Test_cluster_performance_sprint2_B89_manager_1  
006  1-5ebd8747-debian10            10.0.2.15  active  Wazuh 4.2.0   Test_cluster_performance_sprint2_B89_manager_3  
```

## Tests

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
