### PR TITLE
FIM wildcards usage tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1326,7 +1326,8 @@ def callback_detect_end_runtime_wildcards(line):
     return match is not None
 
 
-def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None):
+def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None,
+                      timeout=global_parameters.default_timeout):
     """Change date and time of the system depending on a boolean condition.
 
     Optionally, a monitor may be used to check if a scheduled scan has been performed.

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1321,8 +1321,12 @@ def callback_dbsync_no_data(line):
     return None
 
 
-def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None,
-                      timeout=global_parameters.default_timeout):
+def callback_detect_end_runtime_wildcards(line):
+    match = re.match(r".*Configuration wildcards update finalize\.", line)
+    return match is not None
+
+
+def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None):
     """Change date and time of the system depending on a boolean condition.
 
     Optionally, a monitor may be used to check if a scheduled scan has been performed.

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -278,3 +278,18 @@ def set_file_owner_and_group(file_path, owner, group):
         gid = getgrnam(group).gr_gid
 
         os.chown(file_path, uid, gid)
+
+
+def recursive_directory_creation(path):
+    """Recursive function to create folders.
+       Args:
+        path (str): Path to create. If a folder doesn't exists, it will create it.
+    """
+    parent, _ = os.path.split(path)
+    if not os.path.exists(parent):
+        split = os.path.split(parent)
+        recursive_directory_creation(split[0])
+        os.mkdir(parent)
+
+    if not os.path.exists(path):
+        os.mkdir(path)

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -286,7 +286,7 @@ def recursive_directory_creation(path):
         path (str): Path to create. If a folder doesn't exists, it will create it.
     """
     parent, _ = os.path.split(path)
-    if not os.path.exists(parent):
+    if parent != '' and not os.path.exists(parent):
         split = os.path.split(parent)
         recursive_directory_creation(split[0])
         os.mkdir(parent)

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
@@ -12,7 +12,7 @@ The test check for the correct expansion of wildcards in syscheck directories pa
 ## Test logic
 
 The test creates a group of directories that match wildcards expressions and other that
-doesn't match the expressions set in syscheck directories to be monitored. Then, the test will create, modify and delete files inside a folder. The test will expect events only if the folder where the changes are made matches the configured expresion
+doesn't match the expressions set in syscheck directories to be monitored. Then, the test will create, modify and delete files inside a folder passed as argument. The test will expect events only if the folder where the changes are made matches the expresion previously set under syscheck stanza.
 
 ## Execution result
 

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
@@ -1,0 +1,34 @@
+# Test basic usage wildcards
+
+The test check for the correct expansion of wildcards in syscheck directories path definition.
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | Linux | 85s |
+| 0 | Windows | 142s |
+
+## Test logic
+
+The test creates a group of directories that match wildcards expressions and other that
+doesn't match the expressions set in syscheck directories to be monitored. Then, the test will create, modify and delete files inside a folder. The test will expect events only if the folder where the changes are made matches the configured expresion
+
+## Execution result
+
+```
+=========================================================================================== test session starts ===========================================================================================
+platform linux -- Python 3.6.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: metadata-1.11.0, html-2.0.1, testinfra-6.0.0, testinfra-6.3.0
+collected 9 items
+
+wazuh-qa/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py .........                                                                                             [100%]
+
+-------------------------------------------------------------------------- generated html file: file:///vagrant/html_report.html --------------------------------------------------------------------------
+====================================================================================== 9 passed in 85.37s (0:01:25) =======================================================================================
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_basic_usage.test_basic_usage_wildcards

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
@@ -4,10 +4,10 @@ The test check for the correct expansion of wildcards in syscheck directories pa
 
 ## General info
 
-| Tier | Platforms | Time spent| Test file |
+| Tier | Platforms | Time spent | Test file |
 |:--:|:--:|:--:|:--:|
-| 0 | Linux | 85s |
-| 0 | Windows | 142s |
+| 0 | Linux | 85s | test_basic_usage_wildcards.py
+| 0 | Windows | 142s | test_basic_usage_wildcards.py
 
 ## Test logic
 

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
@@ -1,4 +1,4 @@
-# Test complex wildcards
+# Test basic usage wildcards runtime
 In every scan, FIM looks for any new folder that matches a configured wildcard expression. This test checks this
 functionality using simple wildcards expressions.
 

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
@@ -1,0 +1,25 @@
+# Test complex wildcards
+In every scan, FIM looks for any new folder that matches a configured wildcard expression. This test checks this
+functionality using simple wildcards expressions.
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | Linux | 1503s |
+| 0 | Windows | 756s |
+
+## Test logic
+The test will configure wildcards expressions and will create an empty folder. Once that FIM has started and the
+baseline scan is completed, the test will create folders that may match a configured expression and will wait until
+the wildcards are expanded again (in the next scan). Once the wildcards are reloaded, the test will create, modify and
+delete files inside those folders. The test will wait for events of a folder only if it matches a configured expression.
+## Execution result
+
+```
+
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_basic_usage.test_basic_usage_wildcards_runtime

--- a/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
+++ b/docs/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
@@ -6,8 +6,7 @@ functionality using simple wildcards expressions.
 
 | Tier | Platforms | Time spent| Test file |
 |:--:|:--:|:--:|:--:|
-| 0 | Linux | 1503s |
-| 0 | Windows | 756s |
+| 0 | Linux, windows | 248s | test_basic_usage_wildcards_runtime.py
 
 ## Test logic
 The test will configure wildcards expressions and will create an empty folder. Once that FIM has started and the
@@ -17,6 +16,16 @@ delete files inside those folders. The test will wait for events of a folder onl
 ## Execution result
 
 ```
+root@ubuntumanager:/vagrant/wazuh-qa/tests/integration/test_fim/test_files/test_basic_usage# python3 -m pytest test_basic_usage_wildcards_runtime.py
+==================================================================== test session starts ====================================================================
+platform linux -- Python 3.8.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
+rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: testinfra-5.0.0, metadata-1.11.0, html-3.1.1
+collected 9 items
+
+test_basic_usage_wildcards_runtime.py .........                                                                                                       [100%]
+
+=============================================================== 9 passed in 247.79s (0:04:07) ===============================================================
 
 ```
 

--- a/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_widlcards_complex_runtime.md
+++ b/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_widlcards_complex_runtime.md
@@ -1,0 +1,25 @@
+# Test complex wildcards
+In every scan, FIM looks for any new folder that matches a configured wildcard expression. This test checks this
+functionality using complex wildcards expression (expressions that may match a given subdirectory, all subdirectories, etc).
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 1 | Linux | 1503s |
+| 1 | Windows | 756s |
+
+## Test logic
+The test will configure wildcards expressions and will create an empty folder. Once that FIM has started and the
+baseline scan is completed, the test will create folders that may match a configured expression and will wait until
+the wildcards are expanded again (in the next scan). Once the wildcards are reloaded, the test will create, modify and
+delete files inside those folders. The test will wait for events of a folder only if it matches a configured expression.
+## Execution result
+
+```
+
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_wildcards_complex.test_wildcards_complex_runtime

--- a/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
+++ b/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
@@ -1,0 +1,33 @@
+# Test complex wildcards
+
+The test check for the correct expansion of complex wildcards in syscheck directories path definition including wildcards expansion in both root folders and subdirectories.
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 1 | Linux | 1109s |
+| 1 | Windows | 569s |
+
+## Test logic
+
+The test creates a group of root directories and subdirectories that match comples wildcards expressions and other that doesn't match the expressions set in syscheck directories to be monitored. Then, the test will create, modify and delete files inside a folder passed as argument. The test will expect fim events only if the folder where the changes are made matches the expression previously set under syscheck stanza.
+
+## Execution result
+
+```
+=========================================================================================== test session starts ===========================================================================================
+platform linux -- Python 3.6.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: metadata-1.11.0, html-2.0.1, testinfra-6.0.0, testinfra-6.3.0
+collected 84 items
+
+test_wildcards_complex.py ....................................................................................                                                                                      [100%]
+
+-------------------------------------------------------------------------- generated html file: file:///vagrant/html_report.html --------------------------------------------------------------------------
+===================================================================================== 84 passed in 1109.08s (0:18:29) =====================================================================================
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_wildcards_complex.test_wildcards_complex

--- a/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
+++ b/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
@@ -4,10 +4,10 @@ The test check for the correct expansion of complex wildcards in syscheck direct
 
 ## General info
 
-| Tier | Platforms | Time spent| Test file |
+| Tier | Platforms | Time spent | Test file |
 |:--:|:--:|:--:|:--:|
-| 1 | Linux | 1503s |
-| 1 | Windows | 756s |
+| 1 | Linux | 1503s | test_wildcards_complex.py
+| 1 | Windows | 756s | test_wildcards_complex.py
 
 ## Test logic
 

--- a/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
+++ b/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
@@ -6,8 +6,8 @@ The test check for the correct expansion of complex wildcards in syscheck direct
 
 | Tier | Platforms | Time spent| Test file |
 |:--:|:--:|:--:|:--:|
-| 1 | Linux | 1109s |
-| 1 | Windows | 569s |
+| 1 | Linux | 1503s |
+| 1 | Windows | 756s |
 
 ## Test logic
 
@@ -16,16 +16,17 @@ The test creates a group of root directories and subdirectories that match compl
 ## Execution result
 
 ```
-=========================================================================================== test session starts ===========================================================================================
+============================= test session starts ==============================
 platform linux -- Python 3.6.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
 rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
 plugins: metadata-1.11.0, html-2.0.1, testinfra-6.0.0, testinfra-6.3.0
-collected 84 items
+collected 96 items
 
-test_wildcards_complex.py ....................................................................................                                                                                      [100%]
+test_wildcards_complex.py .............................................. [ 47%]
+..................................................                       [100%]
 
--------------------------------------------------------------------------- generated html file: file:///vagrant/html_report.html --------------------------------------------------------------------------
-===================================================================================== 84 passed in 1109.08s (0:18:29) =====================================================================================
+------------ generated html file: file:///vagrant/html_report.html -------------
+======================= 96 passed in 1503.30s (0:25:03) ========================
 ```
 
 ## Code documentation

--- a/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.md
+++ b/docs/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.md
@@ -6,8 +6,7 @@ functionality using complex wildcards expression (expressions that may match a g
 
 | Tier | Platforms | Time spent| Test file |
 |:--:|:--:|:--:|:--:|
-| 1 | Linux | 1503s |
-| 1 | Windows | 756s |
+| 1 | Linux, windows | 1503s | test_wildcards_complex_runtime.py
 
 ## Test logic
 The test will configure wildcards expressions and will create an empty folder. Once that FIM has started and the
@@ -17,7 +16,16 @@ delete files inside those folders. The test will wait for events of a folder onl
 ## Execution result
 
 ```
+root@ubuntumanager:/vagrant/wazuh-qa/tests/integration/test_fim/test_files/test_wildcards_complex# python3 -m pytest test_wildcards_complex_runtime.py
+==================================================================== test session starts ====================================================================
+platform linux -- Python 3.8.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
+rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: testinfra-5.0.0, metadata-1.11.0, html-3.1.1
+collected 18 items
 
+test_wildcards_complex_runtime.py ..................                                                                                                  [100%]
+
+============================================================== 18 passed in 454.13s (0:07:34) ===========
 ```
 
 ## Code documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,8 @@ nav:
               - Test basic usage quick changes: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_quick_changes.md
               - Test basic usage rename: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_rename.md
               - Test basic usage starting agent: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_starting_agent.md
+              - Test basic usage wildcards: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.md
+              - Test basic usage wildcards runtime: tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.md
             - Test benchmark:
               - tests/integration/test_fim/test_files/test_benchmark/index.md
               - Test benchmark:  tests/integration/test_fim/test_files/test_benchmark/test_benchmark.md
@@ -313,6 +315,10 @@ nav:
               - tests/integration/test_fim/test_files/test_windows_audit_interval/index.md
               - Manage acl: tests/integration/test_fim/test_files/test_windows_audit_interval/manage_acl.md
               - Test windows audit interval: tests/integration/test_fim/test_files/test_windows_audit_interval/test_windows_audit_interval.md
+            - Test wildcards complex:
+              - tests/integration/test_fim/test_files/test_wildcards_complex/index.md
+              - Test wildcards complex: tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.md
+              - Test wildcards complex runtime: tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.md
           - Test registry:
             - tests/integration/test_fim/test_registry/index.md
             - Test registry ambiguous confs:

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards.yml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards.yml
@@ -1,16 +1,15 @@
----
 # conf 1
 - tags:
-  - ossec_conf
+  - ossec_conf_wildcards_start
   apply_to_modules:
-  - MODULE_NAME
+  - test_basic_usage_wildcards
   sections:
   - section: syscheck
     elements:
     - disabled:
         value: 'no'
     - directories:
-        value: TEST_DIRECTORIES
+        value: TEST_WILDCARDS_START
         attributes:
         - check_all: 'yes'
         - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards.yml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards.yml
@@ -1,6 +1,6 @@
 # conf 1
 - tags:
-  - ossec_conf_wildcards_start
+  - ossec_conf_wildcards
   apply_to_modules:
   - test_basic_usage_wildcards
   sections:
@@ -9,7 +9,6 @@
     - disabled:
         value: 'no'
     - directories:
-        value: TEST_WILDCARDS_START
+        value: TEST_WILDCARDS
         attributes:
         - check_all: 'yes'
-        - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards.yml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards.yml
@@ -12,3 +12,4 @@
         value: TEST_WILDCARDS
         attributes:
         - check_all: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards_rt.yml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_wildcards_rt.yml
@@ -1,0 +1,15 @@
+# conf 1
+- tags:
+  - ossec_conf_wildcards_runtime
+  apply_to_modules:
+  - test_basic_usage_wildcards_runtime
+  sections:
+  - section: syscheck
+    elements:
+    - frequency:
+        value: FREQUENCY
+    - directories:
+        value: TEST_WILDCARDS
+        attributes:
+          - check_all: 'yes'
+          - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.py
@@ -28,8 +28,7 @@ testdir1, testdir2 = test_directories
 
 # configurations
 
-conf_params = {'TEST_DIRECTORIES': directory_str, 'TEST_WILDCARDS': os.path.join(PREFIX, 'testdir?'),
-               'MODULE_NAME': __name__}
+conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}
 p, m = generate_params(extra_params=conf_params)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_changes.py
@@ -64,10 +64,7 @@ def get_configuration(request):
                                                                         pytest.mark.sunos5)),
     pytest.param('Ξ³ΞµΞΉΞ±', None, {CHECK_ALL}, {'ossec_conf'}, marks=(pytest.mark.win32,
                                                                        pytest.mark.xfail(reason='Xfail due to issue: \
-                                                                       https://github.com/wazuh/wazuh/issues/4612'))),
-    pytest.param('regular1', None, {CHECK_ALL}, {'ossec_conf_wildcards'}, marks=(pytest.mark.linux,
-                                                                                 pytest.mark.darwin,
-                                                                                 pytest.mark.sunos5))
+                                                                       https://github.com/wazuh/wazuh/issues/4612')))
 ])
 def test_regular_file_changes(folder, name, encoding, checkers, tags_to_apply,
                               get_configuration, configure_environment,

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
@@ -5,8 +5,8 @@
 import os
 import sys
 import pytest
-from wazuh_testing import global_parameters, logger
-from wazuh_testing.fim import CHECK_ALL, LOG_FILE_PATH, regular_file_cud, generate_params
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud, generate_params
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -15,92 +15,81 @@ from wazuh_testing.tools.monitoring import FileMonitor
 
 pytestmark = pytest.mark.tier(level=0)
 
-# variables
+# Variables
 
 test_folder = os.path.join(PREFIX, 'test_folder')
-test_directories = [test_folder]
-test_subdirectories = ['simple1', 'simple2', 'simple3']
+matched_directories = ['simple1', 'simple2', 'star12', 'stars123', 'multiple_1', 'multiplet']
+matched_subdirectories = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar', '_submult', 'submult']
+matched_subdirectories = [os.path.join(matched_directories[index], matched_subdirectories[index])
+for index in range(len(matched_subdirectories))]
+test_subdirectories = matched_directories + matched_subdirectories + ['random_directory', 'not_monitored_directory']
+wildcards = [os.path.join(test_folder, 'simple?'),
+                  os.path.join(test_folder, 'star*'),
+                  os.path.join(test_folder, '*ple*'),
+                  os.path.join(test_folder, 'simple?/*'),
+                  os.path.join(test_folder, 'star*/sub?*'),
+                  os.path.join(test_folder, 'mul*/*?lt')]
 
+wildcards = ','.join(wildcards)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards.yml')
 
-# configurations
+# Configurations
 
-conf_params = {'TEST_WILDCARDS_START': [os.path.join(test_folder, 'simple?'),
-os.path.join(test_folder, 'simp*'), os.path.join(test_folder, '*ple?')], 'FIM_MODE': ['scheduled', 'realtime', "whodata"],
- 'MODULE_NAME': __name__}
+conf_params = {'TEST_WILDCARDS': wildcards}
 parameters, metadata = generate_params(extra_params=conf_params)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 
 def extra_configuration_before_yield():
 
+    if not os.path.exists(test_folder):
+        os.mkdir(test_folder)
+
     for sub_directory in test_subdirectories:
         if not os.path.exists(os.path.join(test_folder, sub_directory)):
             os.mkdir(os.path.join(test_folder, sub_directory))
 
 
-'''
-def extra_configuration_after_yield():
-    for sub_directory in test_subdirectories:
-        if os.path.exists(os.path.join(test_folder, sub_directory)):
-            os.rmdir(os.path.join(test_folder, sub_directory))
-'''
-
-# fixtures
-
-
+# Fixtures
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-# tests
+# Test
+@pytest.mark.parametrize('parent_folder', [test_folder])
+@pytest.mark.parametrize('subfolder', test_subdirectories)
+@pytest.mark.parametrize('file_name', ['regular_1', 'regular2', '*.*', '*.log'])
+@pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards'}])
+def test_basic_usage_wildcards(parent_folder, subfolder, file_name, tags_to_apply,
+                               get_configuration, configure_environment,
+                               restart_syscheckd, wait_for_fim_start):
+    """Test the correct expansion of wildcards for monitored directories in syscheck
 
