### PR TITLE
Update cluster functions to allow message divisions

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/cluster.py
+++ b/deps/wazuh_testing/wazuh_testing/cluster.py
@@ -15,6 +15,8 @@ CLUSTER_CMD_HEADER_SIZE = 12
 CLUSTER_HEADER_FORMAT = '!2I{}s'.format(CLUSTER_CMD_HEADER_SIZE)
 FERNET_KEY = ''.join(random.choices(string.ascii_lowercase + string.digits, k=32))
 _my_fernet = Fernet(base64.b64encode(FERNET_KEY.encode()))
+DIVIDE_FLAG = b'd'
+REQUEST_CHUNK = 5242880
 
 
 def callback_detect_master_serving(line):
@@ -57,11 +59,11 @@ def detect_initial_master_serving(file_monitor):
     file_monitor.start(timeout=5, callback=callback_detect_master_serving)
 
 
-def cluster_msg_build(cmd: bytes = None, counter: int = None, payload: bytes = None, encrypt=True) -> bytes:
+def cluster_msg_build(command: bytes = None, counter: int = None, payload: bytes = None, encrypt=True) -> bytes:
     """Build a message using cluster protocol.
 
     Args:
-        cmd (bytes): command to send
+        command (bytes): command to send
         counter (int): message id
         payload (bytes): data to send
         encrypt (bool): whether to use fernet encryption or not
@@ -69,21 +71,50 @@ def cluster_msg_build(cmd: bytes = None, counter: int = None, payload: bytes = N
     Returns:
         bytes: built message
     """
-    cmd_len = len(cmd)
-    if cmd_len > CLUSTER_CMD_HEADER_SIZE:
+    cmd_len = len(command)
+    if cmd_len > CLUSTER_CMD_HEADER_SIZE - len(DIVIDE_FLAG):
         raise Exception("Length of command '{}' exceeds limit ({}/{}).".format(cmd, cmd_len,
-                                                                               CLUSTER_CMD_HEADER_SIZE))
-
-    encrypted_data = _my_fernet.encrypt(payload) if encrypt else payload
-    out_msg = bytearray(CLUSTER_DATA_HEADER_SIZE + len(encrypted_data))
+                                                                               CLUSTER_CMD_HEADER_SIZE - len(
+                                                                                   DIVIDE_FLAG)))
 
     # Add - to command until it reaches cmd length
-    cmd = cmd + b' ' + b'-' * (CLUSTER_CMD_HEADER_SIZE - cmd_len - 1)
+    command = command + b' ' + b'-' * (CLUSTER_CMD_HEADER_SIZE - cmd_len - 1)
+    encrypted_data = _my_fernet.encrypt(payload) if encrypt else payload
+    message_size = self.header_len + len(encrypted_data)
 
-    out_msg[:CLUSTER_DATA_HEADER_SIZE] = struct.pack(CLUSTER_HEADER_FORMAT, counter, len(encrypted_data), cmd)
-    out_msg[CLUSTER_DATA_HEADER_SIZE:CLUSTER_DATA_HEADER_SIZE + len(encrypted_data)] = encrypted_data
+    # Message size is <= request_chunk, send the message
+    if message_size <= self.request_chunk:
+        msg = bytearray(message_size)
+        msg[:CLUSTER_DATA_HEADER_SIZE] = struct.pack(CLUSTER_HEADER_FORMAT, counter, len(encrypted_data), command)
+        msg[CLUSTER_DATA_HEADER_SIZE:message_size] = encrypted_data
+        return [msg]
 
-    return bytes(out_msg[:CLUSTER_DATA_HEADER_SIZE + len(encrypted_data)])
+    # Message size > request_chunk, send the message divided
+    else:
+        # Command with the flag d (divided)
+        command = command[:-len(DIVIDE_FLAG)] + DIVIDE_FLAG
+        msg_list = []
+        partial_data_size = 0
+        data_size = len(encrypted_data)
+        while partial_data_size < data_size:
+            message_size = REQUEST_CHUNK \
+                if data_size - partial_data_size + CLUSTER_DATA_HEADER_SIZE >= REQUEST_CHUNK \
+                else data_size - partial_data_size + CLUSTER_DATA_HEADER_SIZE
+
+            # Last divided message, remove the flag
+            if message_size == data_size - partial_data_size + CLUSTER_DATA_HEADER_SIZE:
+                command = command[:-len(DIVIDE_FLAG)] + b'-' * len(DIVIDE_FLAG)
+
+            msg = bytearray(message_size)
+            msg[:CLUSTER_DATA_HEADER_SIZE] = struct.pack(CLUSTER_HEADER_FORMAT, counter,
+                                                         message_size - CLUSTER_DATA_HEADER_SIZE,
+                                                         command)
+            msg[CLUSTER_DATA_HEADER_SIZE:message_size] = encrypted_data[
+                                                         partial_data_size:partial_data_size + message_size - CLUSTER_DATA_HEADER_SIZE]
+            partial_data_size += message_size - CLUSTER_DATA_HEADER_SIZE
+            msg_list.append(msg)
+
+        return msg_list
 
 
 def _master_action(counter: int = None, cmd: bytes = None, payload: bytes = None, **kwargs):
