### PR TITLE
Add test to check the behavior of test_max_fd_win_rt option.

### DIFF
--- a/docs/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.md
+++ b/docs/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.md
@@ -1,0 +1,39 @@
+# Test max fd win rt
+Test to check that the option `max_fd_win_rt` is working properly. This option limits the number of realtime file descriptors that FIM can open.
+
+## General info
+
+| Tier | Platforms | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 1 | Windows | 00:00:30 | [test_max_fd_rt.py](../../../../../../tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.py)|
+
+## Test logic
+- The test will set the limit to 2.
+- FIM will be monitoring 4 folders, 2 of them are created before FIM starts.
+- The test will remove the 2 existing folders and will create them again, and will check that events are triggered.
+- The test will remove those 2 folders.
+- Finally, the test will create 2 folders and will check that events are triggered.
+## Checks
+
+- [x] Checks that FIM properly counts the number of realtime file descriptor opened.
+- [x] FIM decreases the counter when a monitored folder is removed.
+
+## Execution result
+
+```
+PS C:\Users\Administrator\Desktop\wazuh-qa\tests\integration\test_fim\test_files> python -m pytest .\test_inotify\test_m
+ax_fd_rt.py
+================================================= test session starts =================================================
+platform win32 -- Python 3.6.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+rootdir: C:\Users\Administrator\Desktop\wazuh-qa\tests\integration, configfile: pytest.ini
+plugins: html-2.0.1, metadata-1.11.0, testinfra-6.3.0, testinfra-6.0.0
+collected 1 item
+
+test_inotify\test_max_fd_rt.py .                                                                                 [100%]
+
+================================================= 1 passed in 26.69s ==================================================
+```
+
+## Code documentation
+
+::: tests.integration.test_fim.test_files.test_inotify.test_max_fd_rt

--- a/docs/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.md
+++ b/docs/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.md
@@ -1,38 +1,30 @@
 # Test max fd win rt
-Test to check that the option `max_fd_win_rt` is working properly. This option limits the number of realtime file descriptors that FIM can open.
+
+## Overview
+This test will check that the option `max_fd_win_rt` is working properly.
+This option limits the number of realtime file descriptors that FIM can open.
 
 ## General info
 
-| Tier | Platforms | Time spent| Test file |
-|:--:|:--:|:--:|:--:|
-| 1 | Windows | 00:00:30 | [test_max_fd_rt.py](../../../../../../tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.py)|
+| Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 1 | 1 | 00:00:30 |
 
-## Test logic
-- The test will set the limit to 2.
-- FIM will be monitoring 4 folders, 2 of them are created before FIM starts.
-- The test will remove the 2 existing folders and will create them again, and will check that events are triggered.
+## Expected behavior
+
+The agent can add new folders to the monitoring if any folder is removed after the limit is reached.
+
+## Testing
+
+FIM will be monitoring 4 folders, 2 of them are created before FIM starts, setting the limit to two folders.
+
+- Once FIM is started, the test will remove the 2 existing folders and will create them again, checking that events are triggered.
 - The test will remove those 2 folders.
-- Finally, the test will create 2 folders and will check that events are triggered.
+- Finally, the test will remove those two folders and will create other 2 folders and will check that events are triggered.
 ## Checks
 
-- [x] Checks that FIM properly counts the number of realtime file descriptor opened.
-- [x] FIM decreases the counter when a monitored folder is removed.
-
-## Execution result
-
-```
-PS C:\Users\Administrator\Desktop\wazuh-qa\tests\integration\test_fim\test_files> python -m pytest .\test_inotify\test_m
-ax_fd_rt.py
-================================================= test session starts =================================================
-platform win32 -- Python 3.6.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
-rootdir: C:\Users\Administrator\Desktop\wazuh-qa\tests\integration, configfile: pytest.ini
-plugins: html-2.0.1, metadata-1.11.0, testinfra-6.3.0, testinfra-6.0.0
-collected 1 item
-
-test_inotify\test_max_fd_rt.py .                                                                                 [100%]
-
-================================================= 1 passed in 26.69s ==================================================
-```
+- FIM detect changes when monitored folders are deleted and created again
+- Fim detect changes on new folders
 
 ## Code documentation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -254,6 +254,7 @@ nav:
               - tests/integration/test_fim/test_files/test_inotify/index.md
               - Test num watches: tests/integration/test_fim/test_files/test_inotify/test_num_watches.md
               - Test remove rename folder: tests/integration/test_fim/test_files/test_inotify/test_remove_rename_folder.md
