### PR TITLE
Update basic configuration tests for only_future_events options with …

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
+++ b/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
@@ -17,6 +17,22 @@ def callback_invalid_value(option, value, prefix, severity='ERROR'):
     msg = fr"{severity}: \(\d+\): Invalid value for element '{option}': {value}."
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 
+def callback_invalid_attribute(option, attribute, value, prefix, severity='WARNING'):
+    """Create a callback to detect invalid values in ossec.conf file.
+
+    Args:
+        option (str): Wazuh manager configuration option.
+        attribute (str): Wazuh manager configuration attribute.
+        value (str): Value of the configuration option.
+        prefix (str): Daemon that generates the error log.
+        severity (str): Severity of the error (WARNING, ERROR or CRITICAL)
+
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"{severity}: \(\d+\): Invalid value '{value}' for attribute '{attribute}' in '{option}' option."
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
 
 def callback_error_in_configuration(severity, prefix, conf_path=WAZUH_CONF):
     """Create a callback to detect configuration error in ossec.conf file.

--- a/docs/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.md
+++ b/docs/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.md
@@ -2,13 +2,14 @@
 ## Overview 
 
 Check if `wazuh-agent` fails using invalid `only-future-events` values and allows valid `only-future-events` 
-values.
+values. It also tests the attribute `max-size` for the option which is supposed to accept a number and an unit suach 
+as 'KB' or 'GB' 
 
 ## Objective
 
-- To confirm `only-future-events` option allows valid values.
-- To confirm `wazuh-logcollector` and `wazuh-agent` fails when invalid `only-future-events` 
-  values are provided.
+- To confirm `only-future-events` option and the attribute `max-size`allow valid values.
+- To confirm `wazuh-logcollector` and `wazuh-agent` fails when invalid `only-future-events`  or invalid `max-size` 
+  values are provided
 - To confirm the API response is equal to set configuration.
 
 ## General info

--- a/tests/integration/test_logcollector/test_configuration/data/wazuh_basic_configuration.yaml
+++ b/tests/integration/test_logcollector/test_configuration/data/wazuh_basic_configuration.yaml
@@ -65,6 +65,8 @@
         value: LOG_FORMAT
     - only-future-events:
         value: ONLY_FUTURE_EVENTS
+        attributes:
+          - 'max-size': MAX_SIZE
 
 - tags:
   - test_basic_configuration_frequency

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
@@ -9,17 +9,13 @@ import sys
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 import wazuh_testing.generic_callbacks as gc
 import wazuh_testing.logcollector as logcollector
-from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX
-from wazuh_testing.tools import get_service
-
+from wazuh_testing.tools.monitoring import AGENT_DETECTOR_PREFIX, FileMonitor, LOG_COLLECTOR_DETECTOR_PREFIX
+from wazuh_testing.tools import get_service, LOG_FILE_PATH
 
 LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
 
 # Marks
-if sys.platform != 'win32':
-    pytestmark = [pytest.mark.skip, pytest.mark.tier(level=0)]
-else:
-    pytestmark = pytest.mark.tier(level=0)
+# pytestmark = pytest.mark.tier(level=0)
 
 # Configuration
 no_restart_windows_after_configuration_set = True
@@ -27,33 +23,148 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_basic_configuration.yaml')
 
 wazuh_component = get_service()
-prefix = AGENT_DETECTOR_PREFIX
 
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-parameters = [
-    {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'yes'},
-    {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no'},
-    {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'yesTesting'},
-    {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'noTesting'},
-    {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'testingvalue'},
-    {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': '1234'}
+if sys.platform == 'win32':
+    prefix = AGENT_DETECTOR_PREFIX
+    parameters = [
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no',
+            'MAX_SIZE': '9999999999999999999999999999999B'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '5000B'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '500KB'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '50MB'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '5GB'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '43423423423'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '-12345'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': 'test'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '{}'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '!32817--'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'yes'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'no'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'yesTesting'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'noTesting'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': 'testingvalue'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'eventchannel', 'ONLY_FUTURE_EVENTS': '1234'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'yes'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'no'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'yesTesting'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'noTesting'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'testingvalue'},
+        {'LOCATION': 'Security', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': '1234'}
+    ]
 
-]
+    metadata = [
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no',
+         'max-size': '9999999999999999999999999999999B', 'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '5000B',
+            'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '500KB',
+            'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '50MB',
+            'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '5GB',
+            'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '43423423423',
+         'invalid_value': 'max-size'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '-12345',
+         'invalid_value': 'max-size'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': 'test',
+         'invalid_value': 'max-size'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '{}',
+         'invalid_value': 'max-size'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'max-size': '!32817--',
+         'invalid_value': 'max-size'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'yes', 'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'yesTesting',
+         'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'noTesting', 'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'testingvalue',
+         'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': '1234', 'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'syslog', 'only-future-events': 'yes', 'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'syslog', 'only-future-events': 'no', 'invalid_value': ''},
+        {'location': 'Security', 'log_format': 'syslog', 'only-future-events': 'yesTesting',
+         'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'syslog', 'only-future-events': 'noTesting', 'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'syslog', 'only-future-events': 'testingvalue',
+         'invalid_value': 'only-future-events'},
+        {'location': 'Security', 'log_format': 'syslog', 'only-future-events': '1234', 'invalid_value': 'only-future-events'}
+    ]
 
-metadata = [
-    {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'yes', 'valid_value': True},
-    {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'no', 'valid_value': True},
-    {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'yesTesting', 'valid_value': False},
-    {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'noTesting', 'valid_value': False},
-    {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': 'testingvalue', 'valid_value': False},
-    {'location': 'Security', 'log_format': 'eventchannel', 'only-future-events': '1234', 'valid_value': False}
+else:
+    prefix = LOG_COLLECTOR_DETECTOR_PREFIX
+    parameters = [
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no',
+            'MAX_SIZE': '9999999999999999999999999999999B'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '5000B'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '500KB'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '50MB'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '5GB'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '43423423423'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '-12345'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': 'test'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '{/}'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '!32817--'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'yes'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'no'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'yesTesting'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'noTesting'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': 'testingvalue'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'json', 'ONLY_FUTURE_EVENTS': '1234'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'yes'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'no'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'yesTesting'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'noTesting'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': 'testingvalue'},
+        {'LOCATION': '/var/log/testing.log', 'LOG_FORMAT': 'syslog', 'ONLY_FUTURE_EVENTS': '1234'}
+    ]
 
-]
+    metadata = [
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': '',
+            'max-size': '9999999999999999999999999999999B'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': '',
+            'max-size': '5000B'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': '',
+            'max-size': '500KB'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': '',
+            'max-size': '50MB'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': '',
+            'max-size': '5GB'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': 'max-size',
+         'max-size': '43423423423'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': 'max-size',
+         'max-size': '-12345'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': 'max-size',
+         'max-size': 'test'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': 'max-size',
+         'max-size': '{/}'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': 'max-size',
+         'max-size': '!32817--'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'yes', 'invalid_value': ''},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'no', 'invalid_value': ''},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'yesTesting',
+         'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'noTesting', 'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': 'testingvalue',
+         'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'json', 'only-future-events': '1234', 'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'syslog', 'only-future-events': 'yes', 'invalid_value': ''},
+        {'location': '/var/log/testing.log', 'log_format': 'syslog', 'only-future-events': 'no', 'invalid_value': ''},
+        {'location': '/var/log/testing.log', 'log_format': 'syslog', 'only-future-events': 'yesTesting',
+         'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'syslog', 'only-future-events': 'noTesting', 'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'syslog', 'only-future-events': 'testingvalue',
+         'invalid_value': 'only-future-events'},
+        {'location': '/var/log/testing.log', 'log_format': 'syslog', 'only-future-events': '1234', 'invalid_value': 'only-future-events'}
+    ]
 
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=parameters,
                                            metadata=metadata)
