### PR TITLE
Logcollector integration tests T0: Check keep running

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -279,11 +279,7 @@ def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_
     if len(log_line_message):
         with open(log_path, 'a') as f:
             lines = ceil((size_kib * 1024) / len(log_line_message))
-            if print_line_num is True:
-                for x in range(line_start, line_start + lines + 1):
-                    f.write(f"{log_line_message}{x}\n")
-            else:
-                for x in range(line_start, line_start + lines + 1):
-                    f.write(f"{log_line_message}\n")
+            for x in range(line_start, line_start + lines + 1):
+                f.write(f"{log_line_message}{x}\n") if print_line_num else f.write(f"{log_line_message}\n")
         return line_start + lines - 1
     return 0

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -263,32 +263,15 @@ def callback_excluded_file(file):
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
 
 
-def add_log_data(log_path, log_line_message, size_mib=10):
+def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_line_num=False):
     """Increase the space occupied by a log file by adding lines to it.
-
-    Args:
-        log_path (str): Path to log file.
-        log_line_message (str): Line content to be added to the log.
-        size_mib (int, optional): Size in mebibytes (1024^2 bytes). Defaults to 10 MiB.
-    """
-    if len(log_line_message):
-        with open(log_path, 'a') as f:
-            lines = ceil((size_mib * 1024 ** 2) / len(log_line_message))
-            for _ in range(0, lines):
-                f.write(f"{log_line_message}\n")
-
-
-def add_log_data_line_num(log_path, log_line_message, size_kib=1024, line_start=1):
-    """Increase the space occupied by a log file by adding lines to it.
-
-    In each line of the log, its number is added, so the final size of the log
-    is always larger than the specified size.
 
     Args:
         log_path (str): Path to log file.
         log_line_message (str): Line content to be added to the log.
         size_kib (int, optional): Size in kibibytes (1024^2 bytes). Defaults to 1 MiB (1024 KiB).
         line_start (int, optional): Line number to start with. Defaults to 1.
+        print_line_num (bool, optional): If True, in each line of the log its number is added. Defaults to False.
 
     Returns:
         int: Last line number written.
@@ -296,7 +279,11 @@ def add_log_data_line_num(log_path, log_line_message, size_kib=1024, line_start=
     if len(log_line_message):
         with open(log_path, 'a') as f:
             lines = ceil((size_kib * 1024) / len(log_line_message))
-            for x in range(line_start, line_start + lines + 1):
-                f.write(f"{log_line_message}{x}\n")
+            if print_line_num is True:
+                for x in range(line_start, line_start + lines + 1):
+                    f.write(f"{log_line_message}{x}\n")
+            else:
+                for x in range(line_start, line_start + lines + 1):
+                    f.write(f"{log_line_message}\n")
         return line_start + lines - 1
     return 0

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -1,4 +1,5 @@
 import sys
+from math import ceil
 
 from wazuh_testing.tools import monitoring
 
@@ -14,6 +15,7 @@ if sys.platform == 'win32':
     prefix = monitoring.AGENT_DETECTOR_PREFIX
 else:
     prefix = monitoring.LOG_COLLECTOR_DETECTOR_PREFIX
+
 
 def callback_analyzing_file(file):
     """Create a callback to detect if logcollector is monitoring a file.
