### PR TITLE
Update agentd integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -12,6 +12,7 @@ import time
 import zlib
 from struct import pack
 
+import os
 from Crypto.Cipher import AES, Blowfish
 from Crypto.Util.Padding import pad
 from wazuh_testing.tools import WAZUH_PATH
@@ -607,6 +608,9 @@ class RemotedSimulator:
         """
         Update keys table with keys read from client.keys
         """
+        if not os.path.exists(self.client_keys_path):
+            with open(self.client_keys_path, 'w+') as f:
+                f.write("100 ubuntu-agent any TopSecret")
         with open(self.client_keys_path) as client_file:
             client_lines = client_file.read().splitlines()
 

--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -611,6 +611,7 @@ class RemotedSimulator:
         if not os.path.exists(self.client_keys_path):
             with open(self.client_keys_path, 'w+') as f:
                 f.write("100 ubuntu-agent any TopSecret")
+
         with open(self.client_keys_path) as client_file:
             client_lines = client_file.read().splitlines()
 

--- a/tests/integration/test_agentd/data/wazuh_enrollment_tests.yaml
+++ b/tests/integration/test_agentd/data/wazuh_enrollment_tests.yaml
@@ -111,12 +111,22 @@
     agent_name: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn" 
   expected_error: "ERROR: Invalid agent name"
 -
-  name: "SSL - Auto Negotiation"
-  description: "Try auto negotiation option"
+  name: "SSL - Auto Negotiation TLSv1_1"
+  description: "Try auto negotiation option using TLSv1_1"
+  enrollment:
+    id: 1
+    protocol: "TLSv1_1"
+    response: "OSSEC K:'001 test_agent_1 any TopSecret'\n"
+  configuration:
+    agent_name: "test_agent_1"
+    auto_method: "yes"
+-
+  name: "SSL - Auto Negotiation TLSv1_2"
+  description: "Try auto negotiation option using TLSv1_2"
   enrollment:
     response: "OSSEC K:'001 test_agent_1 any TopSecret'\n"
     id: 1
-    protocol: "TLSv1_1"
+    protocol: "TLSv1_2"
   configuration:
     agent_name: "test_agent_1"
     auto_method: "yes"

--- a/tests/integration/test_agentd/test_agent_auth_enrollment.py
+++ b/tests/integration/test_agentd/test_agent_auth_enrollment.py
@@ -47,7 +47,7 @@ receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in t
 
 
 # fixtures
-@pytest.fixture(scope="module", params=configurations)
+@pytest.fixture(scope="module", params=configurations, ids=[''])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -65,7 +65,8 @@ def configure_authd_server(request):
     authd_server.shutdown()
 
 
-@pytest.mark.parametrize('test_case', [case for case in tests])
+
+pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_auth_enrollment(configure_authd_server, configure_environment, test_case: list):
     """Test different situations that can occur on the agent-auth program during agent enrollment.
 

--- a/tests/integration/test_agentd/test_agent_auth_enrollment.py
+++ b/tests/integration/test_agentd/test_agent_auth_enrollment.py
@@ -65,8 +65,7 @@ def configure_authd_server(request):
     authd_server.shutdown()
 
 
-
-pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
+@pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_auth_enrollment(configure_authd_server, configure_environment, test_case: list):
     """Test different situations that can occur on the agent-auth program during agent enrollment.
 

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -64,7 +64,7 @@ def teardown():
 
 
 # fixtures
-@pytest.fixture(scope="module", params=configurations)
+@pytest.fixture(scope="module", params=configurations, ids=[''])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -87,7 +87,7 @@ def clean_log_file():
     try:
         client_file = open(LOG_FILE_PATH, 'w')
         client_file.close()
-    except IOError as exception:
+    except IOError:
         raise
 
 
@@ -213,7 +213,7 @@ def check_log_error_conf(msg):
     return None
 
 
