### PR TITLE
Create common fixtures for logcollector tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import sys
 from math import ceil
 
@@ -321,3 +323,33 @@ def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_
                 f.write(f"{log_line_message}{x}\n") if print_line_num else f.write(f"{log_line_message}\n")
         return line_start + lines - 1
     return 0
+
+
+def create_file_structure(get_files_list):
+    """Create the specified file tree structure.
+
+    Args:
+        get_files_list(dict):  Files to create.
+    """
+    for file in get_files_list:
+        os.makedirs(file['folder_path'], exist_ok=True, mode=0o777)
+        for name in file['filename']:
+            open(os.path.join(file['folder_path'], name), 'w').close()
+
+            if 'age' in file:
+                fileinfo = os.stat(f"{file['folder_path']}{file['filename']}")
+                os.utime(f"{file['folder_path']}{file['filename']}", (fileinfo.st_atime - file['age'],
+                                                                      fileinfo.st_mtime - file['age']))
+            elif 'size' in file:
+                add_log_data(log_path=os.path.join(file['folder_path'], name),
+                             log_line_message=file['content'], size_kib=file['size_kib'])
+
+
+def delete_file_structure(get_files_list):
+    """Delete the specified file tree structure.
+
+    Args:
+        get_files_list(dict):  Files to delete.
+    """
+    for file in get_files_list:
+        shutil.rmtree(file['folder_path'], ignore_errors=True)

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -17,6 +17,8 @@ from os.path import exists
 import filetype
 import requests
 
+from deps.wazuh_testing.wazuh_testing import logcollector
+
 
 def read_json(file_path):
     """
@@ -286,7 +288,9 @@ def create_file_structure(get_files_list):
                 fileinfo = os.stat(f"{file['folder_path']}{file['filename']}")
                 os.utime(f"{file['folder_path']}{file['filename']}", (fileinfo.st_atime - file['age'],
                                                                       fileinfo.st_mtime - file['age']))
-
+            elif 'size' in file:
+                logcollector.add_log_data(log_path=os.path.join(file['folder_path'], name),
+                                          log_line_message=file['content'], size_kib=10240)
 
 def delete_file_structure(get_files_list):
     """Delete the directory structure specified for a test case"""

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -290,7 +290,8 @@ def create_file_structure(get_files_list):
                                                                       fileinfo.st_mtime - file['age']))
             elif 'size' in file:
                 logcollector.add_log_data(log_path=os.path.join(file['folder_path'], name),
-                                          log_line_message=file['content'], size_kib=10240)
+                                          log_line_message=file['content'], size_kib=file['size_kib'])
+
 
 def delete_file_structure(get_files_list):
     """Delete the directory structure specified for a test case"""

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -276,32 +276,3 @@ def set_file_owner_and_group(file_path, owner, group):
 
         os.chown(file_path, uid, gid)
 
-
-def create_file_structure(get_files_list):
-    """Create the specified file tree structure.
-
-    Args:
-        get_files_list(dict):  Files to create.
-    """
-    for file in get_files_list:
-        os.makedirs(file['folder_path'], exist_ok=True, mode=0o777)
-        for name in file['filename']:
-            open(os.path.join(file['folder_path'], name), 'w').close()
-
-            if 'age' in file:
-                fileinfo = os.stat(f"{file['folder_path']}{file['filename']}")
-                os.utime(f"{file['folder_path']}{file['filename']}", (fileinfo.st_atime - file['age'],
-                                                                      fileinfo.st_mtime - file['age']))
-            elif 'size' in file:
-                logcollector.add_log_data(log_path=os.path.join(file['folder_path'], name),
-                                          log_line_message=file['content'], size_kib=file['size_kib'])
-
-
-def delete_file_structure(get_files_list):
-    """Delete the specified file tree structure.
-
-    Args:
-        get_files_list(dict):  Files to delete.
-    """
-    for file in get_files_list:
-        shutil.rmtree(file['folder_path'], ignore_errors=True)

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -6,13 +6,12 @@ import gzip
 import json
 import os
 import random
+import shutil
+import socket
+import stat
 import string
 import xml.etree.ElementTree as ET
 import zipfile
-import stat
-import shutil
-import socket
-
 from os.path import exists
 
 import filetype

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -278,7 +278,11 @@ def set_file_owner_and_group(file_path, owner, group):
 
 
 def create_file_structure(get_files_list):
-    """Create the directory structure specified for a test case"""
+    """Create the specified file tree structure.
+
+    Args:
+        get_files_list(dict):  Files to create.
+    """
     for file in get_files_list:
         os.makedirs(file['folder_path'], exist_ok=True, mode=0o777)
         for name in file['filename']:
@@ -294,6 +298,10 @@ def create_file_structure(get_files_list):
 
 
 def delete_file_structure(get_files_list):
-    """Delete the directory structure specified for a test case"""
+    """Delete the specified file tree structure.
+
+    Args:
+        get_files_list(dict):  Files to delete.
+    """
     for file in get_files_list:
         shutil.rmtree(file['folder_path'], ignore_errors=True)

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -17,17 +17,17 @@ from os.path import exists
 import filetype
 import requests
 
-from deps.wazuh_testing.wazuh_testing import logcollector
-
 
 def read_json(file_path):
     """
