### PR TITLE
Update test_mitre_check_alert.py test

### DIFF
--- a/tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.py
+++ b/tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.py
@@ -4,6 +4,7 @@
 
 import os
 
+import jsonschema
 import pytest
 from wazuh_testing.mitre import (callback_detect_mitre_event, validate_mitre_event)
 from wazuh_testing.tools import ALERT_FILE_PATH
@@ -18,10 +19,14 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 wazuh_alert_monitor = FileMonitor(ALERT_FILE_PATH)
 _data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
+invalid_configurations = []
+
 configurations = []
 for i in range(1, 15):
     file_test = os.path.join(_data_path, f"test{i}.xml")
     configurations.append(file_test)
+    if i in range(5,9):
+        invalid_configurations.append(os.path.join(_data_path, f"test{i}.xml"))
 
 
 # fixtures
@@ -38,6 +43,11 @@ def test_mitre_check_alert(get_configuration, configure_local_rules, restart_waz
     """Check Mitre alerts have correct format in accordance with configuration"""
 
     # Wait until Mitre's event is detected
-    if get_configuration != os.path.join(_data_path, f"test8.xml"):
+    if get_configuration not in invalid_configurations:
         event = wazuh_alert_monitor.start(timeout=30, callback=callback_detect_mitre_event).result()
         validate_mitre_event(event)
+    else:
+        with pytest.raises(jsonschema.exceptions.ValidationError):
+            event = wazuh_alert_monitor.start(timeout=30, callback=callback_detect_mitre_event).result()
+            validate_mitre_event(event)
+


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1299|

## Description


```
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/tmp/Test_integration_B2523_20210504153218/tests/integration/test_analysisd/test_mitre/data/test5.xml] FAILED [ 99%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/tmp/Test_integration_B2523_20210504153218/tests/integration/test_analysisd/test_mitre/data/test6.xml] FAILED [ 99%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/tmp/Test_integration_B2523_20210504153218/tests/integration/test_analysisd/test_mitre/data/test7.xml] FAILED [ 99%]
```


It seems that those checks are performed with rules that have wrong mitre configurations and fail.

### Example
The `test5.xml` test has this rule:
```
  <rule id="100002" level="5">
    <if_sid>502</if_sid>
    <description>Ossec server started.</description>
    <mitre>
      <id>T1098, T1015</id>
    </mitre>
    <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,</group>
  </rule>
```

The mitre id is invalid so, the alert generated doesn't have any mitre information. This test is supposed to check the mitre generated information on alerts so, it fails.

That happens for test5.xml, test6.xml and test7.xml and this PR is intended to add "invalid configurations" that will be tested (expecting an error) instead of just remove them.

# Test
https://ci.wazuh.info/job/Test_integration/2855/

Best regards. 