### PR TITLE
Logcollector integration tests T0: Check command monitoring

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -22,20 +22,21 @@ def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFI
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 
-def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
     """Create a callback to detect if logcollector is monitoring a command.
 
     Args:
         log_format (str): Log format of the command monitoring (full_command or command).
         command (str): Monitored command.
         prefix (str): Daemon that generates the error log.
+        escape (bool): Flag to escape special characters in the pattern.
 
     Returns:
         callable: callback to detect this event.
     """
-    log_format_message = 'full output' if log_format == 'full_command' else 'output'
-    msg = fr"INFO: Monitoring {log_format_message} of command\(\d+\): {command}"
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
+    # log_format_message = 'full output' if log_format == 'full_command' else 'output'
+    msg = f"{command}"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
 
 
 def callback_monitoring_djb_multilog(program_name, multilog_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -22,21 +22,20 @@ def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFI
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 
-def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
+def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """Create a callback to detect if logcollector is monitoring a command.
 
     Args:
         log_format (str): Log format of the command monitoring (full_command or command).
         command (str): Monitored command.
         prefix (str): Daemon that generates the error log.
-        escape (bool): Flag to escape special characters in the pattern.
 
     Returns:
         callable: callback to detect this event.
     """
-    # log_format_message = 'full output' if log_format == 'full_command' else 'output'
-    msg = f"{command}"
-    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
+    log_format_message = 'full output' if log_format == 'full_command' else 'output'
+    msg = fr"INFO: Monitoring {log_format_message} of command\(\d+\): {command}"
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
 
 
 def callback_monitoring_djb_multilog(program_name, multilog_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
@@ -168,3 +167,35 @@ def callback_invalid_location_pattern(location, prefix=monitoring.LOG_COLLECTOR_
     """
     msg = fr"Glob error. Invalid pattern: '{location}' or no files found."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_dbg_read_lines(command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
+    """Create a callback to detect "DEBUG: Read <number> lines from command <command>" debug line.
+
+    Args:
+        command (str): Command to be monitored.
+        prefix (str): Daemon that generates the log.
+        escape (bool): Flag to escape special characters in the pattern.
+
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"lines from command '{command}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
+
+
+def callback_dbg_running_command(log_format, command,  prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
+    """Create a callback to detect "DEBUG: Running <log_format> '<command>'" debug line.
+
+    Args:
+        log_format (str): Log format of the command monitoring (full_command or command).
+        command (str): Command to be monitored.
+        prefix (str): Daemon that generates the log.
+        escape (bool): Flag to escape special characters in the pattern.
+
+    Returns:
+        callable: callback to detect this event.
+    """
+    log_format_message = 'full command' if log_format == 'full_command' else 'command'
+    msg = fr"DEBUG: Running {log_format_message} '{command}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -169,7 +169,7 @@ def callback_invalid_location_pattern(location, prefix=monitoring.LOG_COLLECTOR_
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 
-def callback_dbg_read_lines(command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
+def callback_read_lines(command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
     """Create a callback to detect "DEBUG: Read <number> lines from command <command>" debug line.
 
     Args:
@@ -184,7 +184,7 @@ def callback_dbg_read_lines(command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PR
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
 
 
-def callback_dbg_running_command(log_format, command,  prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
+def callback_running_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
     """Create a callback to detect "DEBUG: Running <log_format> '<command>'" debug line.
 
     Args:

--- a/docs/tests/integration/test_logcollector/index.md
+++ b/docs/tests/integration/test_logcollector/index.md
@@ -9,9 +9,9 @@ logs and send them to the manager.
 ### Tier 0
 #### Test configuration
 
-For each configuration option, we check if logcollector and agentd correctly
+For each configuration option, we check if `logcollector` and `agentd` correctly
 starts and that any API request to the Manager configuration returns the same options that the specified 
-in `ossec.conf`
+in configuration file.
 
 #### Test command monitoring
 

--- a/docs/tests/integration/test_logcollector/index.md
+++ b/docs/tests/integration/test_logcollector/index.md
@@ -12,3 +12,9 @@ logs and send them to the manager.
 For each configuration option, we check if logcollector and agentd correctly
 starts and that any API request to the Manager configuration returns the same options that the specified 
 in `ossec.conf`
+
+#### Test command monitoring
+
+Command monitoring consists of periodically executing programs and logging their output to detect 
+possible changes in it. These tests will verify that the `logcollector` command monitoring system works 
+correctly by running different commands with special characteristics.

--- a/docs/tests/integration/test_logcollector/test_command_monitoring/index.md
+++ b/docs/tests/integration/test_logcollector/test_command_monitoring/index.md
@@ -1,6 +1,6 @@
-# Test command monitoring
+# Overview 
 
-## Overview 
+## Description
 
 These tests will check if commands with different characteristics are executed correctly. 
 It will also be checked that the info and debug lines are written in the logs when executing these commands.

--- a/docs/tests/integration/test_logcollector/test_command_monitoring/index.md
+++ b/docs/tests/integration/test_logcollector/test_command_monitoring/index.md
@@ -1,0 +1,28 @@
+# Test command monitoring
+
+## Overview 
+
+These tests will check if commands with different characteristics are executed correctly. 
+It will also be checked that the info and debug lines are written in the logs when executing these commands.
+
+The verification will be performed by analyzing the logs and checking the lines that indicate that 
+the command has been executed correctly.
+
+## Objective
+
+Confirm that the different options for command monitoring and configuration work and are correctly loaded.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 52 | 6m17s |
+
+## List of command monitoring tests
+  
+- **[Test command execution](test_command_execution.md)**: Check if the Wazuh runs correctly by executing 
+  different commands with special characteristics.
+  
+- **[Test command execution freq](test_command_execution_freq.md)**: Check if the Wazuh run commands correctly with 
+  the specified command monitoring option `frequency`.
+

--- a/docs/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.md
+++ b/docs/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.md
@@ -1,0 +1,26 @@
+# Test command execution
+
+## Overview 
+
+Check if the Wazuh runs correctly by executing different commands with special characteristics 
+and check if the debug logs are displayed correctly when the test commands are executed.
+
+## Objective
+
+- To confirm `command` option works correctly with different types of commands.
+- To confirm that debug logs are generated correctly.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 44 | 2m49s |
+
+## Expected behavior
+
+- Fail if it is not possible to verify that the command is executed correctly.
+- Fail if debug logs are not displayed when executing the command.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_command_monitoring.test_command_execution

--- a/docs/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.md
+++ b/docs/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.md
@@ -1,0 +1,23 @@
+# Test command execution freq
+
+## Overview 
+
+Check if the Wazuh run commands correctly with the specified command monitoring option `frequency`.
+
+## Objective
+
+To confirm `frequency` option works correctly with different time intervals.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 8 | 3m28s |
+
+## Expected behavior
+
+- Fail if the command is executed before the established interval.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_command_monitoring.test_command_execution_freq

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -445,6 +445,10 @@ nav:
                 - Test basic configuration query: tests/integration/test_logcollector/test_configuration/test_basic_configuration_query.md
                 - Test basic configuration reconnect time: tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.md
                 - Test basic configuration target: tests/integration/test_logcollector/test_configuration/test_basic_configuration_target.md
+            - Test command monitoring:
+                - Overview: tests/integration/test_logcollector/test_command_monitoring/index.md
+                - Test command execution: tests/integration/test_logcollector/test_command_monitoring/test_command_execution.md
+                - Test command execution freq: tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.md
         - Logtest:
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md

--- a/tests/integration/test_logcollector/conftest.py
+++ b/tests/integration/test_logcollector/conftest.py
@@ -15,7 +15,7 @@ DAEMON_NAME = "wazuh-logcollector"
 
 @pytest.fixture(scope='module')
 def restart_logcollector(get_configuration, request):
-    """ Reset log file and start a new monitor."""
+    """Reset log file and start a new monitor."""
     control_service('stop', daemon=DAEMON_NAME)
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/integration/test_logcollector/conftest.py
+++ b/tests/integration/test_logcollector/conftest.py
@@ -15,7 +15,7 @@ DAEMON_NAME = "wazuh-logcollector"
 
 @pytest.fixture(scope='module')
 def restart_logcollector(get_configuration, request):
-    # Reset log file and start a new monitor
+    """ Reset log file and start a new monitor."""
     control_service('stop', daemon=DAEMON_NAME)
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/integration/test_logcollector/test_command_monitoring/data/wazuh_command_conf.yaml
+++ b/tests/integration/test_logcollector/test_command_monitoring/data/wazuh_command_conf.yaml
@@ -1,0 +1,27 @@
+- tags:
+  - test_command_execution
+  apply_to_modules:
+  - test_command_execution
+  sections:
+  - section: localfile
+    elements:
+    - command:
+        value: COMMAND
+    - log_format:
+        value: LOG_FORMAT
+    - alias:
+        value: ALIAS
+
+- tags:
+  - test_command_execution
+  apply_to_modules:
+  - test_command_execution_freq
+  sections:
+  - section: localfile
+    elements:
+    - command:
+        value: COMMAND
+    - log_format:
+        value: LOG_FORMAT
+    - frequency:
+        value: FREQUENCY

--- a/tests/integration/test_logcollector/test_command_monitoring/data/wazuh_command_conf.yaml
+++ b/tests/integration/test_logcollector/test_command_monitoring/data/wazuh_command_conf.yaml
@@ -13,7 +13,7 @@
         value: ALIAS
 
 - tags:
-  - test_command_execution
+  - test_command_execution_freq
   apply_to_modules:
   - test_command_execution_freq
   sections:

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
@@ -143,8 +143,8 @@ def test_command_execution(get_local_internal_options, configure_local_internal_
     Raises:
         TimeoutError: If the command monitoring callback is not generated.
     """
-    cfg = get_configuration['metadata']
-    msg = f": {cfg['command']}"
+    config = get_configuration['metadata']
+    msg = config['command']
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
@@ -170,24 +170,24 @@ def test_command_execution_dbg(get_local_internal_options, configure_local_inter
     Raises:
         TimeoutError: If the command monitoring callback is not generated.
     """
-    cfg = get_configuration['metadata']
+    config = get_configuration['metadata']
 
     # Check log line "DEBUG: Running command '<command>'"
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                            callback=logcollector.callback_dbg_running_command(log_format=cfg['log_format'],
-                                                                               command=cfg['command'],
-                                                                               prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
-                                                                               escape=True))
+                            callback=logcollector.callback_running_command(log_format=config['log_format'],
+                                                                           command=config['command'],
+                                                                           prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                                           escape=True))
 
     # Command with known output to test "Reading command message: ..."
-    if cfg['command'].startswith('echo') and cfg['alias'] != '':
-        dbg_reading_command(cfg['command'], cfg['alias'], cfg['log_format'])
+    if config['command'].startswith('echo') and config['alias'] != '':
+        dbg_reading_command(config['command'], config['alias'], config['log_format'])
 
     # "Read ... lines from command ..." only appears with log_format=command
-    if cfg['log_format'] == 'command':
+    if config['log_format'] == 'command':
         wazuh_log_monitor.start(timeout=60,
                                 error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                                callback=logcollector.callback_dbg_read_lines(command=cfg['command'],
-                                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
-                                                                              escape=True))
+                                callback=logcollector.callback_read_lines(command=config['command'],
+                                                                          prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                                          escape=True))

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
@@ -157,11 +157,8 @@ def test_command_execution_dbg(get_local_internal_options, configure_local_inter
                                configure_environment, restart_logcollector):
     """Check if the debug logs are displayed correctly when the test commands are executed.
 
-    For this purpose, the following items are tested:
-        * "DEBUG: Running command '<command>'"
-        * "DEBUG: Reading command message: 'ossec: output: '<command>': <output>'"
-        * "DEBUG: Reading command message: 'ossec: output: '<alias_command>': <output>'"
-        * "DEBUG: Read <number> lines from command <command>"
+    For this purpose, it checks that the following logs are generated:  "DEBUG: Running command...",
+    "DEBUG: Reading command message..." and, finally "Read ... lines from command...".
 
     Args:
         get_local_internal_options (fixture): Get internal configuration.

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
@@ -5,49 +5,41 @@
 import os
 import pytest
 import sys
-from wazuh_testing.tools import monitoring
-from wazuh_testing.tools import get_service
+
+from subprocess import check_output
+from wazuh_testing.tools import monitoring, LOG_FILE_PATH
+from wazuh_testing import global_parameters
 import wazuh_testing.logcollector as logcollector
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
 
 # Configuration
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_command_conf.yaml')
-wazuh_component = get_service()
-
-if sys.platform == 'win32':
-    prefix = AGENT_DETECTOR_PREFIX
-else:
-    prefix = LOG_COLLECTOR_DETECTOR_PREFIX
 
 local_internal_options = {
     'logcollector.remote_commands': 1,
-    'logcollector.debug': 2
+    'logcollector.debug': 2,
+    'monitord.rotate_log': 0
 }
 
 parameters = [
-    # Command with empty output.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo', 'ALIAS': ''},
     {'LOG_FORMAT': 'command', 'COMMAND': 'echo hello world', 'ALIAS': 'goodbye'},
-    # Command not found.
     {'LOG_FORMAT': 'command', 'COMMAND': 'not_found_command -o option -v', 'ALIAS': ''},
-    # Command that doesn't end.
-    {'LOG_FORMAT': 'command', 'COMMAND': 'tail -f /var/ossec/logs/ossec.log', 'ALIAS': ''},
-    # Command with too long output.
+    {'LOG_FORMAT': 'command', 'COMMAND': f'tail -f {LOG_FILE_PATH}', 'ALIAS': ''},
     {'LOG_FORMAT': 'command', 'COMMAND': 'ls -R /tmp', 'ALIAS': ''},
-    # Command that fails.
     {'LOG_FORMAT': 'command', 'COMMAND': 'cat doesntexists.txt', 'ALIAS': ''},
-    # Commands including special characters and "foreign" language characters.
     {'LOG_FORMAT': 'command', 'COMMAND': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'ALIAS': ''},
     {'LOG_FORMAT': 'command', 'COMMAND': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'ALIAS': ''},
     {'LOG_FORMAT': 'command', 'COMMAND': 'echo ***', 'ALIAS': ''},
-
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo', 'ALIAS': ''},
     {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo hello world', 'ALIAS': 'goodbye'},
     {'LOG_FORMAT': 'full_command', 'COMMAND': 'not_found_command -o option -v', 'ALIAS': ''},
-    {'LOG_FORMAT': 'full_command', 'COMMAND': 'tail -f /var/ossec/logs/ossec.log', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': f'tail -f {LOG_FILE_PATH}', 'ALIAS': ''},
     {'LOG_FORMAT': 'full_command', 'COMMAND': 'ls -R /tmp', 'ALIAS': ''},
     {'LOG_FORMAT': 'full_command', 'COMMAND': 'cat doesntexists.txt', 'ALIAS': ''},
     {'LOG_FORMAT': 'full_command', 'COMMAND': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'ALIAS': ''},
@@ -55,46 +47,46 @@ parameters = [
     {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo ***', 'ALIAS': ''},
 ]
 metadata = [
-    {'log_format': 'command', 'command': 'echo hello world', 'alias': 'goodbye'},
-    {'log_format': 'command', 'command': 'not_found_command -o option -v', 'alias': ''},
-    {'log_format': 'command', 'command': 'tail -f /var/ossec/logs/ossec.log', 'alias': ''},
-    {'log_format': 'command', 'command': 'ls -R /tmp', 'alias': ''},
-    {'log_format': 'command', 'command': 'cat doesntexists.txt', 'alias': ''},
-    {'log_format': 'command', 'command': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'alias': ''},
-    {'log_format': 'command', 'command': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'alias': ''},
-    {'log_format': 'command', 'command': 'echo ***', 'alias': ''},
-
-    {'log_format': 'full_command', 'command': 'echo hello world', 'alias': 'goodbye'},
-    {'log_format': 'full_command', 'command': 'not_found_command -o option -v', 'alias': ''},
-    {'log_format': 'full_command', 'command': 'tail -f /var/ossec/logs/ossec.log', 'alias': ''},
-    {'log_format': 'full_command', 'command': 'ls -R /tmp', 'alias': ''},
-    {'log_format': 'full_command', 'command': 'cat doesntexists.txt', 'alias': ''},
-    {'log_format': 'full_command', 'command': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'alias': ''},
-    {'log_format': 'full_command', 'command': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'alias': ''},
-    {'log_format': 'full_command', 'command': 'echo ***', 'alias': ''},
+    {'log_format': 'command', 'command': 'echo', 'alias': '', 'info': 'empty_output'},
+    {'log_format': 'command', 'command': 'echo hello world', 'alias': 'goodbye', 'info': 'check_output_and_alias'},
+    {'log_format': 'command', 'command': 'not_found_command -o option -v', 'alias': '', 'info': 'not_found'},
+    {'log_format': 'command', 'command': f'tail -f {LOG_FILE_PATH}', 'alias': '', 'info': 'does not end'},
+    {'log_format': 'command', 'command': 'ls -R /tmp', 'alias': '', 'info': 'long_output'},
+    {'log_format': 'command', 'command': 'cat doesntexists.txt', 'alias': '', 'info': 'that_fails'},
+    {'log_format': 'command', 'command': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'alias': '',
+     'info': 'special_chars_filename'},
+    {'log_format': 'command', 'command': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'alias': '',
+     'info': 'special_chars_command'},
+    {'log_format': 'command', 'command': 'echo ***', 'alias': '', 'info': 'special_chars_echo'},
+    {'log_format': 'full_command', 'command': 'echo', 'alias': '', 'info': 'empty_output'},
+    {'log_format': 'full_command', 'command': 'echo hello world', 'alias': 'goodbye', 'info': 'check_output_and_alias'},
+    {'log_format': 'full_command', 'command': 'not_found_command -o option -v', 'alias': '', 'info': 'not_found'},
+    {'log_format': 'full_command', 'command': f'tail -f {LOG_FILE_PATH}', 'alias': '', 'info': 'does not end'},
+    {'log_format': 'full_command', 'command': 'ls -R /tmp', 'alias': '', 'info': 'long_output'},
+    {'log_format': 'full_command', 'command': 'cat doesntexists.txt', 'alias': '', 'info': 'that_fails'},
+    {'log_format': 'full_command', 'command': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'alias': '',
+     'info': 'special_chars_filename'},
+    {'log_format': 'full_command', 'command': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'alias': '',
+     'info': 'special_chars_command'},
+    {'log_format': 'full_command', 'command': 'echo ***', 'alias': '', 'info': 'special_chars_echo'},
 ]
 
 if sys.platform == 'linux':
-    # Command that took few seconds and is killed by the system/test
-    parameters.append({'LOG_FORMAT': 'command',
-                       'COMMAND': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'ALIAS': ''})
-    parameters.append({'LOG_FORMAT': 'full_command',
-                       'COMMAND': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'ALIAS': ''})
-    # Command with many arguments.
+    parameters.append({'LOG_FORMAT': 'command', 'COMMAND': 'timeout 2 tail -f /dev/random', 'ALIAS': 'killed_by_test'})
+    parameters.append({'LOG_FORMAT': 'full_command', 'COMMAND': 'timeout 2 tail -f /dev/random', 'ALIAS': ''})
     parameters.append({'LOG_FORMAT': 'command', 'COMMAND': 'ss -l -p -u -t -4 -6 -n', 'ALIAS': ''})
     parameters.append({'LOG_FORMAT': 'full_command', 'COMMAND': 'ss -l -p -u -t -4 -6 -n', 'ALIAS': ''})
-
-    metadata.append({'log_format': 'command',
-                     'command': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'alias': ''})
-    metadata.append({'log_format': 'full_command',
-                     'command': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'alias': ''})
-    metadata.append({'log_format': 'command',
-                     'command': 'ss -l -p -u -t -4 -6 -n', 'alias': ''})
-    metadata.append({'log_format': 'full_command',
-                     'command': 'ss -l -p -u -t -4 -6 -n', 'alias': ''})
+    metadata.append({'log_format': 'command', 'command': 'timeout 2 tail -f /dev/random', 'alias': '',
+                     'info': 'killed_by_test'})
+    metadata.append({'log_format': 'full_command', 'command': 'timeout 2 tail -f /dev/random', 'alias': '',
+                     'info': 'killed_by_test'})
+    metadata.append({'log_format': 'command', 'command': 'ss -l -p -u -t -4 -6 -n', 'alias': '',
+                     'info': 'many_arguments'})
+    metadata.append({'log_format': 'full_command', 'command': 'ss -l -p -u -t -4 -6 -n', 'alias': '',
+                     'info': 'many_arguments'})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
-configuration_ids = [f"{x['LOG_FORMAT'], x['COMMAND'], x['ALIAS']}" for x in parameters]
+configuration_ids = [f"{x['log_format']}_{x['info']}" for x in metadata]
 
 
 # fixtures
@@ -123,42 +115,23 @@ def dbg_reading_command(command, alias, log_format):
     Raises:
         TimeoutError: If the command monitoring callback is not generated.
     """
-    prfx = prefix
-    output = command
-    output = output.replace('echo ', '')
+    prefix = LOG_COLLECTOR_DETECTOR_PREFIX
+    output = check_output(command, universal_newlines=True, shell=True).strip()
 
     if log_format == 'full_command':
         msg = fr"^{output}'"
-        prfx = ''
+        prefix = ''
     else:
         msg = fr"DEBUG: Reading command message: 'ossec: output: '{alias}': {output}'"
 
-    wazuh_log_monitor.start(timeout=5, callback=monitoring.make_callback(pattern=msg, prefix=prfx),
-                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
-
-
-def dbg_read_lines(command):
-    """
-    Check if the "DEBUG: Read <number> lines from command <command>" line is displayed correctly.
-
-    Args:
-        command (str): Command to be monitored.
-
-    Raises:
-        TimeoutError: If the command monitoring callback is not generated.
-    """
-    msg = fr"lines from command '{command}'"
-
-    wazuh_log_monitor.start(timeout=60, callback=monitoring.make_callback(pattern=msg, prefix=prefix, escape=True),
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=monitoring.make_callback(pattern=msg, prefix=prefix),
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
 
 
 def test_command_execution(get_local_internal_options, configure_local_internal_options, get_configuration,
                            configure_environment, restart_logcollector):
-    """Check if the Wazuh run correctly with the specified command monitoring configuration.
-
-    Ensure command monitoring allow the specified attributes. Also, in the case of manager instance, check if the API
-    answer for localfile block coincides.
+    """Check if the Wazuh runs correctly by executing different commands with special characteristics.
 
     Args:
         get_local_internal_options (fixture): Get internal configuration.
@@ -169,14 +142,15 @@ def test_command_execution(get_local_internal_options, configure_local_internal_
 
     Raises:
         TimeoutError: If the command monitoring callback is not generated.
-        AssertError: In the case of a server instance, the API response is different that the real configuration.
     """
     cfg = get_configuration['metadata']
+    msg = f": {cfg['command']}"
 
-    log_callback = logcollector.callback_monitoring_command(cfg['log_format'], cfg['command'],
-                                                            prefix=prefix, escape=True)
-    wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=msg,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=True))
 
 
 def test_command_execution_dbg(get_local_internal_options, configure_local_internal_options, get_configuration,
@@ -198,17 +172,25 @@ def test_command_execution_dbg(get_local_internal_options, configure_local_inter
 
     Raises:
         TimeoutError: If the command monitoring callback is not generated.
-        AssertError: In the case of a server instance, the API response is different that the real configuration.
     """
     cfg = get_configuration['metadata']
-    log_format_message = 'full command' if cfg['log_format'] == 'full_command' else 'command'
-    msg = fr"DEBUG: Running {log_format_message} '{cfg['command']}'"
 
-    wazuh_log_monitor.start(timeout=10, error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                            callback=monitoring.make_callback(pattern=msg, prefix=prefix, escape=True))
+    # Check log line "DEBUG: Running command '<command>'"
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=logcollector.callback_dbg_running_command(log_format=cfg['log_format'],
+                                                                               command=cfg['command'],
+                                                                               prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                                               escape=True))
 
-    if cfg['command'] == 'echo hello world':  # Command with known output to test "Reading command message: ..."
+    # Command with known output to test "Reading command message: ..."
+    if cfg['command'].startswith('echo') and cfg['alias'] != '':
         dbg_reading_command(cfg['command'], cfg['alias'], cfg['log_format'])
 
-    if cfg['log_format'] == 'command':  # "Read ... lines from command ..." only appears with log_format=command
-        dbg_read_lines(cfg['command'])
+    # "Read ... lines from command ..." only appears with log_format=command
+    if cfg['log_format'] == 'command':
+        wazuh_log_monitor.start(timeout=60,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                callback=logcollector.callback_dbg_read_lines(command=cfg['command'],
+                                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                                              escape=True))

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
@@ -1,0 +1,214 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import sys
+from wazuh_testing.tools import monitoring
+from wazuh_testing.tools import get_service
+import wazuh_testing.logcollector as logcollector
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_command_conf.yaml')
+wazuh_component = get_service()
+
+if sys.platform == 'win32':
+    prefix = AGENT_DETECTOR_PREFIX
+else:
+    prefix = LOG_COLLECTOR_DETECTOR_PREFIX
+
+local_internal_options = {
+    'logcollector.remote_commands': 1,
+    'logcollector.debug': 2
+}
+
+parameters = [
+    # Command with empty output.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo hello world', 'ALIAS': 'goodbye'},
+    # Command not found.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'not_found_command -o option -v', 'ALIAS': ''},
+    # Command that doesn't end.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'tail -f /var/ossec/logs/ossec.log', 'ALIAS': ''},
+    # Command with too long output.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'ls -R /tmp', 'ALIAS': ''},
+    # Command that fails.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'cat doesntexists.txt', 'ALIAS': ''},
+    # Commands including special characters and "foreign" language characters.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'ALIAS': ''},
+    {'LOG_FORMAT': 'command', 'COMMAND': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'ALIAS': ''},
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo ***', 'ALIAS': ''},
+
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo hello world', 'ALIAS': 'goodbye'},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'not_found_command -o option -v', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'tail -f /var/ossec/logs/ossec.log', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'ls -R /tmp', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'cat doesntexists.txt', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'ALIAS': ''},
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo ***', 'ALIAS': ''},
+]
+metadata = [
+    {'log_format': 'command', 'command': 'echo hello world', 'alias': 'goodbye'},
+    {'log_format': 'command', 'command': 'not_found_command -o option -v', 'alias': ''},
+    {'log_format': 'command', 'command': 'tail -f /var/ossec/logs/ossec.log', 'alias': ''},
+    {'log_format': 'command', 'command': 'ls -R /tmp', 'alias': ''},
+    {'log_format': 'command', 'command': 'cat doesntexists.txt', 'alias': ''},
+    {'log_format': 'command', 'command': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'alias': ''},
+    {'log_format': 'command', 'command': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'alias': ''},
+    {'log_format': 'command', 'command': 'echo ***', 'alias': ''},
+
+    {'log_format': 'full_command', 'command': 'echo hello world', 'alias': 'goodbye'},
+    {'log_format': 'full_command', 'command': 'not_found_command -o option -v', 'alias': ''},
+    {'log_format': 'full_command', 'command': 'tail -f /var/ossec/logs/ossec.log', 'alias': ''},
+    {'log_format': 'full_command', 'command': 'ls -R /tmp', 'alias': ''},
+    {'log_format': 'full_command', 'command': 'cat doesntexists.txt', 'alias': ''},
+    {'log_format': 'full_command', 'command': 'cat "ñ", "テスト", "ИСПЫТАНИЕ", "测试", "اختبار".txt', 'alias': ''},
+    {'log_format': 'full_command', 'command': 'テ``ñスト, ИСПЫТА´НИЕ",\'测`试", "اختبا', 'alias': ''},
+    {'log_format': 'full_command', 'command': 'echo ***', 'alias': ''},
+]
+
+if sys.platform == 'linux':
+    # Command that took few seconds and is killed by the system/test
+    parameters.append({'LOG_FORMAT': 'command',
+                       'COMMAND': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'ALIAS': ''})
+    parameters.append({'LOG_FORMAT': 'full_command',
+                       'COMMAND': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'ALIAS': ''})
+    # Command with many arguments.
+    parameters.append({'LOG_FORMAT': 'command', 'COMMAND': 'ss -l -p -u -t -4 -6 -n', 'ALIAS': ''})
+    parameters.append({'LOG_FORMAT': 'full_command', 'COMMAND': 'ss -l -p -u -t -4 -6 -n', 'ALIAS': ''})
+
+    metadata.append({'log_format': 'command',
+                     'command': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'alias': ''})
+    metadata.append({'log_format': 'full_command',
+                     'command': 'timeout 2 tail -f /var/ossec/logs/active-responses.log', 'alias': ''})
+    metadata.append({'log_format': 'command',
+                     'command': 'ss -l -p -u -t -4 -6 -n', 'alias': ''})
+    metadata.append({'log_format': 'full_command',
+                     'command': 'ss -l -p -u -t -4 -6 -n', 'alias': ''})
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"{x['LOG_FORMAT'], x['COMMAND'], x['ALIAS']}" for x in parameters]
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get internal configuration."""
+    return local_internal_options
+
+
+def dbg_reading_command(command, alias, log_format):
+    """Check if the (previously known) output of a command ("echo") is displayed correctly.
+
+    It also checks if the "alias" option is working correctly.
+
+    Args:
+        command (str): Command to be monitored.
+        alias (str): An alternate name for the command.
+        log_format (str): Format of the log to be read ("command" or "full_command").
+
+    Raises:
+        TimeoutError: If the command monitoring callback is not generated.
+    """
+    prfx = prefix
+    output = command
+    output = output.replace('echo ', '')
+
+    if log_format == 'full_command':
+        msg = fr"^{output}'"
+        prfx = ''
+    else:
+        msg = fr"DEBUG: Reading command message: 'ossec: output: '{alias}': {output}'"
+
+    wazuh_log_monitor.start(timeout=5, callback=monitoring.make_callback(pattern=msg, prefix=prfx),
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+
+
+def dbg_read_lines(command):
+    """
+    Check if the "DEBUG: Read <number> lines from command <command>" line is displayed correctly.
+
+    Args:
+        command (str): Command to be monitored.
+
+    Raises:
+        TimeoutError: If the command monitoring callback is not generated.
+    """
+    msg = fr"lines from command '{command}'"
+
+    wazuh_log_monitor.start(timeout=60, callback=monitoring.make_callback(pattern=msg, prefix=prefix, escape=True),
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+
+
+def test_command_execution(get_local_internal_options, configure_local_internal_options, get_configuration,
+                           configure_environment, restart_logcollector):
+    """Check if the Wazuh run correctly with the specified command monitoring configuration.
+
+    Ensure command monitoring allow the specified attributes. Also, in the case of manager instance, check if the API
+    answer for localfile block coincides.
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_logcollector (fixture): Reset log file and start a new monitor.
+
+    Raises:
+        TimeoutError: If the command monitoring callback is not generated.
+        AssertError: In the case of a server instance, the API response is different that the real configuration.
+    """
+    cfg = get_configuration['metadata']
+
+    log_callback = logcollector.callback_monitoring_command(cfg['log_format'], cfg['command'],
+                                                            prefix=prefix, escape=True)
+    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+
+
+def test_command_execution_dbg(get_local_internal_options, configure_local_internal_options, get_configuration,
+                               configure_environment, restart_logcollector):
+    """Check if the debug logs are displayed correctly when the test commands are executed.
+
+    For this purpose, the following items are tested:
+        * "DEBUG: Running command '<command>'"
+        * "DEBUG: Reading command message: 'ossec: output: '<command>': <output>'"
+        * "DEBUG: Reading command message: 'ossec: output: '<alias_command>': <output>'"
+        * "DEBUG: Read <number> lines from command <command>"
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_logcollector (fixture): Reset log file and start a new monitor.
+
+    Raises:
+        TimeoutError: If the command monitoring callback is not generated.
+        AssertError: In the case of a server instance, the API response is different that the real configuration.
+    """
+    cfg = get_configuration['metadata']
+    log_format_message = 'full command' if cfg['log_format'] == 'full_command' else 'command'
+    msg = fr"DEBUG: Running {log_format_message} '{cfg['command']}'"
+
+    wazuh_log_monitor.start(timeout=10, error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=msg, prefix=prefix, escape=True))
+
+    if cfg['command'] == 'echo hello world':  # Command with known output to test "Reading command message: ..."
+        dbg_reading_command(cfg['command'], cfg['alias'], cfg['log_format'])
+
+    if cfg['log_format'] == 'command':  # "Read ... lines from command ..." only appears with log_format=command
+        dbg_read_lines(cfg['command'])

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import sys
+from datetime import timedelta, datetime
+
+from wazuh_testing import logger
+from wazuh_testing.tools import get_service, monitoring
+from wazuh_testing.tools.time import TimeMachine
+import wazuh_testing.logcollector as logcollector
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_command_conf.yaml')
+wazuh_component = get_service()
+
+if sys.platform == 'win32':
+    prefix = AGENT_DETECTOR_PREFIX
+else:
+    prefix = LOG_COLLECTOR_DETECTOR_PREFIX
+
+local_internal_options = {
+    'logcollector.remote_commands': 1,
+    'logcollector.debug': 2,
+    'monitord.rotate_log': 0
+}
+
+parameters = [
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo execution frequency 300', 'FREQUENCY': 300},  # 5 minutes.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo execution frequency 1800', 'FREQUENCY': 1800},  # 30 minutes.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo execution frequency 3600', 'FREQUENCY': 3600},  # 1 hour.
+    {'LOG_FORMAT': 'command', 'COMMAND': 'echo execution frequency 86400', 'FREQUENCY': 86400},  # 24 hours.
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo full_command frequency 300', 'FREQUENCY': 300},  # 5 minutes.
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo full_command frequency 1800', 'FREQUENCY': 1800},  # 30 minutes.
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo full_command frequency 3600', 'FREQUENCY': 3600},  # 1 hour.
+    {'LOG_FORMAT': 'full_command', 'COMMAND': 'echo full_command frequency 86400', 'FREQUENCY': 86400}  # 24 hours.
+]
+metadata = [
+    {'log_format': 'command', 'command': 'echo execution frequency 300', 'frequency': 300},  # 5 minutes.
+    {'log_format': 'command', 'command': 'echo execution frequency 1800', 'frequency': 1800},  # 30 minutes.
+    {'log_format': 'command', 'command': 'echo execution frequency 3600', 'frequency': 3600},  # 1 hour.
+    {'log_format': 'command', 'command': 'echo execution frequency 86400', 'frequency': 86400},  # 24 hours.
+    {'log_format': 'full_command', 'command': 'echo full_command frequency 300', 'frequency': 300},  # 5 minutes.
+    {'log_format': 'full_command', 'command': 'echo full_command frequency 1800', 'frequency': 1800},  # 30 minutes.
+    {'log_format': 'full_command', 'command': 'echo full_command frequency 3600', 'frequency': 3600},  # 1 hour.
+    {'log_format': 'full_command', 'command': 'echo full_command frequency 86400', 'frequency': 86400}  # 24 hours.
+]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"{x['LOG_FORMAT'], x['COMMAND'], x['FREQUENCY']}" for x in parameters]
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+
+def test_command_execution_freq(get_local_internal_options, configure_local_internal_options, get_configuration,
+                                configure_environment, restart_logcollector):
+    """Check if the Wazuh run correctly with the specified command monitoring option "frequency".
+
+    For this purpose, it is verified that the command has not been executed
+    before the period established in this option.
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_logcollector (fixture): Reset log file and start a new monitor.
+
+    Raises:
+        TimeoutError: If the command monitoring callback is not generated.
+        AssertError: In the case of a server instance, the API response is different that the real configuration.
+    """
+    cfg = get_configuration['metadata']
+    log_format_message = 'full command' if cfg['log_format'] == 'full_command' else 'command'
+    msg = fr"DEBUG: Running {log_format_message} '{cfg['command']}'"
+    log_callback = monitoring.make_callback(pattern=msg, prefix=prefix)
+    seconds_to_travel = cfg['frequency'] / 2  # Middle of the command execution cycle.
+
+    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+
+    before = str(datetime.now())
+    TimeMachine.travel_to_future(timedelta(seconds=seconds_to_travel))
+    logger.debug(f"Changing the system clock from {before} to {str(datetime.now())}")
+
+    # The command should not be executed in the middle of the command execution cycle.
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+
+    before = str(datetime.now())
+    TimeMachine.travel_to_future(timedelta(seconds=seconds_to_travel-5))
+    logger.debug(f"Changing the system clock from {before} to {str(datetime.now())}")
+
+    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.py
@@ -80,10 +80,10 @@ def test_command_execution_freq(get_local_internal_options, configure_local_inte
     Raises:
         TimeoutError: If the command monitoring callback is not generated.
     """
-    cfg = get_configuration['metadata']
-    log_callback = logcollector.callback_dbg_running_command(log_format=cfg['log_format'], command=cfg['command'],
-                                                             prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
-    seconds_to_travel = cfg['frequency'] / 2  # Middle of the command execution cycle.
+    config = get_configuration['metadata']
+    log_callback = logcollector.callback_running_command(log_format=config['log_format'], command=config['command'],
+                                                         prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
+    seconds_to_travel = config['frequency'] / 2  # Middle of the command execution cycle.
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=log_callback,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1236 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds tests for the logcollector command monitoring functionality as part of #1027. 
To achieve this, the following is verified:
- [x] Test command  and full_command options.
- [x] The commands tested must be available on **Linux/MacOS** or use different commands for each one.
- [x] Test command with empty output.
- [x] Test command not found.
- [x] Test command that doesn't end.
- [x] Test command with too long output.
- [x] Test command that fails.
- [x] Test command that took few seconds and is killed by the system/test.
- [x] Test command with many arguments.
- [x] Test command including special characters and "foreign" language characters.
- [x] Verify that the debug logs are correctly written:
  - [x] "Read ... lines from command '...'"
  - [x] "Running command ..."
  - [x] "Reading command message ... " appear and the output coincides with the expected one.
- [x] Test the alias option

These tests are valid for manager and agent in Linux and MacOS systems.

## Test results
### Manager
 
![manager](https://user-images.githubusercontent.com/80053749/116575030-93d86200-a90e-11eb-8d0e-bd0a27f759cf.png)
![manager_freq](https://user-images.githubusercontent.com/80053749/116575047-976be900-a90e-11eb-98de-72578bb55ed8.png)

### Linux agent 

![agent](https://user-images.githubusercontent.com/80053749/116575080-9dfa6080-a90e-11eb-9973-8b217c5ee964.png)
![agent_freq](https://user-images.githubusercontent.com/80053749/116575092-9f2b8d80-a90e-11eb-936b-ab59dd1648ae.png)

## Test

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.