-    Read a JSON file from a given path, return a dictionary with the json data
+    Read a JSON file from a given path, return a dictionary with the json data.
 
     Args:
-        file_path (str): Path of the JSON file to be readed
+        file_path (str): Path of the JSON file to be read.
+
+    Returns:
+        output(dict): Read json data.
     """
-    # Read JSON data templates
     with open(file_path, 'r') as f:
         output = json.loads(f.read())
 
@@ -61,7 +61,7 @@ def random_string_unicode(length, encode=None):
 
     Args:
         length (int) : String length.
-        encode (str, optional) : Encoding type. Default `None`
+        encode (str, optional) : Encoding type. Default `None`.
 
     Returns:
         (str or binary): Random unicode string.
@@ -81,7 +81,7 @@ def random_string(length, encode=None):
 
     Args:
         length (int): String length.
-        encode (str, optional): Encoding type. Default `None`
+        encode (str, optional): Encoding type. Default `None`.
 
     Returns:
         str or binary: Random string.
@@ -115,9 +115,11 @@ def write_json_file(file_path, data, ensure_ascii=False):
     Write dict data to JSON file
 
     Args:
-    file_path (str): File path where is located the JSON file to write
-    data (dict): Data to write
-    ensure_ascii (boolean) : If ensure_ascii is true, the output is guaranteed to have all incoming non-ASCII characters escaped. If ensure_ascii is false, these characters will be output as-is.
+        file_path (str): File path where is located the JSON file to write.
+        data (dict): Data to write.
+        ensure_ascii (boolean) : If ensure_ascii is true, the output is guaranteed to have all incoming
+                                 non-ASCII characters escaped. If ensure_ascii is false, these characters will
+                                 be output as-is.
     """
     write_file(file_path, json.dumps(data, indent=4, ensure_ascii=ensure_ascii))
 
@@ -173,14 +175,14 @@ def decompress_zip(zip_file_path, dest_file_path):
 
 def read_xml_file(file_path, namespaces=None, xml_header=False):
     """
-    Function to read XML file as string
+    Function to read XML file as string.
 
     Args:
-        file_path (str): File path where is the XML file
-        namespaces (list): List with data {name: namespace, url: url_namespace}
+        file_path (str): File path where is the XML file.
+        namespaces (list): List with data {name: namespace, url: url_namespace}.
 
     Returns:
-        str: XML string data
+        xml_string_data (str): XML string data
     """
     xml_root = ET.parse(file_path).getroot()
 
@@ -201,7 +203,7 @@ def read_xml_file(file_path, namespaces=None, xml_header=False):
 
 def compress_gzip_file(src_path, dest_path):
     """
-    Compresses a text file into a .gz one
+    Compresses a text file into a .gz one.
 
     Args:
         src_path : Path to source file.
@@ -214,10 +216,11 @@ def compress_gzip_file(src_path, dest_path):
 
 def copy(source, destination):
     """
-    Copy file with metadata and ownership to a specific destination
+    Copy file with metadata and ownership to a specific destination.
+
     Args:
-        source (str): Source file path to copy
-        destination (str): Destination file
+        source (str): Source file path to copy.
+        destination (str): Destination file.
     """
     shutil.copy2(source, destination)
     source_stats = os.stat(source)
@@ -249,7 +252,7 @@ def is_socket(socket_path):
         socket_path (str): File path to check.
 
     Returns:
-        boolean: True if is a socket, False otherwhise.
+        stat.S_ISSOCK (bool): True if is a socket, False otherwise.
     """
     mode = os.stat(socket_path).st_mode
 
