### PR TITLE
Improve regex expression and log parsing function

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -37,7 +37,7 @@ def run_agents(agents_number=1, manager_address='localhost', protocol=TCP, agent
 
     for _ in range(agents_number):
         agent = ag.Agent(manager_address, "aes", os=agent_os, version=agent_version, fim_eps=eps,
-                         fixed_message_size=fixed_message_size, syscollector_frequency=0,
+                         fixed_message_size=fixed_message_size, syscollector_frequency=0, sca_frequency=0,
                          registration_address=registration_address, retry_enrollment=True, labels=labels)
         available_modules = agent.modules.keys()
 

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -163,6 +163,7 @@ class DataVisualizer:
             y_label (str): label for the Y axis.
             title (str): title of the plot.
             rotation (int, optional): optional int to set the rotation of the X-axis labels.
+            cluster_log (bool, optional): optional flag used to plot specific graphics for the cluster.
             statistics (str, optional): optional statistics measures.
         """
         if statistics:
@@ -220,7 +221,7 @@ class DataVisualizer:
                 for node, color in zip(nodes, self._color_palette(len(nodes) + 1)):
                     self._basic_plot(ax=ax, dataframe=current_df[current_df.node_name == node]['time_spent(s)'],
                                      label=node, color=color)
-                self._save_custom_plot(ax, 'time_spent(s)', element, cluster_log=True,
+                self._save_custom_plot(ax, 'time_spent(s)', element.replace(' ', '_').lower(), cluster_log=True,
                                        statistics=DataVisualizer._get_statistics(
                                            current_df['time_spent(s)'], calculate_mean=True, calculate_median=True))
 


### PR DESCRIPTION
|Related issue|
|---|
|#1287|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds some fixes to #1287 by improving the regex used to parse the cluster's logs, improving the function used to read the logs, and minor improvements in the `simulate_agents` tool.

## Configuration options

NA

## Logs example

NA

## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.