### PR TITLE
Test files scanned per second on inode collision

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1321,7 +1321,8 @@ def callback_dbsync_no_data(line):
     return None
 
 
-def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None):
+def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=13), monitor: FileMonitor = None,
+                      timeout=global_parameters.default_timeout):
     """Change date and time of the system depending on a boolean condition.
 
     Optionally, a monitor may be used to check if a scheduled scan has been performed.
@@ -1333,6 +1334,7 @@ def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=1
         interval (timedelta, optional): time interval that will be added to system clock. Default: 13 hours.
         monitor (FileMonitor, optional): if passed, after changing system clock it will check for the end of the
             scheduled scan. The `monitor` will not consume any log line. Default `None`.
+        timeout (int, optional): If a monitor is provided, this parameter sets how log to wait for the end of scan.
 
     Raises
         TimeoutError: if `monitor` is not `None` and the scan has not ended in the
@@ -1349,10 +1351,10 @@ def check_time_travel(time_travel: bool, interval: timedelta = timedelta(hours=1
         logger.info(f"Changing the system clock from {before} to {str(datetime.now())}")
 
         if monitor:
-            monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+            monitor.start(timeout=timeout, callback=callback_detect_end_scan,
                           update_position=False,
                           error_message=f'End of scheduled scan not detected after '
-                                        f'{global_parameters.default_timeout} seconds')
+                                        f'{timeout} seconds')
 
 
 def callback_configuration_warning(line):

--- a/docs/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
+++ b/docs/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.md
@@ -6,7 +6,7 @@ This test checks the FIM behavior when the option `max_files_per_second` is enab
 
 | Tier | Platforms | Time spent| Test file |
 |:--:|:--:|:--:|:--:|
-| 1 | Linux, Windows, MacOS, Solaris | 00:00:40 | [test_max_files_per_second.py](../../../../../../tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py)|
+| 1 | Linux, Windows, MacOS, Solaris | 00:01:33 | [test_max_files_per_second.py](../../../../../../tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py)|
 
 ## Test logic
 - After the baseline is generated, the test will create files inside a monitored folder.
@@ -15,20 +15,21 @@ This test checks the FIM behavior when the option `max_files_per_second` is enab
 
 - [x] Checks that FIM sleeps once the maximum files per second is reached.
 - [x] Checks that FIM doesn't sleeps if `max_files_per_second` is not enabled.
+- [x] Checks the file limit is also applied to the inode collision algorithm.
 
 ## Execution result
 
 ```
 python3 -m pytest test_max_files_per_second/
-============================= test session starts ==============================
+============================================================ test session starts ============================================================
 platform linux -- Python 3.8.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
-rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
-plugins: html-2.0.1, testinfra-5.0.0, metadata-1.11.0
-collected 6 items
+rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: testinfra-5.0.0, html-2.0.1, metadata-1.11.0
+collected 12 items
 
-test_max_files_per_second/test_max_files_per_second.py ......                                                                                                                                                                         [100%]
+test_files/test_max_files_per_second/test_max_files_per_second.py ...s.s...s.s                                                        [100%]
 
-============================================================================================================ 6 passed in 42.96s =============================================================================================================
+================================================== 8 passed, 4 skipped in 93.70s (0:01:33) ==================================================
 ```
 
 ## Code documentation

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -42,8 +42,12 @@ def get_configuration(request):
 
 # Tests
 
-
-def test_max_files_per_second(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+@pytest.mark.parametrize('inode_collision', [
+                         (False),
+                         pytest.param(True, marks=(pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5))
+                         ])
+def test_max_files_per_second(inode_collision, get_configuration, configure_environment, restart_syscheckd,
+                              wait_for_fim_start):
     """ Check that FIM sleeps for one second when the option max_files_per_second is enabled
 
     Args:
@@ -55,14 +59,48 @@ def test_max_files_per_second(get_configuration, configure_environment, restart_
     Raises:
         TimeoutError: If an expected event couldn't be captured.
     """
+    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
+
+    if inode_collision is True and scheduled is False:
+        pytest.skip("realtime and whodata modes do not verify inode collisions")
+
     # Create the files in an empty folder to check realtime and whodata.
     for i in range(n_files_to_create):
         fim.create_file(fim.REGULAR, test_directories[0], f'test_{i}', content='')
 
     extra_timeout = n_files_to_create / max_files_per_second
 
-    scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
-    fim.check_time_travel(scheduled)
+    fim.check_time_travel(scheduled, monitor=wazuh_log_monitor,
+                          timeout=global_parameters.default_timeout + extra_timeout)
+
+    try:
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout + extra_timeout,
+                                callback=fim.callback_detect_max_files_per_second)
+    except TimeoutError as e:
+        if get_configuration['metadata']['max_files_per_sec'] == 0:
+            pass
+        else:
+            raise e
+
+    if scheduled and get_configuration['metadata']['max_files_per_sec'] != 0:
+        # Walk to the end of the scan
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout + extra_timeout,
+                                callback=fim.callback_detect_end_scan)
+
+    # Remove all files
+    for i in range(n_files_to_create):
+        fim.delete_file(test_directories[0], f'test_{i}')
+
+    if inode_collision is False:
+        return  # Done testing this case
+
+    # Create the files again changing all inodes
+    fim.create_file(fim.REGULAR, test_directories[0], 'test', content='')
+    for i in range(n_files_to_create):
+        fim.create_file(fim.REGULAR, test_directories[0], f'test_{i}', content='')
+
+    fim.check_time_travel(scheduled, monitor=wazuh_log_monitor,
+                          timeout=global_parameters.default_timeout + extra_timeout)
     try:
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout + extra_timeout,
                                 callback=fim.callback_detect_max_files_per_second)


### PR DESCRIPTION
|Related issue|
|---|
|#1375|

## Description

This PR closes #1375.

The existing `test_max_files_per_second.py` has been modified so that it tests the limit when the agent is solving inode collisions in FIM.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.