### PR TITLE
Add API simulator templates and configuration

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/api_extra_load_template.yaml
+++ b/deps/wazuh_testing/wazuh_testing/data/api_extra_load_template.yaml
@@ -1,0 +1,26 @@
+requests:
+  -
+    endpoint: /agents
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /cluster/healthcheck
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /cluster/configuration/validation
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /groups/default/agents
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /syscheck
+    method: put
+    parameters: {}
+    body: {}

--- a/deps/wazuh_testing/wazuh_testing/data/api_kibana_template.yaml
+++ b/deps/wazuh_testing/wazuh_testing/data/api_kibana_template.yaml
@@ -1,0 +1,40 @@
+requests:
+  -
+    endpoint: /cluster/status
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /agents
+    method: get
+    parameters:
+      limit: 1
+      q: "id!=000"
+    body: {}
+  -
+    endpoint: /manager/info
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /security/users/me/policies
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /agents/summary/status
+    method: get
+    parameters: {}
+    body: {}
+  -
+    endpoint: /manager/stats/remoted
+    method: get
+    parameters:
+      pretty: True
+    body: {}
+  -
+    endpoint: /manager/stats/analysisd
+    method: get
+    parameters:
+      pretty: True
+    body: {}

--- a/deps/wazuh_testing/wazuh_testing/data/api_simulator_config.yaml
+++ b/deps/wazuh_testing/wazuh_testing/data/api_simulator_config.yaml
@@ -1,0 +1,10 @@
+remote:
+  host: localhost
+  port: 55000
+
+kibana:
+  enabled: True
+
+extra_load:
+  enabled: True
+  api_requests_percentage: 50


### PR DESCRIPTION
Hello team,

We are adding the configuration file and templates for the [API simulator script](https://github.com/wazuh/wazuh-qa/blob/master/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py).

These YAML files are located in `deps/wazuh_testing/wazuh_testing/data/`. Default values are already set.

Regards,
Víctor Fernández