@@ -275,4 +278,3 @@ def set_file_owner_and_group(file_path, owner, group):
         gid = getgrnam(group).gr_gid
 
         os.chown(file_path, uid, gid)
-

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -274,3 +274,22 @@ def set_file_owner_and_group(file_path, owner, group):
         gid = getgrnam(group).gr_gid
 
         os.chown(file_path, uid, gid)
+
+
+def create_file_structure(get_files_list):
+    """Create the directory structure specified for a test case"""
+    for file in get_files_list:
+        os.makedirs(file['folder_path'], exist_ok=True, mode=0o777)
+        for name in file['filename']:
+            open(os.path.join(file['folder_path'], name), 'w').close()
+
+            if 'age' in file:
+                fileinfo = os.stat(f"{file['folder_path']}{file['filename']}")
+                os.utime(f"{file['folder_path']}{file['filename']}", (fileinfo.st_atime - file['age'],
+                                                                      fileinfo.st_mtime - file['age']))
+
+
+def delete_file_structure(get_files_list):
+    """Delete the directory structure specified for a test case"""
+    for file in get_files_list:
+        shutil.rmtree(file['folder_path'], ignore_errors=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,8 +17,7 @@ from numpydoc.docscrape import FunctionDoc
 from py.xml import html
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_CONF, get_service, ALERT_FILE_PATH
-from wazuh_testing.tools.file import create_file_structure
-from wazuh_testing.tools.file import delete_file_structure
+from wazuh_testing.tools.file import create_file_structure, delete_file_structure
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController, close_sockets
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -577,7 +577,7 @@ def put_env_variables(get_configuration, request):
                 os.unsetenv(env[0])
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def create_file_structure_module(get_files_list):
     """Module scope version of create_file_structure."""
     create_file_structure(get_files_list)
@@ -587,7 +587,7 @@ def create_file_structure_module(get_files_list):
     delete_file_structure(get_files_list)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def create_file_structure_function(get_files_list):
     """Function scope version of create_file_structure."""
     create_file_structure(get_files_list)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,23 +9,23 @@ import shutil
 import subprocess
 import sys
 import uuid
-from datetime import datetime, timedelta
-import time
+from datetime import datetime
 
 import pytest
+import wazuh_testing.tools.configuration as conf
 from numpydoc.docscrape import FunctionDoc
 from py.xml import html
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_CONF, get_service, ALERT_FILE_PATH
-import wazuh_testing.tools.configuration as conf
+from wazuh_testing.tools.file import create_file_structure
+from wazuh_testing.tools.file import delete_file_structure
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController, close_sockets
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs
-from wazuh_testing.tools.time import TimeMachine, time_to_seconds
+from wazuh_testing.tools.time import TimeMachine
 
 if sys.platform == 'win32':
     from wazuh_testing.fim import KEY_WOW64_64KEY, KEY_WOW64_32KEY, delete_registry, registry_parser, create_registry
-    import win32api
 
 PLATFORMS = set("darwin linux win32 sunos5".split())
 HOST_TYPES = set("server agent".split())
@@ -426,29 +426,6 @@ def configure_local_internal_options(get_local_internal_options):
         yield
 
 
-@pytest.fixture(scope='function')
-def create_file_structure(get_files_list):
-    """Creates the directory structure specified for a test case
-
-    Args:
-        get_file_list (Fixture): Fixture that returns a dictionary with the file structure to be created
-    """
-    for file in get_files_list:
-        absolute_file_path = os.path.join(file['folder_path'], file['filename'])
-        os.makedirs(file['folder_path'], exist_ok=True, mode=0o777)
-        open(absolute_file_path, "w").close()
-
-        if 'age' in file:
-            fileinfo = os.stat(absolute_file_path)
-            os.utime(absolute_file_path, (fileinfo.st_atime - file['age'],
-                                          fileinfo.st_mtime - file['age']))
-    yield
-
-    for file in get_files_list:
-        absolute_file_path = os.path.join(file['folder_path'], file['filename'])
-        shutil.rmtree(absolute_file_path, ignore_errors=True)
-
-
 @pytest.fixture(scope='module')
 def configure_environment(get_configuration, request):
     """Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."""
@@ -599,3 +576,23 @@ def put_env_variables(get_configuration, request):
         for env in environment_variables:
             if sys.platform != 'win32':
                 os.unsetenv(env[0])
+
+
+@pytest.fixture(scope='module')
+def create_file_structure_module(get_files_list):
+    """Module scope version of create_file_structure."""
+    create_file_structure(get_files_list)
+
+    yield
+
+    delete_file_structure(get_files_list)
+
+
+@pytest.fixture(scope='function')
+def create_file_structure_function(get_files_list):
+    """Function scope version of create_file_structure."""
+    create_file_structure(get_files_list)
+
+    yield
+
+    delete_file_structure(get_files_list)

--- a/tests/integration/test_logcollector/test_age/test_age_basic.py
+++ b/tests/integration/test_logcollector/test_age/test_age_basic.py
@@ -26,33 +26,33 @@ local_internal_options = {'logcollector.vcheck_files': 0}
 
 file_structure = [
     {
-        "folder_path": folder_path,
-        "filename": ["testing_file_40s.log"],
-        "age": 40,
+        'folder_path': folder_path,
+        'filename': ['testing_file_40s.log'],
+        'age': 40,
         'content': f'Content of testing_file_40s\n'
     },
     {
-        "folder_path": folder_path,
-        "filename": ["testing_file_5m.log"],
-        "age": 300,
+        'folder_path': folder_path,
+        'filename': ['testing_file_5m.log'],
+        'age': 300,
         'content': f'Content of testing_file_5m\n'
     },
     {
-        "folder_path": folder_path,
-        "filename": ["testing_file_3h.log"],
-        "age": 10800,
+        'folder_path': folder_path,
+        'filename': ['testing_file_3h.log'],
+        'age': 10800,
         'content': f'Content of testing_file_3h\n'
     },
     {
-        "folder_path": folder_path,
-        "filename": ["testing_file_5d.log"],
-        "age": 432000,
+        'folder_path': folder_path,
+        'filename': ['testing_file_5d.log'],
+        'age': 432000,
         'content': f'Content of testing_file_5d\n'
     },
     {
-        "folder_path": folder_path,
-        "filename": ["testing_file_300d.log"],
-        "age": 25920000,
+        'folder_path': folder_path,
+        'filename': ['testing_file_300d.log'],
+        'age': 25920000,
         'content': f'Content of testing_file_300d\n'
     },
 ]
@@ -94,7 +94,7 @@ def get_local_internal_options():
     return local_internal_options
 
 
-@pytest.mark.xfail(reason="Expected error. Issue https://github.com/wazuh/wazuh/issues/8438")
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8438')
 def test_configuration_age_basic(get_local_internal_options, configure_local_internal_options, get_files_list,
                                  create_file_structure_function, get_configuration, configure_environment, restart_logcollector):
     """Check if logcollector works correctly and uses the specified age value.
@@ -111,34 +111,36 @@ def test_configuration_age_basic(get_local_internal_options, configure_local_int
     age_seconds = time_to_seconds(cfg['age'])
 
     for file in file_structure:
-        absolute_file_path = os.path.join(file['folder_path'], file['filename'])
-        wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+        for name in file['filename']:
+            absolute_file_path = os.path.join(file['folder_path'], name)
+            wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
-        log_callback = logcollector.callback_match_pattern_file(cfg['location'], absolute_file_path)
-        wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                error_message=f'{file["filename"]} was not detected')
-
-        if int(age_seconds) <= int(file['age']):
-            log_callback = logcollector.callback_ignoring_file(
-                absolute_file_path)
+            log_callback = logcollector.callback_match_pattern_file(cfg['location'], absolute_file_path)
             wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                    error_message=f'{file["filename"]} was not ignored')
+                                    error_message=f"{name} was not detected")
 
-        else:
-            with pytest.raises(TimeoutError):
-                log_callback = logcollector.callback_ignoring_file(absolute_file_path)
+            if int(age_seconds) <= int(file['age']):
+                log_callback = logcollector.callback_ignoring_file(
+                    absolute_file_path)
                 wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                        error_message=f'{file["filename"]} was not ignored')
+                                        error_message=f"{name} was not ignored")
+
+            else:
+                with pytest.raises(TimeoutError):
+                    log_callback = logcollector.callback_ignoring_file(absolute_file_path)
+                    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                            error_message=f"{name} was not ignored")
 
     for file in file_structure:
-        absolute_file_path = os.path.join(file['folder_path'], file['filename'])
-        with open(absolute_file_path, 'a') as file_to_write:
-            file_to_write.write(file['content'])
+        for name in file['filename']:
+            absolute_file_path = os.path.join(file['folder_path'], name)
+            with open(absolute_file_path, 'a') as file_to_write:
+                file_to_write.write(file['content'])
 
-        log_callback = logcollector.callback_reading_syslog_message(file['content'][:-1])
-        wazuh_log_monitor.start(timeout=10, callback=log_callback,
-                                error_message=f'No syslog message received from {file["filename"]}')
+            log_callback = logcollector.callback_reading_syslog_message(file['content'][:-1])
+            wazuh_log_monitor.start(timeout=10, callback=log_callback,
+                                    error_message=f"No syslog message received from {name}")
 
-        log_callback = logcollector.callback_read_line_from_file(1, absolute_file_path)
-        wazuh_log_monitor.start(timeout=10, callback=log_callback,
-                                error_message=f'No lines read from {file["filename"]}')
+            log_callback = logcollector.callback_read_line_from_file(1, absolute_file_path)
+            wazuh_log_monitor.start(timeout=10, callback=log_callback,
+                                    error_message=f"No lines read from {name}")

--- a/tests/integration/test_logcollector/test_age/test_age_basic.py
+++ b/tests/integration/test_logcollector/test_age/test_age_basic.py
@@ -27,31 +27,31 @@ local_internal_options = {'logcollector.vcheck_files': 0}
 file_structure = [
     {
         "folder_path": folder_path,
-        "filename": "testing_file_40s.log",
+        "filename": ["testing_file_40s.log"],
         "age": 40,
         'content': f'Content of testing_file_40s\n'
     },
     {
         "folder_path": folder_path,
-        "filename": "testing_file_5m.log",
+        "filename": ["testing_file_5m.log"],
         "age": 300,
         'content': f'Content of testing_file_5m\n'
     },
     {
         "folder_path": folder_path,
-        "filename": "testing_file_3h.log",
+        "filename": ["testing_file_3h.log"],
         "age": 10800,
         'content': f'Content of testing_file_3h\n'
     },
     {
         "folder_path": folder_path,
-        "filename": "testing_file_5d.log",
+        "filename": ["testing_file_5d.log"],
         "age": 432000,
         'content': f'Content of testing_file_5d\n'
     },
     {
         "folder_path": folder_path,
-        "filename": "testing_file_300d.log",
+        "filename": ["testing_file_300d.log"],
         "age": 25920000,
         'content': f'Content of testing_file_300d\n'
     },
@@ -96,7 +96,7 @@ def get_local_internal_options():
 
 @pytest.mark.xfail(reason="Expected error. Issue https://github.com/wazuh/wazuh/issues/8438")
 def test_configuration_age_basic(get_local_internal_options, configure_local_internal_options, get_files_list,
-                                 create_file_structure, get_configuration, configure_environment, restart_logcollector):
+                                 create_file_structure_function, get_configuration, configure_environment, restart_logcollector):
     """Check if logcollector works correctly and uses the specified age value.
 
     Check that those files that have not been modified for a time greater than age value, are ignored for logcollector.

--- a/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
+++ b/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
@@ -31,7 +31,7 @@ folder_path_regex = os.path.join(folder_path, '*')
 file_structure = [
     {
         'folder_path': folder_path,
-        'filename': ["testing_age_dating.log"],
+        'filename': ['testing_age_dating.log'],
     }
 ]
 
@@ -58,13 +58,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__,
 configuration_ids = [f"{x['LOCATION'], x['LOG_FORMAT'], x['AGE']}" for x in parameters]
 
 
-@pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def get_files_list():
     """Get file list to create from the module."""
     return file_structure

--- a/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
+++ b/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
@@ -40,11 +40,22 @@ metadata = [
      'log_line_after': "log test line: AFTER "}
 ]
 
