### PR TITLE
Test to check duplicate registries with same name but different capitalisation

### DIFF
--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -1,12 +1,12 @@
 # Test duplicated regitry entries
 
-This test will check that for two monitored registries with the same name value but with different capitalisation only triggers  one modified event when the registry is changed.
+This test will check that for two monitored registries with the same name value but with different capitalisation only triggers one modified event when the registry is changed.
 
 ## General info
 
-|Tier | Number of tests | Time spent| Test file |
-|:--:|:--:|:--:|:--:|
-| 0 | 1 | 0:0:25 | [test_basic_usage_registry_duplicated_entries.py](../../../../../../tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py)|
+|Tier | Number of tests | Time spent|
+|:--:|:--:|:--:|
+| 0 | 1 | 25s |
 
 ## Test logic
 
@@ -17,6 +17,7 @@ ensures the windows agent doesn't duplicate alerts due to windows being case ins
 
 
 ## Execution result
+
 python3 -m pytest test_files/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
 ```
 ===================================================================================== test session starts =====================================================================================

--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -1,34 +1,33 @@
 # Test duplicated regitry entries
 
-This test will check that for two monitored registries with the same name value but with different capitalisation only triggers one modified event when the registry is changed.
+This test will check that for two monitored registries with the same name value but with different capitalisation only triggers one added event when the registry is created.
 
 ## General info
 
 |Tier | Number of tests | Time spent|
 |:--:|:--:|:--:|
-| 0 | 1 | 25s |
+| 0 | 1 | 15s |
 
 ## Test logic
 
-The test creates two registries with the same name but different capitalization,
-modifies one of them and waits for the monitor to grab that event.
-The second call to the monitor should arise TimeoutError to be successful. This test
-ensures the windows agent doesn't duplicate alerts due to windows being case insensitive.
-
+The test monitor two registries with the same path but different capitalization. It creates
+one registry with the path being one of the two registries monitorized and then tries to grab
+one added event for the registry creation. Finally it tries to grab the added event one second
+time but it should rise one TimeoutError to ensure only one added event was sent.
 
 ## Execution result
-
-python3 -m pytest test_files/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
 ```
-===================================================================================== test session starts =====================================================================================
-platform win32 -- Python 3.8.1, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
-rootdir: C:\Users\vagrant\Desktop\wazuh-qa\tests\integration, configfile: pytest.ini
-plugins: html-2.0.1, metadata-1.11.0, testinfra-6.2.0, testinfra-6.0.0
+python3 -m pytest test_files/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+============================================================== test session starts ==============================================================
+platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
+rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
+plugins: html-2.0.1, metadata-1.10.0, testinfra-5.0.0
 collected 1 item
 
-test_basic_usage_registry_duplicated_entries.py  .                                                                                                                           [100%]
+test_basic_usage_registry_duplicated_entries.py .                                                                                          [100%]
 
-=================================================================================== 1 passed in -46763.03s ====================================================================================
+------ generated html file: file://C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration\test_fim\test_registry\report_dupl_reg_master.html ------
+============================================================== 1 passed in 15.02s ===============================================================
 ```
 
 ## Code documentation

--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -1,0 +1,35 @@
+# Test duplicated regitry entries
+
+This test will check that for two monitored registries with the same name value but with different capitalisation only triggers  one modified event when the registry is changed.
+
+## General info
+
+|Tier | Number of tests | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | 1 | 0:0:25 | [test_basic_usage_registry_duplicated_entries.py](../../../../../../tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py)|
+
+## Test logic
+
+The test creates two registries with the same name but different capitalisation,
+and then modifies one of them and wait for the monitor to grab that event.
+The second call to the monitor should arise TimeoutError to be succesful. This test
+ensures the windows agent doesn't duplicate alerts due to windows being case insensitive.
+
+
+## Execution result
+python3 -m pytest test_files/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+```
+===================================================================================== test session starts =====================================================================================
+platform win32 -- Python 3.8.1, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
+rootdir: C:\Users\vagrant\Desktop\wazuh-qa\tests\integration, configfile: pytest.ini
+plugins: html-2.0.1, metadata-1.11.0, testinfra-6.2.0, testinfra-6.0.0
+collected 1 item
+
+test_basic_usage_registry_duplicated_entries.py  .                                                                                                                           [100%]
+
+=================================================================================== 1 passed in -46763.03s ====================================================================================
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_registry.test_registry_basic_usage.test_basic_usage_registry_duplicated_entries