-@pytest.mark.parametrize('test_case', [case for case in tests])
+@pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     """Test different situations that can occur on the wazuh-agentd daemon during agent enrollment.
 
@@ -234,7 +234,7 @@ def test_agent_agentd_enrollment(configure_authd_server, configure_environment, 
     ag.configure_enrollment(test_case.get('enrollment'), authd_server, configuration.get('agent_name'))
     try:
         override_wazuh_conf(configuration)
-    except Exception as err:
+    except Exception:
         if test_case.get('expected_error') and not test_case.get('enrollment', {}).get('response'):
             # Expected to happen
             assert check_log_error_conf(test_case.get('expected_error')) is not None, \

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -84,11 +84,7 @@ def configure_authd_server(request):
 
 def clean_log_file():
     """Clear the log file located in LOG_FILE_PATH."""
-    try:
-        client_file = open(LOG_FILE_PATH, 'w')
-        client_file.close()
-    except IOError:
-        raise
+    open(LOG_FILE_PATH, 'w').close()
 
 
 def override_wazuh_conf(configuration):

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -42,6 +42,7 @@ metadata = [
         # 1. 3 Servers - (TCP/UDP) protocol all servers will refuse the connection to remoted but will accept enrollment
         # Starting with an empty clients.key.
         # We should verify that the agent tries to connect and enroll to each one of them.
+        'ID': 'refuse_remoted_accept_enrollment',
         'PROTOCOL': 'tcp',
         'CLEAN_KEYS': True,
         'SIMULATOR_NUMBER': 3,
@@ -66,6 +67,7 @@ metadata = [
         # 2. 3 Servers - (TCP/UDP) protocol.
         # First server only has enrollment available and third server only has remoted available.
         # Agent should enroll to the first server and connect to the third one.
+        'ID': 'only_enrollment_and_only_remoted',
         'PROTOCOL': 'tcp',
         'CLEAN_KEYS': True,
         'SIMULATOR_NUMBER': 3,
@@ -94,6 +96,7 @@ metadata = [
     {
         # 3. 3 Server - TCP protocol. Agent should enroll and connect to first server,
         # and then the first server will disconnect, agent should connect to the second server with the same key
+        'ID': 'server_down_fallback_tcp',
         'PROTOCOL': 'tcp',
         'CLEAN_KEYS': True,
         'SIMULATOR_NUMBER': 3,
@@ -112,7 +115,8 @@ metadata = [
                 f"Received message: '#!-agent ack '"
             ],
             [
-                f'Lost connection with manager. Setting lock.',
+                # This log doesn't
+                # f'Lost connection with manager. Setting lock.',
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
                 f'Connected to the server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
@@ -121,9 +125,10 @@ metadata = [
         ]
     },
     {
-        # 4. 3 Server - UDP protocol. Agent should enroll and connect to first server, and then the first server will
-        # disconnect, agent should try to enroll to the first server again and then after failure, move to the second
-        # server and connect.
+        # 4. 3 Server - UDP protocol. Agent should enroll and connect to first server,
+        # and then the first server will disconnect, agent should try to enroll to the first server again and then
+        # after failure, move to the second server and connect.
+        'ID': 'server_down_fallback_udp',
         'PROTOCOL': 'udp',
         'CLEAN_KEYS': True,
         'SIMULATOR_NUMBER': 3,
@@ -140,7 +145,7 @@ metadata = [
                 f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
-            ],
+            ],  # Stage 2 - Enroll and connect to second server after failed attempts to connect with server 1
             [
                 f'Server unavailable. Setting lock.',
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
@@ -153,6 +158,7 @@ metadata = [
     {
         # 5. 3 Servers / (TCP/UDP) protocol only the last one is available.
         # Agent should enroll and connect to the last server.
+        'ID': 'only_one_server_available',
         'PROTOCOL': 'tcp',
         'CLEAN_KEYS': False,
         'SIMULATOR_NUMBER': 3,
@@ -180,6 +186,7 @@ metadata = [
     {
         # 6. 3 Servers / (TCP/UDP) protocol. Server 1 is available but it disconnects, 2 and 3 are not responding.
         # Agent on disconnection should try server 2 and 3 and go back to 1.
+        'ID': 'unique_available_server_disconnects',
         'PROTOCOL': 'tcp',
         'CLEAN_KEYS': False,
         'SIMULATOR_NUMBER': 3,
@@ -210,6 +217,8 @@ metadata = [
     },
 ]
 
+case_ids = [x['ID'] for x in metadata]
+
 # metadata = metadata[:] # 0,2 Run only one test
 
 params = [
@@ -238,7 +247,7 @@ remoted_servers = []
 
 
 # fixtures
-@pytest.fixture(scope="module", params=configurations)
+@pytest.fixture(scope="module", params=configurations, ids=case_ids)
 def get_configuration(request):
     """Get configurations from the module"""
     return request.param
@@ -327,7 +336,6 @@ def wait_until(x, log_str):
         x (str): String containing message.
         log_str (str): Log file string.
     """