+message_line = f"{metadata[0]['log_line_before']}{metadata[0]['mode']}"
+
+file_structure = [
+    {
+        'folder_path': temp_dir,
+        'filename': ['test_log.log'],
+        'content': f"{metadata[0]['log_line_before']}{metadata[0]['mode']}",
+        'size_kib': 10240
+    }
+]
+
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 configuration_ids = [f"{x['mode']}_{x['location']}_in_{x['log_format']}_format" for x in metadata]
 
 
-# fixtures
+# Fixtures
 @pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
@@ -58,17 +69,13 @@ def get_local_internal_options():
 
 
 @pytest.fixture(scope="module")
-def generate_log_file():
-    """Generate a log file of approximately 10 mebibytes for testing."""
-    message_line = f"{metadata[0]['log_line_before']}{metadata[0]['mode']}"
-    file.write_file(log_test_path, '')
-    logcollector.add_log_data(log_path=log_test_path, log_line_message=message_line, size_kib=10240)
-    yield
-    file.remove_file(log_test_path)
+def get_files_list():
+    """Get file list to create from the module."""
+    return file_structure
 
 
 def test_keep_running(get_local_internal_options, configure_local_internal_options, get_configuration,
-                      configure_environment, generate_log_file, restart_logcollector):
+                      configure_environment, create_file_structure_module, restart_logcollector):
     """Check if logcollector keeps running once a log is rotated.
 
     To do this, logcollector is configured to monitor a log file, then data is added to the log and it is rotated.

--- a/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
+++ b/tests/integration/test_logcollector/test_keep_running/test_keep_running.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_keep_running_conf.yaml')
 temp_dir = tempfile.gettempdir()
-log_test_path = os.path.join(temp_dir, 'test_log.log')
+log_test_path = os.path.join(temp_dir, 'wazuh-testing', 'test_log.log')
 
 local_internal_options = {
     'logcollector.debug': 2,
@@ -44,7 +44,7 @@ message_line = f"{metadata[0]['log_line_before']}{metadata[0]['mode']}"
 
 file_structure = [
     {
-        'folder_path': temp_dir,
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing'),
         'filename': ['test_log.log'],
         'content': f"{metadata[0]['log_line_before']}{metadata[0]['mode']}",
         'size_kib': 10240

--- a/tests/integration/test_logcollector/test_location/test_location.py
+++ b/tests/integration/test_logcollector/test_location/test_location.py
@@ -101,18 +101,6 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 
 # Fixtures
-@pytest.fixture(scope="module")
-def create_directory():
-    """Create expected directories."""
-    os.makedirs(os.path.join(temp_dir, 'wazuh-testing', 'multiple-logs'), exist_ok=True)
-    os.makedirs(os.path.join(temp_dir, 'wazuh-testing', 'depth1', 'depth2'), exist_ok=True)
-    os.makedirs(os.path.join(temp_dir, 'wazuh-testing', 'duplicated'), exist_ok=True)
-
-    yield
-
-    rmtree(os.path.join(temp_dir, 'wazuh-testing'), ignore_errors=True)
-
-
 @pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
@@ -125,28 +113,13 @@ def get_local_internal_options():
     return local_internal_options
 
 
-@pytest.fixture(scope='module')
-def create_files(request, get_configuration):
-    """Create expected files."""
-    files = get_configuration['metadata']['files']
-    file_type = get_configuration['metadata']['file_type']
-
-    if file_type != 'non_existent_file':
-        for file_location in files:
-            if file_type == 'multiple_logs':
-                for i in range(2000):
-                    open(f'{file_location}{i}.txt', 'w').close()
-            else:
-                open(file_location, 'w').close()
-                
-    yield
-
-    for file_location in files:
-        if os.path.exists(file_location):
-            os.remove(file_location)
+@pytest.fixture(scope="module")
+def get_files_list():
+    """Get file list to create from the module."""
+    return file_structure
 
 
-def test_location(get_local_internal_options, configure_local_internal_options, create_directory, create_files,
+def test_location(get_local_internal_options, configure_local_internal_options, create_file_structure_module,
                   get_configuration, configure_environment, restart_logcollector):
     """Check if logcollector is running properly with the specified configuration.
 

