### PR TITLE
Fix test_integrity_sync QA system test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -44,7 +44,7 @@ class HostManager:
         dest_path (str): Destination path
         check (bool, optional): Ansible check mode("Dry Run")(https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html), by default it is enabled so no changes will be applied. Default `False`
         """
-        self.get_host(host).ansible("copy", f"src={src_path} dest={dest_path} owner=ossec group=ossec mode=0775",
+        self.get_host(host).ansible("copy", f"src={src_path} dest={dest_path} owner=wazuh group=wazuh mode=0775",
                                     check=check)
 
     def add_block_to_file(self, host: str, path: str, replace: str, before: str, after, check: bool = False):

--- a/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
+++ b/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
@@ -3,10 +3,9 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import pytest
 import time
 from secrets import token_hex
-
-import pytest
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.system import HostManager
 
@@ -26,9 +25,10 @@ directories_to_create = [os.path.join(WAZUH_PATH, "etc", "shared", "test_group")
 # Files that, after created in the master, should be present in all nodes.
 files_to_sync = [os.path.join(WAZUH_PATH, "etc", "lists", "test_file"),
                  os.path.join(WAZUH_PATH, "etc", "rules", "test_file"),
-                 os.path.join(WAZUH_PATH, "etc", "decoders", "test_file"),
-                 os.path.join(directories_to_create[0], 'merged.mg'),
-                 os.path.join(directories_to_create[1], 'merged.mg')]
+                 os.path.join(WAZUH_PATH, "etc", "decoders", "test_file")]
+# merged.mg files that must be created after creating each group folder.
+merged_mg_files = [os.path.join(directories_to_create[0], "merged.mg"),
+                   os.path.join(directories_to_create[1], "merged.mg")]
 # Files inside directories where not 'all' files have to be synchronized, according to cluster.json.
 files_not_to_sync = [os.path.join(WAZUH_PATH, "etc", "test_file"),
                      os.path.join(WAZUH_PATH, "etc", "lists", 'ar.conf'),
@@ -38,6 +38,8 @@ files_not_to_sync = [os.path.join(WAZUH_PATH, "etc", "test_file"),
                      os.path.join(WAZUH_PATH, "etc", "lists", 'test.swp'),
                      os.path.join(directories_to_create[0], 'test_file'),
                      os.path.join(directories_to_create[1], 'test_file')]
+agent_conf_files_to_create = [os.path.join(directories_to_create[0], 'agent.conf'),
+                              os.path.join(directories_to_create[1], 'agent.conf')]
 
 
 @pytest.fixture(scope='function')
@@ -63,7 +65,7 @@ def test_missing_file(clean_files):
         host_manager.run_command(test_hosts[0], f'chown wazuh:wazuh {subdir}')
 
     # Create all specified files inside the master node.
-    for file in files_to_sync + files_not_to_sync:
+    for file in files_to_sync + files_not_to_sync + agent_conf_files_to_create:
         host_manager.run_command(test_hosts[0], f'touch {file}')
         host_manager.run_command(test_hosts[0], f'chown wazuh:wazuh {file}')
 
@@ -79,7 +81,7 @@ def test_missing_file(clean_files):
             assert perm == '660', f"{file} permissions were expected to be '660' in {host}, but they are {perm}."
         # Check that files which should not be synchronized are not sent to the workers. For example, only
         # merged.mg file inside /var/ossec/etc/shared/ directory should be synchronized, but nothing else.
-        for file in files_not_to_sync:
+        for file in files_not_to_sync + agent_conf_files_to_create:
             result = host_manager.run_command(host, f'ls {file}')
             assert result == '', f"File {file} was expected not to be copied in {host}, but it was."
 
@@ -90,23 +92,41 @@ def test_shared_files():
     Update the content of the files in the master node and check if they are updated in the workers.
     Then, update the content in the workers and check if it is overwritten by the one in the master.
     """
