### PR TITLE
Logcollector integration tests T0: Check keep running 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -7,7 +7,7 @@ from time import sleep
 import wazuh_testing.tools.agent_simulator as ag
 from wazuh_testing import TCP
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent_version='v4.0.0',

--- a/docs/tests/integration/test_logcollector/index.md
+++ b/docs/tests/integration/test_logcollector/index.md
@@ -18,3 +18,8 @@ in configuration file.
 Command monitoring consists of periodically executing programs and logging their output to detect 
 possible changes in it. These tests will verify that the `logcollector` command monitoring system works 
 correctly by running different commands with special characteristics.
+
+#### Test keep running
+
+This test will check if `logcollector` keeps running once a log is rotated 
+(move the data to another file and empty the file that is being monitored).

--- a/docs/tests/integration/test_logcollector/test_keep_running/test_keep_running.md
+++ b/docs/tests/integration/test_logcollector/test_keep_running/test_keep_running.md
@@ -1,0 +1,24 @@
+# Test keep running
+
+## Overview 
+
+Check if Wazuh works correctly when monitoring log files (through `logcollector`) 
+and these are modified by a log rotation.
+
+## Objective
+
+- To confirm that `logcollector` continues to monitor log files after they have been rotated.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 1 | 54s |
+
+## Expected behavior
+
+- Fail if `logcollector` cannot read data from a log after it is rotated.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_keep_running.test_keep_running

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -449,6 +449,8 @@ nav:
                 - Overview: tests/integration/test_logcollector/test_command_monitoring/index.md
                 - Test command execution: tests/integration/test_logcollector/test_command_monitoring/test_command_execution.md
                 - Test command execution freq: tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.md
+            - Test keep running:
+                - Test keep running: tests/integration/test_logcollector/test_keep_running/test_keep_running.md
         - Logtest:
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md

--- a/tests/integration/test_logcollector/test_keep_running/data/wazuh_keep_running_conf.yaml
+++ b/tests/integration/test_logcollector/test_keep_running/data/wazuh_keep_running_conf.yaml
@@ -1,0 +1,11 @@
+- tags:
+  - test_keep_running
+  apply_to_modules:
+  - test_keep_running
+  sections:
+  - section: localfile
+    elements:
+    - location:
+        value: LOCATION
+    - log_format:
+        value: LOG_FORMAT

--- a/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
+++ b/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import tempfile
+
+import pytest
+
+import wazuh_testing.logcollector as logcollector
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import monitoring, file
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_keep_running_conf.yaml')
+temp_dir = tempfile.gettempdir()
+log_test_path = os.path.join(temp_dir, 'test_log.log')
+
+local_internal_options = {
+    'logcollector.debug': 2,
+    'monitord.rotate_log': 0,
+    'logcollector.vcheck_files': 5
+}
+
+parameters = [
+    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path}
+]
+metadata = [
+    {'log_format': 'syslog', 'location': log_test_path,
+     'log_line_before': "DEBUG: Reading syslog message: 'BEFORE'",
+     'log_line_after': "DEBUG: Reading syslog message: 'AFTER'"}
+]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"rotate_{x['location']}_in_{x['log_format']}_format" for x in metadata]
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get internal configuration."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="module")
+def generate_log_file():
+    """Generate a log file for testing."""
+    file.write_file(log_test_path, '')
+    yield
+    file.remove_file(log_test_path)
+
+
+def test_keep_running(get_local_internal_options, configure_local_internal_options, get_configuration,
+                      configure_environment, generate_log_file, restart_logcollector):
+    """Check if logcollector keeps running once a log is rotated.
+
+    To do this, logcollector is configured to monitor a log file, then data is added to the log and it is rotated.
+    Finally, write data back to the rotated log and check that logcollector continues to monitor it.
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        generate_log_file (fixture): Generate a log file for testing.
+        restart_logcollector (fixture): Reset log file and start a new monitor.
+    """
+    config = get_configuration['metadata']
+
+    # Add first line to log
+    message = config['log_line_before']
+    with open(config['location'], 'a') as f:
+        f.write(f"{message}\n")
+
+    # Ensure that the file is being analyzed
+    message = fr"INFO: \(\d*\): Analyzing file: '{log_test_path}'."
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))
+
+    # Add another line to log
+    message = config['log_line_before']
+    with open(config['location'], 'a') as f:
+        f.write(f"{message}\n")
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))
+
+    file.truncate_file(config['location'])
+
+    # Ensure that the rotation has been completed:
+    message = f"DEBUG: File size reduced. {log_test_path}"
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))
+    # Add first line to rotated log
+    message = config['log_line_after']
+    with open(config['location'], 'a') as f:
+        f.write(f"{message}\n")
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1250|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a test to check that logcollector keeps running once a log is rotated as part of #1027.

## Test results

### Manager

![manager](https://user-images.githubusercontent.com/80053749/117138900-e94bbd80-adab-11eb-93e5-81a2e2bebdad.png)

### Linux agent

![agente](https://user-images.githubusercontent.com/80053749/117138911-ecdf4480-adab-11eb-8df3-b536dd4287c1.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.