### PR TITLE
Remove timeout parameter and add a new one to set the log path in API load simulator tool and script

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import time
 from base64 import b64encode
 from os.path import join, dirname, abspath
 from threading import Thread, Event
@@ -24,12 +23,13 @@ class ThreadFilter(logging.Filter):
 
 
 class CustomLogger:
-    def __init__(self, name, filename='wazuh_api_simulator.log', foreground=False, tag='Main', level=logging.INFO):
+    def __init__(self, name, file_path='/tmp/wazuh_api_simulator.log', foreground=False, tag='Main',
+                 level=logging.INFO):
         logger = logging.getLogger(name)
         logger.addFilter(ThreadFilter(tag))
         logger_formatter = logging.Formatter('{asctime} {levelname}: [{thread_name}] {message}', style='{',
                                              datefmt='%Y/%m/%d %H:%M:%S')
-        logging.basicConfig(filename=join(dirname(abspath(__file__)), filename), filemode='a', level=level,
+        logging.basicConfig(filename=file_path, filemode='a', level=level,
                             format='%(asctime)s %(levelname)s: [%(thread_name)s] %(message)s',
                             datefmt='%Y/%m/%d %H:%M:%S')
 
@@ -45,13 +45,12 @@ class CustomLogger:
 
 
 class APISimulator:
-    def __init__(self, host, port, protocol='https', frequency=60, user='wazuh', password='wazuh', timeout=60,
+    def __init__(self, host, port, protocol='https', frequency=60, user='wazuh', password='wazuh',
                  external_logger=None, request_percentage=0, request_template=None):
         self.host = host
         self.port = port
         self.protocol = protocol
         self.frequency = frequency
-        self.timeout = timeout
         self.logger = external_logger if external_logger else logging.getLogger('wazuh-api-requester')
         self.user = user
         self.password = password
@@ -118,11 +117,14 @@ class APISimulator:
 
         try:
             response = getattr(requests, request['method'])(endpoint, headers=headers, params=request['parameters'],
-                                                            data=request['body'], verify=False, timeout=self.timeout)
+                                                            data=request['body'], verify=False)
             if result:
                 return response
-        except requests.exceptions.Timeout:
-            self.logger.error(f"API request timed out: {request['endpoint']}")
+
+        except Exception as exception:
+            self.logger.error(f'Unhandled exception: {exception}')
+            self.logger.info('Waiting 5 seconds...')
+            sleep(5)
             return
 
         if response.status_code == 401:
@@ -130,13 +132,14 @@ class APISimulator:
             self.get_token()
             try:
                 response = getattr(requests, request['method'])(endpoint, headers=headers, params=request['parameters'],
-                                                                data=request['body'], verify=False,
-                                                                timeout=self.timeout)
+                                                                data=request['body'], verify=False)
                 if result:
                     return response
 
-            except requests.exceptions.Timeout:
-                self.logger.error(f'API request timed out. Current timeout: {self.timeout}s')
+            except Exception as exception:
+                self.logger.error(f'Unhandled exception: {exception}')
+                self.logger.info('Waiting 5 seconds...')
+                sleep(5)
                 return
 
         self.logger.info(f"API request {request['endpoint']} | {response.status_code}")
@@ -164,7 +167,7 @@ class APISimulator:
             self.logger.info('There are no requests to do. Process aborted')
             exit(0)
         self.logger.info(f'{len(self.requests)} requests per loop')
-        self.logger.info(f'Frequency: {self.frequency} - Timeout: {self.timeout}')
+        self.logger.info(f'Frequency: {self.frequency}')
         self.get_token()
 
         time_per_request = self.frequency / len(self.requests)


### PR DESCRIPTION
|Related issue|
|---|
|#1281|

This PR makes the following changes:
- Remove the `timeout` parameter from `simulate_api_load` and `api_simulator`. The main reason is to wait for the `timeout` from the `requests` library.

- Add a new parameter to set the custom log path for the simulation info (Necessary to store these logs as Jenkins artifacts in the cluster performance test).

