### PR TITLE
Logcollector integration tests T0: only-future-events option

### DIFF
--- a/docs/tests/integration/test_logcollector/index.md
+++ b/docs/tests/integration/test_logcollector/index.md
@@ -18,3 +18,9 @@ in configuration file.
 Command monitoring consists of periodically executing programs and logging their output to detect 
 possible changes in it. These tests will verify that the `logcollector` command monitoring system works 
 correctly by running different commands with special characteristics.
+
+#### Test only future events
+
+By default, when Wazuh starts it will only read the contents of the logs of a certain file since 
+the agent was started, with the `only-future-events` option Wazuh can read these logs that were 
+produced while the agent was stopped. 

--- a/docs/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.md
+++ b/docs/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.md
@@ -1,0 +1,25 @@
+# Test only future events
+
+## Overview 
+
+Check if Wazuh works correctly when monitoring log files (through `logcollector`), 
+and for whatever reason, it becomes unavailable for some time. When Wazuh is active 
+again these logs that could not be monitored can be analyzed using the `only-future-events` option.
+
+## Objective
+
+- To confirm that `logcollector` continues to monitor log files after they have been rotated.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 1 | 30s |
+
+## Expected behavior
+
+- Fail if `logcollector` cannot read data from a log after it is rotated.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_only_future_events.test_only_future_events

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_fields_archlinux_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_fields_archlinux_feed.md
@@ -1,3 +1,3 @@
 ## Code documentation
 
-::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_extra_fields_archlinux_feed
+[comment]: <> (::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_extra_fields_archlinux_feed)

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.md
@@ -1,3 +1,3 @@
 ## Code documentation
 
-::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_invalid_syntax_archlinux_feed
+[comment]: <> (::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_invalid_syntax_archlinux_feed)

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.md
@@ -1,3 +1,3 @@
 ## Code documentation
 
-::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_invalid_values_archlinux_feed
+[comment]: <> (::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_invalid_values_archlinux_feed)

--- a/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_missing_fields_archlinux_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_missing_fields_archlinux_feed.md
@@ -1,3 +1,3 @@
 ## Code documentation
 
-::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_missing_fields_archlinux_feed
+[comment]: <> (::: tests.integration.test_vulnerability_detector.test_feeds.archlinux.test_missing_fields_archlinux_feed)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -450,6 +450,7 @@ nav:
                 - Overview: tests/integration/test_logcollector/test_command_monitoring/index.md
                 - Test command execution: tests/integration/test_logcollector/test_command_monitoring/test_command_execution.md
                 - Test command execution freq: tests/integration/test_logcollector/test_command_monitoring/test_command_execution_freq.md
+            - Test only future events: tests/integration/test_logcollector/test_only_future_events/test_only_future_events.md
         - Logtest:
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md

