### PR TITLE
Fix issue with vulnerability detector integration tests on 4.2 branch

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/feeds/custom_nvd_feed.json
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/feeds/custom_nvd_feed.json
@@ -1,0 +1,534 @@
+{
+  "CVE_data_type": "CVE",
+  "CVE_data_format": "MITRE",
+  "CVE_data_version": "4.0",
+  "CVE_data_numberOfCVEs": "1",
+  "CVE_data_timestamp": "2020-05-21T07:00Z",
+  "CVE_Items": [
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-000",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-0",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-0:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
+    },
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-001",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-1",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-1:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
+    },
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-002",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-2",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-2:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
+    },
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-003",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-3",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-3:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
+    },
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-004",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-4",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-4:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

The following test for Vulnerability Detector is failing:

```
======================================================= short test summary info =======================================================
FAILED test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_yes]
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
==================================================== 1 failed in 61.54s (0:01:01) =====================================================
```

The reason is that the NVD feed is not located where the test defines it, so the scanner fails to fetch it:
```
2021/04/30 20:16:10 wazuh-modulesd:vulnerability-detector[35242] wm_vuln_detector.c:3978 at wm_vuldet_fetch_feed(): DEBUG: (5403): Fetching feed from '/root/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/data/feeds/custom_nvd_feed.json'
2021/04/30 20:16:10 wazuh-modulesd:vulnerability-detector[35242] wm_vuln_detector.c:6590 at wm_vuldet_index_json(): ERROR: (5551): Invalid multi_path '/root/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/data/feeds': 'No such file or directory'
```

After adding the feed, the test passes as expected.

```
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_yes] PASSED [ 50%]
test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py::test_run_on_start[run_on_start_no] PASSED [100%]

========================================================= 2 passed in 24.56s ==========================================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.