-@pytest.mark.parametrize('parent_folder', [
-    test_folder
-])
-@pytest.mark.parametrize('tags_to_apply', [
-    {'ossec_conf_wildcards_start'}
-])
-@pytest.mark.parametrize('subfolder_name, file_name, encoding, checkers, triggers_event', [
-    pytest.param('simple1', 'regular1', None, {CHECK_ALL}, True),
-    pytest.param('simple2', '*.log', None, {CHECK_ALL}, True),
-    pytest.param('simple3', '*.*', None, {CHECK_ALL}, True),
-
-    pytest.param('imple', 'regular1', None, {CHECK_ALL}, False),
-    pytest.param('simble1', 'regular1', None, {CHECK_ALL}, False),
-    ])
-def test_basic_usage_wildcards(parent_folder, subfolder_name, file_name, encoding, checkers, tags_to_apply,
-                              get_configuration, configure_environment,
-                              restart_syscheckd, wait_for_fim_start, triggers_event):
+    Params:
+        parent_folder (str): Name of the root folder.
+        subfolder (str): Name of the subfolder under root folder.
+        file_name (str): Name of the file that will be created under subfolder.
+        tags_to_apply (str): Value holding the configuration used in the test.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
     """
-    Check if syscheckd detects regular file changes with wildcards (add, modify, delete)
+    folder = os.path.join(parent_folder, subfolder)
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the files will be created.
-    checkers : dict
-        Syscheck checkers (check_all).
-    """
+    mult = 1 if sys.platform == 'win32' else 2
 
     if sys.platform == 'win32':
