### PR TITLE
Fix API integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -49,24 +49,25 @@ def get_login_headers(user, password):
             'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
 
 
-def get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout):
+def get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout, login_attempts, sleep_time):
     """Get API login token"""
 
     login_url = f"{get_base_url(protocol, host, port)}{login_endpoint}"
 
-    for _ in range(10):
+    for _ in range(login_attempts):
         response = requests.get(login_url, headers=get_login_headers(user, password), verify=False, timeout=timeout)
 
         if response.status_code == 200:
             return json.loads(response.content.decode())['data']['token']
-        time.sleep(1)
+        time.sleep(sleep_time)
     else:
         raise RuntimeError(f"Error obtaining login token: {response.json()}")
 
 
 def get_api_details_dict(protocol=API_PROTOCOL, host=API_HOST, port=API_PORT, user=API_USER, password=API_PASS,
-                         login_endpoint=API_LOGIN_ENDPOINT, timeout=10):
-    login_token = get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout)
+                         login_endpoint=API_LOGIN_ENDPOINT, timeout=10, login_attempts=1, sleep_time=0):
+    login_token = get_token_login_api(protocol, host, port, user, password, login_endpoint, timeout, login_attempts,
+                                      sleep_time)
     """Get API details"""
     return {
         'base_url': get_base_url(protocol, host, port),

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -55,8 +55,7 @@ def configure_api_environment(get_configuration, request):
             shutil.rmtree(test_dir, ignore_errors=True)
 
     # Restore previous configuration
-    if backup_config:
-        write_api_conf(WAZUH_API_CONF, backup_config)
+    write_api_conf(WAZUH_API_CONF, backup_config if backup_config else {})
 
     # Restore previous RBAC configuration
     if backup_security_config:

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -50,9 +50,8 @@ def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_
     max_login_attempts = get_configuration['configuration']['access']['max_login_attempts']
 
     # Provoke a block from an unknown IP ('max_login_attempts' attempts with incorrect credentials).
-    for _ in range(max_login_attempts):
-        with pytest.raises(Exception):
-            get_api_details(user='wrong', password='wrong')
+    with pytest.raises(Exception):
+        get_api_details(user='wrong', password='wrong', login_attempts=max_login_attempts, sleep_time=0)
 
     # Request with correct credentials before blocking time expires.
     with pytest.raises(Exception) as login_exc:

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -50,11 +50,11 @@ def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_
     max_login_attempts = get_configuration['configuration']['access']['max_login_attempts']
 
     # Provoke a block from an unknown IP ('max_login_attempts' attempts with incorrect credentials).
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         get_api_details(user='wrong', password='wrong', login_attempts=max_login_attempts, sleep_time=0)
 
     # Request with correct credentials before blocking time expires.
-    with pytest.raises(Exception) as login_exc:
+    with pytest.raises(RuntimeError) as login_exc:
         get_api_details()
     assert 'Error obtaining login token' in login_exc.value.args[0], f'An error getting the token was expected, but ' \
                                                                      f'it was not obtained. \nFull response: ' \

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -29,6 +29,7 @@ def get_configuration(request):
 
 # Tests
 
+@pytest.mark.xfail(reason="Error fixed in this issue: https://github.com/wazuh/wazuh/issues/8485")
 @pytest.mark.parametrize('origin, tags_to_apply', [
     ('https://test_url.com', {'cors'}),
     ('http://other_url.com', {'cors'}),

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -146,8 +146,10 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
     Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
     is not active, an error is returned.
 
-    Attributes:
-        tags_to_apply (set): Run test if match with a configuration identifier, skip otherwise.
+    Parameters
+    ----------
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
 

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -77,11 +77,11 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
-        assert post_response.status_code == 500, 'Expected status code was 500, ' \
-                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 400, 'Expected status code was 400, but {post_response.status_code} was ' \
+                                                 'returned. \nFull response: {post_response.text}'
     else:
-        assert post_response.status_code == 200, 'Expected status code was 200, ' \
-                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 200, 'Expected status code was 200, but {post_response.status_code} was ' \
+                                                 'returned. \nFull response: {post_response.text}'
 
         # Delete the agent created
         agent_id = post_response.json()['data']['id']
@@ -123,11 +123,11 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
-        assert post_response.status_code == 500, 'Expected status code was 500, ' \
-                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 400, 'Expected status code was 400, but {post_response.status_code} was ' \
+                                                 'returned. \nFull response: {post_response.text}'
     else:
-        assert post_response.status_code == 200, 'Expected status code was 200, ' \
-                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 200, 'Expected status code was 200, but {post_response.status_code} was ' \
+                                                 'returned. \nFull response: {post_response.text}'
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']
@@ -164,11 +164,11 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
-        assert post_response.status_code == 500, 'Expected status code was 500, ' \
-                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 400, 'Expected status code was 400, but {post_response.status_code} was ' \
+                                                 'returned. \nFull response: {post_response.text}'
     else:
-        assert post_response.status_code == 200, 'Expected status code was 200, ' \
-                                                 f'but {post_response.status_code} was returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 200, 'Expected status code was 200, but {post_response.status_code} was ' \
+                                                 'returned. \nFull response: {post_response.text}'
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -77,11 +77,11 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
-        assert post_response.status_code == 400, 'Expected status code was 400, but {post_response.status_code} was ' \
-                                                 'returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 400, f'Expected status code was 400, but {post_response.status_code} was ' \
+                                                 f'returned. \nFull response: {post_response.text}'
     else:
-        assert post_response.status_code == 200, 'Expected status code was 200, but {post_response.status_code} was ' \
-                                                 'returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 200, f'Expected status code was 200, but {post_response.status_code} was ' \
+                                                 f'returned. \nFull response: {post_response.text}'
 
         # Delete the agent created
         agent_id = post_response.json()['data']['id']
@@ -123,11 +123,11 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
-        assert post_response.status_code == 400, 'Expected status code was 400, but {post_response.status_code} was ' \
-                                                 'returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 400, f'Expected status code was 400, but {post_response.status_code} was ' \
+                                                 f'returned. \nFull response: {post_response.text}'
     else:
-        assert post_response.status_code == 200, 'Expected status code was 200, but {post_response.status_code} was ' \
-                                                 'returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 200, f'Expected status code was 200, but {post_response.status_code} was ' \
+                                                 f'returned. \nFull response: {post_response.text}'
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']
@@ -146,10 +146,8 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
     Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
     is not active, an error is returned.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
+    Attributes:
+        tags_to_apply (set): Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
@@ -164,11 +162,11 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.
     if use_only_authd:
-        assert post_response.status_code == 400, 'Expected status code was 400, but {post_response.status_code} was ' \
-                                                 'returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 400, f'Expected status code was 400, but {post_response.status_code} was ' \
+                                                 f'returned. \nFull response: {post_response.text}'
     else:
-        assert post_response.status_code == 200, 'Expected status code was 200, but {post_response.status_code} was ' \
-                                                 'returned. \nFull response: {post_response.text}'
+        assert post_response.status_code == 200, f'Expected status code was 200, but {post_response.status_code} was ' \
+                                                 f'returned. \nFull response: {post_response.text}'
 
         # Delete the agent
         agent_id = post_response.json()['data']['id']

--- a/tests/integration/test_api/test_rbac/conftest.py
+++ b/tests/integration/test_api/test_rbac/conftest.py
@@ -26,12 +26,17 @@ def set_security_resources(request):
     # Create new user
     response = requests.post(users_endpoint,
                              json={'username': f'test_user',
-                                   'password': 'Password1!',
-                                   'allow_run_as': False},
+                                   'password': 'Password1!'},
                              headers=api_details['auth_headers'], verify=False)
     assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
                                         f'{response.text}'
     user_id = response.json()['data']['affected_items'][0]['id']
+
+    # Edit allow_run_as
+    response = requests.put(users_endpoint + f'/{user_id}/run_as?allow_run_as=true',
+                            headers=api_details['auth_headers'], verify=False)
+    assert response.status_code == 200, f'Expected status code was 200. Full response: ' \
+                                        f'{response.text}'
 
     # Create new role
     response = requests.post(roles_endpoint,


### PR DESCRIPTION
## Description
Hi team!

This PR fixes the API integration tests that were failing in 4.2.

## Tests
```
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 -m pytest /wazuh-qa/tests/integration/test_api
/var/ossec/framework/python/lib/python3.9/site-packages/_testinfra_renamed.py:5: DeprecationWarning: testinfra package has been renamed to pytest-testinfra. Please `pip install pytest-testinfra` and `pip uninstall testinfra` and update your package requirements to avoid this message
  warnings.warn((
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-6.3.0, testinfra-6.0.0, metadata-1.11.0
collected 78 items                                                                                                                                                                              

wazuh-qa/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss.                                                                                 [  5%]
wazuh-qa/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss.                                                                   [ 10%]
wazuh-qa/tests/integration/test_api/test_config/test_cache/test_cache.py .ss.                                                                                                             [ 15%]
wazuh-qa/tests/integration/test_api/test_config/test_cors/test_cors.py xX                                                                                                                 [ 17%]
wazuh-qa/tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.                                                                                         [ 23%]
wazuh-qa/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py .ss.                                                                             [ 28%]
wazuh-qa/tests/integration/test_api/test_config/test_host_port/test_host_port.py .s.ss.s.                                                                                                 [ 38%]
wazuh-qa/tests/integration/test_api/test_config/test_https/test_https.py .ss.                                                                                                             [ 43%]
wazuh-qa/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                             [ 48%]
wazuh-qa/tests/integration/test_api/test_config/test_logs/test_logs.py .ss.                                                                                                               [ 53%]
wazuh-qa/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py .ss.                                                                                                          [ 58%]
wazuh-qa/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.s.ss.s.s.s.                                                                               [ 79%]
wazuh-qa/tests/integration/test_api/test_rbac/test_add_old_resource.py ....                                                                                                               [ 84%]
wazuh-qa/tests/integration/test_api/test_rbac/test_admin_resources.py ..FF                                                                                                                [ 89%]
wazuh-qa/tests/integration/test_api/test_rbac/test_policy_position.py E                                                                                                                   [ 91%]
wazuh-qa/tests/integration/test_api/test_rbac/test_remove_relationship.py EEE                                                                                                             [ 94%]
wazuh-qa/tests/integration/test_api/test_rbac/test_remove_resource.py EEEE                                                                                                                [100%]
```

RBAC tests are failing due to:
```JSON
Error obtaining login token: 
{
    "title": "Too Many Requests",
    "detail": "Maximum number of request per minute reached",
    "remediation": "This limit can be changed in security.yaml file. More information here: https://documentation.wazuh.com/current/user-manual/api/configuration.html#configuration-file",
    "error": 6001,
}
```

It is strange because the API is restarted before each test. It doesn't seem to happen when separately running the `test_rbac`. I'm still investigaing it. 

Regards,
Selu.