--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -10,9 +10,9 @@ This test will check that for two monitored registries with the same name value 
 
 ## Test logic
 
-The test creates two registries with the same name but different capitalisation,
-and then modifies one of them and wait for the monitor to grab that event.
-The second call to the monitor should arise TimeoutError to be succesful. This test
+The test creates two registries with the same name but different capitalization,
+modifies one of them and waits for the monitor to grab that event.
+The second call to the monitor should arise TimeoutError to be successful. This test
 ensures the windows agent doesn't duplicate alerts due to windows being case insensitive.
 
 

--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -1,6 +1,6 @@
-# Test duplicated regitry entries
+# Test duplicated registry entries
 
-This test will check that for two monitored registries with the same name value but with different capitalization only triggers one added event when the registry is created.
+This test will check that two monitored registries with the same name value but with different capitalization only triggers one added event when the registry is created.
 
 ## General info
 

--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -1,6 +1,6 @@
 # Test duplicated regitry entries
 
-This test will check that for two monitored registries with the same name value but with different capitalisation only triggers one added event when the registry is created.
+This test will check that for two monitored registries with the same name value but with different capitalization only triggers one added event when the registry is created.
 
 ## General info
 

--- a/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
+++ b/docs/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
@@ -11,9 +11,9 @@ This test will check that two monitored registries with the same name value but 
 ## Test logic
 
 The test monitor two registries with the same path but different capitalization. It creates
-one registry with the path being one of the two registries monitorized and then tries to grab
-one added event for the registry creation. Finally it tries to grab the added event one second
-time but it should rise one TimeoutError to ensure only one added event was sent.
+one registry with the path being one of the two registries monitored and then tries to grab
+one added event for the registry creation. Finally, it tries to grab the added event one second
+time but it should raise one TimeoutError to ensure only one added event was sent.
 
 ## Execution result
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -324,6 +324,7 @@ nav:
               - Test basic usage registry changes: tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_changes.md
               - Test basic new key: tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_new_key.md
               - Test long registry path: tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.md
+              - Test duplicated registry entries: tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.md
             - Test registry checks:
               - tests/integration/test_fim/test_registry/test_registry_checks/index.md
               - Test registry checks others: tests/integration/test_fim/test_registry/test_registry_checks/test_registry_check_others.md

--- a/tests/integration/test_fim/test_registry/conftest.py
+++ b/tests/integration/test_fim/test_registry/conftest.py
@@ -27,7 +27,7 @@ def wait_for_fim_start(get_configuration, request):
     """
     Wait for realtime start, whodata start or end of initial FIM scan.
     """
-    file_monitor = getattr(request.module, 'wazuh_log_monitor')
+    file_monitor = FileMonitor(LOG_FILE_PATH)
     mode_key = 'fim_mode' if 'fim_mode2' not in get_configuration['metadata'] else 'fim_mode2'
 
     try:

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_duplicated_registry.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_duplicated_registry.yaml
@@ -1,0 +1,21 @@
+---
+# conf 2
+- tags:
+  - ossec_conf_2
+  apply_to_modules:
+  - test_basic_usage_registry_duplicated_entries
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - windows_registry:
+        value: WINDOWS_DUPLICATED_REGISTRY_1
+        attributes:
+          - ATTRIBUTE
+          - arch: "32bit"
+    - windows_registry:
+        value: WINDOWS_DUPLICATED_REGISTRY_2
+        attributes:
+          - ATTRIBUTE
+          - arch: "32bit"

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_duplicated_registry.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_duplicated_registry.yaml
@@ -13,9 +13,9 @@
         value: WINDOWS_DUPLICATED_REGISTRY_1
         attributes:
           - ATTRIBUTE
-          - arch: "32bit"
+          - arch: "64bit"
     - windows_registry:
         value: WINDOWS_DUPLICATED_REGISTRY_2
         attributes:
           - ATTRIBUTE
