### PR TITLE
Fix Vulnerability Detector IT

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -16,6 +16,7 @@ from wazuh_testing.tools import file
 from wazuh_testing.tools.services import control_service, check_if_process_is_running
 
 VULN_DETECTOR_GLOBAL_TIMEOUT = 20
+VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT = 60
 VULN_DETECTOR_SCAN_TIMEOUT = 40
 DEBIAN_IMPORT_FEED_TIMEOUT = 50
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -61,7 +61,7 @@ redhat_custom_files = custom_files + [custom_redhat_oval_feed_path + f"{extensio
                                       for extension in custom_correctly_extensions]
 redhat_configurations = [{'REDHAT_ENABLED': 'yes', 'REDHAT_CUSTOM_OVAL_FEED': custom_file,
                           'REDHAT_CUSTOM_JSON_FEED': custom_redhat_json_feed_path + '$', 'CANONICAL_ENABLED': 'no',
-                          'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                          'ARCH_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                          for custom_file in redhat_custom_files]
 redhat_metadata = [{'feed': 'redhat', 'custom_feed': custom_file, 'log_system_name': 'Red Hat Enterprise Linux 8',
                     'expected_num_vulnerabilities': vd.REDHAT_NUM_CUSTOM_VULNERABILITIES}
@@ -73,7 +73,7 @@ json_redhat_custom_files = custom_files + [custom_redhat_json_feed_path + f"{ext
                                            for extension in custom_correctly_extensions]
 json_redhat_configurations = [{'REDHAT_ENABLED': 'yes', 'REDHAT_CUSTOM_OVAL_FEED': custom_redhat_oval_feed_path,
                                'REDHAT_CUSTOM_JSON_FEED': custom_file, 'CANONICAL_ENABLED': 'no',
-                               'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                               'ARCH_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                               for custom_file in json_redhat_custom_files]
 json_redhat_metadata = [
     {'feed': 'redhat', 'custom_feed': custom_file, 'log_system_name': 'JSON Red Hat Enterprise Linux',
@@ -85,7 +85,7 @@ json_redhat_ids = [f"JSON_RedHat_{custom_file}" for custom_file in json_redhat_c
 canonical_custom_files = custom_files + [custom_canonical_oval_feed_path + f"{extension}"
                                          for extension in custom_correctly_extensions]
 canonical_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'yes',
-                             'CANONICAL_CUSTOM_FEED': custom_file, 'DEBIAN_ENABLED': 'no',
+                             'CANONICAL_CUSTOM_FEED': custom_file, 'DEBIAN_ENABLED': 'no', 'ARCH_ENABLED': 'no',
                              'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'} for custom_file in canonical_custom_files]
 canonical_metadata = [{'feed': 'canonical', 'custom_feed': custom_file, 'log_system_name': 'Ubuntu Bionic',
                        'expected_num_vulnerabilities': vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES}
@@ -97,7 +97,7 @@ debian_custom_files = custom_files + [custom_debian_oval_feed_path + f"{extensio
                                       for extension in custom_correctly_extensions]
 debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
                           'DEBIAN_CUSTOM_FEED': custom_file, 'DEBIAN_CUSTOM_JSON_FEED': custom_debian_json_feed_path,
-                          'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                          'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                          for custom_file in debian_custom_files]
 debian_metadata = [{'feed': 'debian', 'custom_feed': custom_file, 'log_system_name': 'Debian Buster',
                     'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
@@ -106,7 +106,7 @@ debian_ids = [f"Debian_{custom_file}" for custom_file in debian_custom_files]
 
 # JSON Debian configurations
 json_debian_custom_files = custom_files + [custom_debian_json_feed_path]
-json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
+json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes', 'ARCH_ENABLED': 'no',
                                'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
                                'DEBIAN_CUSTOM_JSON_FEED': custom_file, 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                               for custom_file in json_debian_custom_files]
@@ -119,7 +119,7 @@ json_debian_ids = [f"JSON_Debian_{custom_file}" for custom_file in json_debian_c
 msu_custom_files = custom_files + [custom_msu_json_feed_path + f"{extension}" + "$"
                                    for extension in custom_correctly_extensions]
 msu_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no',
-                       'MSU_ENABLED': 'yes', 'MSU_CUSTOM_FEED': custom_file, 'NVD_ENABLED': 'no'}
+                       'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'yes', 'MSU_CUSTOM_FEED': custom_file, 'NVD_ENABLED': 'no'}
                       for custom_file in msu_custom_files]
 msu_metadata = [{'feed': 'msu', 'custom_feed': custom_file, 'log_system_name': 'Microsoft Security Update',
                  'expected_num_vulnerabilities': 0}
@@ -129,7 +129,7 @@ msu_ids = [f"MSU_{custom_file}" for custom_file in msu_custom_files]
 # NVD configurations
 nvd_custom_files = custom_files + [custom_nvd_json_path + f"{extension}" for extension in custom_correctly_extensions]
 nvd_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no',
-                       'NVD_ENABLED': 'yes', 'NVD_CUSTOM_FEED': custom_file} for custom_file in nvd_custom_files]
+                       'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'yes', 'NVD_CUSTOM_FEED': custom_file} for custom_file in nvd_custom_files]
 nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_file, 'log_system_name': 'National Vulnerability Database',
                  'expected_num_vulnerabilities': vd.NVD_NUM_CUSTOM_VULNERABILITIES}
                 for custom_file in nvd_custom_files]

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -48,7 +48,7 @@ redhat_custom_urls = custom_urls + [custom_redhat_oval_feed_url + f"{extension}"
                                     for extension in custom_correctly_extensions]
 redhat_configurations = [{'REDHAT_ENABLED': 'yes', 'REDHAT_URL_FEED': custom_url,
                           'REDHAT_JSON_FEED': custom_redhat_json_feed_url, 'CANONICAL_ENABLED': 'no',
-                          'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                          'DEBIAN_ENABLED': 'no', 'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                          for custom_url in redhat_custom_urls]
 redhat_metadata = [{'feed': 'redhat', 'custom_feed': custom_url, 'log_system_name': 'Red Hat Enterprise Linux 8',
                     'expected_num_vulnerabilities': vd.REDHAT_NUM_CUSTOM_VULNERABILITIES}
@@ -60,7 +60,7 @@ json_redhat_custom_urls = custom_urls + [custom_redhat_json_feed_url + f"{extens
                                          for extension in custom_correctly_extensions]
 json_redhat_configurations = [{'REDHAT_ENABLED': 'yes', 'REDHAT_URL_FEED': custom_redhat_oval_feed_url,
                                'REDHAT_JSON_FEED': custom_url, 'CANONICAL_ENABLED': 'no',
-                               'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                               'ARCH_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                               for custom_url in json_redhat_custom_urls]
 json_redhat_metadata = [
     {'feed': 'redhat', 'custom_feed': custom_url, 'log_system_name': 'JSON Red Hat Enterprise Linux',
@@ -73,7 +73,7 @@ canonical_custom_urls = custom_urls + [custom_canonical_oval_feed_url + f"{exten
                                        for extension in custom_correctly_extensions]
 canonical_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'yes',
                              'CANONICAL_URL_FEED': custom_url, 'DEBIAN_ENABLED': 'no',
-                             'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'} for custom_url in canonical_custom_urls]
+                             'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'} for custom_url in canonical_custom_urls]
 canonical_metadata = [{'feed': 'canonical', 'custom_feed': custom_url, 'log_system_name': 'Ubuntu Bionic',
                        'expected_num_vulnerabilities': vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES}
                       for custom_url in canonical_custom_urls]
@@ -84,7 +84,7 @@ debian_custom_urls = custom_urls + [custom_debian_oval_feed_url + f"{extension}"
                                     for extension in custom_correctly_extensions]
 debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
                           'DEBIAN_URL_FEED': custom_url, 'DEBIAN_JSON_FEED': custom_debian_json_feed_url,
-                          'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                          'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                          for custom_url in debian_custom_urls]
 debian_metadata = [{'feed': 'debian', 'custom_feed': custom_url, 'log_system_name': 'Debian Buster',
                     'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
@@ -95,7 +95,7 @@ debian_ids = [f"Debian_{custom_url}" for custom_url in debian_custom_urls]
 json_debian_custom_urls = custom_urls + [custom_debian_json_feed_url]
 json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
                                'DEBIAN_URL_FEED': custom_debian_oval_feed_url, 'DEBIAN_JSON_FEED': custom_url,
-                               'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                               'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                               for custom_url in json_debian_custom_urls]
 json_debian_metadata = [{'feed': 'json debian', 'custom_feed': custom_url, 'log_system_name': 'Debian Buster',
                          'expected_num_vulnerabilities': vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES}
@@ -106,7 +106,7 @@ json_debian_ids = [f"JSON_Debian_{custom_url}" for custom_url in json_debian_cus
 msu_custom_urls = custom_urls + [custom_msu_json_feed_url + f"{extension}"
                                  for extension in custom_correctly_extensions]
 msu_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no',
-                       'MSU_URL_FEED': custom_file, 'MSU_ENABLED': 'yes', 'NVD_ENABLED': 'no'}
+                       'ARCH_ENABLED': 'no', 'MSU_URL_FEED': custom_file, 'MSU_ENABLED': 'yes', 'NVD_ENABLED': 'no'}
                       for custom_file in msu_custom_urls]
 msu_metadata = [{'feed': 'msu', 'custom_feed': custom_file, 'log_system_name': 'Microsoft Security Update',
                  'expected_num_vulnerabilities': 0}
@@ -117,7 +117,7 @@ msu_ids = [f"MSU_{custom_file}" for custom_file in msu_custom_urls]
 nvd_custom_urls = custom_urls + [custom_nvd_json_url + f"{extension}"
                                  for extension in custom_correctly_extensions]
 nvd_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no',
-                       'NVD_ENABLED': 'yes', 'NVD_URL_FEED': custom_url} for custom_url in nvd_custom_urls]
+                       'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'yes', 'NVD_URL_FEED': custom_url} for custom_url in nvd_custom_urls]
 nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_url, 'log_system_name': 'National Vulnerability Database',
                  'expected_num_vulnerabilities': vd.NVD_NUM_CUSTOM_VULNERABILITIES}
                 for custom_url in nvd_custom_urls]

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -176,7 +176,7 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
 
         vd.clean_vuln_and_sys_programs_tables()
     else:
-        timeout = vd.VULN_DETECTOR_GLOBAL_TIMEOUT + 10
+        timeout = vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
         expected_vulnerabilities_number = 1 if log_system_name == 'JSON Red Hat Enterprise Linux' else 0
         test_skipped = 1 if get_configuration['metadata']['feed'] == 'msu' and custom_feed == '/tmp/dummy.json' else 0
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -57,8 +57,6 @@ def prepare_agent(mock_agent):
 
     yield mock_agent
 
-    vd.clean_vuln_and_sys_programs_tables(mock_agent)
-
 
 def test_ignore_time(get_configuration, configure_environment, restart_modulesd, prepare_agent,
                      custom_callback_vulnerability=vd.make_vuln_callback(callback_string_vulnerability)):

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_archlinux_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/wazuh_archlinux_inventory.yaml
@@ -26,4 +26,4 @@
         - enabled:
             value: 'yes'
         - path:
-            value:  '/tmp/wazuh-qa/tests/integration/test_vulnerability_detector/test_scan_results/data/custom_nvd_feed.json'
+            value:  NVD_JSON_PATH

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_archliux_inventory_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_archliux_inventory_archlinux_feed.py
@@ -23,7 +23,7 @@ configurations_path = os.path.join(test_data_path, 'wazuh_archlinux_inventory.ya
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'ARCH_CUSTOM_FEED': custom_arch_json_path}]
+parameters = [{'ARCH_CUSTOM_FEED': custom_arch_json_path, 'NVD_JSON_PATH': os.path.join(test_data_path, vd.CUSTOM_NVD_FEED)}]
 
 
 # read vulnerabilities