@@ -259,3 +261,42 @@ def callback_excluded_file(file):
     """
     msg = fr"File excluded: '{file}'."
     return monitoring.make_callback(pattern=msg, prefix=prefix, escape=True)
+
+
+def add_log_data(log_path, log_line_message, size_mib=10):
+    """Increase the space occupied by a log file by adding lines to it.
+
+    Args:
+        log_path (str): Path to log file.
+        log_line_message (str): Line content to be added to the log.
+        size_mib (int, optional): Size in mebibytes (1024^2 bytes). Defaults to 10 MiB.
+    """
+    if len(log_line_message):
+        with open(log_path, 'a') as f:
+            lines = ceil((size_mib * 1024 ** 2) / len(log_line_message))
+            for _ in range(0, lines):
+                f.write(f"{log_line_message}\n")
+
+
+def add_log_data_line_num(log_path, log_line_message, size_kib=1024, line_start=1):
+    """Increase the space occupied by a log file by adding lines to it.
+
+    In each line of the log, its number is added, so the final size of the log
+    is always larger than the specified size.
+
+    Args:
+        log_path (str): Path to log file.
+        log_line_message (str): Line content to be added to the log.
+        size_kib (int, optional): Size in kibibytes (1024^2 bytes). Defaults to 1 MiB (1024 KiB).
+        line_start (int, optional): Line number to start with. Defaults to 1.
+
+    Returns:
+        int: Last line number written.
+    """
+    if len(log_line_message):
+        with open(log_path, 'a') as f:
+            lines = ceil((size_kib * 1024) / len(log_line_message))
+            for x in range(line_start, line_start + lines + 1):
+                f.write(f"{log_line_message}{x}\n")
+        return line_start + lines - 1
+    return 0

--- a/docs/tests/integration/test_logcollector/index.md
+++ b/docs/tests/integration/test_logcollector/index.md
@@ -18,3 +18,8 @@ in configuration file.
 Command monitoring consists of periodically executing programs and logging their output to detect 
 possible changes in it. These tests will verify that the `logcollector` command monitoring system works 
 correctly by running different commands with special characteristics.
+
+#### Test keep running
+
+This test will check if `logcollector` keeps running once a log is rotated 
+(move the data to another file and empty the file that is being monitored).

--- a/docs/tests/integration/test_logcollector/test_keep_running/test_keep_running.md
+++ b/docs/tests/integration/test_logcollector/test_keep_running/test_keep_running.md
@@ -1,0 +1,24 @@
+# Test keep running
+
+## Overview 
+
+Check if Wazuh works correctly when monitoring log files (through `logcollector`) 
+and these are modified by a log rotation.
+
+## Objective
+
+- To confirm that `logcollector` continues to monitor log files after they have been rotated.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 1 | 54s |
+
+## Expected behavior
+
+- Fail if `logcollector` cannot read data from a log after it is rotated.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_keep_running.test_keep_running

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -449,6 +449,8 @@ nav:
                 - Overview: tests/integration/test_logcollector/test_command_monitoring/index.md
                 - Test command execution: tests/integration/test_logcollector/test_command_monitoring/test_command_execution.md
                 - Test command execution freq: tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.md
+            - Test keep running:
+                - Test keep running: tests/integration/test_logcollector/test_keep_running/test_keep_running.md
         - Logtest:
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md

--- a/tests/integration/test_logcollector/test_keep_running/data/wazuh_keep_running_conf.yaml
+++ b/tests/integration/test_logcollector/test_keep_running/data/wazuh_keep_running_conf.yaml
@@ -1,0 +1,11 @@
+- tags:
+  - test_keep_running
+  apply_to_modules:
+  - test_keep_running
+  sections:
+  - section: localfile
+    elements:
+    - location:
+        value: LOCATION
+    - log_format:
+        value: LOG_FORMAT

--- a/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
+++ b/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import tempfile
+
+import pytest
+
+import wazuh_testing.logcollector as logcollector
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import monitoring, file
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_keep_running_conf.yaml')
+temp_dir = tempfile.gettempdir()
+log_test_path = os.path.join(temp_dir, 'test_log.log')
+
+local_internal_options = {
+    'logcollector.debug': 2,
+    'monitord.rotate_log': 0,
+    'logcollector.vcheck_files': 5
+}
+
+parameters = [
+    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path}
+]
+metadata = [
+    {'log_format': 'syslog', 'location': log_test_path,
+     'log_line_before': "DEBUG: Reading syslog message: 'BEFORE'",
+     'log_line_after': "DEBUG: Reading syslog message: 'AFTER'"}
+]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"rotate_{x['location']}_in_{x['log_format']}_format" for x in metadata]
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get internal configuration."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="module")
+def generate_log_file():
+    """Generate a log file for testing."""
+    file.write_file(log_test_path, '')
+    yield
+    file.remove_file(log_test_path)
+
+
+def test_keep_running(get_local_internal_options, configure_local_internal_options, get_configuration,
+                      configure_environment, generate_log_file, restart_logcollector):
+    """Check if logcollector keeps running once a log is rotated.
+
+    To do this, logcollector is configured to monitor a log file, then data is added to the log and it is rotated.
+    Finally, write data back to the rotated log and check that logcollector continues to monitor it.
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        generate_log_file (fixture): Generate a log file for testing.
+        restart_logcollector (fixture): Reset log file and start a new monitor.
+    """
+    config = get_configuration['metadata']
+
+    # Add first line to log
+    message = config['log_line_before']
+    with open(config['location'], 'a') as f:
+        f.write(f"{message}\n")
+
+    # Ensure that the file is being analyzed
+    message = fr"INFO: \(\d*\): Analyzing file: '{log_test_path}'."
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))
+
+    # Add another line to log
+    message = config['log_line_before']
+    with open(config['location'], 'a') as f:
+        f.write(f"{message}\n")
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))
+
+    file.truncate_file(config['location'])
+
+    # Ensure that the rotation has been completed:
+    message = f"DEBUG: File size reduced. {log_test_path}"
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))
+    # Add first line to rotated log
+    message = config['log_line_after']
+    with open(config['location'], 'a') as f:
+        f.write(f"{message}\n")
+
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=monitoring.make_callback(pattern=message,
+                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                              escape=False))

--- a/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
+++ b/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
@@ -62,7 +62,7 @@ def generate_log_file():
     """Generate a log file of approximately 10 mebibytes for testing."""
     message_line = f"{metadata[0]['log_line_before']}{metadata[0]['mode']}"
     file.write_file(log_test_path, '')
-    logcollector.add_log_data(log_test_path, message_line, 10)
+    logcollector.add_log_data(log_path=log_test_path, log_line_message=message_line, size_kib=10240)
     yield
     file.remove_file(log_test_path)
 
@@ -92,7 +92,9 @@ def test_keep_running(get_local_internal_options, configure_local_internal_optio
                             callback=callback_message)
 
     # Add another MiB of data to log
-    logcollector.add_log_data(config['location'], f"{config['log_line_before']}{config['mode']}", 1)
+    logcollector.add_log_data(log_path=config['location'],
+                              log_line_message=f"{config['log_line_before']}{config['mode']}",
+                              size_kib=1024)
 
     message = f"DEBUG: Reading syslog message: '{config['log_line_before']}{config['mode']}'"
     callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
@@ -119,7 +121,9 @@ def test_keep_running(get_local_internal_options, configure_local_internal_optio
                                 callback=callback_message)
 
     # Add a MiB of data to rotated/truncated log
-    logcollector.add_log_data(config['location'], f"{config['log_line_after']}{config['mode']}", 1)
+    logcollector.add_log_data(log_path=config['location'],
+                              log_line_message=f"{config['log_line_after']}{config['mode']}",
+                              size_kib=1024)
 
     message = f"DEBUG: Reading syslog message: '{config['log_line_after']}{config['mode']}'"
     callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)

--- a/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
+++ b/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+import math
 import os
 import tempfile
 
@@ -29,16 +29,36 @@ local_internal_options = {
 }
 
 parameters = [
-    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path}
+    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path},
+    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path},
 ]
 metadata = [
-    {'log_format': 'syslog', 'location': log_test_path,
-     'log_line_before': "DEBUG: Reading syslog message: 'BEFORE'",
-     'log_line_after': "DEBUG: Reading syslog message: 'AFTER'"}
+    {'log_format': 'syslog', 'location': log_test_path, 'mode': 'rotate',
+     'log_line_before': "log test line: BEFORE ",
+     'log_line_after': "log test line: AFTER "},
+    {'log_format': 'syslog', 'location': log_test_path, 'mode': 'truncate',
+     'log_line_before': "log test line: BEFORE ",
+     'log_line_after': "log test line: AFTER "}
 ]
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
-configuration_ids = [f"rotate_{x['location']}_in_{x['log_format']}_format" for x in metadata]
+configuration_ids = [f"{x['mode']}_{x['location']}_in_{x['log_format']}_format" for x in metadata]
+
+
+def add_log_data(log_path, log_line_message, size_mib):
+    """
+    Increase the space occupied by a log file by adding lines to it.
+
+    Args:
+        log_path (str): Path to log file.
+        log_line_message (str): Line content to be added to the log.
+        size_mib (int): Size in mebibytes (1024^2 bytes).
+    """
+    if len(log_line_message):
+        with open(log_path, 'a') as f:
+            lines = math.ceil((size_mib * 1024 ** 2) / len(log_line_message))
+            for _ in range(0, lines):
+                f.write(f"{log_line_message}\n")
 
 
 # fixtures
@@ -56,8 +76,10 @@ def get_local_internal_options():
 
 @pytest.fixture(scope="module")
 def generate_log_file():
-    """Generate a log file for testing."""
+    """Generate a log file of approximately 10 mebibytes for testing."""
+    message_line = f"{metadata[0]['log_line_before']}{metadata[0]['mode']}"
     file.write_file(log_test_path, '')
+    add_log_data(log_test_path, message_line, 10)
     yield
     file.remove_file(log_test_path)
 
@@ -79,46 +101,45 @@ def test_keep_running(get_local_internal_options, configure_local_internal_optio
     """
     config = get_configuration['metadata']
 