-        if "?" or "*" in file_name:
+        if "?" in file_name or "*" in file_name:
             pytest.skip("Windows can't create files with wildcards.")
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    mult = 1 if sys.platform == 'win32' else 2
-
-    if encoding is not None:
-        file_name = file_name.encode(encoding)
-        parent_folder = parent_folder.encode(encoding)
-
-    folder = os.path.join(parent_folder, subfolder_name)
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                     min_timeout=global_parameters.default_timeout * mult, options=checkers, encoding=encoding,
-                     triggers_event=triggers_event)
+                     min_timeout=global_parameters.default_timeout * mult,
+                     triggers_event=subfolder in matched_directories or subfolder in matched_subdirectories)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.tier(level=0)
 # Variables
 
 test_folder = os.path.join(PREFIX, 'test_folder')
+test_directories = [test_folder]
 matched_directories = ['simple1', 'simple2', 'star12', 'stars123', 'multiple_1', 'multiplet']
 matched_subdirs = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar', '_submult', 'submult']
 matched_subdirs = [os.path.join(parent, child) for parent, child in zip(matched_directories, matched_subdirs)]
@@ -48,6 +49,13 @@ def extra_configuration_before_yield():
     for sub_directory in test_subdirectories:
         if not os.path.exists(os.path.join(test_folder, sub_directory)):
             os.mkdir(os.path.join(test_folder, sub_directory))