+    agent_conf_content = '<agent_config></agent_config>'
+    file_test_content_master = 'test_content_from_master'
+    file_test_content_worker = 'test_content_from_worker'
+
     # Modify the content of each file in the master node to check if it is updated in the workers.
     for file in files_to_sync:
-        host_manager.modify_file_content(host=test_hosts[0], path=file, content='test_content_from_master')
+        host_manager.modify_file_content(host=test_hosts[0], path=file, content=file_test_content_master)
+
+    # Modify the content of agent.conf files to check if each merged.mg file is updated in master and synchronized in
+    # workers.
+    for file in agent_conf_files_to_create:
+        host_manager.modify_file_content(host=test_hosts[0], path=file,
+                                         content=f"{agent_conf_content}\n")
 
     time.sleep(time_to_sync)
 
-    # Check whether files are correctly updated in the workers.
+    # Check whether files are correctly updated in the workers or not.
     for host in worker_hosts:
         for file in files_to_sync:
             result = host_manager.run_command(host, f'cat {file}')
-            assert result == 'test_content_from_master', f'File {file} inside {host} should contain ' \
-                                                         f'"test_content_from_master", but it has: {result}'
+            assert result == file_test_content_master, f'File {file} inside {host} should contain ' \
+                                                       f'{file_test_content_master}, but it has: {result}'
+
+    # Check whether merged.mg files are correctly updated in master and synchronized in workers or not.
+    for host in test_hosts:
+        for file in merged_mg_files:
+            result = host_manager.run_command(host, f'cat {file}')
+            # The agent.conf content will be before the !0 test_file line in merged.mg.
+            assert agent_conf_content in result, f'File {file} inside {host} should contain ' \
+                                                 f'{agent_conf_content}, but it has: {result} '
 
     # Update the content of files in the worker node.
     for host in worker_hosts:
         for file in files_to_sync:
-            host_manager.modify_file_content(host=host, path=file, content='test_content_from_worker')
+            host_manager.modify_file_content(host=host, path=file, content=file_test_content_worker)
 
     time.sleep(time_to_sync)
 
@@ -114,8 +134,8 @@ def test_shared_files():
     for host in worker_hosts:
         for file in files_to_sync:
             result = host_manager.run_command(host, f'cat {file}')
-            assert result == 'test_content_from_master', f'File {file} inside {host} should contain ' \
-                                                         f'"test_content_from_master", but it has: {result}'
+            assert result == file_test_content_master, f'File {file} inside {host} should contain ' \
+                                                       f'{file_test_content_master}, but it has: {result}'
 
 
 def test_extra_files(clean_files):


### PR DESCRIPTION
|Related issue|
|---|
| #1379 |

This PR closes #1379 .

The **integrity_sync** QA system test test is failing in master because `merged.mg` files are automatically created once the group folder has been created. When we try to write something in a `merged.mg` file, the `merged.mg` file is updated with the old content.

This is the expected behaviour which means we were not testing a real use case in versions `<=4.2`. In 4.2 and older versions, we were creating the group folder with `ossec:ossec` so the `merged.mg` file was not created automatically. To create it automatically, the user must had been `ossecr`. 

We were testing the integrity sync, as we were checking the file content changed, but we were not testing the real use case.


I have changed the `test_integrity_sync` test to create a `agent.conf` file in the group folder. I am now testing that, after writing something in the group's `agent.conf`, its respective `merged.mg` file is correctly updated and synchronized in the worker nodes.

In case of the multigroup, the test case will be the same as before as remoted is not creating a `merged.mg` because we are not in the real use case: agents with more than a group (this can't be done as we are in the agentless environment).

- test_integrity_sync result after the changes:

```
pytest test_integrity_sync/
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.9.2, pytest-4.5.0, py-1.10.0, pluggy-0.13.1
rootdir: /home/manuel/git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.11.0, html-2.0.1, testinfra-5.0.0
collected 4 items                                                                                                                                                                 

test_integrity_sync/test_integrity_sync.py ....                                                                                                                             [100%]

=========================================================================== 4 passed in 428.79 seconds ============================================================================
```


Regards,
Manuel.
## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.