--- a/tests/integration/test_logcollector/test_location/test_location.py
+++ b/tests/integration/test_logcollector/test_location/test_location.py
@@ -141,7 +141,7 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 
 # Fixtures
-@pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param

--- a/tests/integration/test_logcollector/test_location/test_location.py
+++ b/tests/integration/test_logcollector/test_location/test_location.py
@@ -159,8 +159,8 @@ def get_files_list():
     return file_structure
 
 
-def test_location(get_local_internal_options, configure_local_internal_options, create_file_structure_module,
-                  get_configuration, configure_environment, restart_logcollector):
+def test_location(get_local_internal_options, configure_local_internal_options, get_files_list,
+                  create_file_structure_module, get_configuration, configure_environment, restart_logcollector):
     """Check if logcollector is running properly with the specified configuration.
 
     Raises:

--- a/tests/integration/test_logcollector/test_location/test_location.py
+++ b/tests/integration/test_logcollector/test_location/test_location.py
@@ -6,7 +6,6 @@ import datetime
 import os
 import sys
 import tempfile
-from shutil import rmtree
 
 import pytest
 from wazuh_testing import logcollector
@@ -26,6 +25,35 @@ local_internal_options = {'logcollector.debug': '2'}
 
 temp_dir = tempfile.gettempdir()
 date = datetime.date.today().strftime("%Y-%m-%d")
+
+file_structure = [
+    {
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing'),
+        'filename': ['test.txt', 'foo.txt', 'bar.log', 'test.yaml', 'ñ.txt', 'Testing white spaces', 'test.log',
+                     'c1test.txt', 'c2test.txt', 'c3test.txt', f'file.log-{date}'],
+        'content': f'Content of testing_file\n'
+    },
+    {
+        'folder_path':  os.path.join(temp_dir, 'wazuh-testing', 'depth1'),
+        'filename': ['depth_test.txt'],
+        'content': f'Content of testing_file\n'
+    },
+    {
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing', 'depth1', 'depth2'),
+        'filename': ['depth_test.txt'],
+        'content': f'Content of testing_file\n'
+    },
+    {
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing', 'duplicated'),
+        'filename': ['duplicated.txt'],
+        'content': f'Content of testing_file\n'
+    },
+    {
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing', 'multiple-logs'),
+        'filename': [],
+        'content': f'Content of testing_file\n'
+    }
+]
 
 parameters = [
     {'LOCATION': os.path.join(temp_dir, 'wazuh-testing', 'depth1', 'test.txt'), 'LOG_FORMAT': 'syslog'},
@@ -89,10 +117,22 @@ metadata = [
 if sys.platform != 'win32':
     for case in metadata:
         if case['location'] == os.path.join(temp_dir, 'wazuh-testing', '*'):
+            for value in file_structure:
+                if value['folder_path'] == os.path.join(temp_dir, 'wazuh-testing'):
+                    value['filename'].append('テスト.txt')
+                    value['filename'].append('ИСПЫТАНИЕ.txt')
+                    value['filename'].append('测试.txt')
+                    value['filename'].append( 'اختبار.txt')
             case['files'].append(os.path.join(temp_dir, 'wazuh-testing', 'テスト.txt'))
             case['files'].append(os.path.join(temp_dir, 'wazuh-testing', 'ИСПЫТАНИЕ.txt'))
             case['files'].append(os.path.join(temp_dir, 'wazuh-testing', '测试.txt'))
             case['files'].append(os.path.join(temp_dir, 'wazuh-testing', 'اختبار.txt'))
+
+for value in file_structure:
+    if value['folder_path'] == os.path.join(temp_dir, 'wazuh-testing', 'multiple-logs'):
+        for i in range(2000):
+            value['filename'].append(f'multiple{i}.txt')
+
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)

--- a/tests/integration/test_logcollector/test_location/test_location_exclude.py
+++ b/tests/integration/test_logcollector/test_location/test_location_exclude.py
@@ -134,16 +134,6 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 
 # Fixtures
-@pytest.fixture(scope="module")
-def create_directory():
-    """Create expected directories."""
-    os.makedirs(os.path.join(temp_dir, 'wazuh-testing'), exist_ok=True)
-
-    yield
-
-    rmtree(os.path.join(temp_dir, 'wazuh-testing'), ignore_errors=True)
-
-
 @pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
@@ -156,22 +146,13 @@ def get_local_internal_options():
     return local_internal_options
 
 
-@pytest.fixture(scope='module')
-def create_files(request, get_configuration):
-    """Create expected files."""
-    files = get_configuration['metadata']['files']
-
-    for file_location in files:
-        open(file_location, 'w').close()
-
-    yield
-
-    for file_location in files:
-        if os.path.exists(file_location):
-            os.remove(file_location)
+@pytest.fixture(scope="module")
+def get_files_list():
+    """Get file list to create from the module."""
+    return file_structure
 
 
-def test_location_exclude(get_local_internal_options, configure_local_internal_options, create_directory, create_files,
+def test_location_exclude(get_local_internal_options, configure_local_internal_options, create_file_structure_module,
                  get_configuration, configure_environment, restart_logcollector):
     """Check if logcollector is excluding specified files.
 