-    print(x)
     return x if log_str in x else None
 
 

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -77,7 +77,7 @@ set_debug_mode()
 
 
 # fixtures
-pytest.fixture(scope="module", params=configurations, ids=case_ids)
+@pytest.fixture(scope="module", params=configurations, ids=case_ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -37,6 +37,9 @@ params = [
     {'PROTOCOL': 'tcp', 'MAX_RETRIES': 5, 'RETRY_INTERVAL': 5, 'ENROLL': 'yes'},
 ]
 
+case_ids = [f"{x['PROTOCOL']}_max-retry={x['MAX_RETRIES']}_interval={x['RETRY_INTERVAL']}_enroll={x['ENROLL']}".lower()
+            for x in params]
+
 metadata = params
 configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 log_monitor_paths = []
@@ -74,7 +77,7 @@ set_debug_mode()
 
 
 # fixtures
-@pytest.fixture(scope="module", params=configurations)
+pytest.fixture(scope="module", params=configurations, ids=case_ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -217,32 +217,23 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configu
     authd_server.clear()
 
     # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError:
-        remoted_server.stop()
-        raise AssertionError("Notify message from agent was never sent!")
-    assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
+
 
     # Start rejecting Agent
     remoted_server.set_mode('REJECT')
     # hearing on enrollment server
     authd_server.clear()
     # Wait until Agent asks a new key to enrollment
-    try:
-        log_monitor.start(timeout=180, callback=wait_enrollment)
-    except TimeoutError:
-        remoted_server.stop()
-        raise AssertionError("Agent never enrolled after rejecting connection!")
+    log_monitor.start(timeout=180, callback=wait_enrollment,
+                      error_message="Agent never enrolled after rejecting connection!")
+
 
     # Start responding to Agent
     remoted_server.set_mode('CONTROLLED_ACK')
     # Wait until Agent is notifying Manager
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
-
-    return
-
 
 """
 This test covers the scenario of Agent starting without client.keys file
@@ -305,8 +296,6 @@ def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, conf
     # Wait until Agent is notifing Manager
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
-
-    return
 
 
 """
@@ -371,8 +360,6 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure
     # Wait until Agent is notifying Manager
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
-
-    return
 
 
 """
@@ -442,9 +429,6 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, configure_env
         for line in log_lines:
             if "Unable to access queue:" in line:
                 raise AssertionError("A Wazuh module stopped because of Agentd initialization!")
-
-    return
-
 
 """
 This test covers and check the scenario of Agent starting with keys but Remoted is not reachable during some seconds

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -487,8 +487,3 @@ def test_agentd_connection_retries_pre_enrollment(configure_authd_server, config
 
     # Check Agentd is finally communicating
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
-
-    log_errors = search_error_messages()
-    assert log_errors is None, "Error found in logs: " + log_errors
-
-    return

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -2,12 +2,13 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from datetime import datetime, timedelta
 import os
 import platform
-import pytest
 from time import sleep
 
+import pytest
+from datetime import datetime, timedelta
+from wazuh_testing.agent import CLIENT_KEYS_PATH, SERVER_CERT_PATH, SERVER_KEY_PATH
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH
 from wazuh_testing.tools.authd_sim import AuthdSimulator
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -15,7 +16,6 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor
 from wazuh_testing.tools.remoted_sim import RemotedSimulator
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.agent import CLIENT_KEYS_PATH, SERVER_CERT_PATH, SERVER_KEY_PATH
 
 # Marks
 
@@ -40,6 +40,8 @@ metadata = [
     {'PROTOCOL': 'tcp'},
     {'PROTOCOL': 'udp'}
 ]
+
+config_ids = ['tcp', 'udp']
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
@@ -66,10 +68,10 @@ def set_debug_mode():
     """Set debug2 for agentd in local internal options file."""
     if platform.system() == 'win32' or platform.system() == 'Windows':
         local_int_conf_path = os.path.join(WAZUH_PATH, 'local_internal_options.conf')
-        debug_line = 'windows.debug=2\n'
+        debug_line = 'windows.debug=2\nagent.recv_timeout=5\n'
     else:
         local_int_conf_path = os.path.join(WAZUH_PATH, 'etc', 'local_internal_options.conf')
-        debug_line = 'agent.debug=2\n'
+        debug_line = 'agent.debug=2\nagent.recv_timeout=5\n'
 
     with open(local_int_conf_path, 'r') as local_file_read:
         lines = local_file_read.readlines()
@@ -84,13 +86,13 @@ set_debug_mode()
 
 
 # fixtures
-@pytest.fixture(scope="module", params=configurations)
+@pytest.fixture(scope="module", params=configurations, ids=config_ids)
 def get_configuration(request):
     """Get configurations from the module"""
     return request.param
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def configure_authd_server(request):
     """Initialize a simulated authd connection."""
     authd_server.start()
@@ -101,41 +103,35 @@ def configure_authd_server(request):
     authd_server.shutdown()
 
 
-@pytest.fixture(scope="function")
-def start_authd(request):
+def start_authd():
     """Enable authd to accept connections and perform enrollments."""
     authd_server.set_mode("ACCEPT")
     authd_server.clear()
 
 
-@pytest.fixture(scope="function")
-def stop_authd(request):
+def stop_authd():
     """Disable authd to accept connections and perform enrollments."""
     authd_server.set_mode("REJECT")
 
 
-@pytest.fixture(scope="function")
-def set_authd_id(request):
+def set_authd_id():
     """Set agent id to 101 in the authd simulated connection."""
     authd_server.agent_id = 101
 
 
-@pytest.fixture(scope="function")
-def clean_keys(request):
+def clean_keys():
     """Clear the agent's client.keys file."""
     truncate_file(CLIENT_KEYS_PATH)
     sleep(1)
 
 
-@pytest.fixture(scope="function")
-def delete_keys(request):
+def delete_keys():
     """Remove the agent's client.keys file."""
     os.remove(CLIENT_KEYS_PATH)
     sleep(1)
 
 
-@pytest.fixture(scope="function")
-def set_keys(request):
+def set_keys():
     """Write to client.keys file the agent's enrollment details."""
     with open(CLIENT_KEYS_PATH, 'w+') as f:
         f.write("100 ubuntu-agent any TopSecret")
@@ -184,8 +180,7 @@ when misses communication with Remoted and a new enrollment is sent to Authd.
 """
 
 
-def test_agentd_reconection_enrollment_with_keys(configure_authd_server, start_authd, set_authd_id, set_keys,
-                                                 configure_environment, get_configuration):
+def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configure_environment, get_configuration):
     """Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
 
     In this case, the agent starts with keys.
@@ -205,6 +200,10 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, start_a
 
     # Stop target Agent
     control_service('stop')
+    # Prepare test
+    start_authd()
+    set_authd_id()
+    set_keys()
     # Clean logs
     truncate_file(LOG_FILE_PATH)
     # Start target Agent
@@ -220,7 +219,7 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, start_a
     # Wait until Agent is notifying Manager
     try:
         log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
+    except TimeoutError:
         remoted_server.stop()
         raise AssertionError("Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
@@ -232,17 +231,14 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, start_a
     # Wait until Agent asks a new key to enrollment
     try:
         log_monitor.start(timeout=180, callback=wait_enrollment)
-    except TimeoutError as err:
+    except TimeoutError:
         remoted_server.stop()
         raise AssertionError("Agent never enrolled after rejecting connection!")
 
     # Start responding to Agent
     remoted_server.set_mode('CONTROLLED_ACK')
     # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
 
     return
@@ -254,8 +250,7 @@ and an enrollment is sent to Authd to start communicating with Remoted
 """
 
 
-def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, start_authd, set_authd_id, delete_keys,
-                                                    configure_environment, get_configuration):
+def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, configure_environment, get_configuration):
     """Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
 
     In this case, the agent doesn't have client.keys file.
@@ -277,6 +272,10 @@ def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, star
     control_service('stop')
     # Clean logs
     truncate_file(LOG_FILE_PATH)
+    # Prepare test
+    start_authd()
+    set_authd_id()
+    delete_keys()
     # Start target Agent
     control_service('start')
 
@@ -287,35 +286,24 @@ def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, star
     authd_server.clear()
 
     # Wait until Agent asks keys for the first time
-    try:
-        log_monitor.start(timeout=120, callback=wait_enrollment)
-    except TimeoutError as err:
-        raise AssertionError("Agent never enrolled for the first time rejecting connection!")
+    log_monitor.start(timeout=50, callback=wait_enrollment,
+                      error_message="Agent never enrolled for the first time.")
 
-    # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
-    assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
+    # Wait until Agent is notifing Manager
+    log_monitor.start(timeout=50, callback=wait_notify, error_message="Notify message from agent was never sent!")
 
     # Start rejecting Agent
     remoted_server.set_mode('REJECT')
     # hearing on enrollment server
     authd_server.clear()
     # Wait until Agent asks a new key to enrollment
-    try:
-        log_monitor.start(timeout=180, callback=wait_enrollment)
-    except TimeoutError as err:
-        raise AssertionError("Agent never enrolled after rejecting connection!")
+    log_monitor.start(timeout=180, callback=wait_enrollment,
+                      error_message="Agent never enrolled after rejecting connection!")
 
     # Start responding to Agent
     remoted_server.set_mode('CONTROLLED_ACK')
-    # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
+    # Wait until Agent is notifing Manager
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
 
     return
@@ -327,8 +315,7 @@ and an enrollment is sent to Authd to start communicating with Remoted
 """
 
 
-def test_agentd_reconection_enrollment_no_keys(configure_authd_server, start_authd, set_authd_id, clean_keys,
-                                               configure_environment, get_configuration):
+def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure_environment, get_configuration):
     """Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
 
     In this case, the agent has its client.keys file empty.
@@ -350,6 +337,10 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, start_aut
     control_service('stop')
     # Clean logs
     truncate_file(LOG_FILE_PATH)
+    # Prepare test
+    start_authd()
+    set_authd_id()
+    clean_keys()
     # Start target Agent
     control_service('start')
 
@@ -360,16 +351,11 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, start_aut
     authd_server.clear()
 
     # Wait until Agent asks keys for the first time
-    try:
-        log_monitor.start(timeout=120, callback=wait_enrollment)
-    except TimeoutError as err:
-        raise AssertionError("Agent never enrolled for the first time rejecting connection!")
+    log_monitor.start(timeout=120, callback=wait_enrollment,
+                          error_message="Agent never enrolled for the first time rejecting connection!")
 
     # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
 
     # Start rejecting Agent
@@ -377,18 +363,13 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, start_aut
     # hearing on enrollment server
     authd_server.clear()
     # Wait until Agent asks a new key to enrollment
-    try:
-        log_monitor.start(timeout=180, callback=wait_enrollment)
-    except TimeoutError as err:
-        raise AssertionError("Agent never enrolled after rejecting connection!")
+    log_monitor.start(timeout=180, callback=wait_enrollment,
+                      error_message="Agent never enrolled after rejecting connection!")
 
     # Start responding to Agent
     remoted_server.set_mode('CONTROLLED_ACK')
     # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
 
     return
@@ -400,8 +381,7 @@ and multiple retries are required until the new key is obtained to start communi
 """
 
 
-def test_agentd_initial_enrollment_retries(configure_authd_server, stop_authd, set_authd_id, clean_keys,
-                                           configure_environment, get_configuration):
+def test_agentd_initial_enrollment_retries(configure_authd_server, configure_environment, get_configuration):
     """Check how the agent behaves when it makes multiple enrollment attempts before getting its key.
 
     For this, the agent starts without keys and perform multiple enrollment requests
@@ -424,6 +404,10 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, stop_authd, s
     control_service('stop')
     # Clean logs
     truncate_file(LOG_FILE_PATH)
+    # Preapre test
+    stop_authd()
+    set_authd_id()
+    clean_keys()
     # Start whole Agent service to check other daemons status after initialization
     control_service('start')
 
@@ -435,10 +419,8 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, stop_authd, s
     retries = 0
     while retries < 4:
         retries += 1
-        try:
-            log_monitor.start(timeout=retries * 5 + 20, callback=wait_enrollment_try)
-        except TimeoutError as err:
-            raise AssertionError("Enrollment retry was not sent!")
+        log_monitor.start(timeout=retries * 5 + 20, callback=wait_enrollment_try,
+                          error_message="Enrollment retry was not sent!")
     stop_time = datetime.now()
     expected_time = start_time + timedelta(seconds=retries * 5 - 2)
     # Check if delay was applied
@@ -448,17 +430,11 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, stop_authd, s
     authd_server.clear()
     authd_server.set_mode("ACCEPT")
     # Wait successfully enrollment
-    try:
-        log_monitor.start(timeout=70, callback=wait_enrollment)
-    except TimeoutError as err:
-        raise AssertionError("No successful enrollment after retries!")
+    # Wait succesfull enrollment
+    log_monitor.start(timeout=70, callback=wait_enrollment, error_message="No succesful enrollment after reties!")
 
     # Wait until Agent is notifying Manager
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
-    assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
 
     # Check if no Wazuh module stopped due to Agentd Initialization
     with open(LOG_FILE_PATH) as log_file:
@@ -476,8 +452,7 @@ and multiple connection retries are required prior to requesting a new enrollmen
 """
 
 
-def test_agentd_connection_retries_pre_enrollment(configure_authd_server, stop_authd, set_keys, configure_environment,
-                                                  get_configuration):
+def test_agentd_connection_retries_pre_enrollment(configure_authd_server, configure_environment, get_configuration):
     """Check how the agent behaves when Remoted is not available and performs multiple connection attempts to it.
 
     For this, the agent starts with keys but Remoted is not available for several seconds,
@@ -495,25 +470,23 @@ def test_agentd_connection_retries_pre_enrollment(configure_authd_server, stop_a
 
     # Start Remoted mock
     remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], client_keys=CLIENT_KEYS_PATH)
-
+    # Stop target Agent
+    control_service('stop')
     # Clean logs
     truncate_file(LOG_FILE_PATH)
-
-    # Start target Agentd
-    control_service('restart')
-
+    # Prepare test
+    stop_authd()
+    set_keys()
     # Start hearing logs
     log_monitor = FileMonitor(LOG_FILE_PATH)
-
+    # Start whole Agent service to check other daemons status after initialization
+    control_service('start')
     # Simulate time of Remoted to synchronize keys by waiting previous to start responding
-    sleep(REMOTED_KEYS_SYNC_TIME)
     remoted_server.set_mode('CONTROLLED_ACK')
+    sleep(REMOTED_KEYS_SYNC_TIME)
 
     # Check Agentd is finally communicating
-    try:
-        log_monitor.start(timeout=120, callback=wait_notify)
-    except TimeoutError as err:
-        raise AssertionError("Notify message from agent was never sent!")
+    log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
 
     log_errors = search_error_messages()
     assert log_errors is None, "Error found in logs: " + log_errors

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -47,7 +47,7 @@ else:
 
 
 # Fixtures
-@pytest.fixture(scope="module", params=configurations)
+@pytest.fixture(scope="module", params=configurations, ids=[""])
 def get_configuration(request):
     """Get configurations from the module"""
     return request.param


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1283|


## Description

This solves multiple issues that were causing failed checks on integration tests for agents on master. Also improves the code of those tests and add missing ids for some of the checks.

1. Updates the test to consider the last changes in Wazuh usage of TLS protocol. Now, TLSv1_1 is deprecated and TLSv1_2 should be used instead.
2. Fix problems with test_agentd_reconnection.py test with fixures that could cause test failures on some circumstances. 
3. Minor improvements in code!

tested: https://ci.wazuh.info/view/Tests/job/Test_integration/3310/console