### PR TITLE
Remove absolute path from AR tests

### DIFF
--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -155,7 +155,7 @@ def wait_message_line(line):
         line (str): String containing message.
     """
     if "{\"version\"" in line:
-        return line.split("/ossec/active-response/bin/firewall-drop: ", 1)[1]
+        return line.split("active-response/bin/firewall-drop: ", 1)[1]
     return None
 
 

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -109,7 +109,7 @@ def wait_message_line(line):
     """Callback function to wait for Active Response JSON message."""
     if platform.system() == 'Windows' and "active-response/bin/restart-wazuh.exe: {\"version\"" in line:
         return True
-    elif "ossec/active-response/bin/restart-wazuh: {\"version\"" in line:
+    elif "active-response/bin/restart-wazuh: {\"version\"" in line:
         return True
     return None
 


### PR DESCRIPTION
## Description

The AR tests were expecting to receive a log with the absolute path of the active-reponse/bin directory.

Since WAZUH_HOME, now all paths are relative paths and these tests were not updated, which was the reason why AR logs weren't matching the expected ones.

Jenkins execution: https://ci.wazuh.info/job/Test_integration/2307/console

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.