--- a/tests/integration/test_logcollector/test_location/test_location_exclude.py
+++ b/tests/integration/test_logcollector/test_location/test_location_exclude.py
@@ -141,7 +141,7 @@ wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 
 # Fixtures
-@pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param

--- a/tests/integration/test_logcollector/test_location/test_location_exclude.py
+++ b/tests/integration/test_logcollector/test_location/test_location_exclude.py
@@ -159,8 +159,8 @@ def get_files_list():
     return file_structure
 
 
-def test_location_exclude(get_local_internal_options, configure_local_internal_options, create_file_structure_module,
-                 get_configuration, configure_environment, restart_logcollector):
+def test_location_exclude(get_local_internal_options, configure_local_internal_options, get_files_list,
+                          create_file_structure_module, get_configuration, configure_environment, restart_logcollector):
     """Check if logcollector is excluding specified files.
 
     Raises:

--- a/tests/integration/test_logcollector/test_location/test_location_exclude.py
+++ b/tests/integration/test_logcollector/test_location/test_location_exclude.py
@@ -3,9 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import fnmatch
 import os
-import sys
 import tempfile
-from shutil import rmtree
 
 import pytest
 from wazuh_testing import logcollector
@@ -24,6 +22,15 @@ configurations_path = os.path.join(test_data_path, 'wazuh_location.yaml')
 local_internal_options = {'logcollector.debug': '2'}
 
 temp_dir = tempfile.gettempdir()
+
+file_structure = [
+    {
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing'),
+        'filename': ['test.txt', 'test1.log', 'test2.log', '1test.txt', '2test.txt', '1test1.txt', '1test1.log',
+                     '2test2.log', 'test1.txt', 'test2.txt'],
+        'content': f'Content of testing_file\n'
+    },
+]
 
 parameters = [
     {'LOCATION': os.path.join(temp_dir, 'wazuh-testing', 'test*'), 'LOG_FORMAT': 'syslog',

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -70,17 +70,6 @@ def get_local_internal_options():
     return local_internal_options
 
 
-#@pytest.fixture(scope="module")
-#def generate_log_file():
-#    """Generate a log of size greater than 10 MiB for testing."""
-#    global current_line
-#    file.write_file(log_test_path, '')
-#    current_line = logcollector.add_log_data(log_path=log_test_path, log_line_message=metadata[0]['log_line'],
-#                                             size_kib=10240, print_line_num=True)
-#    yield
-#    file.remove_file(log_test_path)
-
-
 @pytest.fixture(scope="module")
 def get_files_list():
     """Get file list to create from the module."""

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -21,7 +21,7 @@ DAEMON_NAME = "wazuh-logcollector"
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_only_future_events_conf.yaml')
 temp_dir = tempfile.gettempdir()
-log_test_path = os.path.join(temp_dir, 'test.log')
+log_test_path = os.path.join(temp_dir, 'wazuh-testing', 'test.log')
 current_line = 0
 
 local_internal_options = {
@@ -46,7 +46,7 @@ current_line = logcollector.add_log_data(log_path=log_test_path, log_line_messag
 
 file_structure = [
     {
-        'folder_path': temp_dir,
+        'folder_path': os.path.join(temp_dir, 'wazuh-testing'),
         'filename': ['test.log'],
         'content': current_line,
         'size_kib': 10240


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1314 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description


We've added the next lines in `wazuh_testing/tools/file.py`:
https://github.com/wazuh/wazuh-qa/blob/f632c12fe682c822f017a1a4d7709e66af59efc6/deps/wazuh_testing/wazuh_testing/tools/file.py#L280-L307
and in `tests/integration/conftest.py`:
https://github.com/wazuh/wazuh-qa/blob/f632c12fe682c822f017a1a4d7709e66af59efc6/tests/integration/conftest.py#L580-L597


## Tests results

Here, we can see that the affected test pass without a problem:
### test_location
![image](https://user-images.githubusercontent.com/80041853/117960284-21f41580-b31d-11eb-9c5a-1a89701bc2ed.png)

### test_age
![image](https://user-images.githubusercontent.com/80041853/117960164-0557dd80-b31d-11eb-8c19-700fb69cb826.png)

### test_keep_running
![image](https://user-images.githubusercontent.com/80041853/117962238-4b15a580-b31f-11eb-9966-2eb1b99bb2ff.png)

### test_only_future_events
![image](https://user-images.githubusercontent.com/80041853/117959227-1522f200-b31c-11eb-868c-da5210e85f5e.png)


- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.