@@ -112,7 +143,7 @@ def _master_action(counter: int = None, cmd: bytes = None, payload: bytes = None
 
     response_counter = counter
 
-    return {'cmd': response_cmd, 'counter': response_counter, 'payload': response_payload}
+    return {'command': response_cmd, 'counter': response_counter, 'payload': response_payload}
 
 
 def _get_info_from_header(data: bytes):
@@ -122,12 +153,14 @@ def _get_info_from_header(data: bytes):
         data (bytes): raw data to process
 
     Returns:
-        dict: counter, cmd, total extracted from header
+        dict: counter, cmd, total and flag_divided extracted from header
     """
     counter, total, cmd = struct.unpack(CLUSTER_HEADER_FORMAT, data[0:CLUSTER_DATA_HEADER_SIZE])
-    cmd = cmd.split(b' ')[0]
+    flag = cmd[-1:]
+    flag_divided = flag if flag == DIVIDE_FLAG else b''
+    cmd = cmd[:-1].split(b' ')[0]
 
-    return {'counter': counter, 'total': total, 'cmd': cmd}
+    return {'counter': counter, 'total': total, 'cmd': cmd, 'flag_divided': flag_divided}
 
 
 def _cluster_message_decompose(data: bytes):
@@ -159,7 +192,7 @@ def master_simulator(data: bytes):
     if header != b'':
         return cluster_msg_build(**_master_action(**_cluster_message_decompose(data)))
     else:
-        return b''
+        return [b'']
 
 
 def _process_clusterd_message(tup, command: bytes = None):


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/6820 |

Hi team,

This pull request is related to the epic Wazuh issue 6820.

This epic issue asks for a division in messages with size larger than the request chunk variable. With this change, the string updates and file updates don't need to be done with manual message divisions.

In this PR, I have updated the cluster_msg_build cluster.py function with the new functionality. Minor changes were needed in other cluster.py functions.


QA tests passing after the changes:


### SYSTEM QA tests:

- enrollment_cluster:

```
pytest test_agent_enrollment/
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.2, pytest-4.5.0, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.11.0, html-2.0.1, testinfra-5.0.0
collected 1 item                                                                                                                                                                            


test_agent_enrollment/test_agent_enrollment.py .                                                                                                                                      [100%]
================================================================================= 1 passed in 79.86 seconds =================================================================================
```


- basic_cluster:

```
pytest test_agent_info_sync/
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.2, pytest-4.5.0, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.11.0, html-2.0.1, testinfra-5.0.0
collected 2 items                                                                                                                                                                           

test_agent_info_sync/test_agent_info_sync.py ..                                                                                                                                       [100%]
================================================================================ 2 passed in 186.57 seconds =================================================================================


pytest test_agent_key_polling/
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.2, pytest-4.5.0, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.11.0, html-2.0.1, testinfra-5.0.0
collected 1 item                                                                                                                                                                            

test_agent_key_polling/test_agent_key_polling.py s                                                                                                                                    [100%]
================================================================================= 1 skipped in 0.13 seconds =================================================================================
```


- agentless_cluster:

```
pytest test_jwt_invalidation/
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.2, pytest-4.5.0, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh-qa/tests/system
plugins: metadata-1.11.0, html-2.0.1, testinfra-5.0.0
collected 19 items                                                                                                                                                                          

test_jwt_invalidation/test_change_rbac_mode.py ....                                                                                                                                   [ 21%]
test_jwt_invalidation/test_change_security_resources.py ....                                                                                                                          [ 42%]
test_jwt_invalidation/test_disconnected_nodes.py .                                                                                                                                    [ 47%]
test_jwt_invalidation/test_revoke_endpoint.py ......                                                                                                                                  [ 78%]
test_jwt_invalidation/test_update_password.py ....                                                                                                                                    [100%]
=============================================================================== 19 passed in 1057.94 seconds ================================================================================

```



### INTEGRATION QA tests:

```
/wazuh-qa/tests/integration# python3 -m pytest test_api/

collected 78 items                                                                                                                                                                          

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss.                                                                                                        [  5%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py .ss.                                                                                          [ 10%]
test_api/test_config/test_cache/test_cache.py .ss.                                                                                                                                    [ 15%]
test_api/test_config/test_cors/test_cors.py xX                                                                                                                                        [ 17%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py .ss.                                                                                                                [ 23%]
test_api/test_config/test_experimental_features/test_experimental_features.py .ss.                                                                                                    [ 28%]
test_api/test_config/test_host_port/test_host_port.py .s.ss.s.                                                                                                                        [ 38%]
test_api/test_config/test_https/test_https.py .ss.                                                                                                                                    [ 43%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                                                    [ 48%]
test_api/test_config/test_logs/test_logs.py .ss.                                                                                                                                      [ 53%]
test_api/test_config/test_rbac/test_rbac_mode.py .ss.                                                                                                                                 [ 58%]
test_api/test_config/test_use_only_authd/test_use_only_authd.py .s.s.s.ss.s.s.s.                                                                                                      [ 79%]
test_api/test_rbac/test_add_old_resource.py ....                                                                                                                                      [ 84%]
test_api/test_rbac/test_admin_resources.py ....                                                                                                                                       [ 89%]
test_api/test_rbac/test_policy_position.py .                                                                                                                                          [ 91%]
test_api/test_rbac/test_remove_relationship.py ...                                                                                                                                    [ 94%]
test_api/test_rbac/test_remove_resource.py ....                                                                                                                                       [100%]
======================================================= 46 passed, 30 skipped, 1 xfailed, 1 xpassed, 41 warnings in 792.21s (0:13:12) =======================================================


/wazuh-qa/tests/integration# python3 -m pytest test_cluster/

test_cluster/test_key_polling/test_key_polling_master.py ss                                                                                                                           [ 50%]
test_cluster/test_key_polling/test_key_polling_worker.py ss                                                                                                                           [100%]
==================================================================================== 4 skipped in 0.05s =====================================================================================
```


**This PR is blocked by https://github.com/wazuh/wazuh-qa/issues/1379 as the system test `test_integrity_sync` is failing in `master` and didn't pass.**

Regards,
Manuel.