+              - Test max fd win rt: tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.md
             - Test invalid:
               - tests/integration/test_fim/test_files/test_invalid/index.md
               - Test invalid: tests/integration/test_fim/test_files/test_invalid/test_invalid.md

--- a/tests/integration/test_fim/test_files/test_inotify/data/wazuh_conf_max_fd.yaml
+++ b/tests/integration/test_fim/test_files/test_inotify/data/wazuh_conf_max_fd.yaml
@@ -1,0 +1,15 @@
+---
+# conf 1
+- tags:
+  - test_max_fd_rt
+  apply_to_modules:
+  - test_max_fd_rt
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import shutil
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import LOG_FILE_PATH, regular_file_cud,  callback_delete_watch, \
+                              generate_params, change_internal_options, callback_realtime_added_directory
+from wazuh_testing.tools import PREFIX
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
+
+# Variables
+
+test_folder = os.path.join(PREFIX, 'test_folder')
+test_directories = [test_folder]
+fd_rt_value = 2
+
+created_dirs = [os.path.join(test_folder, 'test1'),
+                os.path.join(test_folder, 'test2')]
+
+extra_dirs = [os.path.join(test_folder, 'test3'),
+              os.path.join(test_folder, 'test4')]
+# Add all paths to the monitoring
+dir_str = ','.join(created_dirs + extra_dirs)
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf_max_fd.yaml')
+
+# Configurations
+
+conf_params = {'TEST_DIRECTORIES': dir_str}
+parameters, metadata = generate_params(extra_params=conf_params, modes=['realtime'])
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+def extra_configuration_before_yield():
+    for dir in created_dirs:
+        if not os.path.exists(dir):
+            os.mkdir(dir)
+    change_internal_options(param='syscheck.max_fd_win_rt', value=fd_rt_value)
+
+
+def extra_configuration_after_yield():
+    change_internal_options(param='syscheck.max_fd_win_rt', value=256)
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+@pytest.mark.parametrize('tags_to_apply', [{'test_max_fd_rt'}])
+def test_max_fd_win_rt(tags_to_apply, get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+    """Check the correct behavior of the max_fd_win_rt internal option. Then test sets this option to two.
+       The test will remove 2 monitored folders, then it will create those folders and check that events are
+       triggered. After that, it will remove these folders.  Finally will create other 2 folders and will check that
+       events are triggered.
+       Args:
+            tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
+            get_configuration (fixture): Gets the current configuration of the test.
+            configure_environment (fixture): Configure the environment for the execution of the test.
+            restart_syscheckd (fixture): Restarts syscheck.
+            wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
+       Raises:
+            TimeoutError: If an expected event couldn't be captured.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    for dir in created_dirs:
+        shutil.rmtree(dir)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_delete_watch,
+                                error_message='Did not receive expected "Deleted realtime watch ..." event')
+
+        os.mkdir(dir)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_realtime_added_directory,
+                                error_message='Did not receive expected "Directory added for realtime ..." event')
+
+        regular_file_cud(dir, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, time_travel=False)
+        shutil.rmtree(dir)
+
+    for dir in extra_dirs:
+        os.mkdir(dir)
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_realtime_added_directory,
+                                error_message='Did not receive expected "Directory added for realtime ..." event')
+        regular_file_cud(dir, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, time_travel=False)


### PR DESCRIPTION
|Related issue|
|---|
|#1386|

## Description
This PR aims to add a new integration test that checks the correct behavior of the option `max_fd_win_rt`
Closes #1386 

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in wazuh-qa/docs.
- [X] `provision_documentation.sh` generate the docs without errors.