-configuration_ids = [f"{x['LOCATION'], x['LOG_FORMAT'], x['ONLY_FUTURE_EVENTS']}" for x in parameters]
+configuration_ids = [f"{x['LOG_FORMAT']}_{x['ONLY_FUTURE_EVENTS']}_{x['MAX_SIZE']}" + f"" if 'MAX_SIZE' in x
+                     else f"{x['LOG_FORMAT']}_{x['ONLY_FUTURE_EVENTS']}" for x in parameters]
 
 
 def check_only_future_events_valid(cfg):
@@ -64,7 +175,11 @@ def check_only_future_events_valid(cfg):
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
     """
-    log_callback = logcollector.callback_eventchannel_analyzing(cfg['location'])
+    if sys.platform == 'win32':
+        log_callback = logcollector.callback_eventchannel_analyzing(cfg['location'])
+    else:
+        log_callback = logcollector.callback_analyzing_file(cfg['location'])
+
     wazuh_log_monitor.start(timeout=5, callback=log_callback,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_EVENTCHANNEL)
 
@@ -78,8 +193,16 @@ def check_only_future_events_invalid(cfg):
         TimeoutError: If error callbacks are not generated.
     """
 
-    log_callback = gc.callback_invalid_value('only-future-events', cfg['only-future-events'],
-                                             prefix, severity="WARNING")
+    invalid_value = cfg['invalid_value']
+
+    if invalid_value == 'max-size':
+        option_value = cfg['max-size']
+        log_callback = gc.callback_invalid_attribute('only-future-events', 'max-size', option_value,
+                                                     prefix, severity="WARNING")
+    else:
+        option_value = cfg['only-future-events']
+        log_callback = gc.callback_invalid_value(invalid_value, option_value, prefix, severity="WARNING")
+
     wazuh_log_monitor.start(timeout=5, callback=log_callback,
                             error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
 
@@ -101,7 +224,7 @@ def test_only_future_events(get_configuration, configure_environment, restart_lo
     """
     cfg = get_configuration['metadata']
 
-    if cfg['valid_value']:
+    if cfg['invalid_value'] == '':
         check_only_future_events_valid(cfg)
     else:
         check_only_future_events_invalid(cfg)


### PR DESCRIPTION
…new 4.2 options

|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1264|

## Description

In 4.2 an option, `max-size`have been added for the logcollector's `only_future_events` options, which, now is also available for Linux and Unix systems. 

This PR aims to add support for this two new features to the existing integration test for logcollector.

## Configuration options
```
<localfile>
    <log_format>syslog</log_format>
    <location>/tmp/mytestlog.log</location>
    <only-future-events>TEST</only-future-events>
  </localfile>
```

## Logs example
```
2021/04/30 09:36:55 wazuh-logcollector[57473] localfile-config.c:106 at Read_Localfile(): WARNING: (8000): Invalid value 'MAX_SIZE' for attribute 'max-size' in 'only-future-events' option. Default value will be used.
2021/04/30 09:36:55 wazuh-logcollector[57473] localfile-config.c:121 at Read_Localfile(): WARNING: (1235): Invalid value for element 'only-future-events': noTesting.
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
![image](https://user-images.githubusercontent.com/15269938/116677389-70fa8c00-a9a8-11eb-98eb-a1b04a315261.png)
- [x] Proven that tests **fail** when they have to fail.
![image](https://user-images.githubusercontent.com/15269938/116677517-98e9ef80-a9a8-11eb-9e40-e20e81cb5682.png)
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.