### PR TITLE
Allow the use of versions below wazuh 4.2.0 in statistic tools

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/wazuh_statistics.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/wazuh_statistics.py
@@ -33,6 +33,8 @@ def get_script_arguments():
                         help='Enable debug level logging.')
     parser.add_argument('--store', dest='store_path', action='store', default=gettempdir(),
                         help=f"Path to store the CSVs with the data. Default {gettempdir()}.")
+    parser.add_argument('-v', '--version', dest='version', action='store', default=None,
+                        help=f"Wazuh version. Default None.")
 
     return parser.parse_args()
 
@@ -51,7 +53,8 @@ def main():
     logger.info(f'Started new session: {CURRENT_SESSION}')
 
     for target in options.target_list:
-        monitor = StatisticMonitor(target=target, time_step=options.sleep_time, dst_dir=options.store_path)
+        monitor = StatisticMonitor(target=target, time_step=options.sleep_time, dst_dir=options.store_path,
+                                   wazuh_version=options.version)
         monitor.start()
         MONITOR_LIST.append(monitor)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -48,6 +48,10 @@ else:
     LOGCOLLECTOR_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-logcollector.state')
     REMOTE_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-remoted.state')
     ANALYSIS_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-analysisd.state')
+    AGENT_STATISTICS_FILE_LEGACY = os.path.join(WAZUH_PATH, 'var', 'run', 'ossec-agentd.state')
+    LOGCOLLECTOR_STATISTICS_FILE_LEGACY = os.path.join(WAZUH_PATH, 'var', 'run', 'ossec-logcollector.state')
+    REMOTE_STATISTICS_FILE_LEGACY = os.path.join(WAZUH_PATH, 'var', 'run', 'ossec-remoted.state')
+    ANALYSIS_STATISTICS_FILE_LEGACY = os.path.join(WAZUH_PATH, 'var', 'run', 'ossec-analysisd.state')
 
     try:
         import grp

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/statistic.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/statistic.py
@@ -13,6 +13,7 @@ from threading import Thread, Event
 from time import sleep
 
 import wazuh_testing.tools as tls
+from wazuh_testing.tools.utils import compare_versions
 
 logger = logging.getLogger('wazuh-statistics-monitor')
 logger.setLevel(logging.INFO)
@@ -42,23 +43,28 @@ class StatisticMonitor:
         target (str): target file to monitor.
     """
 
-    def __init__(self, target='agent', time_step=5, dst_dir=gettempdir()):
+    def __init__(self, target='agent', time_step=5, dst_dir=gettempdir(), wazuh_version=None):
         self.event = None
         self.thread = None
         self.time_step = time_step
         self.target = target
         self.dst_dir = dst_dir
         self.parse_json = False
+        self.wazuh_version = wazuh_version
 
         if self.target == 'agent':
-            self.statistics_file = tls.AGENT_STATISTICS_FILE
+            self.statistics_file = tls.LOGCOLLECTOR_STATISTICS_FILE_LEGACY if self.wazuh_version is not None and \
+                compare_versions('4.2.0', self.wazuh_version) == 1 else tls.AGENT_STATISTICS_FILE
         elif self.target == 'logcollector':
-            self.statistics_file = tls.LOGCOLLECTOR_STATISTICS_FILE
+            self.statistics_file = tls.LOGCOLLECTOR_STATISTICS_FILE_LEGACY if self.wazuh_version is not None and \
+                compare_versions('4.2.0', self.wazuh_version) == 1 else tls.LOGCOLLECTOR_STATISTICS_FILE
             self.parse_json = True
         elif self.target == 'remote':
-            self.statistics_file = tls.REMOTE_STATISTICS_FILE
+            self.statistics_file = tls.REMOTE_STATISTICS_FILE_LEGACY if self.wazuh_version is not None and \
+                compare_versions('4.2.0', self.wazuh_version) == 1 else tls.REMOTE_STATISTICS_FILE
         elif self.target == 'analysis':
-            self.statistics_file = tls.ANALYSIS_STATISTICS_FILE
+            self.statistics_file = tls.ANALYSIS_STATISTICS_FILE_LEGACY if self.wazuh_version is not None and \
+                compare_versions('4.2.0', self.wazuh_version) == 1 else tls.ANALYSIS_STATISTICS_FILE
         else:
             raise ValueError(f'The target {self.target} is not a valid one.')
 

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -6,6 +6,7 @@ import re
 from functools import wraps
 from time import sleep
 from random import randint, SystemRandom, choice
+from distutils.version import StrictVersion
 import string
 
 
@@ -42,7 +43,7 @@ def retry(exceptions, attempts=5, delay=1, delay_multiplier=2):
                     sleep(wait_time)
             return func(*args, **kwargs)  # final attempt
         return to_retry  # actual decorator
-        
+
     return retry_function
 
 
@@ -109,3 +110,20 @@ def get_random_string(string_length, digits=True):
     character_set = string.ascii_uppercase + string.digits if digits else string.ascii_uppercase
 
     return ''.join(SystemRandom().choice(character_set) for _ in range(string_length))
+
+
+def compare_versions(version_1, version_2):
+    """Version comparison function
+
+    Args:
+        version_1 (str): Version 1 to compare in `x.y.z` format
+        version_2 (str): Version 2 to compare in `x.y.z` format
+    Returns:
+        int: 1 if version1 is greater, -1 if version 2 is greater or 0 if versions are equals.
+    """
+    if StrictVersion(version_1) > StrictVersion(version_2):
+        return 1
+    elif StrictVersion(version_1) < StrictVersion(version_2):
+        return -1
+    else:
+        return 0

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -113,13 +113,16 @@ def get_random_string(string_length, digits=True):
 
 
 def compare_versions(version_1, version_2):
-    """Version comparison function
+    """Function to compare two versions in x.y.z format.
 
     Args:
-        version_1 (str): Version 1 to compare in `x.y.z` format
-        version_2 (str): Version 2 to compare in `x.y.z` format
+        version_1 (str): Version 1 to compare in `x.y.z` format.
+        version_2 (str): Version 2 to compare in `x.y.z` format.
+
     Returns:
-        int: 1 if version1 is greater, -1 if version 2 is greater or 0 if versions are equals.
+        int: 1 if version1 is greater.
+            -1 if version 2 is greater.
+             0 if versions are equals.
     """
     if StrictVersion(version_1) > StrictVersion(version_2):
         return 1


### PR DESCRIPTION
|Related issue|
|---|
|#1367|

## Description

This PR makes the following changes:
 - Add the function `compare_versions` in utils module to compare string versions.
 - Add `version` parameter in wazuh_statistics script.
 - Add legacy paths in tools global vars.
 - Update `statistics` class to load wazuh paths according to the wazuh version specified.

