### PR TITLE
Fix Vulnerability Detector IT for 4.2

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -16,6 +16,7 @@ from wazuh_testing.tools import file
 from wazuh_testing.tools.services import control_service, check_if_process_is_running
 
 VULN_DETECTOR_GLOBAL_TIMEOUT = 20
+VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT = 60
 VULN_DETECTOR_SCAN_TIMEOUT = 40
 DEBIAN_IMPORT_FEED_TIMEOUT = 50
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -163,7 +163,7 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
 
         vd.clean_vuln_and_sys_programs_tables()
     else:
-        timeout = vd.VULN_DETECTOR_GLOBAL_TIMEOUT + 10
+        timeout = vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
         expected_vulnerabilities_number = 1 if log_system_name == 'JSON Red Hat Enterprise Linux' else 0
         test_skipped = 1 if get_configuration['metadata']['feed'] == 'msu' and custom_feed == '/tmp/dummy.json' else 0
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -57,8 +57,6 @@ def prepare_agent(mock_agent):
 
     yield mock_agent
 
-    vd.clean_vuln_and_sys_programs_tables(mock_agent)
-
 
 def test_ignore_time(get_configuration, configure_environment, restart_modulesd, prepare_agent,
                      custom_callback_vulnerability=vd.make_vuln_callback(callback_string_vulnerability)):


### PR DESCRIPTION
|Related issue|
|---|
|#1383|

## Description

This PR is a copy of https://github.com/wazuh/wazuh-qa/pull/1400 for branch 4.2.

Although it only modifies the `test_run_on_start` and the timeout of `test_invalid_type_url_feeds`

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.