-          - arch: "32bit"
+          - arch: "64bit"

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -10,6 +10,24 @@ import wazuh_testing.fim as fim
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 
+
+# Helper functions
+
+def extra_configuration_after_yield():
+    fim.delete_registry(fim.registry_parser[key], sub_key_1, fim.KEY_WOW64_32KEY)
+
+
+def check_event_type_and_path(fim_event, monitorized_registry):
+    check_event = False
+
+    if fim_event['type'] == 'added':
+        registry_event_path = fim_event['path']
+        if monitorized_registry.lower() == registry_event_path.lower():
+            check_event = True
+
+    return check_event
+
+
 # Marks
 
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
@@ -39,14 +57,16 @@ registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY), (key, sub_key_2,
                  fim.KEY_WOW64_32KEY)]
 
 
-# fixtures
+# Fixtures
+
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-# test
+# Test
+
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2,
                          fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
@@ -55,7 +75,7 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
     """Two registries with capital differences must trigger just one modify event
 
     Test to check that two registries monitored with the same name but
-    capital differences only triggers one modified event when the registry is changed.
+    capital differences only triggers one added event when the registry is created.
 
 
     Params:
@@ -73,22 +93,23 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
     """
     mode = get_configuration['metadata']['fim_mode']
     scheduled = mode == 'scheduled'
+    monitorized_registry = os.path.join(key, subkey2)
 
-    registry_1 = fim.create_registry(fim.registry_parser[key], subkey1, arch)
     fim.create_registry(fim.registry_parser[key], subkey2, arch)
-
-    fim.modify_registry_value(registry_1, "testkey", fim.REG_SZ, "some content x2")
 
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                            callback=fim.callback_detect_modified_event,
-                            error_message='Did not receive expected '
-                            '"Sending Fim event: ..." event').result()
+    json = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=fim.callback_detect_event,
+                                   error_message='Did not receive expected "Sending Fim event: ..." event').result()
 
-    with pytest.raises(TimeoutError):
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=fim.callback_detect_modified_event,
-                                error_message='Did not receive expected '
-                                '"Sending Fim event: ..." event').result()
-        raise AttributeError('Only one modification event was expected.')
+    if check_event_type_and_path(json['data'], monitorized_registry):
+        with pytest.raises(TimeoutError):
+            json = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                           callback=fim.callback_detect_event, error_message='Did not receive expected '
+                                           '"Sending Fim event: ..." event').result()
+
+            if check_event_type_and_path(json['data'], monitorized_registry):
+                raise pytest.fail("Only one added event for registry was expected.")
+
+    else:
+        raise pytest.fail("Unexpected fim event detected. Added event for " + str(subkey2) + " registry was expected.")

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -60,6 +60,7 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
                                    restart_syscheckd, wait_for_fim_start):
     """Test to check that two registries monitored with the same name but
        capital differences only triggers one modified event when the registry is changed.
+
     Params:
         key(str): Name of the root subpath for registries.
         subkey1(str): Name of the subpath identifying the registry 1 (no capital letter in name).
@@ -69,9 +70,9 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
         configure_environment (fixture): Configure the environment for the execution of the test.
         restart_syscheckd (fixture): Restarts syscheck.
         wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+
     Raises:
         TimeoutError: If an expected event (registry modified) couldn't be captured.
-        Exception: Error: only two modified type events was expected.
     """
     mode = get_configuration['metadata']['fim_mode']
     scheduled = mode == 'scheduled'
@@ -93,6 +94,6 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
                                 callback=fim.callback_detect_modified_event,
                                 error_message='Did not receive expected '
                                 '"Sending Fim event: ..." event').result()
-        raise Exception("Error: only two modified type events was expected.")
+        pytest.fail("Only one modification event was expected.")
     except TimeoutError:
         pass

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -20,52 +20,47 @@ key = "HKEY_LOCAL_MACHINE"
 sub_key_1 = "SOFTWARE\\Classes\\testkey"
 sub_key_2 = "SOFTWARE\\Classes\\Testkey"
 
-test_regs = [os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)]
+registry_1, registry_2 = os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)
 wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
-test_data_path = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), 'data')
-reg1, reg2 = test_regs
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 monitoring_modes = ['scheduled']
 
 # Configurations
 
-conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': reg1,
-               'WINDOWS_DUPLICATED_REGISTRY_2': reg2}
-configurations_path = os.path.join(
-    test_data_path, 'wazuh_conf_duplicated_registry.yaml')
-p, m = fim.generate_params(extra_params=conf_params, modes=monitoring_modes)
-configurations = load_wazuh_configurations(
-    configurations_path, __name__, params=p, metadata=m)
+conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': registry_1,
+               'WINDOWS_DUPLICATED_REGISTRY_2': registry_2}
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_duplicated_registry.yaml')
+parameters, metadata = fim.generate_params(extra_params=conf_params, modes=monitoring_modes)
+configurations = load_wazuh_configurations(configurations_path, __name__,
+params=parameters, metadata=metadata)
 
-registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY),
-                 (key, sub_key_2, fim.KEY_WOW64_32KEY)]
+registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY), (key, sub_key_2,
+fim.KEY_WOW64_32KEY)]
 
 # fixtures
-
-
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 # test
-
-
-@pytest.mark.parametrize('key, subkey1, subkey2, arch', [
-    (key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)
-])
+@pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2,
+fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
                                    get_configuration, configure_environment,
                                    restart_syscheckd, wait_for_fim_start):
-    """Test to check that two registries monitored with the same name but
-       capital differences only triggers one modified event when the registry is changed.
+    """Two registries with capital differences must trigger just one modify event
+
+    Test to check that two registries monitored with the same name but
+    capital differences only triggers one modified event when the registry is changed.
+
 
     Params:
-        key(str): Name of the root subpath for registries.
-        subkey1(str): Name of the subpath identifying the registry 1 (no capital letter in name).
-        subkey1(str): Name of the subpath identifying the registry 2 (capital letter in name).
-        arch(str): Value holding the system architecture for registries.
+        key (str): Name of the root subpath for registries.
+        subkey1 (str): Name of the subpath identifying the registry 1 (no capital letter in name).
+        subkey2 (str): Name of the subpath identifying the registry 2 (capital letter in name).
+        arch (str): Value holding the system architecture for registries.
         get_configuration (fixture): Gets the current configuration of the test.
         configure_environment (fixture): Configure the environment for the execution of the test.
         restart_syscheckd (fixture): Restarts syscheck.
@@ -89,11 +84,9 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
                             error_message='Did not receive expected '
                             '"Sending Fim event: ..." event').result()
 
-    try:
+    with pytest.raises(TimeoutError):
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                 callback=fim.callback_detect_modified_event,
                                 error_message='Did not receive expected '
                                 '"Sending Fim event: ..." event').result()
-        pytest.fail("Only one modification event was expected.")
-    except TimeoutError:
-        pass
+        raise AttributeError('Only one modification event was expected.')

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+from collections import Counter
+
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_registry, modify_registry_value, \
+    callback_detect_modified_event, check_time_travel, registry_parser, KEY_WOW64_32KEY, REG_SZ
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import truncate_file
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
+
+# Variables
+
+key = "HKEY_LOCAL_MACHINE"
+sub_key_1 = "SOFTWARE\\Classes\\testkey"
+sub_key_2 = "SOFTWARE\\Classes\\Testkey"
+
+test_regs = [os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)]
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+reg1, reg2 = test_regs
+
+monitoring_modes = ['scheduled']
+
+# Configurations
+
+conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': reg1, 'WINDOWS_DUPLICATED_REGISTRY_2': reg2}
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_duplicated_registry.yaml')
+p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+
+registry_list = [(key, sub_key_1, KEY_WOW64_32KEY),
+                 (key, sub_key_2, KEY_WOW64_32KEY)]
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+# test
+
+@pytest.mark.parametrize('key, subkey1, subkey2, arch', [
+    (key, sub_key_1, sub_key_2, KEY_WOW64_32KEY)
+])
+
+
+def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
+                         get_configuration, configure_environment,
+                         restart_syscheckd, wait_for_fim_start):
+    """Test to check that two registries monitored with the same name but capital differences
+       only triggers one modified event when the registry is changed.
+    Params:
+        key(str): Name of the root subpath for registries.
+        subkey1(str): Name of the subpath identifying the registry 1 (no capital letter in name).
+        subkey1(str): Name of the subpath identifying the registry 2 (capital letter in name).
+        arch(str): Value holding the system architecture for registries.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+    Raises:
+        TimeoutError: If an expected event (registry modified) couldn't be captured.
+        Exception: Error: only two modified type events was expected.
+    """
+    mode = get_configuration['metadata']['fim_mode']
+    scheduled = mode == 'scheduled'
+
+    registry_1 = create_registry(registry_parser[key], subkey1, arch)
+    registry_2 = create_registry(registry_parser[key], subkey2, arch)
+
+    modify_registry_value(registry_1, "testkey", REG_SZ, "some content x2")
+
+    check_time_travel(scheduled, monitor=wazuh_log_monitor)
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_modified_event, error_message='Did not receive expected '
+                                                                                      '"Sending Fim event: ..." event').result()
+
+    try:
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_modified_event, error_message='Did not receive expected '
+                                                                                      '"Sending Fim event: ..." event').result()
+        raise Exception("Error: only two modified type events was expected.")
+    except TimeoutError:
+        pass

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -50,11 +50,9 @@ conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': registry_1,
                'WINDOWS_DUPLICATED_REGISTRY_2': registry_2}
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_duplicated_registry.yaml')
 parameters, metadata = fim.generate_params(extra_params=conf_params, modes=monitoring_modes)