-    # Add first line to log
-    message = config['log_line_before']
-    with open(config['location'], 'a') as f:
-        f.write(f"{message}\n")
-
     # Ensure that the file is being analyzed
-    message = fr"INFO: \(\d*\): Analyzing file: '{log_test_path}'."
+    message = fr"INFO: \(\d*\): Analyzing file: '{config['location']}'."
+    callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                            callback=monitoring.make_callback(pattern=message,
-                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
-                                                              escape=False))
+                            callback=callback_message)
 
-    # Add another line to log
-    message = config['log_line_before']
-    with open(config['location'], 'a') as f:
-        f.write(f"{message}\n")
+    # Add another MiB of data to log
+    add_log_data(config['location'], f"{config['log_line_before']}{config['mode']}", 1)
 
+    message = f"DEBUG: Reading syslog message: '{config['log_line_before']}{config['mode']}'"
+    callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                            callback=monitoring.make_callback(pattern=message,
-                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
-                                                              escape=False))
+                            callback=callback_message)
 
-    file.truncate_file(config['location'])
+    if config['mode'] == 'rotate':
+        file.remove_file(config['location'])
+        file.write_file(config['location'], '')
+        # Ensure that the rotation has been completed:
+        message = f"DEBUG: File inode changed. {config['location']}"
+        callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                callback=callback_message)
+    else:
+        file.truncate_file(config['location'])
+        # Ensure that the truncate has been completed:
+        message = f"DEBUG: File size reduced. {config['location']}"
+        callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                callback=callback_message)
 
