### PR TITLE
Replace problematic import for null context on authd IT

### DIFF
--- a/tests/integration/test_authd/test_remote_enrollment.py
+++ b/tests/integration/test_authd/test_remote_enrollment.py
@@ -4,13 +4,13 @@
 
 import os
 import pytest
-from contextlib import nullcontext as does_not_raise
 
 from wazuh_testing.tools import monitoring, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import SocketController, FileMonitor
 from wazuh_testing.tools.sockets import wait_for_tcp_port
 from wazuh_testing.tools.wazuh import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
+from contextlib import contextmanager
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
@@ -59,6 +59,14 @@ def get_configuration(request):
     yield request.param
 
 
+@contextmanager
+def not_raises(exception):
+    try:
+        yield
+    except exception:
+        raise pytest.fail("DID RAISE {0}".format(exception))
+
+
 def test_remote_enrollment(get_configuration, configure_environment, restart_authd):
     """Check that Authd remote enrollment is enabled/disabled according to the configuration.
 
@@ -71,7 +79,7 @@ def test_remote_enrollment(get_configuration, configure_environment, restart_aut
         assertRaises: if the expected OSSEC K message doesn't appear in authd response when remote connection
                       are enabled.
     """
-    expectation = does_not_raise()
+    expectation = not_raises(ConnectionRefusedError)
     expected_answer = 'OSSEC K:'
 
     test_metadata = get_configuration['metadata']


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1398|
## ERROR

```
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-centos-7.4.1708-Core', 'Packages': {'pytest': '6.2.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadat
a': '1.8.0', 'testinfra': '5.0.0', 'html': '3.1.1'}}
rootdir: /tmp/Test_integration_B4707_20210601085110/tests/integration, configfile: pytest.ini
plugins: metadata-1.8.0, testinfra-5.0.0, html-3.1.1
collecting ... collected 93 items / 1 error / 92 selected

==================================== ERRORS ====================================
____________ ERROR collecting test_authd/test_remote_enrollment.py _____________
ImportError while importing test module '/tmp/Test_integration_B4707_20210601085110/tests/integration/test_authd/test_remote_enrollment.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test_authd/test_remote_enrollment.py:7: in <module>
    from contextlib import nullcontext as does_not_raise
E   ImportError: cannot import name 'nullcontext'
- generated html file: file:///tmp/Test_integration_B4707_20210601085110/report.html -
=========================== short test summary info ============================
ERROR test_authd/test_remote_enrollment.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```
Example: https://github.com/wazuh/wazuh/runs/2716502657

The problem is that `from contextlib import nullcontext` fails because nullcontext is available from Python3.7 and above and the test is being run with python 3.6.8. [1]

Example of possible alternative [2].

```
from contextlib import contextmanager

@contextmanager
def not_raises(exception):
  try:
    yield
  except exception:
    raise pytest.fail("DID RAISE {0}".format(exception))
```


## References
- Stackoverflow answer about null context on python https://stackoverflow.com/questions/45187286/how-do-i-write-a-null-no-op-contextmanager-in-python
- Stackoverflow implementation of not raises context for any python version https://stackoverflow.com/questions/20274987/how-to-use-pytest-to-check-that-error-is-not-raised## ERROR


## Test

Failing build with master/4.2 branch: https://ci.wazuh.info/job/Test_integration/4707/
Replay with the fix: https://ci.wazuh.info/job/Test_integration/4711/console