-configurations = load_wazuh_configurations(configurations_path, __name__,
-                                           params=parameters, metadata=metadata)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
-registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY), (key, sub_key_2,
-                 fim.KEY_WOW64_32KEY)]
+registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY), (key, sub_key_2, fim.KEY_WOW64_32KEY)]
 
 
 # Fixtures
@@ -67,10 +65,8 @@ def get_configuration(request):
 
 # Test
 
-@pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2,
-                         fim.KEY_WOW64_32KEY)])
-def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
-                                   get_configuration, configure_environment,
+@pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)])
+def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuration, configure_environment,
                                    restart_syscheckd, wait_for_fim_start):
     """Two registries with capital differences must trigger just one modify event
 

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -33,10 +33,11 @@ conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': registry_1,
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_duplicated_registry.yaml')
 parameters, metadata = fim.generate_params(extra_params=conf_params, modes=monitoring_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__,
-params=parameters, metadata=metadata)
+                                           params=parameters, metadata=metadata)
 
 registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY), (key, sub_key_2,
-fim.KEY_WOW64_32KEY)]
+                 fim.KEY_WOW64_32KEY)]
+
 
 # fixtures
 @pytest.fixture(scope='module', params=configurations)
@@ -44,9 +45,10 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # test
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2,
-fim.KEY_WOW64_32KEY)])
+                         fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
                                    get_configuration, configure_environment,
                                    restart_syscheckd, wait_for_fim_start):

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -3,16 +3,12 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-from collections import Counter
 
 import pytest
 from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, generate_params, create_registry, modify_registry_value, \
-    callback_detect_modified_event, check_time_travel, registry_parser, KEY_WOW64_32KEY, REG_SZ
+import wazuh_testing.fim as fim
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.services import control_service
-from wazuh_testing.tools.file import truncate_file
 
 # Marks
 
@@ -25,23 +21,28 @@ sub_key_1 = "SOFTWARE\\Classes\\testkey"
 sub_key_2 = "SOFTWARE\\Classes\\Testkey"
 
 test_regs = [os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)]
-wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
+test_data_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), 'data')
 reg1, reg2 = test_regs
 
 monitoring_modes = ['scheduled']
 
 # Configurations
 
-conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': reg1, 'WINDOWS_DUPLICATED_REGISTRY_2': reg2}
-configurations_path = os.path.join(test_data_path, 'wazuh_conf_duplicated_registry.yaml')
-p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
-configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': reg1,
+               'WINDOWS_DUPLICATED_REGISTRY_2': reg2}
+configurations_path = os.path.join(
+    test_data_path, 'wazuh_conf_duplicated_registry.yaml')
+p, m = fim.generate_params(extra_params=conf_params, modes=monitoring_modes)
+configurations = load_wazuh_configurations(
+    configurations_path, __name__, params=p, metadata=m)
 
-registry_list = [(key, sub_key_1, KEY_WOW64_32KEY),
-                 (key, sub_key_2, KEY_WOW64_32KEY)]
+registry_list = [(key, sub_key_1, fim.KEY_WOW64_32KEY),
+                 (key, sub_key_2, fim.KEY_WOW64_32KEY)]
 
 # fixtures
+
 
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
@@ -50,16 +51,15 @@ def get_configuration(request):
 
 # test
 
+
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [
-    (key, sub_key_1, sub_key_2, KEY_WOW64_32KEY)
+    (key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)
 ])
-
-
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
-                         get_configuration, configure_environment,
-                         restart_syscheckd, wait_for_fim_start):
-    """Test to check that two registries monitored with the same name but capital differences
-       only triggers one modified event when the registry is changed.
+                                   get_configuration, configure_environment,
+                                   restart_syscheckd, wait_for_fim_start):
+    """Test to check that two registries monitored with the same name but
+       capital differences only triggers one modified event when the registry is changed.
     Params:
         key(str): Name of the root subpath for registries.
         subkey1(str): Name of the subpath identifying the registry 1 (no capital letter in name).
@@ -76,19 +76,23 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch,
     mode = get_configuration['metadata']['fim_mode']
     scheduled = mode == 'scheduled'
 
-    registry_1 = create_registry(registry_parser[key], subkey1, arch)
-    registry_2 = create_registry(registry_parser[key], subkey2, arch)
+    registry_1 = fim.create_registry(fim.registry_parser[key], subkey1, arch)
+    fim.create_registry(fim.registry_parser[key], subkey2, arch)
 
-    modify_registry_value(registry_1, "testkey", REG_SZ, "some content x2")
+    fim.modify_registry_value(registry_1, "testkey", fim.REG_SZ, "some content x2")
 
-    check_time_travel(scheduled, monitor=wazuh_log_monitor)
+    fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_modified_event, error_message='Did not receive expected '
-                                                                                      '"Sending Fim event: ..." event').result()
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=fim.callback_detect_modified_event,
+                            error_message='Did not receive expected '
+                            '"Sending Fim event: ..." event').result()
 
     try:
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_modified_event, error_message='Did not receive expected '
-                                                                                      '"Sending Fim event: ..." event').result()
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=fim.callback_detect_modified_event,
+                                error_message='Did not receive expected '
+                                '"Sending Fim event: ..." event').result()
         raise Exception("Error: only two modified type events was expected.")
     except TimeoutError:
         pass

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -12,11 +12,11 @@ def extra_configuration_after_yield():
     fim.delete_registry(fim.registry_parser[key], sub_key_2, fim.KEY_WOW64_64KEY)
 
 
-def check_event_type_and_path(fim_event, monitorized_registry):
+def check_event_type_and_path(fim_event, monitored_registry):
     check_event = False
     if fim_event['type'] == 'added':
         registry_event_path = fim_event['path']
-        if monitorized_registry.lower() == registry_event_path.lower():
+        if monitored_registry.lower() == registry_event_path.lower():
             check_event = True
 
     return check_event
@@ -28,7 +28,7 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
 
 # Variables
 
-key = "HKEY_LOCAL_MACHINE"
+key = 'HKEY_LOCAL_MACHINE'
 classes_subkey = os.path.join('SOFTWARE', 'Classes')
 
 sub_key_1 = os.path.join(classes_subkey, 'testkey')
@@ -88,7 +88,7 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuratio
 
     mode = get_configuration['metadata']['fim_mode']
     scheduled = mode == 'scheduled'
-    monitorized_registry = os.path.join(key, subkey2)
+    monitored_registry = os.path.join(key, subkey2)
 
     fim.create_registry(fim.registry_parser[key], subkey2, arch)
 
@@ -98,14 +98,14 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuratio
                                   error_message='Did not receive expected "Sending Fim event: ..." \
                                   event').result()
 
-    if check_event_type_and_path(fim_event['data'], monitorized_registry):
+    if check_event_type_and_path(fim_event['data'], monitored_registry):
         with pytest.raises(TimeoutError):
             fim_event = log_monitor.start(timeout=global_parameters.default_timeout,
                                           callback=fim.callback_detect_event,
                                           error_message='Did not receive expected '
                                           '"Sending Fim event: ..." event').result()
 
-            if check_event_type_and_path(fim_event['data'], monitorized_registry):
+            if check_event_type_and_path(fim_event['data'], monitored_registry):
                 raise pytest.fail('Only one added event for the registry was expected.')
 
     else:

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -35,11 +35,12 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
 # Variables
 
 key = "HKEY_LOCAL_MACHINE"
-sub_key_1 = "SOFTWARE\\Classes\\testkey"
-sub_key_2 = "SOFTWARE\\Classes\\Testkey"
+classes_subkey = os.path.join('SOFTWARE', 'Classes')
+
+sub_key_1 = os.path.join(classes_subkey, 'testkey')
+sub_key_2 = os.path.join(classes_subkey, 'Testkey')
 
 registry_1, registry_2 = os.path.join(key, sub_key_1), os.path.join(key, sub_key_2)
-wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 monitoring_modes = ['scheduled']
@@ -68,16 +69,16 @@ def get_configuration(request):
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuration, configure_environment,
                                    restart_syscheckd, wait_for_fim_start):
-    """Two registries with capital differences must trigger just one modify event
+    """Two registries with capital differences must trigger just one modify the event.
 
     Test to check that two registries monitored with the same name but
-    capital differences only triggers one added event when the registry is created.
+    capital differences only trigger one added event when the registry is created.
 
 
     Params:
         key (str): Name of the root subpath for registries.
-        subkey1 (str): Name of the subpath identifying the registry 1 (no capital letter in name).
-        subkey2 (str): Name of the subpath identifying the registry 2 (capital letter in name).
+        subkey1 (str): Name of the subpath identifying the registry 1 (no capital letter in the name).
+        subkey2 (str): Name of the subpath identifying the registry 2 (capital letter in the name).
         arch (str): Value holding the system architecture for registries.
         get_configuration (fixture): Gets the current configuration of the test.
         configure_environment (fixture): Configure the environment for the execution of the test.
@@ -95,17 +96,19 @@ def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuratio
 
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
-    json = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=fim.callback_detect_event,
-                                   error_message='Did not receive expected "Sending Fim event: ..." event').result()
+    fim_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=fim.callback_detect_event,
+                                        error_message='Did not receive expected "Sending Fim event: ..." \
+                                        event').result()
 
-    if check_event_type_and_path(json['data'], monitorized_registry):
+    if check_event_type_and_path(fim_event['data'], monitorized_registry):
         with pytest.raises(TimeoutError):
-            json = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                           callback=fim.callback_detect_event, error_message='Did not receive expected '
-                                           '"Sending Fim event: ..." event').result()
+            fim_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                                callback=fim.callback_detect_event,
+                                                error_message='Did not receive expected '
+                                                '"Sending Fim event: ..." event').result()
 
-            if check_event_type_and_path(json['data'], monitorized_registry):
-                raise pytest.fail("Only one added event for registry was expected.")
+            if check_event_type_and_path(fim_event['data'], monitorized_registry):
+                raise pytest.fail('Only one added event for the registry was expected.')
 
     else:
-        raise pytest.fail("Unexpected fim event detected. Added event for " + str(subkey2) + " registry was expected.")
+        raise pytest.fail(f"Unexpected fim event detected. Added event for {str(subkey2)} registry was expected.")

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -8,7 +8,7 @@ import pytest
 from wazuh_testing import global_parameters
 import wazuh_testing.fim as fim
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
 
 
 # Helper functions
@@ -64,11 +64,18 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.fixture(scope='module', params=configurations)
+def stop_syscheckd_module(request):
+    """Stop syscheckd module after test execution."""
+    yield
+    control_service('stop', daemon='wazuh-syscheckd')
+
+
 # Test
 
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuration, configure_environment,
-                                   restart_syscheckd, wait_for_fim_start):
+                                   restart_syscheckd, wait_for_fim_start, stop_syscheckd_module):
     """Two registries with capital differences must trigger just one modify the event.
 
     Test to check that two registries monitored with the same name but


### PR DESCRIPTION


|Related issue|
|---|
|#1246|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The test register two registries with the same name_value but with different capitalisation, and modifies one of them. Due to windows being case insensitive there should be only one modify event. The first call to monitor must be succesful and the second should give a timeout error. 

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in wazuh-qa/docs.
- [X] `provision_documentation.sh` generate the docs without errors.