### PR TITLE
Add custom labels to the simulate agents script

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent_version='v4.0.0',
                agent_os='debian8', eps=1000, run_duration=20, active_modules=[], modules_eps=None,
-               fixed_message_size=None, registration_address=None):
+               fixed_message_size=None, registration_address=None, labels=None):
     """Run a batch of agents connected to a manager with the same parameters.
 
     Args:
@@ -27,6 +27,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
         modules_eps (list): list with eps for each active modules.
         fixed_message_size (int): size in bytes for the message.
         registration_address (str): Manager IP address where the agent will be registered.
+        labels (dict): Wazuh agent labels in dict format.
     """
 
     logger = logging.getLogger(f"P{os.getpid()}")
@@ -37,7 +38,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
     for _ in range(agents_number):
         agent = ag.Agent(manager_address, "aes", os=agent_os, version=agent_version, fim_eps=eps,
                          fixed_message_size=fixed_message_size, syscollector_frequency=0,
-                         registration_address=registration_address, retry_enrollment=True)
+                         registration_address=registration_address, retry_enrollment=True, labels=labels)
         available_modules = agent.modules.keys()
 
         for module in active_modules:
@@ -119,6 +120,9 @@ def main():
     arg_parser.add_argument('-m', '--modules', dest='modules', required=False, type=str, nargs='+', action='store',
                             default=['fim'], help='Active module separated by whitespace.')
 
+    arg_parser.add_argument('-l', '--labels', dest='labels', required=False, type=str, nargs='+',
+                            action='store', default=None, help='Wazuh agent labels.')
+
     arg_parser.add_argument('-s', '--modules-eps', dest='modules_eps', required=False, type=int, nargs='+',
                             action='store', default=None, help='Active module EPS separated by whitespace.')
 
@@ -145,6 +149,17 @@ def main():
 
     processes = []
 
+    custom_labels = args.labels
+
+    # Parse the custom labels from list format to dict
+    if args.labels is not None:
+        custom_labels = {}
+
+        for item in args.labels:
+            label = item.split(':')
+            custom_labels[label[0]] = label[1]
+
+    # Create the process list
     for i in range(n_processes):
         agents = args.agent_batch
         if remainder != 0 and i == 0:
@@ -152,7 +167,7 @@ def main():
 
         arguments = (
             agents, args.manager_addr, args.agent_protocol, args.version, args.os, args.eps, args.duration,
-            args.modules, args.modules_eps, args.fixed_message_size, args.manager_registration_address
+            args.modules, args.modules_eps, args.fixed_message_size, args.manager_registration_address, custom_labels
         )
 
         processes.append(Process(target=run_agents, args=arguments))

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -618,6 +618,8 @@ class Agent:
                 msg_as_list.insert(1, f'"{key}":{value}')
             msg = '\n'.join(msg_as_list)
 
+        logging.debug(f"Keep alive message = {msg}")
+
         self.keep_alive_event = self.create_event(msg)
         self.keep_alive_raw_msg = msg
 


### PR DESCRIPTION
|Related issue|
|---|
|#1260|

## Description

This PR updates the agent simulator script to add a new parameter that allows us to specify custom labels that will be added in the keep-alive message of each agent.

The new labels must be in the following format:

```
simulate-agents ... -l label1:value1 label2:value2 label3:value3
```

This is an example of a keep-alive message

```
#!-Linux |agent-debian10 |4.9.0-12-amd64 |#1 SMP Debian 4.9.210-1 (2020-01-20) |x86_64 [Debian GNU/Linux|debian: 10 (buster)] - Wazuh 4.2.0 / ab73af41699f13fdd81903b5f23d8d00
"key10":value10
"key9":value9
"key8":value8
"key7":value7
"key6":value6
"key5":value5
"key4":value4
"key3":value3
"key2":value2
"key1":value1
d6e3ac3e75ca0319af3e7c262776f331 merged.mg
#"_agent_ip":10.0.2.15
```

