### PR TITLE
Parse API endpoints data from the log

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -11,7 +11,7 @@ def get_script_arguments():
     parser.add_argument('-s', '--sources', dest='csv_list', required=True, type=str, nargs='+', action='store',
                         help='Paths to the CSV files separated by whitespace.')
     parser.add_argument('-t', '--target', dest='visualization_target', default='binary',
-                        choices=['binary', 'analysis', 'remote', 'agent', 'logcollector', 'cluster'],
+                        choices=['binary', 'analysis', 'remote', 'agent', 'logcollector', 'cluster', 'api'],
                         help='Generate data visualizations for a specific target. Default binary.')
     parser.add_argument('-d', '--destination', dest='destination', default=gettempdir(),
                         help=f'Directory to store the images. Default {gettempdir()}')

--- a/deps/wazuh_testing/wazuh_testing/scripts/wazuh_log_metrics.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/wazuh_log_metrics.py
@@ -4,14 +4,14 @@ from os.path import join
 from tempfile import gettempdir
 from time import time
 
-from wazuh_testing.tools.performance.binary import ClusterLogParser
+from wazuh_testing.tools.performance.binary import ClusterLogParser, APILogParser
 
 METRICS_FOLDER = join(gettempdir(), 'log_metrics')
 CURRENT_SESSION = join(METRICS_FOLDER, datetime.now().strftime('%d-%m-%Y'), str(int(time())))
 
 
 def get_script_arguments():
-    target_choices = ['cluster']
+    target_choices = ['cluster', 'api']
     parser = argparse.ArgumentParser(usage="%(prog)s [options]", description="Wazuh log parser",
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-l', '--log', dest='log', default=None,
@@ -30,6 +30,8 @@ def main():
     if options.log and options.log_type_target:
         if options.log_type_target == 'cluster':
             ClusterLogParser(log_file=options.log, dst_dir=options.output).write_csv()
+        elif options.log_type_target == 'api':
+            APILogParser(log_file=options.log, dst_dir=options.output).write_csv()
 
 
 if __name__ == '__main__':

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -225,6 +225,16 @@ class DataVisualizer:
                                        statistics=DataVisualizer._get_statistics(
                                            current_df['time_spent(s)'], calculate_mean=True, calculate_median=True))
 
+        elif self.target == 'api':
+            for element in elements:
+                fig, ax = plt.subplots()
+                queries = self.dataframe.endpoint.unique()
+                colors = self._color_palette(len(queries))
+                for endpoint, color in zip(queries, colors):
+                    self._basic_plot(ax, self.dataframe[self.dataframe.endpoint == endpoint]['time_spent(s)'],
+                                     label=endpoint, color=color)
+                self._save_custom_plot(ax, element, 'API Response time')
+
         else:
             fig, ax = plt.subplots()
             colors = self._color_palette(len(elements))
@@ -274,6 +284,10 @@ class DataVisualizer:
         """Function to plot the information from the cluster.log file."""
         self._plot_data(elements=list(self.dataframe['activity'].unique()), generic_label='Managers')
 
+    def _plot_api_dataset(self):
+        """Function to plot the information from the api.log file."""
+        self._plot_data(elements=['endpoint'], generic_label='Queries')
+
     def plot(self):
         """Public function to plot the dataset."""
         if self.target == 'binary':
@@ -288,6 +302,8 @@ class DataVisualizer:
             self._plot_logcollector_dataset()
         elif self.target == 'cluster':
             self._plot_cluster_dataset()
+        elif self.target == 'api':
+            self._plot_api_dataset()
         else:
             raise AttributeError(f"Invalid target {self.target}")
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #1365|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #1365 by adding a new log parser class that will read the API log and create a CSV file for each endpoint with the Timestamp, the endpoint, and the response time for each one of them. 

It also adds a new data visualizer to easily see the response times through the test.

## Configuration options

NA

## Logs example

![image](https://user-images.githubusercontent.com/9081114/119472637-b1042300-bd4a-11eb-85ba-139d06b01eb0.png)

## Tests

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.