### PR TITLE
Fix MITRE tests for 4.2

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/mitre_event.json
+++ b/deps/wazuh_testing/wazuh_testing/data/mitre_event.json
@@ -73,7 +73,9 @@
           "type": "object",
           "title": "The Mitre Schema",
           "required": [
-            "id"
+            "id",
+            "tactic",
+            "technique"
           ],
           "properties": {
             "id": {

--- a/docs/tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.md
+++ b/docs/tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.md
@@ -1,3 +1,30 @@
+# Test MITRE check alert
+
+## Overview 
+
+Check if `wazuh-analysisd` generates alerts enriching its fields with MITRE information.   
+
+## Objective
+
+The objective consists on checking if `wazuh-analysisd` can generate alerts using custom rules 
+that contains the `mitre` field to enrich those alerts with MITREs IDs, techniques and tactics.
+
+This test will check if the alert is syntactically and semantically correct. Otherwise, the 
+test will raise an exception.  
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 15 | 42.4s |
+
+## Expected behavior
+
+- Fail if `wazuh-analysisd` doesn't generate the expected alert.
+- Fail if `wazuh-analysisd` generates an alert with syntactic or semantic errors.
+- Fail if `wazuh-analysisd` generates a correctly formatted alert for those 
+  cases with invalid configurations.
+
 ## Code documentation
 
 ::: tests.integration.test_analysisd.test_mitre.test_mitre_check_alert

--- a/docs/tests/integration/test_authd/test_remote_enrollment.md
+++ b/docs/tests/integration/test_authd/test_remote_enrollment.md
@@ -32,5 +32,4 @@ It is executed for stand alone manager and also for cluster manager and worker[2
 
 ## Code documentation
 
-
-::: tests.integration.test_authd.test_remote_enrollment -->
+::: tests.integration.test_authd.test_remote_enrollment

--- a/tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.py
+++ b/tests/integration/test_analysisd/test_mitre/test_mitre_check_alert.py
@@ -25,8 +25,8 @@ configurations = []
 for i in range(1, 15):
     file_test = os.path.join(_data_path, f"test{i}.xml")
     configurations.append(file_test)
-    if i in range(5,9):
-        invalid_configurations.append(os.path.join(_data_path, f"test{i}.xml"))
+    if i in range(5, 9):
+        invalid_configurations.append(file_test)
 
 
 # fixtures


### PR DESCRIPTION
|Related issue|
|---|
|#1388|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #1388 by improving the checks done in the alerts generated by Wazuh. Now the test checks if the configuration generates alerts correctly and if the configuration is syntactically and semantically correct. The rules should generate **always** an alert with MITRE's id, technique, and tactic.

Also the PR adds the docs for this test.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs example
![image](https://user-images.githubusercontent.com/9081114/120204613-4f035c00-c229-11eb-92e4-003a76a100b7.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.