--- a/tests/integration/test_logcollector/test_only_future_events/data/wazuh_only_future_events_conf.yaml
+++ b/tests/integration/test_logcollector/test_only_future_events/data/wazuh_only_future_events_conf.yaml
@@ -1,0 +1,15 @@
+- tags:
+  - test_only_future_events
+  apply_to_modules:
+  - test_only_future_events
+  sections:
+  - section: localfile
+    elements:
+    - location:
+        value: LOCATION
+    - log_format:
+        value: LOG_FORMAT
+    - only-future-events:
+        value: ONLY_FUTURE_EVENTS
+        attributes:
+        - max-size: MAX_SIZE

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -1,0 +1,179 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import math
+import os
+import tempfile
+
+import pytest
+
+import wazuh_testing.logcollector as logcollector
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import monitoring, file
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
+
+# Configuration
+DAEMON_NAME = "wazuh-logcollector"
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_only_future_events_conf.yaml')
+temp_dir = tempfile.gettempdir()
+log_test_path = os.path.join(temp_dir, 'test.log')
+current_line = 0
+
+local_internal_options = {
+    'logcollector.debug': 2,
+    'monitord.rotate_log': 0,
+    'logcollector.vcheck_files': 5
+}
+
+parameters = [
+    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path, 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '10MB'},
+    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path, 'ONLY_FUTURE_EVENTS': 'yes', 'MAX_SIZE': '10MB'}
+]
+metadata = [
+    {'log_format': 'syslog', 'location': log_test_path, 'only_future_events': 'no',
+     'log_line': "Jan  1 00:00:00 localhost test[0]: line="},
+    {'log_format': 'syslog', 'location': log_test_path, 'only_future_events': 'yes',
+     'log_line': "Jan  1 00:00:00 localhost test[0]: line="}
+]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"rotate_{x['location']}_in_{x['log_format']}_format" for x in metadata]
+
+
+def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1):
+    """
+    Increase the space occupied by a log file by adding lines to it.
+
+    In each line of the log, its number is added, so the final size of the log
+    is always larger than the specified size.
+
+    Args:
+        log_path (str): Path to log file.
+        log_line_message (str): Line content to be added to the log.
+        size_kib (int, optional): Size in kibibytes (1024^2 bytes). Defaults to 1 MiB (1024 KiB).
+        line_start (int, optional): Line number to start with. Defaults to 1.
+
+    Returns:
+        int: Last line number written.
+    """
+    if len(log_line_message):
+        with open(log_path, 'a') as f:
+            lines = math.ceil((size_kib * 1024) / len(log_line_message))
+            for x in range(line_start, line_start + lines + 1):
+                f.write(f"{log_line_message}{x}\n")
+        return line_start + lines - 1
+    return 0
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get internal configuration."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="module")
+def generate_log_file():
+    """Generate a log of size greater than 10 MiB for testing."""
+    global current_line
+    file.write_file(log_test_path, '')
+    current_line = add_log_data(log_test_path, metadata[0]['log_line'], size_kib=10240)
+    yield
+    file.remove_file(log_test_path)
+
+
+def test_only_future_events(get_local_internal_options, configure_local_internal_options, get_configuration,
+                            configure_environment, generate_log_file, restart_logcollector):
+    """Check if the "only-future-events" option is working correctly.
+
+    To do this, logcollector is stopped and several lines are added to a test log file.
+    Depending on the value of the "only-future-events" option the following should happen:
+    If the value is "yes" the added lines should not be detected, on the other hand,
+    if the value is "no" those lines should be detected by logcollector.
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        generate_log_file (fixture): Generate a log file for testing.
+        restart_logcollector (fixture): Reset log file and start a new monitor.
+    """
+    config = get_configuration['metadata']
+    global current_line
+
+    # Ensure that the file is being analyzed
+    message = fr"INFO: \(\d*\): Analyzing file: '{log_test_path}'."
+    callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX)
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=callback_message)
+
+    # Add one KiB of data to log
+    current_line = add_log_data(config['location'], config['log_line'], 1, line_start=current_line + 1)
+
+    message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
+    callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=callback_message)
+
+    control_service('stop', daemon=DAEMON_NAME)
+
+    # Add another KiB of data to log while logcollector is stopped
+    first_line = current_line + 1
+    current_line = add_log_data(config['location'], config['log_line'], 1, line_start=first_line)
+
+    control_service('start', daemon=DAEMON_NAME)
+
+    if config['only_future_events'] == 'no':
+        # Logcollector should detect the first line written while it was stopped
+        # Check first line
+        message = f"DEBUG: Reading syslog message: '{config['log_line']}{first_line}'"
+        callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                callback=callback_message)
+        # Check last line
+        message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
+        callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                callback=callback_message)
+    else:
+        # Logcollector should NOT detect the log lines written while it was stopped
+        with pytest.raises(TimeoutError):
+            # Check first line
+            message = f"DEBUG: Reading syslog message: '{config['log_line']}{first_line}'"
+            callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                        escape=True)
+            wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                    error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                    callback=callback_message)
+            # Check last line
+            message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
+            callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX,
+                                                        escape=True)
+            wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                    error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                                    callback=callback_message)
+
+    # Add another KiB of data to log (additional check)
+    current_line = add_log_data(config['location'], config['log_line'], 1, line_start=current_line + 1)
+    message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
+    callback_message = monitoring.make_callback(pattern=message, prefix=LOG_COLLECTOR_DETECTOR_PREFIX, escape=True)
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
+                            callback=callback_message)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1229|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a test to check that `logcollector` `only-future-events` option is working correctly as part of #1027.

## Test results

### Manager

![manager](https://user-images.githubusercontent.com/80053749/117626064-fe8f6600-b176-11eb-854b-a25b1aedbf50.png)

### Linux agent

![agent](https://user-images.githubusercontent.com/80053749/117626080-03541a00-b177-11eb-8652-40e973c056f6.png)

## Documentation

### Test only future events

![doc](https://user-images.githubusercontent.com/80053749/117627815-d143b780-b178-11eb-9d69-518c00e5767b.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.