-    # Ensure that the rotation has been completed:
-    message = f"DEBUG: File size reduced. {log_test_path}"
+    # Add a MiB of data to rotated/truncated log
+    add_log_data(config['location'], f"{config['log_line_after']}{config['mode']}", 1)
+
+    message = f"DEBUG: Reading syslog message: '{config['log_line_after']}{config['mode']}'"
+    callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                            callback=monitoring.make_callback(pattern=message,
-                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
-                                                              escape=False))
-    # Add first line to rotated log
-    message = config['log_line_after']
-    with open(config['location'], 'a') as f:
-        f.write(f"{message}\n")
-
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                            callback=monitoring.make_callback(pattern=message,
-                                                              prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
-                                                              escape=False))
+                            callback=callback_message)

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-import math
 import os
 import tempfile
 
@@ -10,9 +9,9 @@ import pytest
 import wazuh_testing.logcollector as logcollector
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import monitoring, file
-from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX
+from wazuh_testing.tools.services import control_service
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
@@ -46,31 +45,6 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 configuration_ids = [f"rotate_{x['location']}_in_{x['log_format']}_format" for x in metadata]
 
 
-def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1):
-    """
-    Increase the space occupied by a log file by adding lines to it.
-
-    In each line of the log, its number is added, so the final size of the log
-    is always larger than the specified size.
-
-    Args:
-        log_path (str): Path to log file.
-        log_line_message (str): Line content to be added to the log.
-        size_kib (int, optional): Size in kibibytes (1024^2 bytes). Defaults to 1 MiB (1024 KiB).
-        line_start (int, optional): Line number to start with. Defaults to 1.
-
-    Returns:
-        int: Last line number written.
-    """
-    if len(log_line_message):
-        with open(log_path, 'a') as f:
-            lines = math.ceil((size_kib * 1024) / len(log_line_message))
-            for x in range(line_start, line_start + lines + 1):
-                f.write(f"{log_line_message}{x}\n")
-        return line_start + lines - 1
-    return 0
-
-
 # fixtures
 @pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
 def get_configuration(request):
