### PR TITLE
Logcollector integration tests T0: Check log_format values

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
+++ b/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
@@ -26,17 +26,17 @@ def callback_invalid_format_value(line, option, location, prefix, severity='DEBU
         option (str): log format value .
         location (str): Wazuh manager configuration option.
         prefix (str): Daemon that generates the error log.
-        severity (str): Severity of the error (DEBUG)
+        severity (str): Severity of the error (DEBUG, ERROR)
 
     Returns:
         callable: callback to detect this event.
     """
     if option == 'json':
         msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
-    elif option == 'syslog':
-        msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
+    elif option == 'audit':
+        msg = fr"{severity}: Discaring audit message because of invalid syntax."
     else:
-        msg = fr" Quedan aun varios formatos"
+        msg = fr" Quedan varios formatos"
 
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 

--- a/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
+++ b/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
@@ -33,10 +33,12 @@ def callback_invalid_format_value(line, option, location, prefix, severity='DEBU
     """
     if option == 'json':
         msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
-        return monitoring.make_callback(pattern=msg, prefix=prefix)
+    elif option == 'syslog':
+        msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
     else:
-        # NEED TO ADD OTHER CASES
-        pass
+        msg = fr" Quedan aun varios formatos"
+
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
 
 
 def callback_invalid_attribute(option, attribute, value, prefix, severity='WARNING'):

--- a/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
+++ b/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
@@ -17,6 +17,28 @@ def callback_invalid_value(option, value, prefix, severity='ERROR'):
     msg = fr"{severity}: \(\d+\): Invalid value for element '{option}': {value}."
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 
+def callback_invalid_format_value(line, option, location, prefix, severity='DEBUG'):
+
+    """Create a callback to detect content values invalid in ossec.conf file.
+
+    Args:
+        line(str):  content line of file created
+        option (str): log format value .
+        location (str): Wazuh manager configuration option.
+        prefix (str): Daemon that generates the error log.
+        severity (str): Severity of the error (DEBUG)
+
+    Returns:
+        callable: callback to detect this event.
+    """
+    if option == 'json':
+        msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
+        return monitoring.make_callback(pattern=msg, prefix=prefix)
+    else:
+        # NEED TO ADD OTHER CASES
+        pass
+
+
 def callback_invalid_attribute(option, attribute, value, prefix, severity='WARNING'):
     """Create a callback to detect invalid values in ossec.conf file.
 

--- a/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
+++ b/deps/wazuh_testing/wazuh_testing/generic_callbacks.py
@@ -17,30 +17,6 @@ def callback_invalid_value(option, value, prefix, severity='ERROR'):
     msg = fr"{severity}: \(\d+\): Invalid value for element '{option}': {value}."
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 
-def callback_invalid_format_value(line, option, location, prefix, severity='DEBUG'):
-
-    """Create a callback to detect content values invalid in ossec.conf file.
-
-    Args:
-        line(str):  content line of file created
-        option (str): log format value .
-        location (str): Wazuh manager configuration option.
-        prefix (str): Daemon that generates the error log.
-        severity (str): Severity of the error (DEBUG, ERROR)
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    if option == 'json':
-        msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
-    elif option == 'audit':
-        msg = fr"{severity}: Discaring audit message because of invalid syntax."
-    else:
-        msg = fr" Quedan varios formatos"
-
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
 def callback_invalid_attribute(option, attribute, value, prefix, severity='WARNING'):
     """Create a callback to detect invalid values in ossec.conf file.
 

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -33,8 +33,8 @@ def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLEC
     """
     if log_format == 'json':
         msg = fr"Reading json message: '{content_file}'."
-    elif log_format == 'syslog':
-        msg = fr"Reading : '{content_file}'."
+    elif log_format == 'syslog' or log_format == 'snort-full' or log_format == 'squid':
+        msg = fr"Reading syslog message: '{content_file}'."
 
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -320,9 +320,7 @@ def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_
 
 
 def callback_invalid_format_value(line, option, location):
-
-    """
-    Create a callback to detect content values invalid in a log format file specific.
+    """Create a callback to detect content values invalid in a log format file specific.
 
     Args:
         line(str):  content line of file analized
@@ -346,8 +344,7 @@ def callback_invalid_format_value(line, option, location):
 
 
 def callback_reading_file(log_format, content_file, severity='DEBUG'):
-    """
-    Create a callback to detect if the logcollector could read a file with valid content successfully.
+    """Create a callback to detect if the logcollector could read a file with valid content successfully.
 
     Args:
         log_format(str): Log format type(json, syslog, snort-full, squid, djb-multilog, multi-line:3)
@@ -359,7 +356,7 @@ def callback_reading_file(log_format, content_file, severity='DEBUG'):
     """
     if log_format == 'json':
         msg = fr"{severity}: Reading json message: '{content_file}'"
-    elif log_format == 'syslog' or log_format == 'snort-full' or log_format == 'squid':
+    elif log_format in ['syslog', 'snort-full', 'squid']:
         msg = fr"{severity}: Reading syslog message: '{content_file}'"
     elif log_format == 'multi-line:3':
         msg = fr"{severity}: Reading message: '{content_file}'"
@@ -368,8 +365,7 @@ def callback_reading_file(log_format, content_file, severity='DEBUG'):
 
 
 def callback_read_file(location):
-    """
-    Create a callback to detect when the logcollector reads a file.
+    """Create a callback to detect when the logcollector reads a file.
 
     Args:
         location (str): Path Read.

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -63,7 +63,7 @@ def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX
     msg = fr"DEBUG: Read 1 lines from '{location}"
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_invalid_format_value(line, option, location, prefix, severity='DEBUG'):
+def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
 
     """
     Create a callback to detect content values invalid in a log format file specific.

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -50,7 +50,7 @@ def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLEC
 
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
     """
     Create a callback to detect if the logcollector read and not analized a file with specific content.
 
@@ -60,7 +60,8 @@ def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX
     Returns:
         callable: callback to detect this log.
     """
-    msg = fr"DEBUG: Read 1 lines from '{location}"
+
+    msg = fr"{severity}: Read 1 lines from {location}"
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
@@ -73,7 +74,7 @@ def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_
         option (str): log format value .
         location (str): Wazuh manager configuration option.
         prefix (str): Daemon that generates the error log.
-        severity (str): Severity of the error (DEBUG, ERROR)
+        severity (str): Severity of the error (DEBUG)
 
     Returns:
         callable: callback to detect this event.
@@ -81,7 +82,7 @@ def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_
     if option == 'json':
         msg = fr"{severity}: Line '{line}' read from '{location}' is not a JSON object."
     elif option == 'audit':
-        msg = fr"{severity}: Discaring audit message because of invalid syntax."
+        msg = fr"ERROR: Discarding audit message because of invalid syntax."
     elif option == 'nmapg':
         msg = fr"{severity}: Bad formated nmap grepable file."
     elif option == 'djb-multilog':

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -1,5 +1,4 @@
 from wazuh_testing.tools import monitoring
-import sys
 
 GENERIC_CALLBACK_ERROR_COMMAND_MONITORING = 'The expected command monitoring log has not been produced'
 GENERIC_CALLBACK_ERROR_INVALID_LOCATION = 'The expected invalid location error log has not been produced'
@@ -47,7 +46,7 @@ def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLEC
 
 def callback_read_file(format, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
     """
-    Create a callback to detect if the logcollector read and not analized a file with specific content.
+    Create a callback to detect when the logcollector reads a file.
 
     Args:
         location (str): Path Read.
@@ -61,7 +60,7 @@ def callback_read_file(format, location, prefix=monitoring.LOG_COLLECTOR_DETECTO
         msg = fr"{severity}: Read 1 lines from {location}"
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
+def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
 
     """
     Create a callback to detect content values invalid in a log format file specific.
@@ -71,19 +70,18 @@ def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_
         option (str): log format value .
         location (str): Wazuh manager configuration option.
         prefix (str): Daemon that generates the error log.
-        severity (str): Severity of the error (DEBUG)
 
     Returns:
         callable: callback to detect this event.
     """
     if option == 'json':
-        msg = fr"{severity}: Line '{line}' read from '{location}' is not a JSON object."
+        msg = fr"DEBUG: Line '{line}' read from '{location}' is not a JSON object."
     elif option == 'audit':
         msg = fr"ERROR: Discarding audit message because of invalid syntax."
     elif option == 'nmapg':
         msg = fr"ERROR: Bad formated nmap grepable file."
     elif option == 'djb-multilog':
-        msg = fr"{severity}: Invalid DJB log: '{line}'"
+        msg = fr"DEBUG: Invalid DJB log: '{line}'"
 
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -21,7 +21,7 @@ def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFI
     msg = fr"Analyzing file: '{file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_reading_file(content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """Create a callback to detect if logcollector is monitoring a file.
 
     Args:
@@ -31,7 +31,11 @@ def callback_reading_file(content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR
     Returns:
         callable: callback to detect this event.
     """
-    msg = fr"Reading json message: '{content_file}'."
+    if log_format == 'json':
+        msg = fr"Reading json message: '{content_file}'."
+    elif log_format == 'syslog':
+        msg = fr"Reading : '{content_file}'."
+
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -43,14 +43,12 @@ def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLEC
         msg = fr"{severity}: Reading json message: '{content_file}'"
     elif log_format == 'syslog' or log_format == 'snort-full' or log_format == 'squid':
         msg = fr"{severity}: Reading syslog message: '{content_file}'"
-    elif log_format == 'djb-multilog':
-        msg = fr"{severity}: Reading DJB multilog message: '{content_file}'"
     elif log_format == 'multi-line:3':
         msg = fr"{severity}: Reading message: '{content_file}'"
 
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
+def callback_read_file(format, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
     """
     Create a callback to detect if the logcollector read and not analized a file with specific content.
 
@@ -60,8 +58,10 @@ def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX
     Returns:
         callable: callback to detect this log.
     """
-
-    msg = fr"{severity}: Read 1 lines from {location}"
+    if (format == 'nmapg'):
+        msg = fr"{severity}: Read 2 lines from {location}"
+    else:
+        msg = fr"{severity}: Read 1 lines from {location}"
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
@@ -84,7 +84,7 @@ def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_
     elif option == 'audit':
         msg = fr"ERROR: Discarding audit message because of invalid syntax."
     elif option == 'nmapg':
-        msg = fr"{severity}: Bad formated nmap grepable file."
+        msg = fr"ERROR: Bad formated nmap grepable file."
     elif option == 'djb-multilog':
         msg = fr"{severity}: Invalid DJB log: '{line}'"
 

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -316,6 +316,7 @@ def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_
         return line_start + lines - 1
     return 0
 
+
 def callback_invalid_format_value(line, option, location):
 
     """
@@ -362,6 +363,7 @@ def callback_reading_file(log_format, content_file, severity='DEBUG'):
         msg = fr"{severity}: Reading message: '{content_file}'"
 
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
 
 def callback_read_file(location):
     """

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -21,10 +21,7 @@ def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFI
     Returns:
         callable: callback to detect this event.
     """
-    if sys.platform == 'win32':
-        msg = fr"Analyzing file: '{file}'."
-    else:
-        msg = fr"Analyzing file: '{file}'."
+    msg = fr"Analyzing file: '{file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
@@ -108,18 +105,14 @@ def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLE
 
 def callback_monitoring_djb_multilog(program_name, multilog_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """Create a callback to detect if logcollector is monitoring a djb multilog file.
-
     Args:
         program_name (str): Program name of multilog file.
         multilog_file (str): Multilog file name.
-        prefix (str): Daemon that generates the error log.
-
     Returns:
         callable: callback to detect this event.
     """
     msg = fr"INFO: Using program name '{program_name}' for DJB multilog file: '{multilog_file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix)
-
 
 def callback_command_alias_output(alias, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """Create a callback to detect if logcollector is monitoring a command with an assigned alias.

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -27,7 +27,7 @@ def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFI
         msg = fr"Analyzing file: '{file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
     """
     Create a callback to detect if the logcollector could read a file with valid content successfully.
 
@@ -40,15 +40,15 @@ def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLEC
         callable: callback to detect this event.
     """
     if log_format == 'json':
-        msg = fr"Reading json message: '{content_file}'."
+        msg = fr"{severity}: Reading json message: '{content_file}'"
     elif log_format == 'syslog' or log_format == 'snort-full' or log_format == 'squid':
-        msg = fr"Reading syslog message: '{content_file}'."
+        msg = fr"{severity}: Reading syslog message: '{content_file}'"
     elif log_format == 'djb-multilog':
-        msg = fr"Reading DJB multilog message: '{content_file}'"
+        msg = fr"{severity}: Reading DJB multilog message: '{content_file}'"
     elif log_format == 'multi-line:3':
-        msg = fr"Reading message: '{content_file}'"
+        msg = fr"{severity}: Reading message: '{content_file}'"
 
-    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
 
 def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -21,6 +21,19 @@ def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFI
     msg = fr"Analyzing file: '{file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
+def callback_reading_file(content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+    """Create a callback to detect if logcollector is monitoring a file.
+
+    Args:
+        content_file (str): Content file analyzed.
+        prefix (str): Daemon that generates the error log.
+
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"Reading json message: '{content_file}'."
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
 
 def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """Create a callback to detect if logcollector is monitoring a command.

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -48,7 +48,7 @@ def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLEC
     elif log_format == 'multi-line:3':
         msg = fr"{severity}: Reading message: '{content_file}'"
 
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 def callback_read_file(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
     """
@@ -79,7 +79,7 @@ def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_
         callable: callback to detect this event.
     """
     if option == 'json':
-        msg = fr"{severity}: Line '{line}' read from '{location}' is not a {option} object."
+        msg = fr"{severity}: Line '{line}' read from '{location}' is not a JSON object."
     elif option == 'audit':
         msg = fr"{severity}: Discaring audit message because of invalid syntax."
     elif option == 'nmapg':

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -1,3 +1,6 @@
+import sys
+from math import ceil
+
 from wazuh_testing.tools import monitoring
 
 GENERIC_CALLBACK_ERROR_COMMAND_MONITORING = 'The expected command monitoring log has not been produced'
@@ -6,61 +9,314 @@ GENERIC_CALLBACK_ERROR_ANALYZING_FILE = 'The expected analyzing file log has not
 GENERIC_CALLBACK_ERROR_ANALYZING_EVENTCHANNEL = "The expected analyzing eventchannel log has not been produced"
 GENERIC_CALLBACK_ERROR_TARGET_SOCKET = "The expected target socket log has not been produced"
 GENERIC_CALLBACK_ERROR_TARGET_SOCKET_NOT_FOUND = "The expected target socket not found error has not been produced"
+LOG_COLLECTOR_GLOBAL_TIMEOUT = 20
 GENERIC_CALLBACK_ERROR_READING_FILE = "The expected invalid content error log has not been produced"
 GENERIC_CALLBACK_ERROR = 'The expected error output has not been produced'
 
+if sys.platform == 'win32':
+    prefix = monitoring.AGENT_DETECTOR_PREFIX
+else:
+    prefix = monitoring.LOG_COLLECTOR_DETECTOR_PREFIX
 
-def callback_analyzing_file(file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+
+def callback_analyzing_file(file):
     """Create a callback to detect if logcollector is monitoring a file.
-
     Args:
         file (str): Name with absolute path of the analyzed file.
         prefix (str): Daemon that generates the error log.
-
     Returns:
         callable: callback to detect this event.
     """
     msg = fr"Analyzing file: '{file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_reading_file(log_format, content_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
-    """
-    Create a callback to detect if the logcollector could read a file with valid content successfully.
 
+def callback_monitoring_command(log_format, command):
+    """Create a callback to detect if logcollector is monitoring a command.
     Args:
-        log_format(str): Log format type(json, syslog, snort-full, squid, djb-multilog, multi-line:3)
-        content_file (str): Content file to analyze
-        prefix (str): Daemon that generates the error log.
-
+        log_format (str): Log format of the command monitoring (full_command or command).
+        command (str): Monitored command.
     Returns:
         callable: callback to detect this event.
     """
-    if log_format == 'json':
-        msg = fr"{severity}: Reading json message: '{content_file}'"
-    elif log_format == 'syslog' or log_format == 'snort-full' or log_format == 'squid':
-        msg = fr"{severity}: Reading syslog message: '{content_file}'"
-    elif log_format == 'multi-line:3':
-        msg = fr"{severity}: Reading message: '{content_file}'"
+    log_format_message = 'full output' if log_format == 'full_command' else 'output'
+    msg = fr"INFO: Monitoring {log_format_message} of command\(\d+\): {command}"
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
 
-    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_read_file(format, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, severity='DEBUG'):
-    """
-    Create a callback to detect when the logcollector reads a file.
-
+def callback_monitoring_djb_multilog(program_name, multilog_file):
+    """Create a callback to detect if logcollector is monitoring a djb multilog file.
     Args:
-        location (str): Path Read.
-
+        program_name (str): Program name of multilog file.
+        multilog_file (str): Multilog file name.
     Returns:
-        callable: callback to detect this log.
+        callable: callback to detect this event.
     """
-    if (format == 'nmapg'):
-        msg = fr"{severity}: Read 2 lines from {location}"
-    else:
-        msg = fr"{severity}: Read 1 lines from {location}"
+    msg = fr"INFO: Using program name '{program_name}' for DJB multilog file: '{multilog_file}'."
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_command_alias_output(alias):
+    """Create a callback to detect if logcollector is monitoring a command with an assigned alias.
+    Args:
+        alias (str): Command alias.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"Reading command message: 'ossec: output: '{alias}':"
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_eventchannel_bad_format(event_location):
+    """Create a callback to detect if logcollector inform about bad formatted eventchannel location.
+    Args:
+        event_location (str): Eventchannel location.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"ERROR: Could not EvtSubscribe() for ({event_location}) which returned \(\d+\)"
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_socket_target(location, socket_name):
+    """Create a callback to detect if logcollector has assign a socket to a monitored file.
+    Args:
+        location (str): Name with the analyzed file.
+        socket_name (str): Socket name.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"DEBUG: Socket target for '{location}' -> {socket_name}"
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_socket_not_defined(location, socket_name):
+    """Create a callback to detect if a socket has not been defined.
+    Args:
+        location (str): Name with the analyzed file.
+        socket_name (str): Socket name.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"CRITICAL: Socket '{socket_name}' for '{location}' is not defined."
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_log_target_not_found(location, socket_name):
+    """Create a callback to detect if a log target has not been found.
+    Args:
+        location (str): Name with the analyzed file.
+        socket_name (str): Socket name.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"WARNING: Log target '{socket_name}' not found for the output format of localfile '{location}'."
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_invalid_reconnection_time(severity='WARNING', default_value='5'):
+    """Create a callback to detect if a invalid reconnection has been used.
+    Args:
+        severity (str): Severity of the error (WARNING, ERROR or CRITICAL)
+        default_value (int): Default value used instead of specified reconnection time.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"{severity}: Invalid reconnection time value. Changed to {default_value} seconds."
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_eventchannel_analyzing(event_location):
+    """Create a callback to detect if logcollector is monitoring a event log.
+    Args:
+        event_location (str): Event log location.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"INFO: \(\d+\): Analyzing event log: '{event_location}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix)
+
+
+def callback_invalid_location_pattern(location):
+    """Create a callback to detect if invalid location pattern has been used.
+    Args:
+        location (str): Location pattern
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"Glob error. Invalid pattern: '{location}' or no files found."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
+
+def callback_ignoring_file(location_file):
+    """Create a callback to detect if specified file was ignored due to modification time.
+    Args:
+        location_file: File absolute path.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"DEBUG: Ignoring file '{location_file}' due to modification time"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_reading_syslog_message(message):
+    """Create a callback to detect if syslog message has been read.
+    Args:
+        message (str): Syslog message.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"DEBUG: Reading syslog message: '{message}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_read_line_from_file(n_lines, filename):
+    """Create a callback to detect if specified lines number has been read.
+    Args:
+        n_lines (str): Number of lines read.
+        filename (str): Filename from which lines have been read.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"DEBUG: Read {n_lines} lines from {filename}"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_read_lines(command, escape=False):
+    """Create a callback to detect "DEBUG: Read <number> lines from command <command>" debug line.
+    Args:
+        command (str): Command to be monitored.
+        escape (bool): Flag to escape special characters in the pattern.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"lines from command '{command}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
+
+
+def callback_running_command(log_format, command, escape=False):
+    """Create a callback to detect "DEBUG: Running <log_format> '<command>'" debug line.
+    Args:
+        log_format (str): Log format of the command monitoring (full_command or command).
+        command (str): Command to be monitored.
+        escape (bool): Flag to escape special characters in the pattern.
+    Returns:
+        callable: callback to detect this event.
+    """
+    log_format_message = 'full command' if log_format == 'full_command' else 'command'
+    msg = fr"DEBUG: Running {log_format_message} '{command}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
+
+
+def callback_event_log_service_down(location, severity='WARNING'):
+    """Create a callback to detect if eventlog service is down.
+    Args:
+        location (str): Event channel.
+        severity (str): Severity of the error (WARNING, ERROR or CRITICAL).
+    Returns:
+        callable: callback to detect this event.
+    """
+    log_format_message = f"{severity}: The eventlog service is down. Unable to collect logs from '{location}' channel."
+    return monitoring.make_callback(pattern=log_format_message, prefix=monitoring.AGENT_DETECTOR_PREFIX)
+
+
+def callback_trying_to_reconnect(location, reconnect_time):
+    """Create a callback to detect if `wazuh-agentd` is trying to reconnect to specified channel.
+    Args:
+        location (str): Event log channel.
+        reconnect_time (str): Reconnect time.
+    Returns:
+        callable: callback to detect this event.
+    """
+    log_format_message = f"DEBUG: Trying to reconnect {location} channel in {reconnect_time} seconds."
+    return monitoring.make_callback(pattern=log_format_message, prefix=monitoring.AGENT_DETECTOR_PREFIX)
+
+
+def callback_reconnect_eventchannel(location):
+    """Create a callback to detect if specified channel has been reconnected successfully.
+    Args:
+        location (str): Location channel.
+    Returns:
+        callable: callback to detect this event.
+    """
+    log_format_message = f"INFO: '{location}' channel has been reconnected succesfully."
+    return monitoring.make_callback(pattern=log_format_message, prefix=monitoring.AGENT_DETECTOR_PREFIX)
+
+
+def callback_match_pattern_file(file_pattern, file):
+    """Create a callback to detect if logcollector is monitoring a file with wildcard.
+    Args:
+        file_pattern (str): Location pattern.
+        file (str): Name with absolute path of the analyzed file.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"New file that matches the '{file_pattern}' pattern: '{file}'."
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_non_existent_file(file):
+    """Create a callback to detect if logcollector is showing an error when the file does not exist.
+    Args:
+        file (str): Name with absolute path of the analyzed file.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"ERROR: (1103): Could not open file '{file}'"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_duplicated_file(file):
+    """Create a callback to detect if logcollector configuration is duplicated.
+    Args:
+        file (str): Name with absolute path of the analyzed file.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"Log file '{file}' is duplicated."
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_file_limit():
+    """Create a callback to detect if logcollector is monitoring a file.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = f'File limit has been reached'
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def callback_excluded_file(file):
+    """Create a callback to detect if logcollector is excluding files.
+    Args:
+        file (str): Name with absolute path of the analyzed file.
+    Returns:
+        callable: callback to detect this event.
+    """
+    msg = fr"File excluded: '{file}'."
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_line_num=False):
+    """Increase the space occupied by a log file by adding lines to it.
+    Args:
+        log_path (str): Path to log file.
+        log_line_message (str): Line content to be added to the log.
+        size_kib (int, optional): Size in kibibytes (1024^2 bytes). Defaults to 1 MiB (1024 KiB).
+        line_start (int, optional): Line number to start with. Defaults to 1.
+        print_line_num (bool, optional): If True, in each line of the log its number is added. Defaults to False.
+    Returns:
+        int: Last line number written.
+    """
+    if len(log_line_message):
+        with open(log_path, 'a') as f:
+            lines = ceil((size_kib * 1024) / len(log_line_message))
+            for x in range(line_start, line_start + lines + 1):
+                f.write(f"{log_line_message}{x}\n") if print_line_num else f.write(f"{log_line_message}\n")
+        return line_start + lines - 1
+    return 0
+
+def callback_invalid_format_value(line, option, location):
 
     """
     Create a callback to detect content values invalid in a log format file specific.
@@ -85,176 +341,37 @@ def callback_invalid_format_value(line, option, location, prefix=monitoring.LOG_
 
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 
-def callback_monitoring_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if logcollector is monitoring a command.
+
+def callback_reading_file(log_format, content_file, severity='DEBUG'):
+    """
+    Create a callback to detect if the logcollector could read a file with valid content successfully.
 
     Args:
-        log_format (str): Log format of the command monitoring (full_command or command).
-        command (str): Monitored command.
+        log_format(str): Log format type(json, syslog, snort-full, squid, djb-multilog, multi-line:3)
+        content_file (str): Content file to analyze
         prefix (str): Daemon that generates the error log.
 
     Returns:
         callable: callback to detect this event.
     """
-    log_format_message = 'full output' if log_format == 'full_command' else 'output'
-    msg = fr"INFO: Monitoring {log_format_message} of command\(\d+\): {command}"
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
+    if log_format == 'json':
+        msg = fr"{severity}: Reading json message: '{content_file}'"
+    elif log_format == 'syslog' or log_format == 'snort-full' or log_format == 'squid':
+        msg = fr"{severity}: Reading syslog message: '{content_file}'"
+    elif log_format == 'multi-line:3':
+        msg = fr"{severity}: Reading message: '{content_file}'"
 
-
-def callback_monitoring_djb_multilog(program_name, multilog_file, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if logcollector is monitoring a djb multilog file.
-    Args:
-        program_name (str): Program name of multilog file.
-        multilog_file (str): Multilog file name.
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"INFO: Using program name '{program_name}' for DJB multilog file: '{multilog_file}'."
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-def callback_command_alias_output(alias, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if logcollector is monitoring a command with an assigned alias.
-
-    Args:
-        alias (str): Command alias.
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"Reading command message: 'ossec: output: '{alias}':"
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
-def callback_eventchannel_bad_format(event_location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if logcollector inform about bad formatted eventchannel location.
-
-    Args:
-        event_location (str): Eventchannel location.
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"ERROR: Could not EvtSubscribe() for ({event_location}) which returned \(\d+\)"
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
-def callback_socket_target(location, socket_name, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if logcollector has assign a socket to a monitored file.
-
-    Args:
-        location (str): Name with the analyzed file.
-        socket_name (str): Socket name.
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"DEBUG: Socket target for '{location}' -> {socket_name}"
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
-def callback_socket_not_defined(location, socket_name, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if a socket has not been defined.
-
-    Args:
-        location (str): Name with the analyzed file.
-        socket_name (str): Socket name.
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"CRITICAL: Socket '{socket_name}' for '{location}' is not defined."
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
-def callback_log_target_not_found(location, socket_name, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if a log target has not been found.
-
-    Args:
-        location (str): Name with the analyzed file.
-        socket_name (str): Socket name.
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"WARNING: Log target '{socket_name}' not found for the output format of localfile '{location}'."
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
-def callback_invalid_reconnection_time(severity='WARNING', default_value='5',
-                                       prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if a invalid reconnection has been used.
-
-    Args:
-        severity (str): Severity of the error (WARNING, ERROR or CRITICAL)
-        default_value (int): Default value used instead of specified reconnection time.
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"{severity}: Invalid reconnection time value. Changed to {default_value} seconds."
-    return monitoring.make_callback(pattern=msg, prefix=prefix)
-
-
-def callback_eventchannel_analyzing(event_location):
-    """Create a callback to detect if logcollector is monitoring a event log.
-
-    Args:
-        event_location (str): Event log location.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"INFO: \(\d+\): Analyzing event log: '{event_location}'"
-    return monitoring.make_callback(pattern=msg, prefix=monitoring.AGENT_DETECTOR_PREFIX)
-
-
-def callback_invalid_location_pattern(location, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX):
-    """Create a callback to detect if invalid location pattern has been used.
-
-    Args:
-        location (str): Location pattern
-        prefix (str): Daemon that generates the error log.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    msg = fr"Glob error. Invalid pattern: '{location}' or no files found."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
-
-def callback_read_lines(command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
-    """Create a callback to detect "DEBUG: Read <number> lines from command <command>" debug line.
+def callback_read_file(location):
+    """
+    Create a callback to detect when the logcollector reads a file.
 
     Args:
-        command (str): Command to be monitored.
-        prefix (str): Daemon that generates the log.
-        escape (bool): Flag to escape special characters in the pattern.
+        location (str): Path Read.
 
     Returns:
-        callable: callback to detect this event.
+        callable: callback to detect this log.
     """
-    msg = fr"lines from command '{command}'"
-    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
-
-
-def callback_running_command(log_format, command, prefix=monitoring.LOG_COLLECTOR_DETECTOR_PREFIX, escape=False):
-    """Create a callback to detect "DEBUG: Running <log_format> '<command>'" debug line.
-
-    Args:
-        log_format (str): Log format of the command monitoring (full_command or command).
-        command (str): Command to be monitored.
-        prefix (str): Daemon that generates the log.
-        escape (bool): Flag to escape special characters in the pattern.
-
-    Returns:
-        callable: callback to detect this event.
-    """
-    log_format_message = 'full command' if log_format == 'full_command' else 'command'
-    msg = fr"DEBUG: Running {log_format_message} '{command}'"
-    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=escape)
+    msg = fr"lines from {location}"
+    return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)

--- a/docs/tests/integration/test_logcollector/test_log_format/index.md
+++ b/docs/tests/integration/test_logcollector/test_log_format/index.md
@@ -1,4 +1,4 @@
-# Test log format values
+# Test log format
 
 ## Overview 
 

--- a/docs/tests/integration/test_logcollector/test_log_format/index.md
+++ b/docs/tests/integration/test_logcollector/test_log_format/index.md
@@ -1,0 +1,21 @@
+# Test log format values
+
+## Overview 
+
+These tests check if the introduced content in a file works as expected for valid format values.
+
+## Objective
+
+Confirm that the different options for logcollector configuration format work and are correctly loaded.
+
+## General info
+
+|Tier | Total | Time spent |
+| :--:| :--:  | :--:       |
+| 0   |    17 |    3m40s   |
+
+
+## List of tests
+
+- **[Test log_format_values](test_log_format_values.md)**: Check if `wazuh-logcollector` 
+  fails using valid and invalid  `content` values when the log format is valid.

--- a/docs/tests/integration/test_logcollector/test_log_format/test_log_format_values.md
+++ b/docs/tests/integration/test_logcollector/test_log_format/test_log_format_values.md
@@ -1,0 +1,26 @@
+# Test Log format values
+## Overview 
+
+Check if `wazuh-logcollector` or `wazuh-agent` in Windows agent, allows valid `log_format` values with content values valid for the 
+log monitoring and fails using invalid content with valid `log_format` values.
+
+## Objective
+
+- To confirm Wazuh allows all possible `log_format` valid values.
+- To confirm `wazuh-logcollector`, or `wazuh-agent` fails when valid `log_format` with content files invalid.
+
+## General info
+
+|Tier | Total | Time spent |
+| :--:| :--:  | :--:       |
+| 0   |    17 |    3m40s   |
+
+
+## Expected behavior
+
+- Fail if `wazuh-logcollector` or `wazuh-agent` allows invalid `log_format` content values for log monitoring.
+- Fail if `wazuh-logcollector` or `wazuh-agent` does not start correctly using valid `log_format` values.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_log_format.test_log_format_values

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -461,6 +461,9 @@ nav:
                 - Overview: tests/integration/test_logcollector/test_location/index.md
                 - Test location: tests/integration/test_logcollector/test_location/test_location.md
                 - Test exclude: tests/integration/test_logcollector/test_location/test_location_exclude.md
+            - Test log format: 
+                - Overview: tests/integration/test_logcollector/test_log_format/index.md
+                - Test log format: tests/integration/test_logcollector/test_log_format/test_log_format_values.md
             - Test only future events: tests/integration/test_logcollector/test_only_future_events/test_only_future_events.md
         - Logtest:
           - tests/integration/test_logtest/index.md

--- a/tests/integration/test_logcollector/test_log_format/data/wazuh_conf.yaml
+++ b/tests/integration/test_logcollector/test_log_format/data/wazuh_conf.yaml
@@ -1,0 +1,11 @@
+- tags:
+  - test_log_format_values
+  apply_to_modules:
+  - test_log_format_values
+  sections:
+  - section: localfile
+    elements:
+      - log_format:
+          value: LOG_FORMAT
+      - location:
+          value: LOCATION

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -103,103 +103,157 @@ def get_local_internal_options():
     """Get configurations from the module."""
     return local_internal_options
 
-def create_file(files, type):
-    """Create an empty file."""
+def create_file_location(filename, type):
+    """
+    Create a specific content for a specific log_format.
+
+     Args:
+        filename(str): filename create with a specified content.
+        type(str): log format type.
+    """
     if type == 'iis':
         data = '#Software: Microsoft Internet Information Server 6.0\n#Version: 1.0\n#Date: 1998-11-19 22:48:39'
         data += '#Fields: date time c-ip cs-username s-ip cs-method cs-uri-stem cs-uri-query sc-status sc-bytes cs-bytes time-taken cs-version cs(User-Agent) cs(Cookie) cs(Referrer)\n'
     else:
         data = ""
-    file.write_file(files, data)
+    file.write_file(filename, data)
 
-def modify_json_file(file, type):
-    """Create a json content with an specific values"""
+def modify_json_file(filename, type):
+    """
+    Added content with json format and valid or invalid values.
+    Args:
+        filename (str):filename to modify.
+        type (str):type of content value. It can be valid or invalid.
+    """
+
     if type:
         data = '{"issue":22,"severity":1}\n'
     else:
         data = '{"issue:22,"severity":1}\n'
 
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_syslog_file(file):
-    """Create a syslog content with an specific values"""
+def modify_syslog_file(filename):
+    """
+    Added content with syslog format and valid values.
+    Args:
+        filename (str):filename to modify.
+    """
+
     data = 'Apr 29 12:47:51 dev-branch systemd[1]: Starting\n'
+    file.write_file(filename, data)
 
-    with open(file, 'a') as f:
-        f.write(data)
-
-def modify_snort_file(file):
-    """Create a snort content with an specific values"""
+def modify_snort_file(filename):
+    """
+    Added content with syslog format and invalid values.
+    Args:
+        filename (str):filename to modify.
+    """
     data = '10/12-21:29:35.911089 {ICMP} 192.168.1.99 – > 192.168.1.103\n'
+    file.write_file(filename, data)
 
-    with open(file, 'a') as f:
-        f.write(data)
-
-def modify_squid_file(file):
-    """Create a squid content with an specific values"""
+def modify_squid_file(filename):
+    """
+    Added content with squid format and valid values.
+    Args:
+        filename (str):filename to modify.
+    """
     data = '902618.84 440 120.65.1.1 TCP/304 80 GET http://www.web.com:8005\n'
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_audit_file(file, type):
-    """Create a audit content with an specific values"""
+def modify_audit_file(filename, type):
+    """
+    Added content with audit format and specific values.
+    Args:
+        filename (str):filename to modify.
+        type (str):type of content value. It can be valid or invalid.
+    """
+
     if type:
         data = """type=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset"\n"""
     else:
         data = """=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset\n"""
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_mysqlLog_file(file):
-    """Create a mysql_log content with an specific values"""
+
+def modify_mysqlLog_file(filename):
+    """
+    Added content with mysql format and valid values.
+    Args:
+        filename (str):filename to modify.
+    """
+
     data = """show variables like 'general_log%';\n"""
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_postgresqlLog_file(file):
-    """Create a postgresql_log content with an specific values"""
+
+def modify_postgresqlLog_file(filename):
+    """
+    Added content with postgresql format and valid values.
+    Args:
+        filename (str):filename to modify.
+    """
+
     data = """show variables like 'general_log%';\n"""
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_nmapg_file(file, type):
-    """Create a nmapg content with an specific values"""
+def modify_nmapg_file(filename, type):
+    """
+    Added content with nmapg format and specific values.
+    Args:
+        filename (str):filename to modify.
+        type (str):type of content value. It can be valid or invalid.
+    """
     if type:
         data = '# Nmap 7.70 scan initiated Tue May 11 16:48:35 2021 as: nmap -T4 -A -v -oG /var/log/map.log scanme.nmap.org\n'
         data += '# Ports scanned: TCP(1000;1,3-4,6-7,9,13,17,7920-7921,7937-7938,7999-8002,8007-8011,8021-8022,8031,8042,8045,8800,64680,65000,65129,65389) UDP(0;) SCTP(0;) PROTOCOLS(0;)\n'
     else:
         data = 'nmap -n -Pn -p 80 --open -sV -vvv --script banner,http-title -iR 1000\n'
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_djb_multilog_file(file, type):
-    """Create a djb-multilog content with an specific values"""
+def modify_djb_multilog_file(filename, type):
+    """
+    Added content with djb-multilog format and specific values.
+    Args:
+        filename (str):filename to modify.
+        type (str):type of content value. It can be valid or invalid.
+    """
     if type:
         data = '@400000003b4a39c23294b13c fatal: out of memory'
     else:
         data = '@40000000590e30983973bda4-eError'
 
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
 
-def modify_multi_line_file(file):
-    """Create a multi-line content with an specific values"""
+def modify_multi_line_file(filename):
+    """
+    Added content with multiline format and valid values.
+    Args:
+        filename (str):filename to modify.
+    """
 
     data = """Aug 9 14:22:47 log1\nAug 9 14:22:47 log2\nAug 9 14:22:47 log3\n"""
+    file.write_file(filename, data)
 
-    with open(file, 'a') as f:
-        f.write(data)
-
-def modify_iis_file(file):
-    """Create a iis content with an specific values"""
+def modify_iis_file(filename):
+    """
+    Added content with iis format and valid values.
+    Args:
+        filename (str):filename to modify.
+    """
 
     data = '2020-11-19 22:48:39 206.175.82.5 - 208.201.133.173 GET /global/images/navlineboards.gif - 200 540 324 157 HTTP/1.0 Mozilla/4.0+(compatible;+MSIE+4.01;+Windows+95) USERID=CustomerA;+IMPID=01234 http://www.loganalyzer.net\n'
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(filename, data)
+
 
 def modify_file(file, type, content):
-    """ Modify a file to generate logs."""
+    """ Modified a file with a specific log format to generate logs.
+    Args:
+        file (str): filename to modify.
+        type (str): log format type to add.
+        content (str): content type(Valid=True, Invalid=False) to add to the file.
+    """
+
     if type == 'json':
         modify_json_file(file, content)
     elif type == 'syslog':
@@ -224,14 +278,11 @@ def modify_file(file, type, content):
         modify_iis_file(file)
 
 def check_log_format_valid(cfg):
-    """Check if Wazuh run correctly with the specified log formats.
-
-    Ensure logcollector allows the specified log formats. Also, in the case of the manager instance, check if the API
-    answer for localfile block coincides.
+    """
+    Check if Wazuh run correctly with the specified log formats.
 
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
-        AssertError: In the case of a server instance, the API response is different that the real configuration.
     """
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
     if cfg['log_format'] == 'eventchannel' or cfg['log_format'] == 'eventlog':
@@ -242,8 +293,7 @@ def check_log_format_valid(cfg):
 
 def check_log_format_value_valid(conf):
     """
-    Check if Wazuh runs correctly with the correct log format and content.
-    Ensure logcollector allows the specified log formats.
+    Check if Wazuh runs correctly with the correct log format and a specific content.
 
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
@@ -282,10 +332,7 @@ def check_log_format_value_valid(conf):
 
 def analyzing_invalid_value(conf):
     """
-    Created to analyze the content of a file specific.
-    Args:
-        location (str): Path Read.
-        format (str): format Type to analyze error message
+    Checks for the error message that is shown when the record format type is valid but the content is invalid.
     """
 
     with open(conf['location']) as log:
@@ -295,7 +342,7 @@ def analyzing_invalid_value(conf):
 
 def check_log_format_value_invalid(conf):
     """
-    Check if Wazuh fails because of an  log format content invalid.
+    Check if Wazuh fails because of content invalid log.
 
     Raises:
        TimeoutError: If error callback are not generated.
@@ -308,6 +355,11 @@ def check_log_format_value_invalid(conf):
         wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR)
 
 def check_log_format_values(conf):
+    """
+    Set of validations to follow to validate a certain content.
+    The file content could be valid or invalid.
+
+   """
 
     if conf['valid_value']:
         check_log_format_valid(conf)
@@ -339,7 +391,7 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
         # Analyze valid formats with valid content in Windows
         if sys.platform == 'win32':
             if conf['log_format'] == 'iis':
-                create_file(iis_path, conf['log_format'])
+                create_file_location(iis_path, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
             else:
@@ -348,16 +400,16 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
         else:
             # Analyze valid formats with valid content in Linux
             if conf['log_format'] == 'djb-multilog':
-                create_file(filemultilog, conf['log_format'])
+                create_file_location(filemultilog, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
 
             elif conf['log_format'] == 'nmapg':
-                create_file(nmap_log, conf['log_format'])
+                create_file_location(nmap_log, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
             else:
-                create_file(location, conf['log_format'])
+                create_file_location(location, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
 
@@ -369,18 +421,18 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
         else:
         # Analyze valid formats with invalid content in Linux
             if conf['log_format'] == 'djb-multilog':
-                create_file(filemultilog, conf['log_format'])
+                create_file_location(filemultilog, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
 
             elif conf['log_format'] == 'nmapg':
-                create_file(nmap_log, conf['log_format'])
-                create_file(location, conf['log_format'])
+                create_file_location(nmap_log, conf['log_format'])
+                create_file_location(location, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
                 file.remove_file(nmap_log)
 
             else:
-                create_file(location, conf['log_format'])
+                create_file_location(location, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -39,11 +39,11 @@ else:
     prefix = LOG_COLLECTOR_DETECTOR_PREFIX
 
 parameters = [
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
+#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
+#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
+#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
+#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
+     {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
     # {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
     # {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
     # {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
@@ -56,13 +56,11 @@ parameters = [
 ]
 
 metadata = [
-    {'location': f'{location}', 'log_format': 'json', 'valid_value': False},
-
-    # {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
-
-    # {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'squid', 'command': 'example-command', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'audit', 'command': 'example-command', 'valid_value': True},
+ #   {'location': f'{location}', 'log_format': 'json', 'valid_value': False}, #debo agregar un TRUE tmb
+ #   {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
+#    {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
+#    {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
+     {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},  # debo agregar el True tmb
     # {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
     # {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
     # {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': True},
@@ -79,8 +77,8 @@ if sys.platform == 'win32':
     parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'eventchannel'})
     parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'iis'})
 
-    metadata.append({'location': 'Security', 'log_format': 'eventlog', 'command': 'example-command', 'valid_value': True})
-    metadata.append({'location': f'{location}', 'log_format': 'eventchannel', 'command': 'example-command', 'valid_value': True})
+    metadata.append({'location': 'Security', 'log_format': 'eventlog', 'valid_value': True})
+    metadata.append({'location': f'{location}', 'log_format': 'eventchannel', 'valid_value': True})
     metadata.append({'location': f'{location}', 'log_format': 'iis', 'valid_value': True}),
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -111,6 +109,22 @@ def remove_file(file):
     if path.exists(file):
         remove(file)
 
+def modify_file(file, type):
+    """ Modify file created to a specified type."""
+    if type == 'json':
+        modify_json_file(file, type)
+    elif type == 'syslog':
+        modify_syslog_file(file)
+    elif type == 'snort-full':
+        modify_snort_file(file)
+    elif type == 'squid':
+        modify_squid_file(file)
+    elif type == 'audit':
+        modify_audit_file(file, type)
+    else:
+        data = """QUEDAN LOS DEMAS A AGREGAR"""
+
+
 def modify_json_file(file, type):
     """Create a json content with an specific values"""
     if type:
@@ -120,15 +134,34 @@ def modify_json_file(file, type):
     with open(file, 'a') as f:
         f.write(data)
 
-def modify_syslog_file(file, type):
+def modify_syslog_file(file):
     """Create a syslog content with an specific values"""
-    if type:
-        data = """{"issue":22,"severity":1}\n"""
-    else:
-        data = """{"issue:22,"severity":1}\n"""
+    data = """Apr 29 12:47:51 dev-branch systemd[1]: Starting"""
+
     with open(file, 'a') as f:
         f.write(data)
 
+def modify_snort_file(file):
+    """Create a snort content with an specific values"""
+    data = """10/12-21:29:35.911089 [**] [1:0:0] TEST [**] [Priority: 0] {ICMP} 192.168.1.99 – > 192.168.1.103"""
+
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_squid_file(file):
+    """Create a squid content with an specific values"""
+    data = """902351618.864 440 120.65.1.1 TCP_MISS/304 110 GET http://www.webtrends.com:8005/Images/search.gif - DIRECT/www.webtrends.com -"""
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_audit_file(file, type):
+    """Create a audit content with an specific values"""
+    if type:
+        data = """type=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset"\n"""
+    else:
+        data = """=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset\n"""
+    with open(file, 'a') as f:
+        f.write(data)
 
 def check_log_format_valid(cfg):
     """Check if Wazuh run correctly with the specified log formats.
@@ -194,14 +227,18 @@ def check_log_format_value_invalid(conf):
 
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-    # CHECK ONLY JSON FILE FOR NOW
-
     if conf['log_format'] not in log_format_not_print_analyzing_info:
         with open(location, "r") as f:
             line = f.readline()
+            if conf['log_format'] == 'json':
+                log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix)
+            elif conf['log_format'] == 'audit':
+                severity = 'ERROR'
+                log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix, severity)
 
-            log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix)
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
+
+    #NEED TO ADD OTHER CASES
 
 
 def test_log_format(get_configuration, configure_environment):
@@ -223,7 +260,7 @@ def test_log_format(get_configuration, configure_environment):
         create_file(location)
         control_service('start', daemon=LOGCOLLECTOR_DAEMON)
         check_log_format_valid(conf)
-        modify_json_file(location, conf['valid_value'])
+        modify_file(location, conf['valid_value'])
         check_log_format_value_valid(conf)
 
     else:
@@ -236,7 +273,7 @@ def test_log_format(get_configuration, configure_environment):
             create_file(location)
             control_service('start', daemon=LOGCOLLECTOR_DAEMON)
             check_log_format_valid(conf)
-            modify_json_file(location, conf['valid_value'])
+            modify_file(location, conf['valid_value'])
             check_log_format_value_invalid(conf)
 
 

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -288,7 +288,7 @@ def check_log_format_valid(cfg):
     if cfg['log_format'] == 'eventchannel' or cfg['log_format'] == 'eventlog':
         log_callback = logcollector.callback_eventchannel_analyzing(cfg['location'])
     else:
-        log_callback = logcollector.callback_analyzing_file(cfg['location'], prefix=prefix)
+        log_callback = logcollector.callback_analyzing_file(cfg['location'])
     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
 
 def check_log_format_value_valid(conf):
@@ -305,7 +305,7 @@ def check_log_format_value_valid(conf):
         if conf['log_format'] in log_format_not_print_reading_info:
             # Logs format that only shows when a specific file is read.
 
-            log_callback = logcollector.callback_read_file(conf['log_format'], conf['location'], prefix=prefix)
+            log_callback = logcollector.callback_read_file(conf['location'])
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
         elif conf['log_format'] == 'multi-line:3':
@@ -316,18 +316,18 @@ def check_log_format_value_valid(conf):
                 for line in file:
                     msg += line.rstrip('\n')
                     msg += ' '
-                log_callback = logcollector.callback_reading_file(conf['log_format'], msg.rstrip(' '), prefix=prefix)
+                log_callback = logcollector.callback_reading_file(conf['log_format'], msg.rstrip(' '))
                 wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
         else:
             # Verify that the content of the parsed file is equal to the output generated in the logs.
             with open(location, 'r') as f:
                 lines = f.readlines()
                 for line in lines:
-                    log_callback = logcollector.callback_reading_file(conf['log_format'], line.rstrip('\n'), prefix=prefix)
+                    log_callback = logcollector.callback_reading_file(conf['log_format'], line.rstrip('\n'))
                     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
     elif conf['log_format'] == 'iis':
-        log_callback = logcollector.callback_read_file(conf['log_format'], conf['location'], prefix=prefix)
+        log_callback = logcollector.callback_read_file(conf['location'])
         wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
 def analyzing_invalid_value(conf):
@@ -337,7 +337,7 @@ def analyzing_invalid_value(conf):
 
     with open(conf['location']) as log:
         line = log.readline()
-        log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'), conf['log_format'], conf['location'], prefix)
+        log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'), conf['log_format'], conf['location'])
         return log_callback
 
 def check_log_format_value_invalid(conf):

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -90,7 +90,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 configuration_ids = [f"{x['log_format'], x['valid_value']}" for x in metadata]
 
 log_format_windows_print_analyzing_info = ['eventlog', 'eventchannel', 'iis']
-log_format_not_print_reading_info = ['audit', 'mysql_log', 'postgresql_log', 'nmapg', 'djb-multilog']
+log_format_not_print_reading_info = ['audit', 'mysql_log', 'postgresql_log', 'nmapg', 'djb-multilog', 'iis']
 
 
 # fixtures
@@ -343,11 +343,6 @@ def check_log_format_value_valid(conf):
                     wazuh_log_monitor.start(timeout=5, callback=log_callback,
                                             error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
-    elif conf['log_format'] == 'iis':
-        log_callback = logcollector.callback_read_file(conf['location'])
-        wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
-
 
 def analyzing_invalid_value(conf):
     """Checks for the error message that is shown when the record format type is valid but the content is invalid.
@@ -418,26 +413,13 @@ def test_log_format(get_local_internal_options, get_configuration,
         if sys.platform == 'win32':
             if conf['log_format'] == 'iis':
                 create_file_location(iis_path, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)
-            else:
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_valid(conf)
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_valid(conf)
         else:
             # Analyze valid formats with valid content in Linux
-            if conf['log_format'] == 'djb-multilog':
-                create_file_location(file_multilog, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)
-
-            elif conf['log_format'] == 'nmapg':
-                create_file_location(nmap_log, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)
-            else:
-                create_file_location(location, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)
+            create_file_location(conf['location'], conf['log_format'])
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_values(conf)
 
     else:
         # Analyze valid formats with invalid content in Windows
@@ -446,17 +428,7 @@ def test_log_format(get_local_internal_options, get_configuration,
             sb.CalledProcessError
         else:
             # Analyze valid formats with invalid content in Linux
-            if conf['log_format'] == 'djb-multilog':
-                create_file_location(file_multilog, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)
+            create_file_location(conf['location'], conf['log_format'])
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_values(conf)
 
-            elif conf['log_format'] == 'nmapg':
-                create_file_location(nmap_log, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)
-
-            else:
-                create_file_location(location, conf['log_format'])
-                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-                check_log_format_values(conf)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -41,9 +41,9 @@ else:
 parameters = [
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
 #    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
 #    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
 #    {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
@@ -58,9 +58,9 @@ parameters = [
 metadata = [
     {'location': f'{location}', 'log_format': 'json', 'valid_value': True},
     {'location': f'{location}', 'log_format': 'json', 'valid_value': False},
-#    {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
 #    {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},
 #    {'location': f'{location}', 'log_format': 'audit', 'valid_value': True},
 #    {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
@@ -123,14 +123,14 @@ def modify_syslog_file(file):
 
 def modify_snort_file(file):
     """Create a snort content with an specific values"""
-    data = '10/12-21:29:35.911089 [**] [1:0:0] TEST [**] [Priority: 0] {ICMP} 192.168.1.99 – > 192.168.1.103\n'
+    data = '10/12-21:29:35.911089 {ICMP} 192.168.1.99 – > 192.168.1.103\n'
 
     with open(file, 'a') as f:
         f.write(data)
 
 def modify_squid_file(file):
     """Create a squid content with an specific values"""
-    data = '902351618.864 440 120.65.1.1 TCP_MISS/304 110 GET http://www.webtrends.com:8005/Images/search.gif - DIRECT/www.webtrends.com -'
+    data = '902618.84 440 120.65.1.1 TCP/304 80 GET http://www.web.com:8005\n'
     with open(file, 'a') as f:
         f.write(data)
 
@@ -265,7 +265,7 @@ def check_log_format_value_valid(conf):
 
                 # Strips the newline character
                 for line in lines:
-                    log_callback = logcollector.callback_reading_file(conf['log_format'], line.strip(), prefix=prefix)
+                    log_callback = logcollector.callback_reading_file(conf['log_format'], line.rstrip('\n'), prefix=prefix)
                     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
 
@@ -285,8 +285,8 @@ def check_log_format_value_invalid(conf):
             if conf['log_format'] == 'json' or conf['log_format'] == 'djb-multilog':
                 log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'), conf['log_format'], location, prefix)
             elif conf['log_format'] == 'audit' or conf['log_format'] == 'nmapg':
-                severity = 'ERROR'
-                log_callback = logcollector.callback_invalid_format_value(line, conf['log_format'], location, prefix, severity)
+            #    severity = 'ERROR'
+                log_callback = logcollector.callback_invalid_format_value(line, conf['log_format'], location, prefix)
 
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR)
 

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -7,7 +7,7 @@ import pytest
 import sys
 import subprocess as sb
 import wazuh_testing.logcollector as logcollector
-import wazuh_testing.generic_callbacks as gc
+
 from os import remove, path
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -26,10 +26,10 @@ force_restart_after_restoring = True
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 
-local_internal_options = {'logcollector.remote_commands': '1', 'logcollector.debug': '2'}
+local_internal_options = {'logcollector.remote_commands': '1', 'logcollector.vcheck_files': '1', 'logcollector.debug': '2','monitord.rotate_log': '0'}
 
 if sys.platform == 'win32':
-    location = r'C:\testing.txt'
+    location = r'C:\test.txt'
     wazuh_configuration = 'ossec.conf'
     prefix = AGENT_DETECTOR_PREFIX
 
@@ -39,37 +39,37 @@ else:
     prefix = LOG_COLLECTOR_DETECTOR_PREFIX
 
 parameters = [
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
-     {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'command'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'full_command'},
-    # {'LOCATION': '/var/log/testing/current', 'LOG_FORMAT': 'djb-multilog'},
-    # {'LOCATION': '/var/log/testing/current', 'LOG_FORMAT': 'djb-multilog'},
-    # {'LOCATION': '/var/log/testing/current', 'LOG_FORMAT': 'djb-multilog'},
-    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
+    {'LOCATION': '/var/log/current', 'LOG_FORMAT': 'djb-multilog'},
+    {'LOCATION': '/var/log/current', 'LOG_FORMAT': 'djb-multilog'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'},
 ]
 
 metadata = [
- #   {'location': f'{location}', 'log_format': 'json', 'valid_value': False}, #debo agregar un TRUE tmb
- #   {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
-     {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},  # debo agregar el True tmb
-    # {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'command', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'full_command', 'valid_value': True},
-    # {'location': '/var/log/testing/current', 'log_format': 'djb-multilog', 'command': 'example-command', 'valid_value': True},
-    # {'location': '/var/log/testing/current', 'log_format': 'djb-multilog', 'command': 'example-command', 'valid_value': True},
-    # {'location': '/var/log/testing/current', 'log_format': 'djb-multilog', 'command': 'example-command', 'valid_value': True},
-    # {'location': f'{location}', 'log_format': 'multi-line:3', 'command': 'example-command', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'json', 'valid_value': False},
+    {'location': f'{location}', 'log_format': 'json', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},
+    {'location': f'{location}', 'log_format': 'audit', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': False},
+    {'location': '/var/log/current', 'log_format': 'djb-multilog', 'valid_value': True},
+    {'location': '/var/log/current', 'log_format': 'djb-multilog', 'valid_value': False},
+    {'location': f'{location}', 'log_format': 'multi-line:3', 'valid_value': True},
 ]
 
 if sys.platform == 'win32':
@@ -82,11 +82,13 @@ if sys.platform == 'win32':
     metadata.append({'location': f'{location}', 'log_format': 'iis', 'valid_value': True}),
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+#configuration_ids = [f"{x['LOG_FORMAT'] 'Valid' if x['VALID_VALUE'] == TRUE else 'Invalid'}" for x in metadata]
+# configuration_ids = [f"{x['LOCATION'], x['LOG_FORMAT'], x['COMMAND']}" for x in parameters]
+configuration_ids = [f"{x['log_format'], x['valid_value']}" for x in metadata]
 
-configuration_ids = [f"{x['LOG_FORMAT']}" for x in parameters]
+log_format_not_print_analyzing_info = ['eventlog', 'eventchannel', 'iis']
 
-log_format_not_print_analyzing_info = ['command', 'full_command', 'eventlog', 'eventchannel']
-
+log_format_not_print_reading_info = ['audit', 'mysql_log', 'postgresql_log', 'nmapg']
 
 # fixtures
 @pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
@@ -108,22 +110,6 @@ def remove_file(file):
     """ Remove a file created to testing."""
     if path.exists(file):
         remove(file)
-
-def modify_file(file, type):
-    """ Modify file created to a specified type."""
-    if type == 'json':
-        modify_json_file(file, type)
-    elif type == 'syslog':
-        modify_syslog_file(file)
-    elif type == 'snort-full':
-        modify_snort_file(file)
-    elif type == 'squid':
-        modify_squid_file(file)
-    elif type == 'audit':
-        modify_audit_file(file, type)
-    else:
-        data = """QUEDAN LOS DEMAS A AGREGAR"""
-
 
 def modify_json_file(file, type):
     """Create a json content with an specific values"""
@@ -163,6 +149,72 @@ def modify_audit_file(file, type):
     with open(file, 'a') as f:
         f.write(data)
 
+def modify_mysqlLog_file(file):
+    """Create a mysql_log content with an specific values"""
+    data = """show variables like 'general_log%';\n"""
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_postgresqlLog_file(file):
+    """Create a postgresql_log content with an specific values"""
+    data = """show variables like 'general_log%';\n"""
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_nmapg_file(file, type):
+    """Create a nmapg content with an specific values"""
+    if type:
+        with open('/var/log/nmapg.log', 'a') as f:
+            f.write("")
+        data = """"nmap -T4 -A -v -oG /var/log/nmapg.log scanme.nmap.org"""
+    else:
+        data = """nmap -n -Pn -p 80 --open -sV -vvv --script banner,http-title -iR 1000\n"""
+
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_djb_multilog_file(file, type):
+    """Create a djb-multilog content with an specific values"""
+
+    if type:
+        data = """@40000000590e30983973bda4 Message 1"""
+    else:
+        data = """@40000000590e30983973bda4 -e Error\n"""
+
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_multi_line_file(file):
+    """Create a multi-line content with an specific values"""
+
+    data = """Aug 9 14:22:47 log1\nAug 9 14:22:47 log2\nAug 9 14:22:47 log3\n"""
+
+    with open(file, 'a') as f:
+        f.write(data)
+
+def modify_file(file, type, content):
+    """ Modify a file to generate logs."""
+    if type == 'json':
+        modify_json_file(file, content)
+    elif type == 'syslog':
+        modify_syslog_file(file)
+    elif type == 'snort-full':
+        modify_snort_file(file)
+    elif type == 'squid':
+        modify_squid_file(file)
+    elif type == 'audit':
+        modify_audit_file(file, content)
+    elif type == 'mysql_log':
+        modify_mysqlLog_file(file)
+    elif type == 'postgresql_log':
+        modify_postgresqlLog_file(file)
+    elif type == 'nmap':
+        modify_nmapg_file(file, content)
+    elif type == 'djb-multilog':
+        modify_djb_multilog_file(file, content)
+    elif type == 'multi-line:3':
+        modify_multi_line_file(file)
+
 def check_log_format_valid(cfg):
     """Check if Wazuh run correctly with the specified log formats.
 
@@ -179,9 +231,6 @@ def check_log_format_valid(cfg):
         log_callback = logcollector.callback_analyzing_file(cfg['location'], prefix=prefix)
         wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
 
-    elif 'command' in cfg['log_format']:
-        log_callback = logcollector.callback_monitoring_command(cfg['log_format'], cfg['command'], prefix=prefix)
-        wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
     elif cfg['log_format'] == 'djb-multilog':
         log_callback = logcollector.callback_monitoring_djb_multilog(cfg['location'], prefix=prefix)
         wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message="The expected multilog djb log has not been produced")
@@ -190,7 +239,6 @@ def check_log_format_valid(cfg):
 def check_log_format_value_valid(conf):
     """
     Check if Wazuh runs correctly with the correct log format and content.
-
     Ensure logcollector allows the specified log formats.
 
     Raises:
@@ -199,30 +247,39 @@ def check_log_format_value_valid(conf):
 
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-    # CHECK ONLY JSON FILE FOR NOW
-
     if conf['log_format'] not in log_format_not_print_analyzing_info:
-        file1 = open(location, 'r')
-        lines = file1.readlines()
 
-        # Strips the newline character
-        for line in lines:
-            log_callback = logcollector.callback_reading_file(line.strip(), prefix=prefix)
+        if conf['log_format'] in log_format_not_print_reading_info:
+            log_callback = logcollector.callback_read_file(location, prefix=prefix)
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
-    #NEED TO ADD OTHER CASES
+            if conf['log_format'] == 'nampg':
+                remove_file('/var/log/nampg.log')
 
+        elif conf['log_format'] == 'multi-line:3':
+            msg = ""
+            with open(location, 'r') as file:
+                for line in file:
+                    msg += line.strip()
+                    msg += " "
+            log_callback = logcollector.callback_reading_file(msg, prefix=prefix)
+            wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+        else:
+            file1 = open(location, 'r')
+            lines = file1.readlines()
+
+            # Strips the newline character
+            for line in lines:
+                log_callback = logcollector.callback_reading_file(line.strip(), prefix=prefix)
+                wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
 
 def check_log_format_value_invalid(conf):
     """
-    Check if Wazuh fails because of an invalid log format or content.
+    Check if Wazuh fails because of an  log format content invalid.
 
-       Args:
-           cfg (dict): Dictionary with the localfile configuration.
-
-       Raises:
-           TimeoutError: If error callback are not generated.
+    Raises:
+       TimeoutError: If error callback are not generated.
    """
 
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -230,15 +287,13 @@ def check_log_format_value_invalid(conf):
     if conf['log_format'] not in log_format_not_print_analyzing_info:
         with open(location, "r") as f:
             line = f.readline()
-            if conf['log_format'] == 'json':
-                log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix)
-            elif conf['log_format'] == 'audit':
+            if conf['log_format'] == 'json' or conf['log_format'] == 'djb-multilog':
+                log_callback = logcollector.callback_invalid_format_value(line, conf['log_format'], location, prefix)
+            elif conf['log_format'] == 'audit' or conf['log_format'] == 'nmapg':
                 severity = 'ERROR'
-                log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix, severity)
+                log_callback = logcollector.callback_invalid_format_value(line, conf['log_format'], location, prefix, severity)
 
-            wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
-
-    #NEED TO ADD OTHER CASES
+            wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR)
 
 
 def test_log_format(get_configuration, configure_environment):
@@ -257,11 +312,24 @@ def test_log_format(get_configuration, configure_environment):
     truncate_file(LOG_FILE_PATH)
 
     if conf['valid_value']:
-        create_file(location)
-        control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-        check_log_format_valid(conf)
-        modify_file(location, conf['valid_value'])
-        check_log_format_value_valid(conf)
+        if conf['log_format'] == 'djb-multilog':
+            location_multilog = '/var/log/current'
+            create_file(location_multilog)
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_valid(conf)
+            modify_file(location_multilog, conf['log_format'], conf['valid_value'])
+            check_log_format_value_valid(conf)
+            remove_file(location_multilog)
+        elif sys.platform == 'win32':
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_valid(conf)
+        else:
+            create_file(location)
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_valid(conf)
+            modify_file(location, conf['log_format'], conf['valid_value'])
+            check_log_format_value_valid(conf)
+            remove_file(location)
 
     else:
         if sys.platform == 'win32':
@@ -270,11 +338,18 @@ def test_log_format(get_configuration, configure_environment):
             expected_exception = sb.CalledProcessError
 
         with pytest.raises(expected_exception):
-            create_file(location)
-            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-            check_log_format_valid(conf)
-            modify_file(location, conf['valid_value'])
-            check_log_format_value_invalid(conf)
-
-
-#   remove_file(location)
+            if conf['log_format'] == 'djb-multilog':
+                location_multilog = '/var/log/current'
+                create_file(location_multilog)
+                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+                check_log_format_valid(conf)
+                modify_file(location_multilog, conf['log_format'], conf['valid_value'])
+                check_log_format_value_invalid(conf)
+                remove_file(location_multilog)
+            else:
+                create_file(location)
+                control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+                check_log_format_valid(conf)
+                modify_file(location, conf['log_format'], conf['valid_value'])
+                check_log_format_value_invalid(conf)
+                remove_file(location)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -29,10 +29,7 @@ local_internal_options = {'logcollector.vcheck_files': '1', 'logcollector.debug'
 
 if sys.platform == 'win32':
     location = r'C:\test.txt'
-#    iis_path = r'%SystemDrive%\inetpub\logs\LogFiles\W3SVC1\test.log'
     iis_path = r'C:\test_iis.log'
-    filemultilog = r'C:\test_multilog'
-    nmap_log = r'C:\test_nmapg.log'
     wazuh_configuration = 'ossec.conf'
     prefix = AGENT_DETECTOR_PREFIX
 
@@ -52,12 +49,7 @@ parameters = [
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'},
-    {'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'},
-    {'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
-    {'LOCATION': f'{nmap_log}', 'LOG_FORMAT': 'nmapg'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'}
 ]
 
 metadata = [
@@ -69,12 +61,7 @@ metadata = [
     {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},
     {'location': f'{location}', 'log_format': 'audit', 'valid_value': True},
     {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'multi-line:3', 'valid_value': True},
-    {'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': False},
-    {'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': False},
-    {'location': f'{nmap_log}', 'log_format': 'nmapg', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True}
 ]
 
 if sys.platform == 'win32':
@@ -84,7 +71,20 @@ if sys.platform == 'win32':
 
     metadata.append({'location': 'Security', 'log_format': 'eventlog', 'valid_value': True})
     metadata.append({'location': 'Application', 'log_format': 'eventchannel', 'valid_value': True})
-    metadata.append({'location': f'{iis_path}', 'log_format': 'iis', 'valid_value': True}),
+    metadata.append({'location': f'{iis_path}', 'log_format': 'iis', 'valid_value': True})
+else:
+
+    parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'})
+    parameters.append({'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'})
+    parameters.append({'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'})
+    parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'})
+    parameters.append({'LOCATION': f'{nmap_log}', 'LOG_FORMAT': 'nmapg'})
+
+    metadata.append({'location': f'{location}', 'log_format': 'multi-line:3', 'valid_value': True})
+    metadata.append({'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': True})
+    metadata.append({'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': False})
+    metadata.append({'location': f'{location}', 'log_format': 'nmapg', 'valid_value': False})
+    metadata.append({'location': f'{nmap_log}', 'log_format': 'nmapg', 'valid_value': True})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 configuration_ids = [f"{x['log_format'], x['valid_value']}" for x in metadata]
@@ -103,15 +103,14 @@ def get_local_internal_options():
     """Get configurations from the module."""
     return local_internal_options
 
-def create_file(file, type):
+def create_file(files, type):
     """Create an empty file."""
     if type == 'iis':
         data = '#Software: Microsoft Internet Information Server 6.0\n#Version: 1.0\n#Date: 1998-11-19 22:48:39'
         data += '#Fields: date time c-ip cs-username s-ip cs-method cs-uri-stem cs-uri-query sc-status sc-bytes cs-bytes time-taken cs-version cs(User-Agent) cs(Cookie) cs(Referrer)\n'
     else:
         data = ""
-    with open(file, 'a') as f:
-        f.write(data)
+    file.write_file(files, data)
 
 def modify_json_file(file, type):
     """Create a json content with an specific values"""

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -44,10 +44,10 @@ parameters = [
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
     {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
-#    {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
 #    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
 #    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
 #    {'LOCATION': '/var/log/current', 'LOG_FORMAT': 'djb-multilog'},
@@ -61,10 +61,10 @@ metadata = [
     {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
     {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
     {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},
-#    {'location': f'{location}', 'log_format': 'audit', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
-#    {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},
+    {'location': f'{location}', 'log_format': 'audit', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
+    {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
 #    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': True},
 #    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': False},
 #    {'location': '/var/log/current', 'log_format': 'djb-multilog', 'valid_value': True},
@@ -247,10 +247,6 @@ def check_log_format_value_valid(conf):
             log_callback = logcollector.callback_read_file(location, prefix=prefix)
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
-            if conf['log_format'] == 'nampg':
-                pass
-             #   file.remove_file('/var/log/nampg.log')
-
         elif conf['log_format'] == 'multi-line:3':
             msg = ""
             with open(location, 'r') as file:
@@ -285,7 +281,6 @@ def check_log_format_value_invalid(conf):
             if conf['log_format'] == 'json' or conf['log_format'] == 'djb-multilog':
                 log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'), conf['log_format'], location, prefix)
             elif conf['log_format'] == 'audit' or conf['log_format'] == 'nmapg':
-            #    severity = 'ERROR'
                 log_callback = logcollector.callback_invalid_format_value(line, conf['log_format'], location, prefix)
 
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR)
@@ -325,7 +320,10 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
             check_log_format_valid(conf)
             modify_file(location, conf['log_format'], conf['valid_value'])
             check_log_format_value_valid(conf)
-            file.remove_file(location)
+            if conf['log_format'] == 'nampg':
+                file.remove_file('/var/log/nampg.log')
+            else:
+                file.remove_file(location)
 
     else:
 #        if sys.platform == 'win32':
@@ -347,4 +345,7 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
             check_log_format_valid(conf)
             modify_file(location, conf['log_format'], conf['valid_value'])
             check_log_format_value_invalid(conf)
-            file.remove_file(location)
+            if conf['log_format'] == 'nampg':
+                file.remove_file('/var/log/nampg.log')
+            else:
+                file.remove_file(location)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -26,7 +26,7 @@ force_restart_after_restoring = True
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 
-local_internal_options = {'logcollector.remote_commands': '1', 'logcollector.vcheck_files': '1', 'logcollector.debug': '2','monitord.rotate_log': '0'}
+local_internal_options = {'logcollector.vcheck_files': '1', 'logcollector.debug': '2', 'monitord.rotate_log': '0'}
 
 if sys.platform == 'win32':
     location = r'C:\test.txt'
@@ -39,37 +39,11 @@ else:
     prefix = LOG_COLLECTOR_DETECTOR_PREFIX
 
 parameters = [
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
-    {'LOCATION': '/var/log/current', 'LOG_FORMAT': 'djb-multilog'},
-    {'LOCATION': '/var/log/current', 'LOG_FORMAT': 'djb-multilog'},
-    {'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'},
+    {'location': f'{location}', 'log_format': 'json'},
 ]
 
 metadata = [
     {'location': f'{location}', 'log_format': 'json', 'valid_value': False},
-    {'location': f'{location}', 'log_format': 'json', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'squid', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'audit', 'valid_value': False},
-    {'location': f'{location}', 'log_format': 'audit', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': True},
-    {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': False},
-    {'location': '/var/log/current', 'log_format': 'djb-multilog', 'valid_value': True},
-    {'location': '/var/log/current', 'log_format': 'djb-multilog', 'valid_value': False},
-    {'location': f'{location}', 'log_format': 'multi-line:3', 'valid_value': True},
 ]
 
 if sys.platform == 'win32':
@@ -82,8 +56,6 @@ if sys.platform == 'win32':
     metadata.append({'location': f'{location}', 'log_format': 'iis', 'valid_value': True}),
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
-#configuration_ids = [f"{x['LOG_FORMAT'] 'Valid' if x['VALID_VALUE'] == TRUE else 'Invalid'}" for x in metadata]
-# configuration_ids = [f"{x['LOCATION'], x['LOG_FORMAT'], x['COMMAND']}" for x in parameters]
 configuration_ids = [f"{x['log_format'], x['valid_value']}" for x in metadata]
 
 log_format_not_print_analyzing_info = ['eventlog', 'eventchannel', 'iis']
@@ -109,7 +81,7 @@ def create_file(file):
 def remove_file(file):
     """ Remove a file created to testing."""
     if path.exists(file):
-        remove(file)
+        os.remove(file)
 
 def modify_json_file(file, type):
     """Create a json content with an specific values"""
@@ -296,7 +268,7 @@ def check_log_format_value_invalid(conf):
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR)
 
 
-def test_log_format(get_configuration, configure_environment):
+def test_log_format(get_local_internal_options, get_configuration, configure_local_internal_options):
     """
     Check if Wazuh log format field of logcollector works properly.
 
@@ -352,4 +324,4 @@ def test_log_format(get_configuration, configure_environment):
                 check_log_format_valid(conf)
                 modify_file(location, conf['log_format'], conf['valid_value'])
                 check_log_format_value_invalid(conf)
-                remove_file(location)
+ #               remove_file(location)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -35,7 +35,7 @@ if sys.platform == 'win32':
 
 else:
     location = '/tmp/test.txt'
-    filemultilog = '/var/log/current'
+    file_multilog = '/var/log/current'
     nmap_log = '/var/log/wa.log'
     wazuh_configuration = 'etc/ossec.conf'
     prefix = LOG_COLLECTOR_DETECTOR_PREFIX
@@ -75,14 +75,14 @@ if sys.platform == 'win32':
 else:
 
     parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'})
-    parameters.append({'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'})
-    parameters.append({'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'})
+    parameters.append({'LOCATION': f'{file_multilog}', 'LOG_FORMAT': 'djb-multilog'})
+    parameters.append({'LOCATION': f'{file_multilog}', 'LOG_FORMAT': 'djb-multilog'})
     parameters.append({'LOCATION': f'{nmap_log}', 'LOG_FORMAT': 'nmapg'})
     parameters.append({'LOCATION': f'{nmap_log}', 'LOG_FORMAT': 'nmapg'})
 
     metadata.append({'location': f'{location}', 'log_format': 'multi-line:3', 'valid_value': True})
-    metadata.append({'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': True})
-    metadata.append({'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': False})
+    metadata.append({'location': f'{file_multilog}', 'log_format': 'djb-multilog', 'valid_value': True})
+    metadata.append({'location': f'{file_multilog}', 'log_format': 'djb-multilog', 'valid_value': False})
     metadata.append({'location': f'{nmap_log}', 'log_format': 'nmapg', 'valid_value': False})
     metadata.append({'location': f'{nmap_log}', 'log_format': 'nmapg', 'valid_value': True})
 
@@ -91,6 +91,7 @@ configuration_ids = [f"{x['log_format'], x['valid_value']}" for x in metadata]
 
 log_format_windows_print_analyzing_info = ['eventlog', 'eventchannel', 'iis']
 log_format_not_print_reading_info = ['audit', 'mysql_log', 'postgresql_log', 'nmapg', 'djb-multilog']
+
 
 # fixtures
 @pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
@@ -106,8 +107,7 @@ def get_local_internal_options():
 
 
 def create_file_location(filename, type):
-    """
-    Create a specific content for a specific log_format.
+    """Create a specific content for a specific log_format.
 
      Args:
         filename(str): filename create with a specified content.
@@ -122,27 +122,21 @@ def create_file_location(filename, type):
     file.write_file(filename, data)
 
 
-def modify_json_file(filename, type):
-    """
-    Added content with json format and valid or invalid values.
+def modify_json_file(filename, valid):
+    """Added content with JSON format and valid or invalid values.
     Args:
-        filename (str):filename to modify.
-        type (str):type of content value. It can be valid or invalid.
+        filename (str): file's path to modify.
+        valid (bool): type of content value. It can be valid or invalid.
     """
 
-    if type:
-        data = '{"issue":22,"severity":1}\n'
-    else:
-        data = '{"issue:22,"severity":1}\n'
-
+    data = '{"issue":22,"severity":1}\n' if valid else '{"issue:22,"severity":1}\n'
     file.write_file(filename, data)
 
 
 def modify_syslog_file(filename):
-    """
-    Added content with syslog format and valid values.
+    """Added content with Syslog format and valid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): file's path to modify.
     """
 
     data = 'Apr 29 12:47:51 dev-branch systemd[1]: Starting\n'
@@ -150,34 +144,31 @@ def modify_syslog_file(filename):
 
 
 def modify_snort_file(filename):
-    """
-    Added content with syslog format and invalid values.
+    """Added content with snort format and invalid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): file's path to modify.
     """
     data = '10/12-21:29:35.911089 {ICMP} 192.168.1.99 – > 192.168.1.103\n'
     file.write_file(filename, data)
 
 
 def modify_squid_file(filename):
-    """
-    Added content with squid format and valid values.
+    """Added content with squid format and valid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): file's path to modify.
     """
     data = '902618.84 440 120.65.1.1 TCP/304 80 GET http://www.web.com:8005\n'
     file.write_file(filename, data)
 
 
-def modify_audit_file(filename, type):
-    """
-    Added content with audit format and specific values.
+def modify_audit_file(filename, valid):
+    """Added content with audit format and specific values.
     Args:
-        filename (str):filename to modify.
-        type (str):type of content value. It can be valid or invalid.
+        filename (str): file's path to modify.
+        valid (bool): type of content value. It can be valid or invalid.
     """
 
-    if type:
+    if valid:
         data = """type=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 """
         data += """subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" """
         data += """exe="/usr/lib/systemd/systemd" """
@@ -191,10 +182,9 @@ def modify_audit_file(filename, type):
 
 
 def modify_mysqlLog_file(filename):
-    """
-    Added content with mysql format and valid values.
+    """Added content with MySQL format and valid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): file's path to modify.
     """
 
     data = """show variables like 'general_log%';\n"""
@@ -202,24 +192,22 @@ def modify_mysqlLog_file(filename):
 
 
 def modify_postgresqlLog_file(filename):
-    """
-    Added content with postgresql format and valid values.
+    """Added content with Postgresql format and valid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): filename to modify.
     """
 
-    data = """show variables like 'general_log%';\n"""
+    data = "show variables like 'general_log%';\n"
     file.write_file(filename, data)
 
 
-def modify_nmapg_file(filename, type):
-    """
-    Added content with nmapg format and specific values.
+def modify_nmapg_file(filename, valid):
+    """Added content with nmapg format and specific values.
     Args:
-        filename (str):filename to modify.
-        type (str):type of content value. It can be valid or invalid.
+        filename (str): filename to modify.
+        valid (bool): type of content value. It can be valid or invalid.
     """
-    if type:
+    if valid:
         data = '# Nmap 7.70 scan initiated Tue May 11 16:48:35 2021 as: nmap -T4 -A -v '
         data += '-oG /var/log/map.log scanme.nmap.org\n'
         data += '# Ports scanned: TCP(1000;1,3-4,6-7,9,13,17,7920-7921,7937-7938,7999-8002,8007-8011,8021-8022,8031,'
@@ -229,14 +217,13 @@ def modify_nmapg_file(filename, type):
     file.write_file(filename, data)
 
 
-def modify_djb_multilog_file(filename, type):
-    """
-    Added content with djb-multilog format and specific values.
+def modify_djb_multilog_file(filename, valid):
+    """Added content with djb-multilog format and specific values.
     Args:
-        filename (str):filename to modify.
-        type (str):type of content value. It can be valid or invalid.
+        filename (str): filename to modify.
+        valid (bool): type of content value. It can be valid or invalid.
     """
-    if type:
+    if valid:
         data = '@400000003b4a39c23294b13c fatal: out of memory'
     else:
         data = '@40000000590e30983973bda4-eError'
@@ -245,21 +232,19 @@ def modify_djb_multilog_file(filename, type):
 
 
 def modify_multi_line_file(filename):
-    """
-    Added content with multiline format and valid values.
+    """Added content with multiline format and valid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): filename to modify.
     """
 
-    data = """Aug 9 14:22:47 log1\nAug 9 14:22:47 log2\nAug 9 14:22:47 log3\n"""
+    data = "Aug 9 14:22:47 log1\nAug 9 14:22:47 log2\nAug 9 14:22:47 log3\n"
     file.write_file(filename, data)
 
 
 def modify_iis_file(filename):
-    """
-    Added content with iis format and valid values.
+    """Added content with iis format and valid values.
     Args:
-        filename (str):filename to modify.
+        filename (str): filename to modify.
     """
 
     data = '2020-11-19 22:48:39 206.175.82.5 - 208.201.133.173 GET /global/images/navlineboards.gif '
@@ -273,7 +258,7 @@ def modify_file(file, type, content):
     Args:
         file (str): filename to modify.
         type (str): log format type to add.
-        content (str): content type(Valid=True, Invalid=False) to add to the file.
+        content (bool): content type(Valid=True, Invalid=False) to add to the file.
     """
 
     if type == 'json':
@@ -301,25 +286,28 @@ def modify_file(file, type, content):
 
 
 def check_log_format_valid(cfg):
-    """
-    Check if Wazuh run correctly with the specified log formats.
-
+    """Check if Wazuh runs correctly with the specified log formats.
+    Args:
+        cfg (dict): Dictionary with the localfile configuration.
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
     """
+
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
     if cfg['log_format'] == 'eventchannel' or cfg['log_format'] == 'eventlog':
         log_callback = logcollector.callback_eventchannel_analyzing(cfg['location'])
     else:
         log_callback = logcollector.callback_analyzing_file(cfg['location'])
+
     wazuh_log_monitor.start(timeout=5, callback=log_callback,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
 
 
 def check_log_format_value_valid(conf):
-    """
-    Check if Wazuh runs correctly with the correct log format and a specific content.
-
+    """Check if Wazuh runs correctly with the correct log format and specific content.
+    Args:
+        conf (dict): Dictionary with the localfile configuration.
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
     """
@@ -362,21 +350,24 @@ def check_log_format_value_valid(conf):
 
 
 def analyzing_invalid_value(conf):
-    """
-    Checks for the error message that is shown when the record format type is valid but the content is invalid.
+    """Checks for the error message that is shown when the record format type is valid but the content is invalid.
+    Args:
+        conf (dict): Dictionary with the localfile configuration.
+    Returns:
+        callable: callback to detect this event log.
     """
 
     with open(conf['location']) as log:
         line = log.readline()
         log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'),
                                                                   conf['log_format'], conf['location'])
-        return log_callback
+    return log_callback
 
 
 def check_log_format_value_invalid(conf):
-    """
-    Check if Wazuh fails because of content invalid log.
-
+    """Check if Wazuh fails because of content invalid log.
+    Args:
+        conf (dict): Dictionary with the localfile configuration.
     Raises:
        TimeoutError: If error callback are not generated.
    """
@@ -389,31 +380,30 @@ def check_log_format_value_invalid(conf):
 
 
 def check_log_format_values(conf):
-    """
-    Set of validations to follow to validate a certain content.
-    The file content could be valid or invalid.
-
+    """Set of validations to follow to validate a certain content.
+        The file content could be valid or invalid.
+    Args:
+        conf (dict): Dictionary with the localfile configuration.
    """
+    check_log_format_valid(conf)
+    modify_file(conf['location'], conf['log_format'], conf['valid_value'])
 
     if conf['valid_value']:
-        check_log_format_valid(conf)
-        modify_file(conf['location'], conf['log_format'], conf['valid_value'])
         check_log_format_value_valid(conf)
-        file.remove_file(conf['location'])
     else:
-        check_log_format_valid(conf)
-        modify_file(conf['location'], conf['log_format'], conf['valid_value'])
         check_log_format_value_invalid(conf)
-        file.remove_file(conf['location'])
+    file.remove_file(conf['location'])
 
 
 def test_log_format(get_local_internal_options, get_configuration,
                     configure_local_internal_options, configure_environment):
-    """
-    Check if Wazuh log format field of logcollector works properly.
-
+    """Check if Wazuh log format field of logcollector works properly.
     Ensure Wazuh component fails in case of invalid content file and works properly in case of valid log format values.
-
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        get_configuration (fixture): Get configurations from the module.
+        configure_local_internal_options (fixture): Set internal configuration.
+        configure_environment (fixture): Configure a custom environment for testing.
     Raises:
         TimeoutError: If expected callbacks are not generated.
     """
@@ -436,7 +426,7 @@ def test_log_format(get_local_internal_options, get_configuration,
         else:
             # Analyze valid formats with valid content in Linux
             if conf['log_format'] == 'djb-multilog':
-                create_file_location(filemultilog, conf['log_format'])
+                create_file_location(file_multilog, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
 
@@ -457,7 +447,7 @@ def test_log_format(get_local_internal_options, get_configuration,
         else:
             # Analyze valid formats with invalid content in Linux
             if conf['log_format'] == 'djb-multilog':
-                create_file_location(filemultilog, conf['log_format'])
+                create_file_location(file_multilog, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
 

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -22,6 +22,7 @@ no_restart_windows_after_configuration_set = True
 force_restart_after_restoring = True
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+local_internal_options = {'logcollector.vcheck_files': '1', 'logcollector.debug': '2', 'monitord.rotate_log': '0'}
 
 if sys.platform == 'win32':
     location = r'C:\test.txt'
@@ -89,6 +90,11 @@ log_format_not_print_reading_info = ['audit', 'mysql_log', 'postgresql_log', 'nm
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
 
 
 def create_file_location(filename, type):
@@ -375,12 +381,16 @@ def check_log_format_values(conf):
     file.remove_file(conf['location'])
 
 
-def test_log_format(get_configuration, configure_environment):
+def test_log_format(get_configuration, configure_environment, get_local_internal_options,
+                    configure_local_internal_options,):
     """Check if Wazuh log format field of logcollector works properly.
     Ensure Wazuh component fails in case of invalid content file and works properly in case of valid log format values.
     Args:
+        get_local_internal_options (fixture): Get internal configuration.
         get_configuration (fixture): Get configurations from the module.
+        configure_local_internal_options (fixture): Set internal configuration.
         configure_environment (fixture): Configure a custom environment for testing.
+
     Raises:
         TimeoutError: If expected callbacks are not generated.
     """

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -5,7 +5,6 @@
 import os
 import pytest
 import sys
-import subprocess as sb
 import wazuh_testing.tools.file as file
 
 import wazuh_testing.logcollector as logcollector
@@ -98,11 +97,11 @@ def get_local_internal_options():
 
 
 def create_file_location(filename, type):
-    """Create a specific content for a specific log_format.
+    """Creates a file with specific content for a log format particular.
 
      Args:
-        filename(str): filename create with a specified content.
-        type(str): log format type.
+          filename (str): filename to create
+          type (str): type of record format with which the filename will be created.
     """
     if type == 'iis':
         data = '#Software: Microsoft Internet Information Server 6.0\n#Version: 1.0\n#Date: 1998-11-19 22:48:39'
@@ -114,28 +113,29 @@ def create_file_location(filename, type):
 
 
 def modify_json_file(filename, valid):
-    """Added content with JSON format and valid or invalid values.
+    """Adds content in JSON format with valid or invalid values.
+
     Args:
         filename (str): file's path to modify.
         valid (bool): type of content value. It can be valid or invalid.
     """
-
     data = '{"issue":22,"severity":1}\n' if valid else '{"issue:22,"severity":1}\n'
     file.write_file(filename, data)
 
 
 def modify_syslog_file(filename):
-    """Added content with Syslog format and valid values.
+    """Adds content with valid values in Syslog format.
+
     Args:
         filename (str): file's path to modify.
     """
-
     data = 'Apr 29 12:47:51 dev-branch systemd[1]: Starting\n'
     file.write_file(filename, data)
 
 
 def modify_snort_file(filename):
-    """Added content with snort format and invalid values.
+    """Adds content with valid values in snort-full format.
+
     Args:
         filename (str): file's path to modify.
     """
@@ -144,7 +144,8 @@ def modify_snort_file(filename):
 
 
 def modify_squid_file(filename):
-    """Added content with squid format and valid values.
+    """Adds content with valid values in squid format.
+
     Args:
         filename (str): file's path to modify.
     """
@@ -153,12 +154,12 @@ def modify_squid_file(filename):
 
 
 def modify_audit_file(filename, valid):
-    """Added content with audit format and specific values.
+    """Adds content in audit format with valid or invalid values.
+
     Args:
         filename (str): file's path to modify.
         valid (bool): type of content value. It can be valid or invalid.
     """
-
     if valid:
         data = """type=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 """
         data += """subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" """
@@ -173,29 +174,30 @@ def modify_audit_file(filename, valid):
 
 
 def modify_mysqlog_file(filename):
-    """Added content with MySQL format and valid values.
+    """Adds content with valid values in MySQL format.
+
     Args:
         filename (str): file's path to modify.
     """
-
     data = """show variables like 'general_log%';\n"""
     file.write_file(filename, data)
 
 
 def modify_postgresqlog_file(filename):
-    """Added content with Postgresql format and valid values.
-    Args:
-        filename (str): filename to modify.
-    """
+    """Adds content with valid values in Postgresql format.
 
+    Args:
+        filename (str): file's path to modify.
+    """
     data = "show variables like 'general_log%';\n"
     file.write_file(filename, data)
 
 
 def modify_nmapg_file(filename, valid):
-    """Added content with nmapg format and specific values.
+    """Adds content in nmapg format with valid or invalid values.
+
     Args:
-        filename (str): filename to modify.
+        filename (str): file's path to modify.
         valid (bool): type of content value. It can be valid or invalid.
     """
     if valid:
@@ -209,9 +211,10 @@ def modify_nmapg_file(filename, valid):
 
 
 def modify_djb_multilog_file(filename, valid):
-    """Added content with djb-multilog format and specific values.
+    """Adds content in djb-multilog format with valid or invalid values.
+
     Args:
-        filename (str): filename to modify.
+        filename (str): file's path to modify.
         valid (bool): type of content value. It can be valid or invalid.
     """
     if valid:
@@ -223,21 +226,21 @@ def modify_djb_multilog_file(filename, valid):
 
 
 def modify_multi_line_file(filename):
-    """Added content with multiline format and valid values.
-    Args:
-        filename (str): filename to modify.
-    """
+    """Adds content with valid values in multi-line format.
 
+    Args:
+        filename (str): file's path to modify.
+    """
     data = "Aug 9 14:22:47 log1\nAug 9 14:22:47 log2\nAug 9 14:22:47 log3\n"
     file.write_file(filename, data)
 
 
 def modify_iis_file(filename):
-    """Added content with iis format and valid values.
-    Args:
-        filename (str): filename to modify.
-    """
+    """Adds content in iis format with valid values.
 
+    Args:
+        filename (str): file's path to modify.
+    """
     data = '2020-11-19 22:48:39 206.175.82.5 - 208.201.133.173 GET /global/images/navlineboards.gif '
     data += '- 200 540 324 157 HTTP/1.0 Mozilla/4.0+(compatible;+MSIE+4.01;+Windows+95) '
     data += 'USERID=CustomerA;+IMPID=01234 http://www.loganalyzer.net\n'
@@ -245,13 +248,13 @@ def modify_iis_file(filename):
 
 
 def modify_file(file, type, content):
-    """ Modified a file with a specific log format to generate logs.
-    Args:
-        file (str): filename to modify.
-        type (str): log format type to add.
-        content (bool): content type(Valid=True, Invalid=False) to add to the file.
-    """
+    """Modifies a file's content to generate logs.
 
+    Args:
+        file (str): file's path to modify.
+        type (str): log format type.
+        content (bool): content type(Valid=True, Invalid=False) to add in the file.
+    """
     if type == 'json':
         modify_json_file(file, content)
     elif type == 'syslog':
@@ -277,13 +280,13 @@ def modify_file(file, type, content):
 
 
 def check_log_format_valid(cfg):
-    """Check if Wazuh runs correctly with the specified log formats.
+    """Checks if Wazuh runs correctly with the specified log formats.
+
     Args:
         cfg (dict): Dictionary with the localfile configuration.
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
     """
-
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
     if cfg['log_format'] == 'eventchannel' or cfg['log_format'] == 'eventlog':
@@ -296,13 +299,13 @@ def check_log_format_valid(cfg):
 
 
 def check_log_format_value_valid(conf):
-    """Check if Wazuh runs correctly with the correct log format and specific content.
+    """Checks if Wazuh runs correctly with the correct log format and specific content.
+
     Args:
         conf (dict): Dictionary with the localfile configuration.
     Raises:
         TimeoutError: If the "Analyzing file" callback is not generated.
     """
-
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
     if conf['log_format'] not in log_format_windows_print_analyzing_info:
@@ -337,12 +340,12 @@ def check_log_format_value_valid(conf):
 
 def analyzing_invalid_value(conf):
     """Checks for the error message that is shown when the record format type is valid but the content is invalid.
+
     Args:
         conf (dict): Dictionary with the localfile configuration.
     Returns:
         callable: callback to detect this event log.
     """
-
     with open(conf['location']) as log:
         line = log.readline()
         log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'),
@@ -352,12 +355,12 @@ def analyzing_invalid_value(conf):
 
 def check_log_format_value_invalid(conf):
     """Check if Wazuh fails because of content invalid log.
+
     Args:
         conf (dict): Dictionary with the localfile configuration.
     Raises:
        TimeoutError: If error callback are not generated.
    """
-
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
     if conf['log_format'] not in log_format_windows_print_analyzing_info:
@@ -367,7 +370,8 @@ def check_log_format_value_invalid(conf):
 
 def check_log_format_values(conf):
     """Set of validations to follow to validate a certain content.
-        The file content could be valid or invalid.
+    The file content could be valid or invalid.
+
     Args:
         conf (dict): Dictionary with the localfile configuration.
    """
@@ -385,6 +389,7 @@ def test_log_format(get_configuration, configure_environment, get_local_internal
                     configure_local_internal_options,):
     """Check if Wazuh log format field of logcollector works properly.
     Ensure Wazuh component fails in case of invalid content file and works properly in case of valid log format values.
+
     Args:
         get_local_internal_options (fixture): Get internal configuration.
         get_configuration (fixture): Get configurations from the module.
@@ -414,13 +419,8 @@ def test_log_format(get_configuration, configure_environment, get_local_internal
             check_log_format_values(conf)
 
     else:
-        # Analyze valid formats with invalid content in Windows
-        # Return Exception Error
-        if sys.platform == 'win32':
-            sb.CalledProcessError
-        else:
-            # Analyze valid formats with invalid content in Linux
-            create_file_location(conf['location'], conf['log_format'])
-            control_service('start')
-            check_log_format_values(conf)
+        # Analyze valid formats with invalid content in Linux
+        create_file_location(conf['location'], conf['log_format'])
+        control_service('start')
+        check_log_format_values(conf)
 

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -5,7 +5,6 @@
 import os
 import pytest
 import sys
-import json
 import subprocess as sb
 import wazuh_testing.logcollector as logcollector
 import wazuh_testing.generic_callbacks as gc
@@ -15,7 +14,6 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX, FileMonitor
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
-import time
 
 LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
 
@@ -108,6 +106,11 @@ def create_file(file):
     with open(file, 'a') as f:
         f.write("")
 
+def remove_file(file):
+    """ Remove a file created to testing."""
+    if path.exists(file):
+        remove(file)
+
 def modify_json_file(file, type):
     """Create a json content with an specific values"""
     if type:
@@ -117,10 +120,15 @@ def modify_json_file(file, type):
     with open(file, 'a') as f:
         f.write(data)
 
+def modify_syslog_file(file, type):
+    """Create a syslog content with an specific values"""
+    if type:
+        data = """{"issue":22,"severity":1}\n"""
+    else:
+        data = """{"issue:22,"severity":1}\n"""
+    with open(file, 'a') as f:
+        f.write(data)
 
-def remove_file(file):
-    if path.exists(file):
-        remove(file)
 
 def check_log_format_valid(cfg):
     """Check if Wazuh run correctly with the specified log formats.
@@ -194,6 +202,7 @@ def check_log_format_value_invalid(conf):
 
             log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix)
             wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
+
 
 def test_log_format(get_configuration, configure_environment):
     """

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -98,10 +98,12 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 @pytest.fixture(scope="module")
 def get_local_internal_options():
     """Get configurations from the module."""
     return local_internal_options
+
 
 def create_file_location(filename, type):
     """
@@ -113,10 +115,12 @@ def create_file_location(filename, type):
     """
     if type == 'iis':
         data = '#Software: Microsoft Internet Information Server 6.0\n#Version: 1.0\n#Date: 1998-11-19 22:48:39'
-        data += '#Fields: date time c-ip cs-username s-ip cs-method cs-uri-stem cs-uri-query sc-status sc-bytes cs-bytes time-taken cs-version cs(User-Agent) cs(Cookie) cs(Referrer)\n'
+        data += '#Fields: date time c-ip cs-username s-ip cs-method cs-uri-stem cs-uri-query sc-status sc-bytes '
+        data += 'cs-bytes time-taken cs-version cs(User-Agent) cs(Cookie) cs(Referrer)\n'
     else:
         data = ""
     file.write_file(filename, data)
+
 
 def modify_json_file(filename, type):
     """
@@ -133,6 +137,7 @@ def modify_json_file(filename, type):
 
     file.write_file(filename, data)
 
+
 def modify_syslog_file(filename):
     """
     Added content with syslog format and valid values.
@@ -143,6 +148,7 @@ def modify_syslog_file(filename):
     data = 'Apr 29 12:47:51 dev-branch systemd[1]: Starting\n'
     file.write_file(filename, data)
 
+
 def modify_snort_file(filename):
     """
     Added content with syslog format and invalid values.
@@ -151,6 +157,7 @@ def modify_snort_file(filename):
     """
     data = '10/12-21:29:35.911089 {ICMP} 192.168.1.99 – > 192.168.1.103\n'
     file.write_file(filename, data)
+
 
 def modify_squid_file(filename):
     """
@@ -161,6 +168,7 @@ def modify_squid_file(filename):
     data = '902618.84 440 120.65.1.1 TCP/304 80 GET http://www.web.com:8005\n'
     file.write_file(filename, data)
 
+
 def modify_audit_file(filename, type):
     """
     Added content with audit format and specific values.
@@ -170,9 +178,15 @@ def modify_audit_file(filename, type):
     """
 
     if type:
-        data = """type=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset"\n"""
+        data = """type=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 """
+        data += """subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" """
+        data += """exe="/usr/lib/systemd/systemd" """
+        data += """hostname=? addr=? terminal=? res=success'UID="root" AUID="unset"\n"""
+
     else:
-        data = """=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset\n"""
+        data = """=SERVICE_START msg=audit(1620164215.922:963): pid=1 uid=0 auid=4294967295 """
+        data += """ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=dnf-makecache comm="systemd" """
+        data += """exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'UID="root" AUID="unset\n"""
     file.write_file(filename, data)
 
 
@@ -197,6 +211,7 @@ def modify_postgresqlLog_file(filename):
     data = """show variables like 'general_log%';\n"""
     file.write_file(filename, data)
 
+
 def modify_nmapg_file(filename, type):
     """
     Added content with nmapg format and specific values.
@@ -205,11 +220,14 @@ def modify_nmapg_file(filename, type):
         type (str):type of content value. It can be valid or invalid.
     """
     if type:
-        data = '# Nmap 7.70 scan initiated Tue May 11 16:48:35 2021 as: nmap -T4 -A -v -oG /var/log/map.log scanme.nmap.org\n'
-        data += '# Ports scanned: TCP(1000;1,3-4,6-7,9,13,17,7920-7921,7937-7938,7999-8002,8007-8011,8021-8022,8031,8042,8045,8800,64680,65000,65129,65389) UDP(0;) SCTP(0;) PROTOCOLS(0;)\n'
+        data = '# Nmap 7.70 scan initiated Tue May 11 16:48:35 2021 as: nmap -T4 -A -v '
+        data += '-oG /var/log/map.log scanme.nmap.org\n'
+        data += '# Ports scanned: TCP(1000;1,3-4,6-7,9,13,17,7920-7921,7937-7938,7999-8002,8007-8011,8021-8022,8031,'
+        data += '8042,8045,8800,64680,65000,65129,65389) UDP(0;) SCTP(0;) PROTOCOLS(0;)\n'
     else:
         data = 'nmap -n -Pn -p 80 --open -sV -vvv --script banner,http-title -iR 1000\n'
     file.write_file(filename, data)
+
 
 def modify_djb_multilog_file(filename, type):
     """
@@ -225,6 +243,7 @@ def modify_djb_multilog_file(filename, type):
 
     file.write_file(filename, data)
 
+
 def modify_multi_line_file(filename):
     """
     Added content with multiline format and valid values.
@@ -235,6 +254,7 @@ def modify_multi_line_file(filename):
     data = """Aug 9 14:22:47 log1\nAug 9 14:22:47 log2\nAug 9 14:22:47 log3\n"""
     file.write_file(filename, data)
 
+
 def modify_iis_file(filename):
     """
     Added content with iis format and valid values.
@@ -242,7 +262,9 @@ def modify_iis_file(filename):
         filename (str):filename to modify.
     """
 
-    data = '2020-11-19 22:48:39 206.175.82.5 - 208.201.133.173 GET /global/images/navlineboards.gif - 200 540 324 157 HTTP/1.0 Mozilla/4.0+(compatible;+MSIE+4.01;+Windows+95) USERID=CustomerA;+IMPID=01234 http://www.loganalyzer.net\n'
+    data = '2020-11-19 22:48:39 206.175.82.5 - 208.201.133.173 GET /global/images/navlineboards.gif '
+    data += '- 200 540 324 157 HTTP/1.0 Mozilla/4.0+(compatible;+MSIE+4.01;+Windows+95) '
+    data += 'USERID=CustomerA;+IMPID=01234 http://www.loganalyzer.net\n'
     file.write_file(filename, data)
 
 
@@ -277,6 +299,7 @@ def modify_file(file, type, content):
     elif type == 'iis':
         modify_iis_file(file)
 
+
 def check_log_format_valid(cfg):
     """
     Check if Wazuh run correctly with the specified log formats.
@@ -289,7 +312,9 @@ def check_log_format_valid(cfg):
         log_callback = logcollector.callback_eventchannel_analyzing(cfg['location'])
     else:
         log_callback = logcollector.callback_analyzing_file(cfg['location'])
-    wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
+    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
+
 
 def check_log_format_value_valid(conf):
     """
@@ -306,10 +331,12 @@ def check_log_format_value_valid(conf):
             # Logs format that only shows when a specific file is read.
 
             log_callback = logcollector.callback_read_file(conf['location'])
-            wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+            wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                    error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
         elif conf['log_format'] == 'multi-line:3':
-            # It is necessary to reorganize the content of the file to compare it with the generated output of the 'multiline' format.
+            # It is necessary to reorganize the content of the file to compare it
+            # with the generated output of the 'multiline' format.
 
             msg = ""
             with open(location, 'r') as file:
@@ -317,18 +344,22 @@ def check_log_format_value_valid(conf):
                     msg += line.rstrip('\n')
                     msg += ' '
                 log_callback = logcollector.callback_reading_file(conf['log_format'], msg.rstrip(' '))
-                wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+                wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                        error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
         else:
             # Verify that the content of the parsed file is equal to the output generated in the logs.
             with open(location, 'r') as f:
                 lines = f.readlines()
                 for line in lines:
                     log_callback = logcollector.callback_reading_file(conf['log_format'], line.rstrip('\n'))
-                    wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+                    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                            error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
 
     elif conf['log_format'] == 'iis':
         log_callback = logcollector.callback_read_file(conf['location'])
-        wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+        wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+
 
 def analyzing_invalid_value(conf):
     """
@@ -337,8 +368,10 @@ def analyzing_invalid_value(conf):
 
     with open(conf['location']) as log:
         line = log.readline()
-        log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'), conf['log_format'], conf['location'])
+        log_callback = logcollector.callback_invalid_format_value(line.rstrip('\n'),
+                                                                  conf['log_format'], conf['location'])
         return log_callback
+
 
 def check_log_format_value_invalid(conf):
     """
@@ -353,6 +386,7 @@ def check_log_format_value_invalid(conf):
     if conf['log_format'] not in log_format_windows_print_analyzing_info:
         log_callback = analyzing_invalid_value(conf)
         wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR)
+
 
 def check_log_format_values(conf):
     """
@@ -372,7 +406,9 @@ def check_log_format_values(conf):
         check_log_format_value_invalid(conf)
         file.remove_file(conf['location'])
 
-def test_log_format(get_local_internal_options, get_configuration, configure_local_internal_options, configure_environment):
+
+def test_log_format(get_local_internal_options, get_configuration,
+                    configure_local_internal_options, configure_environment):
     """
     Check if Wazuh log format field of logcollector works properly.
 
@@ -419,7 +455,7 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
         if sys.platform == 'win32':
             sb.CalledProcessError
         else:
-        # Analyze valid formats with invalid content in Linux
+            # Analyze valid formats with invalid content in Linux
             if conf['log_format'] == 'djb-multilog':
                 create_file_location(filemultilog, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -77,13 +77,13 @@ else:
     parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'})
     parameters.append({'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'})
     parameters.append({'LOCATION': f'{filemultilog}', 'LOG_FORMAT': 'djb-multilog'})
-    parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'})
+    parameters.append({'LOCATION': f'{nmap_log}', 'LOG_FORMAT': 'nmapg'})
     parameters.append({'LOCATION': f'{nmap_log}', 'LOG_FORMAT': 'nmapg'})
 
     metadata.append({'location': f'{location}', 'log_format': 'multi-line:3', 'valid_value': True})
     metadata.append({'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': True})
     metadata.append({'location': f'{filemultilog}', 'log_format': 'djb-multilog', 'valid_value': False})
-    metadata.append({'location': f'{location}', 'log_format': 'nmapg', 'valid_value': False})
+    metadata.append({'location': f'{nmap_log}', 'log_format': 'nmapg', 'valid_value': False})
     metadata.append({'location': f'{nmap_log}', 'log_format': 'nmapg', 'valid_value': True})
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -427,10 +427,8 @@ def test_log_format(get_local_internal_options, get_configuration, configure_loc
 
             elif conf['log_format'] == 'nmapg':
                 create_file_location(nmap_log, conf['log_format'])
-                create_file_location(location, conf['log_format'])
                 control_service('start', daemon=LOGCOLLECTOR_DAEMON)
                 check_log_format_values(conf)
-                file.remove_file(nmap_log)
 
             else:
                 create_file_location(location, conf['log_format'])

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -1,0 +1,234 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import pytest
+import sys
+import json
+import subprocess as sb
+import wazuh_testing.logcollector as logcollector
+import wazuh_testing.generic_callbacks as gc
+from os import remove, path
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX, FileMonitor
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.services import control_service
+import time
+
+LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+
+# Marks
+pytestmark = pytest.mark.tier(level=0)
+
+# Configuration
+no_restart_windows_after_configuration_set = True
+force_restart_after_restoring = True
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+
+local_internal_options = {'logcollector.remote_commands': '1', 'logcollector.debug': '2'}
+
+if sys.platform == 'win32':
+    location = r'C:\testing.txt'
+    wazuh_configuration = 'ossec.conf'
+    prefix = AGENT_DETECTOR_PREFIX
+
+else:
+    location = '/tmp/test.txt'
+    wazuh_configuration = 'etc/ossec.conf'
+    prefix = LOG_COLLECTOR_DETECTOR_PREFIX
+
+parameters = [
+    {'LOCATION': f'{location}', 'LOG_FORMAT': 'json'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'syslog'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'snort-full'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'squid'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'audit'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'mysql_log'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'postgresql_log'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'nmapg'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'command'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'full_command'},
+    # {'LOCATION': '/var/log/testing/current', 'LOG_FORMAT': 'djb-multilog'},
+    # {'LOCATION': '/var/log/testing/current', 'LOG_FORMAT': 'djb-multilog'},
+    # {'LOCATION': '/var/log/testing/current', 'LOG_FORMAT': 'djb-multilog'},
+    # {'LOCATION': f'{location}', 'LOG_FORMAT': 'multi-line:3'},
+]
+
+metadata = [
+    {'location': f'{location}', 'log_format': 'json', 'valid_value': False},
+
+    # {'location': f'{location}', 'log_format': 'syslog', 'valid_value': True},
+
+    # {'location': f'{location}', 'log_format': 'snort-full', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'squid', 'command': 'example-command', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'audit', 'command': 'example-command', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'mysql_log', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'postgresql_log', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'nmapg', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'command', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'full_command', 'valid_value': True},
+    # {'location': '/var/log/testing/current', 'log_format': 'djb-multilog', 'command': 'example-command', 'valid_value': True},
+    # {'location': '/var/log/testing/current', 'log_format': 'djb-multilog', 'command': 'example-command', 'valid_value': True},
+    # {'location': '/var/log/testing/current', 'log_format': 'djb-multilog', 'command': 'example-command', 'valid_value': True},
+    # {'location': f'{location}', 'log_format': 'multi-line:3', 'command': 'example-command', 'valid_value': True},
+]
+
+if sys.platform == 'win32':
+    parameters.append({'LOCATION': 'Security', 'LOG_FORMAT': 'eventlog'})
+    parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'eventchannel'})
+    parameters.append({'LOCATION': f'{location}', 'LOG_FORMAT': 'iis'})
+
+    metadata.append({'location': 'Security', 'log_format': 'eventlog', 'command': 'example-command', 'valid_value': True})
+    metadata.append({'location': f'{location}', 'log_format': 'eventchannel', 'command': 'example-command', 'valid_value': True})
+    metadata.append({'location': f'{location}', 'log_format': 'iis', 'valid_value': True}),
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+configuration_ids = [f"{x['LOG_FORMAT']}" for x in parameters]
+
+log_format_not_print_analyzing_info = ['command', 'full_command', 'eventlog', 'eventchannel']
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+def create_file(file):
+    """Create an empty file."""
+    with open(file, 'a') as f:
+        f.write("")
+
+def modify_json_file(file, type):
+    """Create a json content with an specific values"""
+    if type:
+        data = """{"issue":22,"severity":1}\n"""
+    else:
+        data = """{"issue:22,"severity":1}\n"""
+    with open(file, 'a') as f:
+        f.write(data)
+
+
+def remove_file(file):
+    if path.exists(file):
+        remove(file)
+
+def check_log_format_valid(cfg):
+    """Check if Wazuh run correctly with the specified log formats.
+
+    Ensure logcollector allows the specified log formats. Also, in the case of the manager instance, check if the API
+    answer for localfile block coincides.
+
+    Raises:
+        TimeoutError: If the "Analyzing file" callback is not generated.
+        AssertError: In the case of a server instance, the API response is different that the real configuration.
+    """
+    wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+    if cfg['log_format'] not in log_format_not_print_analyzing_info:
+        log_callback = logcollector.callback_analyzing_file(cfg['location'], prefix=prefix)
+        wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
+
+    elif 'command' in cfg['log_format']:
+        log_callback = logcollector.callback_monitoring_command(cfg['log_format'], cfg['command'], prefix=prefix)
+        wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
+    elif cfg['log_format'] == 'djb-multilog':
+        log_callback = logcollector.callback_monitoring_djb_multilog(cfg['location'], prefix=prefix)
+        wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message="The expected multilog djb log has not been produced")
+
+
+def check_log_format_value_valid(conf):
+    """
+    Check if Wazuh runs correctly with the correct log format and content.
+
+    Ensure logcollector allows the specified log formats.
+
+    Raises:
+        TimeoutError: If the "Analyzing file" callback is not generated.
+    """
+
+    wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+    # CHECK ONLY JSON FILE FOR NOW
+
+    if conf['log_format'] not in log_format_not_print_analyzing_info:
+        file1 = open(location, 'r')
+        lines = file1.readlines()
+
+        # Strips the newline character
+        for line in lines:
+            log_callback = logcollector.callback_reading_file(line.strip(), prefix=prefix)
+            wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_READING_FILE)
+
+    #NEED TO ADD OTHER CASES
+
+
+
+def check_log_format_value_invalid(conf):
+    """
+    Check if Wazuh fails because of an invalid log format or content.
+
+       Args:
+           cfg (dict): Dictionary with the localfile configuration.
+
+       Raises:
+           TimeoutError: If error callback are not generated.
+   """
+
+    wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
+    # CHECK ONLY JSON FILE FOR NOW
+
+    if conf['log_format'] not in log_format_not_print_analyzing_info:
+        with open(location, "r") as f:
+            line = f.readline()
+
+            log_callback = gc.callback_invalid_format_value(line, conf['log_format'], location, prefix)
+            wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
+
+def test_log_format(get_configuration, configure_environment):
+    """
+    Check if Wazuh log format field of logcollector works properly.
+
+    Ensure Wazuh component fails in case of invalid content file and works properly in case of valid log format values.
+
+    Raises:
+        TimeoutError: If expected callbacks are not generated.
+    """
+
+    conf = get_configuration['metadata']
+
+    control_service('stop', daemon=LOGCOLLECTOR_DAEMON)
+    truncate_file(LOG_FILE_PATH)
+
+    if conf['valid_value']:
+        create_file(location)
+        control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+        check_log_format_valid(conf)
+        modify_json_file(location, conf['valid_value'])
+        check_log_format_value_valid(conf)
+
+    else:
+        if sys.platform == 'win32':
+            expected_exception = ValueError
+        else:
+            expected_exception = sb.CalledProcessError
+
+        with pytest.raises(expected_exception):
+            create_file(location)
+            control_service('start', daemon=LOGCOLLECTOR_DAEMON)
+            check_log_format_valid(conf)
+            modify_json_file(location, conf['valid_value'])
+            check_log_format_value_invalid(conf)
+
+
+#   remove_file(location)

--- a/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
+++ b/tests/integration/test_logcollector/test_log_format/test_log_format_values.py
@@ -235,8 +235,10 @@ def check_log_format_valid(cfg):
         AssertError: In the case of a server instance, the API response is different that the real configuration.
     """
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
-    log_callback = logcollector.callback_analyzing_file(cfg['location'], prefix=prefix)
+    if cfg['log_format'] == 'eventchannel' or cfg['log_format'] == 'eventlog':
+        log_callback = logcollector.callback_eventchannel_analyzing(cfg['location'])
+    else:
+        log_callback = logcollector.callback_analyzing_file(cfg['location'], prefix=prefix)
     wazuh_log_monitor.start(timeout=5, callback=log_callback, error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_FILE)
 
 def check_log_format_value_valid(conf):


### PR DESCRIPTION
| Related issue   |
|  Closed  [1126 ](https://github.com/wazuh/wazuh-qa/issues/1226)             |

## Description

- [x] Create tests for valid and invalid values for the following localfile log_format values options:
        - Json
        - Snort-full
        - Squid
        - Syslog
        - Audit
        - mysql_log
        - Postgresql_log
        - nmapg
        - djb-multilog
        - multi-line:3
        - eventlog
        - eventchannel
        - iis

- [x] Testing and debugging process.
       - These tests will check that if you add a file with `valid` content is accepted and showed in `ossec.log.`
       - They will also make sure that the Wazuh manager shows an error in `ossec.log` when a file has `invalid` content.
       - Jenkins Results:  [Last Iteration](https://ci.wazuh.info/view/Tests/job/Test_integration/4094/).
            
        
## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.


## Documentation


![imagen](https://user-images.githubusercontent.com/3978434/118713379-3b530100-b7f8-11eb-90f8-b65e17e12902.png)

![imagen](https://user-images.githubusercontent.com/3978434/118716419-2deb4600-b7fb-11eb-96c3-b5b74e072a53.png)

![imagen](https://user-images.githubusercontent.com/3978434/118716624-6c810080-b7fb-11eb-9479-2b4dbd18b17c.png)

