### PR TITLE
Retry enrollment process in case of error

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -37,7 +37,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
     for _ in range(agents_number):
         agent = ag.Agent(manager_address, "aes", os=agent_os, version=agent_version, fim_eps=eps,
                          fixed_message_size=fixed_message_size, syscollector_frequency=0,
-                         registration_address=registration_address)
+                         registration_address=registration_address, retry_enrollment=True)
         available_modules = agent.modules.keys()
 
         for module in active_modules:
@@ -63,6 +63,8 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
         active_agents.append(agent)
         sender = ag.Sender(manager_address, protocol=protocol)
         injectors.append(ag.Injector(sender, agent))
+
+    sleep(30)
 
     try:
         start(injectors)


### PR DESCRIPTION
|Related issue|
|---|
|#1240|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

While running the scalability tests with more than 30K agents, we discovered that `auth` was discarding key generation requests due to the number of simultaneous requests.
```
2021/04/26 13:33:26 wazuh-authd: ERROR: Too many connections. Rejecting.
```
If `auth` closes the socket, the agent_simulator fails while performing the enrollment and the process stops. This PR adds a new retry block to perform the enrollment in case of errors. 

Also, to avoid CPU throttling while creating the simulated agents, we added a `sleep` before starting the injector threads.