+
+
+def extra_configuration_after_yield():
+
+    for sub_directory in test_subdirectories:
+        if os.path.exists(os.path.join(test_folder, sub_directory)):
+            os.rmdir(os.path.join(test_folder, sub_directory))
 
 
 # Fixtures

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import pytest
+from wazuh_testing import global_parameters, logger
+from wazuh_testing.fim import CHECK_ALL, LOG_FILE_PATH, regular_file_cud, generate_params
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+
+test_folder = os.path.join(PREFIX, 'test_folder')
+test_directories = [test_folder]
+test_subdirectories = ['simple1', 'simple2', 'simple3']
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards.yml')
+
+# configurations
+
+conf_params = {'TEST_WILDCARDS_START': [os.path.join(test_folder, 'simple?'),
+os.path.join(test_folder, 'simp*'), os.path.join(test_folder, '*ple?')], 'FIM_MODE': ['scheduled', 'realtime', "whodata"],
+ 'MODULE_NAME': __name__}
+parameters, metadata = generate_params(extra_params=conf_params)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+def extra_configuration_before_yield():
+
+    for sub_directory in test_subdirectories:
+        if not os.path.exists(os.path.join(test_folder, sub_directory)):
+            os.mkdir(os.path.join(test_folder, sub_directory))
+
+
+'''
+def extra_configuration_after_yield():
+    for sub_directory in test_subdirectories:
+        if os.path.exists(os.path.join(test_folder, sub_directory)):
+            os.rmdir(os.path.join(test_folder, sub_directory))
+'''
+
+# fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+@pytest.mark.parametrize('parent_folder', [
+    test_folder
+])
+@pytest.mark.parametrize('tags_to_apply', [
+    {'ossec_conf_wildcards_start'}
+])
+@pytest.mark.parametrize('subfolder_name, file_name, encoding, checkers, triggers_event', [
+    pytest.param('simple1', 'regular1', None, {CHECK_ALL}, True),
+    pytest.param('simple2', '*.log', None, {CHECK_ALL}, True),
+    pytest.param('simple3', '*.*', None, {CHECK_ALL}, True),
+
+    pytest.param('imple', 'regular1', None, {CHECK_ALL}, False),
+    pytest.param('simble1', 'regular1', None, {CHECK_ALL}, False),
+    ])
+def test_basic_usage_wildcards(parent_folder, subfolder_name, file_name, encoding, checkers, tags_to_apply,
+                              get_configuration, configure_environment,
+                              restart_syscheckd, wait_for_fim_start, triggers_event):
+    """
+    Check if syscheckd detects regular file changes with wildcards (add, modify, delete)
+
+    Parameters
+    ----------
+    folder : str
+        Directory where the files will be created.
+    checkers : dict
+        Syscheck checkers (check_all).
+    """
+
+    if sys.platform == 'win32':
+        if "?" or "*" in file_name:
+            pytest.skip("Windows can't create files with wildcards.")
+
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    mult = 1 if sys.platform == 'win32' else 2
+
+    if encoding is not None:
+        file_name = file_name.encode(encoding)
+        parent_folder = parent_folder.encode(encoding)
+
+    folder = os.path.join(parent_folder, subfolder_name)
+
+    regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
+                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                     min_timeout=global_parameters.default_timeout * mult, options=checkers, encoding=encoding,
+                     triggers_event=triggers_event)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
@@ -19,16 +19,14 @@ pytestmark = pytest.mark.tier(level=0)
 
 test_folder = os.path.join(PREFIX, 'test_folder')
 matched_directories = ['simple1', 'simple2', 'star12', 'stars123', 'multiple_1', 'multiplet']
-matched_subdirectories = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar', '_submult', 'submult']
-matched_subdirectories = [os.path.join(matched_directories[index], matched_subdirectories[index])
-for index in range(len(matched_subdirectories))]
-test_subdirectories = matched_directories + matched_subdirectories + ['random_directory', 'not_monitored_directory']
+matched_subdirs = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar', '_submult', 'submult']
+matched_subdirs = [os.path.join(parent, child) for parent, child in zip(matched_directories, matched_subdirs)]
+test_subdirectories = matched_directories + matched_subdirs + ['random_directory', 'not_monitored_directory']
 wildcards = [os.path.join(test_folder, 'simple?'),
-                  os.path.join(test_folder, 'star*'),
-                  os.path.join(test_folder, '*ple*'),
-                  os.path.join(test_folder, 'simple?/*'),
-                  os.path.join(test_folder, 'star*/sub?*'),
-                  os.path.join(test_folder, 'mul*/*?lt')]
+             os.path.join(test_folder, 'star*'),
+             os.path.join(test_folder, '*ple*'),
+             os.path.join(test_folder, 'star*/sub*'),
+             os.path.join(test_folder, 'mul*/*lt')]
 
 wildcards = ','.join(wildcards)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
@@ -92,4 +90,4 @@ def test_basic_usage_wildcards(parent_folder, subfolder, file_name, tags_to_appl
     regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
                      min_timeout=global_parameters.default_timeout * mult,
-                     triggers_event=subfolder in matched_directories or subfolder in matched_subdirectories)
+                     triggers_event=subfolder in matched_directories or subfolder in matched_subdirs)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
@@ -11,73 +11,69 @@ from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
-# Marks
+# marks
 
 pytestmark = pytest.mark.tier(level=0)
 
-# Variables
+# variables
 
 test_folder = os.path.join(PREFIX, 'test_folder')
 test_directories = [test_folder]
-matched_directories = ['simple1', 'simple2', 'star12', 'stars123', 'multiple_1', 'multiplet']
-matched_subdirs = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar', '_submult', 'submult']
-matched_subdirs = [os.path.join(parent, child) for parent, child in zip(matched_directories, matched_subdirs)]
-test_subdirectories = matched_directories + matched_subdirs + ['random_directory', 'not_monitored_directory']
-wildcards = [os.path.join(test_folder, 'simple?'),
-             os.path.join(test_folder, 'star*'),
-             os.path.join(test_folder, '*ple*'),
-             os.path.join(test_folder, 'star*/sub*'),
-             os.path.join(test_folder, 'mul*/*lt')]
-
-wildcards = ','.join(wildcards)
+matched_dirs = ['simple1', 'stars123']
+test_subdirectories = matched_dirs + ['not_monitored_directory']
+expresions = [os.path.join(test_folder, 'simple?'),
+              os.path.join(test_folder, 'star*')]
+expresion_str = ','.join(expresions)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards.yml')
 
-# Configurations
+# configurations
 
