### PR TITLE
Improve enrollment process in the agent_simulator

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -7,7 +7,7 @@ from time import sleep
 import wazuh_testing.tools.agent_simulator as ag
 from wazuh_testing import TCP
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent_version='v4.0.0',


### PR DESCRIPTION
|Related issue|
|---|
|closes #1292 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #1292 by refactoring the enrollment function of the simulated agent. After some research, I found `authd` may return different exceptions depending on what's happening on the manager side, the agent side, or even in the network. So, to fix this, instead of catching specific exceptions, the script now catches the base exception, increases the number of retries and the time between them.

Also, if something happens while enrolling the agent, now it is ensured all the sockets are successfully closed. I detected an error where if something went wrong while enrolling the agent, the function will lead behind lingering sockets. These sockets will keep the connection with `wazuh-authd` and this daemon may fall in a state where it will always have too many connections (none of them were closed),

PS: this PR references #1294 too. During the test of this feature, the TCP sessions were constant during the test.

## Configuration options

NA
## Logs example
For 50K agents: 
```shellsession
$ grep "wazuh-authd: INFO: Received request for a new agent " master/logs/ossec.log | wc -l
49999
```
![image](https://user-images.githubusercontent.com/9081114/117152635-80b80d00-adba-11eb-8448-6ebdfa6ffc6d.png)


## Tests

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.