### PR DESCRIPTION
|Related issue|
|---|
|#1383|

## Description

With this PR, the following tests that failed in the master branch are fixed:

- `test_run_on_start`: In `test_general_settings_ignore_time` the agent table was cleaned both at the beginning and at the end, emptying it completely in the last iteration and causing the failure of the `test_run_on_start`. After removing the cleanup from the table at the end of the test, it no longer causes any failure in the db, and therefore the test passes.

- `test_invalid_type_url_feeds`: It has been fixed by increasing the _timeout_ and avoiding an error related to the _`ARCH_ENABLED`_ flag. More information in https://github.com/wazuh/wazuh-qa/issues/1383#issuecomment-851520754 and https://github.com/wazuh/wazuh-qa/issues/1383#issuecomment-852019121.

- `test_arch_linux_vulnerabilities_report`: The full path was found in the NVD configuration, so the test could not find this path and caused the failure. Fixed with relative path.

## Logs example

Tier 0 (includes `test_run_on_start`):
```
================= 67 passed, 1931 skipped in 835.05s (0:13:55) =================
```

Tier 1 (includes `test_invalid_type_url_feeds` and `test_arch_linux_vulnerabilities_report`):
```
============ 289 passed, 1684 skipped, 25 xfailed in 5276.81s (1:27:56) ============
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.