-conf_params = {'TEST_WILDCARDS': wildcards}
+conf_params = {'TEST_WILDCARDS': expresion_str}
 parameters, metadata = generate_params(extra_params=conf_params)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 
 def extra_configuration_before_yield():
-
-    if not os.path.exists(test_folder):
-        os.mkdir(test_folder)
-
     for sub_directory in test_subdirectories:
+
         if not os.path.exists(os.path.join(test_folder, sub_directory)):
             os.mkdir(os.path.join(test_folder, sub_directory))
 
 
-def extra_configuration_after_yield():
+# fixtures
 
-    for sub_directory in test_subdirectories:
-        if os.path.exists(os.path.join(test_folder, sub_directory)):
-            os.rmdir(os.path.join(test_folder, sub_directory))
-
-
-# Fixtures
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-# Test
+# tests
+
 @pytest.mark.parametrize('parent_folder', [test_folder])
-@pytest.mark.parametrize('subfolder', test_subdirectories)
-@pytest.mark.parametrize('file_name', ['regular_1', 'regular2', '*.*', '*.log'])
+@pytest.mark.parametrize('subfolder_name', test_subdirectories)
+@pytest.mark.parametrize('file_name', ['regular_1'])
 @pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards'}])
-def test_basic_usage_wildcards(parent_folder, subfolder, file_name, tags_to_apply,
-                               get_configuration, configure_environment,
-                               restart_syscheckd, wait_for_fim_start):
+def test_basic_usage_wildcards(parent_folder, subfolder_name, file_name, tags_to_apply,
+                               get_configuration, configure_environment, restart_syscheckd,
+                               wait_for_fim_start):
     """Test the correct expansion of wildcards for monitored directories in syscheck
+
+    The following wildcards expansions will be tried against the directory list:
+        - test_folder/simple? will match simple?
+        - test_folder/star* will match stars123
+        - test_folder/*ple* will match simple1 and multiple_1
+        - not_monitored_directory won't match any of the previous expressions
+
+    For each subfolder there will be three different calls to regular_file_cud and
+    for every subfolder the variable triggers_event will be set properly depending on the
+    wildcards matching of the subfolder.
 
     Params:
         parent_folder (str): Name of the root folder.
-        subfolder (str): Name of the subfolder under root folder.
+        subfolder_name (str): Name of the subfolder under root folder.
         file_name (str): Name of the file that will be created under subfolder.
         tags_to_apply (str): Value holding the configuration used in the test.
         get_configuration (fixture): Gets the current configuration of the test.
@@ -85,17 +81,12 @@ def test_basic_usage_wildcards(parent_folder, subfolder, file_name, tags_to_appl
         restart_syscheckd (fixture): Restarts syscheck.
         wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
     """
-    folder = os.path.join(parent_folder, subfolder)
-
-    mult = 1 if sys.platform == 'win32' else 2
-
     if sys.platform == 'win32':
-        if "?" in file_name or "*" in file_name:
+        if '?' in file_name or '*' in file_name:
             pytest.skip("Windows can't create files with wildcards.")
-
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
+    folder = os.path.join(parent_folder, subfolder_name)
     regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                     min_timeout=global_parameters.default_timeout * mult,
-                     triggers_event=subfolder in matched_directories or subfolder in matched_subdirs)
+                     min_timeout=global_parameters.default_timeout, triggers_event=subfolder_name in matched_dirs)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards.py
@@ -21,9 +21,9 @@ test_folder = os.path.join(PREFIX, 'test_folder')
 test_directories = [test_folder]
 matched_dirs = ['simple1', 'stars123']
 test_subdirectories = matched_dirs + ['not_monitored_directory']
-expresions = [os.path.join(test_folder, 'simple?'),
-              os.path.join(test_folder, 'star*')]
-expresion_str = ','.join(expresions)
+expressions = [os.path.join(test_folder, 'simple?'),
+               os.path.join(test_folder, 'star*')]
+expresion_str = ','.join(expressions)
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards.yml')
@@ -37,7 +37,6 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 def extra_configuration_before_yield():
     for sub_directory in test_subdirectories:
-
         if not os.path.exists(os.path.join(test_folder, sub_directory)):
             os.mkdir(os.path.join(test_folder, sub_directory))
 
@@ -52,13 +51,11 @@ def get_configuration(request):
 
 # tests
 
-@pytest.mark.parametrize('parent_folder', [test_folder])
 @pytest.mark.parametrize('subfolder_name', test_subdirectories)
 @pytest.mark.parametrize('file_name', ['regular_1'])
 @pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards'}])