@@ -89,7 +63,7 @@ def generate_log_file():
     """Generate a log of size greater than 10 MiB for testing."""
     global current_line
     file.write_file(log_test_path, '')
-    current_line = add_log_data(log_test_path, metadata[0]['log_line'], size_kib=10240)
+    current_line = logcollector.add_log_data_line_num(log_test_path, metadata[0]['log_line'], size_kib=10240)
     yield
     file.remove_file(log_test_path)
 
@@ -122,7 +96,10 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
                             callback=callback_message)
 
     # Add one KiB of data to log
-    current_line = add_log_data(config['location'], config['log_line'], 1, line_start=current_line + 1)
+    current_line = logcollector.add_log_data_line_num(log_path=config['location'],
+                                                      log_line_message=config['log_line'],
+                                                      size_kib=1,
+                                                      line_start=current_line + 1)
 
     message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
     callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
@@ -134,7 +111,10 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
 
     # Add another KiB of data to log while logcollector is stopped
     first_line = current_line + 1
-    current_line = add_log_data(config['location'], config['log_line'], 1, line_start=first_line)
+    current_line = logcollector.add_log_data_line_num(log_path=config['location'],
+                                                      log_line_message=config['log_line'],
+                                                      size_kib=1,
+                                                      line_start=first_line)
 
     control_service('start', daemon=DAEMON_NAME)
 
@@ -171,7 +151,11 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
                                     callback=callback_message)
 
     # Add another KiB of data to log (additional check)
-    current_line = add_log_data(config['location'], config['log_line'], 1, line_start=current_line + 1)
+    current_line = logcollector.add_log_data_line_num(log_path=config['location'],
+                                                      log_line_message=config['log_line'],
+                                                      size_kib=1,
+                                                      line_start=current_line + 1)
+
     message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
     callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -63,7 +63,8 @@ def generate_log_file():
     """Generate a log of size greater than 10 MiB for testing."""
     global current_line
     file.write_file(log_test_path, '')
-    current_line = logcollector.add_log_data_line_num(log_test_path, metadata[0]['log_line'], size_kib=10240)
+    current_line = logcollector.add_log_data(log_path=log_test_path, log_line_message=metadata[0]['log_line'],
+                                             size_kib=10240, print_line_num=True)
     yield
     file.remove_file(log_test_path)
 
@@ -96,10 +97,8 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
                             callback=callback_message)
 
     # Add one KiB of data to log
-    current_line = logcollector.add_log_data_line_num(log_path=config['location'],
-                                                      log_line_message=config['log_line'],
-                                                      size_kib=1,
-                                                      line_start=current_line + 1)
+    current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
+                                             size_kib=1, line_start=current_line + 1, print_line_num=True)
 
     message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
     callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
@@ -111,10 +110,8 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
 
     # Add another KiB of data to log while logcollector is stopped
     first_line = current_line + 1
-    current_line = logcollector.add_log_data_line_num(log_path=config['location'],
-                                                      log_line_message=config['log_line'],
-                                                      size_kib=1,
-                                                      line_start=first_line)
+    current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
+                                             size_kib=1, line_start=first_line, print_line_num=True)
 
     control_service('start', daemon=DAEMON_NAME)
 
@@ -151,10 +148,8 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
                                     callback=callback_message)
 
     # Add another KiB of data to log (additional check)
-    current_line = logcollector.add_log_data_line_num(log_path=config['location'],
-                                                      log_line_message=config['log_line'],
-                                                      size_kib=1,
-                                                      line_start=current_line + 1)
+    current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
+                                             size_kib=1, line_start=current_line + 1, print_line_num=True)
 
     message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
     callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1250|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a test to check that `logcollector` keeps running once a log is rotated as part of #1027.

## Test results

### Manager

![manager](https://user-images.githubusercontent.com/80053749/117138900-e94bbd80-adab-11eb-93e5-81a2e2bebdad.png)

### Linux agent

![agente](https://user-images.githubusercontent.com/80053749/117138911-ecdf4480-adab-11eb-8df3-b536dd4287c1.png)

## Documentation

### Test keep running

![docu](https://user-images.githubusercontent.com/80053749/117651499-4bcd0100-b192-11eb-953c-f601e7cd9668.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.