### PR TITLE
Fix random time travel failures.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1911,6 +1911,11 @@ if sys.platform == 'win32':
         if triggers_event_add:
             logger.info("'added' {} detected as expected.\n".format("events" if len(value_list) > 1 else "event"))
 
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                          update_position=True,
+                          error_message=f'End of scheduled scan not detected after '
+                          f'{global_parameters.default_timeout} seconds')
+
         # Modify previous registry values
         for name, content in value_list.items():
             if name in registry_path:
@@ -1925,6 +1930,11 @@ if sys.platform == 'win32':
         if triggers_event_modified:
             logger.info("'modified' {} detected as expected.\n".format("events" if len(value_list) > 1 else "event"))
 
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                          update_position=True,
+                          error_message=f'End of scheduled scan not detected after '
+                          f'{global_parameters.default_timeout} seconds')
+
         # Delete previous registry values
         for name, _ in value_list.items():
             if name in registry_path:
@@ -1937,6 +1947,11 @@ if sys.platform == 'win32':
 
         if triggers_event_delete:
             logger.info("'deleted' {} detected as expected.\n".format("events" if len(value_list) > 1 else "event"))
+
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                          update_position=True,
+                          error_message=f'End of scheduled scan not detected after '
+                          f'{global_parameters.default_timeout} seconds')
 
 
     def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64KEY, key_list=['test_key'],
@@ -2039,6 +2054,11 @@ if sys.platform == 'win32':
         if triggers_event_add:
             logger.info("'added' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
 
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                          update_position=True,
+                          error_message=f'End of scheduled scan not detected after '
+                          f'{global_parameters.default_timeout} seconds')
+
         # Modify previous registry subkeys
         for name, _ in key_list.items():
             if name in registry_path:
@@ -2053,6 +2073,11 @@ if sys.platform == 'win32':
         if triggers_event_modified:
             logger.info("'modified' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
 
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                          update_position=True,
+                          error_message=f'End of scheduled scan not detected after '
+                          f'{global_parameters.default_timeout} seconds')
+
         # Delete previous registry subkeys
         for name, _ in key_list.items():
             if name in registry_path:
@@ -2065,6 +2090,11 @@ if sys.platform == 'win32':
 
         if triggers_event_delete:
             logger.info("'deleted' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
+
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                          update_position=True,
+                          error_message=f'End of scheduled scan not detected after '
+                          f'{global_parameters.default_timeout} seconds')
 
 
 class CustomValidator:


### PR DESCRIPTION
|Related issue|
|---|
|#1305|

## Description
This PR aims to fix random failures when time traveling. The problem is that when a modification is performed in scheduled, there is the risk to execute a time travel before the current scan ends, causing the next scan to not be triggered. 
With this change, before changing the hour of the system, the test will wait until the current scan has finished.

Closes #1305
## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.