### PR TITLE
Fix local_client logs parsing

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py
@@ -246,7 +246,7 @@ class ClusterLogParser(LogParser):
     def __init__(self, log_file, dst_dir=gettempdir()):
         # group1 Timestamp - group2 node_name - group3 activity - group4 time_spent(s)
         regex = r'(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) .* ' \
-                r'\[Worker .*_(manager_\d+)] \[(.*)] Finished in (\d+.\d+)s.*'
+                r'(?:\[(?:Worker|Client) .*_(manager_\d+)]) \[(.*)] Finished in (\d+.\d+)s.*'
         columns = ['Timestamp', 'node_name', 'activity', 'time_spent(s)']
         super().__init__(log_file, regex, columns, dst_dir)
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1332 |

## Description

Hi team,

This PR changes the regex so it accepts both `[Worker manager-name]` and `[Client manager-name]` logs. After this PR, agent-info logs can be parsed in `cluster.log` files of Wazuh before and after the agent-info refactor.

Regards,
Selu.