-def test_basic_usage_wildcards(parent_folder, subfolder_name, file_name, tags_to_apply,
-                               get_configuration, configure_environment, restart_syscheckd,
-                               wait_for_fim_start):
+def test_basic_usage_wildcards(subfolder_name, file_name, tags_to_apply,
+                               get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Test the correct expansion of wildcards for monitored directories in syscheck
 
     The following wildcards expansions will be tried against the directory list:
@@ -72,7 +69,6 @@ def test_basic_usage_wildcards(parent_folder, subfolder_name, file_name, tags_to
     wildcards matching of the subfolder.
 
     Params:
-        parent_folder (str): Name of the root folder.
         subfolder_name (str): Name of the subfolder under root folder.
         file_name (str): Name of the file that will be created under subfolder.
         tags_to_apply (str): Value holding the configuration used in the test.
@@ -86,7 +82,7 @@ def test_basic_usage_wildcards(parent_folder, subfolder_name, file_name, tags_to
             pytest.skip("Windows can't create files with wildcards.")
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    folder = os.path.join(parent_folder, subfolder_name)
+    folder = os.path.join(test_folder, subfolder_name)
     regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
                      min_timeout=global_parameters.default_timeout, triggers_event=subfolder_name in matched_dirs)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.py
@@ -5,10 +5,10 @@
 import os
 import sys
 import pytest
-from shutil import rmtree
 from wazuh_testing import global_parameters
 from wazuh_testing import fim
 from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.file import recursive_directory_creation
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -23,10 +23,10 @@ test_directories = [test_folder]
 frequency_scan = 10
 matched_dirs = ['simple1', 'stars123']
 test_subdirectories = matched_dirs + ['not_monitored_directory']
-expresions = [os.path.join(test_folder, 'simple?'),
-              os.path.join(test_folder, 'star*')]
+expressions = [os.path.join(test_folder, 'simple?'),
+               os.path.join(test_folder, 'star*')]
 
-expresion_str = ','.join(expresions)
+expresion_str = ','.join(expressions)
 wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards_rt.yml')
@@ -50,18 +50,13 @@ def wait_for_initial_scan():
 def create_test_folders():
     """Fixture that creates all the folders specified in the `test_subdirectories` list"""
     for dir in test_subdirectories:
-        split_path = os.path.split(dir)
-        parent_folder = os.path.join(test_folder, split_path[0])
-        if not os.path.exists(parent_folder):
-            os.mkdir(os.path.join(parent_folder))
-        if not os.path.exists(os.path.join(parent_folder, split_path[1])):
-            os.mkdir(os.path.join(parent_folder, split_path[1]))
+        recursive_directory_creation(os.path.join(test_folder, dir))
 
 
 @pytest.fixture()
 def wait_for_wildcards_scan():
     """Fixture that waits until the end of the wildcards scan.
-    The wildcards scan is triggered at the beggining of the FIM scan)."""
+    The wildcards scan is triggered at the beginning of the FIM scan)."""
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout + frequency_scan,
                             callback=fim.callback_detect_end_scan,
                             error_message='End of FIM scan not detected').result()
@@ -73,11 +68,10 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.parametrize('parent_folder', [test_folder])
 @pytest.mark.parametrize('subfolder_name', test_subdirectories)
 @pytest.mark.parametrize('file_name', ['regular_1'])
 @pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards_runtime'}])
-def test_basic_usage_wildcards_runtime(parent_folder, subfolder_name, file_name, tags_to_apply,
+def test_basic_usage_wildcards_runtime(subfolder_name, file_name, tags_to_apply,
                                        get_configuration, configure_environment, restart_syscheckd,
                                        wait_for_initial_scan, create_test_folders, wait_for_wildcards_scan):
     """Test the expansion once a given directory matches a configured expresion.
@@ -86,7 +80,6 @@ def test_basic_usage_wildcards_runtime(parent_folder, subfolder_name, file_name,
     folders that doesn't match the expresion and check that no event is triggered if changes are made inside a folder
     that doesn't match the glob expresion.
     Params:
-        parent_folder (str): Name of the root folder.
         subfolder_name (str): Name of the subfolder under root folder.
         file_name (str): Name of the file that will be created under subfolder.
         tags_to_apply (str): Value holding the configuration used in the test.
@@ -107,7 +100,7 @@ def test_basic_usage_wildcards_runtime(parent_folder, subfolder_name, file_name,
         whodata = get_configuration['metadata']['fim_mode'] == 'whodata'
         fim.wait_for_audit(whodata, wazuh_log_monitor)
 
-    folder_path = os.path.join(parent_folder, subfolder_name)
+    folder_path = os.path.join(test_folder, subfolder_name)
 
     fim.regular_file_cud(folder_path, wazuh_log_monitor, file_list=[file_name],
                          time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_wildcards_runtime.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import pytest
+from shutil import rmtree
+from wazuh_testing import global_parameters
+from wazuh_testing import fim
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+
+test_folder = os.path.join(PREFIX, 'test_folder')
+test_directories = [test_folder]
+frequency_scan = 10
+matched_dirs = ['simple1', 'stars123']
+test_subdirectories = matched_dirs + ['not_monitored_directory']
+expresions = [os.path.join(test_folder, 'simple?'),
+              os.path.join(test_folder, 'star*')]
+
+expresion_str = ','.join(expresions)
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards_rt.yml')
+
+# configurations
+
+conf_params = {'TEST_WILDCARDS': expresion_str, 'FREQUENCY': frequency_scan}
+parameters, metadata = fim.generate_params(extra_params=conf_params)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+# fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def wait_for_initial_scan():
+    """Fixture that waits for the initial scan, independently of the configured mode."""
+    fim.detect_initial_scan(wazuh_log_monitor)
+
+
+@pytest.fixture()
+def create_test_folders():
+    """Fixture that creates all the folders specified in the `test_subdirectories` list"""
+    for sub_directory in test_subdirectories:
+        if not os.path.exists(os.path.join(test_folder, sub_directory)):
+            os.mkdir(os.path.join(test_folder, sub_directory))
+
+
+@pytest.fixture()
+def remove_test_folders():
+    """Fixture that removes all the folders specified in the `test_subdirectories` list"""
+    for sub_directory in test_subdirectories:
+        if os.path.exists(os.path.join(test_folder, sub_directory)):
+            rmtree(os.path.join(test_folder, sub_directory))
+
+
+@pytest.fixture()
+def wait_for_wildcards_scan():
+    """Fixture that waits until the end of the wildcards scan.
+    The wildcards scan is triggered at the beggining of the FIM scan)."""
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout + frequency_scan,
+                            callback=fim.callback_detect_end_scan,
+                            error_message='End of FIM scan not detected').result()
+
+
+@pytest.mark.parametrize('parent_folder', [test_folder])
+@pytest.mark.parametrize('subfolder_name', test_subdirectories)
+@pytest.mark.parametrize('file_name', ['regular_1'])
+@pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards_runtime'}])
+def test_basic_usage_wildcards_runtime(parent_folder, subfolder_name, file_name, tags_to_apply,
+                                       get_configuration, configure_environment, remove_test_folders, restart_syscheckd,
+                                       wait_for_initial_scan, create_test_folders, wait_for_wildcards_scan):
+    """Test the expansion once a given directory matches a configured expresion.
+
+    The test monitors a given expresion and will create folders that match the configured expresion. It also creates
+    folders that doesn't match the expresion and check that no event is triggered if changes are made inside a folder
+    that doesn't match the glob expresion.
+    Params:
+        parent_folder (str): Name of the root folder.
+        subfolder_name (str): Name of the subfolder under root folder.
+        file_name (str): Name of the file that will be created under subfolder.
+        tags_to_apply (str): Value holding the configuration used in the test.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        remove_test_folders (fixture): Fixture that will delete all folders inside the test folder
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_initial_scan (fixture): Waits until the first FIM scan is completed.
+        create_test_folders (fixture): Creates the folders that will match (or not) the configured glob expresion.
+        wait_for_wildcards_scan (fixture): Waits until the end of wildcards scan event is triggered.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    if sys.platform == 'win32':
+        if '?' in file_name or '*' in file_name:
+            pytest.skip("Windows can't create files with wildcards.")
+
+    folder_path = os.path.join(parent_folder, subfolder_name)
+
+    fim.regular_file_cud(folder_path, wazuh_log_monitor, file_list=[file_name],
+                         time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                         min_timeout=global_parameters.default_timeout, triggers_event=subfolder_name in matched_dirs)

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/data/wazuh_conf_wildcards.yml
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/data/wazuh_conf_wildcards.yml
@@ -1,0 +1,15 @@
+# conf 1
+- tags:
+  - ossec_conf_wildcards
+  apply_to_modules:
+  - test_wildcards_complex
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_WILDCARDS
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/data/wazuh_conf_wildcards_runtime.yml
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/data/wazuh_conf_wildcards_runtime.yml
@@ -1,0 +1,15 @@
+# conf 1
+- tags:
+  - ossec_conf_wildcards_runtime
+  apply_to_modules:
+  - test_wildcards_complex_runtime
+  sections:
+  - section: syscheck
+    elements:
+    - frequency:
+        value: FREQUENCY
+    - directories:
+        value: TEST_WILDCARDS
+        attributes:
+          - check_all: 'yes'
+          - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from genericpath import exists
+import os
+import sys
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud, generate_params
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# Variables
+
+test_folder = os.path.join(PREFIX, 'test_folder')
+test_directories = [test_folder]
+matched_directories = ['simple1', 'simple2', 'star12', 'stars123', 'multiple_1', 'multiplet']
+matched_subdirs = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar', '_submult', 'submult']
+matched_subdirs = [os.path.join(parent, child) for parent, child in zip(matched_directories, matched_subdirs)]
+no_match_directories = ['random_directory', 'not_monitored_directory']
+test_subdirectories = matched_directories + matched_subdirs + no_match_directories
+wildcards = [os.path.join(test_folder, 'star*/sub*'),
+             os.path.join(test_folder, 'mul*/*lt'),
+             os.path.join(test_folder, '*ple*')]
+
+wildcards = ','.join(wildcards)
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards.yml')
+
+# Configurations
+
+conf_params = {'TEST_WILDCARDS': wildcards}
+parameters, metadata = generate_params(extra_params=conf_params)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+def extra_configuration_before_yield():
+
+    if not os.path.exists(test_folder):
+        os.mkdir(test_folder)
+
+    for matched_dir in matched_directories:
+        if not os.path.exists(os.path.join(test_folder, matched_dir)):
+            os.mkdir(os.path.join(test_folder, matched_dir))
+
+    for sub_directory in matched_subdirs:
+        if not os.path.exists(os.path.join(test_folder, sub_directory)):
+            os.mkdir(os.path.join(test_folder, sub_directory))
+
+    for no_match_dir in no_match_directories:
+        if not os.path.exists(os.path.join(test_folder, no_match_dir)):
+            os.mkdir(os.path.join(test_folder, no_match_dir))
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Test
+
+@pytest.mark.parametrize('parent_folder', [test_folder])
+@pytest.mark.parametrize('subfolder', test_subdirectories)
+@pytest.mark.parametrize('file_name', ['regular_1', '*.*'])
+@pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards'}])
+def test_wildcards_complex(parent_folder, subfolder, file_name, tags_to_apply,
+                           get_configuration, configure_environment,
+                           restart_syscheckd, wait_for_fim_start):
+    """Test the correct expansion of complex wildcards for monitored directories in syscheck
+
+    Params:
+        parent_folder (str): Name of the root folder.
+        subfolder (str): Name of the subfolder under root folder.
+        file_name (str): Name of the file that will be created under subfolder.
+        tags_to_apply (str): Value holding the configuration used in the test.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+    """
+
+    folder = os.path.join(parent_folder, subfolder)
+
+    mult = 1 if sys.platform == 'win32' else 2
+
+    if sys.platform == 'win32':
+        if "?" in file_name or "*" in file_name:
+            pytest.skip("Windows can't create files with wildcards.")
+
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
+                     time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                     min_timeout=global_parameters.default_timeout * mult,
+                     triggers_event=subfolder in matched_directories or subfolder in matched_subdirs)

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
@@ -8,6 +8,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud, generate_params
 from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.file import recursive_directory_creation
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -44,13 +45,9 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 
 def extra_configuration_before_yield():
+    """Function to create the test subdirectories that will be used for the test."""
     for dir in test_subdirectories:
-        split_path = os.path.split(dir)
-        parent_folder = os.path.join(test_folder, split_path[0])
-        if not os.path.exists(parent_folder):
-            os.mkdir(os.path.join(parent_folder))
-        if not os.path.exists(os.path.join(parent_folder, split_path[1])):
-            os.mkdir(os.path.join(parent_folder, split_path[1]))
+        recursive_directory_creation(os.path.join(test_folder, dir))
 
 
 # Fixtures

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
@@ -20,20 +20,17 @@ pytestmark = pytest.mark.tier(level=1)
 test_folder = os.path.join(PREFIX, 'test_folder')
 test_directories = [test_folder]
 
-matched_dirs = ['simple1', 'simple2', 'star12', 'stars123', 'multiple_1', 'multiplet']
-matched_subdirs = ['sub_simple1', 'sub_simple2', 'substar', 'subdtar1', '_submult', 'submult']
-no_match_dirs = ['random_directory', 'not_monitored_directory', 'star12', 'stars123']
+matched_dirs = [os.path.join('stardir', 'sub_test'), os.path.join('multiple_wildcards', 'sub_test'),
+                os.path.join('directory_test', 'test_subdir1'), os.path.join('test_all', 'testdir'),
+                os.path.join('test_all', 'testdir', 'all')]
 
-matched_dirs = [os.path.join(test_folder, directory) for directory in matched_dirs]
-matched_subdirs = [os.path.join(parent, child) for parent, child in zip(matched_dirs, matched_subdirs)]
-no_match_dirs = [os.path.join(test_folder, directory) for directory in no_match_dirs]
+no_match_dirs = ['random_directory']
 
-test_subdirectories = matched_dirs + matched_subdirs + no_match_dirs
+wildcards = ','.join([os.path.join(test_folder, 'star*', 'sub*'), os.path.join(test_folder, 'mul*', '*test'),
+                      os.path.join(test_folder, '*test*', '*dir?'), os.path.join(test_folder, 'test_all', '*'),
+                      os.path.join(test_folder, 'test_all', '*', '*')])
 
-wildcards = [os.path.join(test_folder, 'star*/sub*'),
-             os.path.join(test_folder, 'mul*/*lt'),
-             os.path.join(test_folder, '*ple*')]
-wildcards = ','.join(wildcards)
+test_subdirectories = matched_dirs + no_match_dirs
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -46,19 +43,14 @@ parameters, metadata = generate_params(extra_params=conf_params)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 
-def recursive_directory_creation(splitted_path):
-    if splitted_path[0] != PREFIX:
-        if not os.path.exists(splitted_path[0]):
-            splitted_path = os.path.split(splitted_path[0])
-            recursive_directory_creation(splitted_path)
-        elif not os.path.exists(os.path.join(splitted_path[0], splitted_path[1])):
-            os.mkdir(os.path.join(splitted_path[0], splitted_path[1]))
-
-
 def extra_configuration_before_yield():
-    for subdir in test_subdirectories:
-        splitted_path = os.path.split(subdir)
-        recursive_directory_creation(splitted_path)
+    for dir in test_subdirectories:
+        split_path = os.path.split(dir)
+        parent_folder = os.path.join(test_folder, split_path[0])
+        if not os.path.exists(parent_folder):
+            os.mkdir(os.path.join(parent_folder))
+        if not os.path.exists(os.path.join(parent_folder, split_path[1])):
+            os.mkdir(os.path.join(parent_folder, split_path[1]))
 
 
 # Fixtures
@@ -80,7 +72,6 @@ def test_wildcards_complex(subfolder, file_name, tags_to_apply,
     """Test the correct expansion of complex wildcards for monitored directories in syscheck
 
     Params:
-        parent_folder (str): Name of the root folder.
         subfolder (str): Name of the subfolder under root folder.
         file_name (str): Name of the file that will be created under subfolder.
         tags_to_apply (str): Value holding the configuration used in the test.
@@ -98,7 +89,7 @@ def test_wildcards_complex(subfolder, file_name, tags_to_apply,
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    regular_file_cud(subfolder, wazuh_log_monitor, file_list=[file_name],
+    regular_file_cud(os.path.join(test_folder, subfolder), wazuh_log_monitor, file_list=[file_name],
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
                      min_timeout=global_parameters.default_timeout * mult,
                      triggers_event=subfolder not in no_match_dirs)

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
@@ -70,8 +70,6 @@ def wait_for_wildcards_scan():
                             callback=fim.callback_detect_end_scan,
                             error_message='End of FIM scan not detected').result()
 
-# Fixtures
-
 
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
@@ -108,6 +106,10 @@ def test_wildcards_complex_runtime(subfolder_name, file_name, tags_to_apply,
         if "?" in file_name or "*" in file_name:
             pytest.skip("Windows can't create files with wildcards.")
 
+    if sys.platform == 'linux':
+        # wait until the audit rules are reloaded
+        whodata = get_configuration['metadata']['fim_mode'] == 'whodata'
+        fim.wait_for_audit(whodata, wazuh_log_monitor)
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     fim.regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
@@ -9,6 +9,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing import fim
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.file import recursive_directory_creation
 from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
@@ -54,18 +55,13 @@ def wait_for_initial_scan():
 def create_test_folders():
     """Fixture that creates all the folders specified in the `test_subdirectories` list"""
     for dir in test_folders:
-        split_path = os.path.split(dir)
-        parent_folder = os.path.join(test_folder, split_path[0])
-        if not os.path.exists(parent_folder):
-            os.mkdir(os.path.join(parent_folder))
-        if not os.path.exists(os.path.join(parent_folder, split_path[1])):
-            os.mkdir(os.path.join(parent_folder, split_path[1]))
+        recursive_directory_creation(os.path.join(test_folder, dir))
 
 
 @pytest.fixture()
 def wait_for_wildcards_scan():
     """Fixture that waits until the end of the wildcards scan.
-    The wildcards scan is triggered at the beggining of the FIM scan)."""
+    The wildcards scan is triggered at the beginning of the FIM scan)."""
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout + frequency_scan,
                             callback=fim.callback_detect_end_scan,
                             error_message='End of FIM scan not detected').result()
@@ -87,7 +83,7 @@ def test_wildcards_complex_runtime(subfolder_name, file_name, tags_to_apply,
                                    wait_for_initial_scan, create_test_folders, wait_for_wildcards_scan):
     """Test the correct expansion of complex wildcards in runtime for monitored directories in syscheck.
         The test will monitor an empty folder and once the baseline scan is completed, it will create folders that may
-        match one of the monitored expresions and will check that the events are triggered (in case that a folder
+        match one of the monitored expressions and will check that the events are triggered (in case that a folder
         doesn't match the configured expresion, the test will check that no events are triggered in those folders.)
     Params:
         subfolder (str): Name of the subfolder under root folder.

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing import fim
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=1)
+
+# Variables
+frequency_scan = 10
+test_folder = os.path.join(PREFIX, 'test_folder')
+test_directories = [test_folder]
+
+matched_dirs = [os.path.join('stardir', 'sub_test'), os.path.join('multiple_wildcards', 'sub_test'),
+                os.path.join('directory_test', 'test_subdir1'), os.path.join('test_all', 'testdir'),
+                os.path.join('test_all', 'testdir', 'all')]
+
+no_match_dirs = ['random_directory']
+
+wildcards = ','.join([os.path.join(test_folder, 'star*', 'sub*'), os.path.join(test_folder, 'mul*', '*test'),
+                      os.path.join(test_folder, '*test*', '*dir?'), os.path.join(test_folder, 'test_all', '*'),
+                      os.path.join(test_folder, 'test_all', '*', '*')])
+
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_wildcards_runtime.yml')
+test_folders = matched_dirs + no_match_dirs
+
+# Configurations
+
+conf_params = {'TEST_WILDCARDS': wildcards, 'FREQUENCY': frequency_scan}
+parameters, metadata = fim.generate_params(extra_params=conf_params)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# Fixtures
+
+@pytest.fixture()
+def wait_for_initial_scan():
+    """Fixture that waits for the initial scan, independently of the configured mode."""
+    fim.detect_initial_scan(wazuh_log_monitor)
+
+
+@pytest.fixture()
+def create_test_folders():
+    """Fixture that creates all the folders specified in the `test_subdirectories` list"""
+    for dir in test_folders:
+        split_path = os.path.split(dir)
+        parent_folder = os.path.join(test_folder, split_path[0])
+        if not os.path.exists(parent_folder):
+            os.mkdir(os.path.join(parent_folder))
+        if not os.path.exists(os.path.join(parent_folder, split_path[1])):
+            os.mkdir(os.path.join(parent_folder, split_path[1]))
+
+
+@pytest.fixture()
+def wait_for_wildcards_scan():
+    """Fixture that waits until the end of the wildcards scan.
+    The wildcards scan is triggered at the beggining of the FIM scan)."""
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout + frequency_scan,
+                            callback=fim.callback_detect_end_scan,
+                            error_message='End of FIM scan not detected').result()
+
+# Fixtures
+
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Test
+
+@pytest.mark.parametrize('subfolder_name', test_folders)
+@pytest.mark.parametrize('file_name', ['regular_1'])
+@pytest.mark.parametrize('tags_to_apply', [{'ossec_conf_wildcards_runtime'}])
+def test_wildcards_complex_runtime(subfolder_name, file_name, tags_to_apply,
+                                   get_configuration, configure_environment, restart_syscheckd,
+                                   wait_for_initial_scan, create_test_folders, wait_for_wildcards_scan):
+    """Test the correct expansion of complex wildcards in runtime for monitored directories in syscheck.
+        The test will monitor an empty folder and once the baseline scan is completed, it will create folders that may
+        match one of the monitored expresions and will check that the events are triggered (in case that a folder
+        doesn't match the configured expresion, the test will check that no events are triggered in those folders.)
+    Params:
+        subfolder (str): Name of the subfolder under root folder.
+        file_name (str): Name of the file that will be created under subfolder.
+        tags_to_apply (str): Value holding the configuration used in the test.
+        get_configuration (fixture): Gets the current configuration of the test.
+        configure_environment (fixture): Configure the environment for the execution of the test.
+        restart_syscheckd (fixture): Restarts syscheck.
+        wait_for_initial_scan (fixture): Waits until the first FIM scan is completed.
+        create_test_folders (fixture): Creates the folders that will match (or not) the configured glob expresion.
+        wait_for_wildcards_scan (fixture): Waits until the end of wildcards scan event is triggered.
+    """
+
+    folder = os.path.join(test_folder, subfolder_name)
+    if sys.platform == 'win32':
+        if "?" in file_name or "*" in file_name:
+            pytest.skip("Windows can't create files with wildcards.")
+
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    fim.regular_file_cud(folder, wazuh_log_monitor, file_list=[file_name],
+                         time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
+                         min_timeout=global_parameters.default_timeout, triggers_event=subfolder_name in matched_dirs)


### PR DESCRIPTION
|Related issue|
|---|
|#1263|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to add new tests to check that FIM expand correctly wildcards
Closes #1263 

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.