### PR TITLE
Fix API simulator getting a 401 status code after getting a new token

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
@@ -130,6 +130,7 @@ class APISimulator:
             self.logger.warning('API token expired')
             self.get_token()
             try:
+                headers = {'Authorization': f'Bearer {self.token}'}
                 response = getattr(requests, request['method'])(endpoint, headers=headers, params=request['parameters'],
                                                                 data=request['body'], verify=False)
                 if result:


### PR DESCRIPTION
|Related issue|
|---|
| #1320 |

Hi team,

This PR closes #1320.

I have replicated this error in a local docker environmnet.
I have set "`auth_token_exp_timeout"` to 30 to test this.

`root@wazuh-test-master:/wazuh-qa/deps/wazuh_testing/wazuh_testing/scripts# python3 simulate_api_load.py -t 180 -l ./api.log -c ../data/api_simulator_config.yaml -kt ../data/api_kibana_template.yaml -et ../data/api_extra_load_template.yaml`

**`api.log` content:**

```
2021/06/01 06:39:41 INFO: [Kibana] API request /cluster/status | 200
2021/06/01 06:39:50 WARNING: [Kibana] API token expired
2021/06/01 06:39:50 INFO: [Kibana] Trying to obtain API token
2021/06/01 06:39:50 INFO: [Kibana] API request /agents | 401
2021/06/01 06:39:58 INFO: [Kibana] API request /manager/info | 200
2021/06/01 06:40:07 INFO: [Kibana] API request /security/users/me/policies | 200
2021/06/01 06:40:16 INFO: [Kibana] API request /agents/summary/status | 200
2021/06/01 06:40:24 WARNING: [Kibana] API token expired
2021/06/01 06:40:24 INFO: [Kibana] Trying to obtain API token
2021/06/01 06:40:24 INFO: [Kibana] API request /manager/stats/remoted | 401
2021/06/01 06:40:33 INFO: [Kibana] API request /manager/stats/analysisd | 200
```


The problem is we are repeating the API request with the old headers, which means we still have the old token in the first API request after getting a new token.

**`api.log` content after the changes:**

```
...
2021/06/01 07:10:46 INFO: [Kibana] API request /agents | 200
2021/06/01 07:10:54 WARNING: [Kibana] API token expired
2021/06/01 07:10:54 INFO: [Kibana] Trying to obtain API token
2021/06/01 07:10:54 INFO: [Kibana] API request /manager/info | 200
2021/06/01 07:11:03 INFO: [Kibana] API request /security/users/me/policies | 200
2021/06/01 07:11:11 INFO: [Kibana] API request /agents/summary/status | 200
2021/06/01 07:11:20 INFO: [Kibana] API request /manager/stats/remoted | 200
2021/06/01 07:11:29 WARNING: [Kibana] API token expired
2021/06/01 07:11:29 INFO: [Kibana] Trying to obtain API token
2021/06/01 07:11:29 INFO: [Kibana] API request /manager/stats/analysisd | 200
2021/06/01 07:11:37 INFO: [Kibana] Attempting to finish process
2021/06/01 07:11:37 INFO: [Kibana] Process finished
```

Regards,
Manuel.