### PR TITLE
Updating IT with the new CVE's severity and score fields for vulnerability detector module

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -22,13 +22,17 @@
                                         "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
                                         "type":"PACKAGE",
                                         "status":"VALID",
-                                        "check_pkg_existence":false}'
+                                        "check_pkg_existence":false,
+                                        "severity":"Medium",
+                                        "cvss2_score":5.0,
+                                        "cvss3_score":6.1}'
     output: ['ok {"action":"INSERT","status":"SUCCESS"}']
     stage: "agent vuln_cves insert test_package without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves'
-    output: ['ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001","reference":"03c06c4f118618400772367b1cf7e73ce0178e02","type":"PACKAGE","status":"VALID"}]']
+    output: ['ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"Medium","cvss2_score":5,"cvss3_score":6.1,"reference":"03c06c4f118618400772367b1cf7e73ce0178e02","type":"PACKAGE","status":"VALID"}]']
     stage: "agent vuln_cves checking test_package"
+    use_regex: "yes"
   -
     input: 'agent 000 vuln_cves insert {"name":"test_package",
                                         "version":"1.0",
@@ -37,8 +41,11 @@
                                         "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
                                         "type":"PACKAGE",
                                         "status":"VALID",
-                                        "check_pkg_existence":false}'
-    output: ['ok {"action":"UPDATE","status":"SUCCESS"}']
+                                        "check_pkg_existence":false,
+                                        "severity":"Medium",
+                                        "cvss2_score":5.0,
+                                        "cvss3_score":6.1}'
+    output: ['ok {"action":"UPDATE"}']
     stage: "agent vuln_cves update already inserted entry"
   -
     input: 'agent 000 sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,checksum,item_id)
@@ -62,8 +69,9 @@
     stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test package"'
-    output: ['ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]']
+    output: ['ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","cvss2_score":0,"cvss3_score":0,"reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]']
     stage: "agent vuln_cves checking test package"
+    use_regex: "yes"
   -
     input: 'agent 000 vuln_cves insert {"name":"test_package","cve":"CVE-2021-1001"}'
     output: ["err Invalid JSON data, missing required fields"]
@@ -88,13 +96,17 @@
                                         "reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa",
                                         "type":"PACKAGE",
                                         "status":"VALID",
-                                        "check_pkg_existence":false}'
+                                        "check_pkg_existence":false,
+                                        "severity":"-",
+                                        "cvss2_score":0,
+                                        "cvss3_score":0}'
     output: ['ok {"action":"INSERT","status":"SUCCESS"}']
     stage: "agent vuln_cves insert package with same CVE without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2"'
-    output: ['ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]']
+    output: ['ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"-","cvss2_score":0,"cvss3_score":0,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]']
     stage: "agent vuln_cves checking package insertion with same CVE"
+    use_regex: "yes"
   -
     input: 'agent 000 vuln_cves insert {"name":"test_package2",
                                         "version":"3.0",
@@ -103,13 +115,17 @@
                                         "reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa",
                                         "type":"PACKAGE",
                                         "status":"VALID",
-                                        "check_pkg_existence":false}'
+                                        "check_pkg_existence":false,
+                                        "severity":"High",
+                                        "cvss2_score":8.2,
+                                        "cvss3_score":9.35}'
     output: ['ok {"action":"INSERT","status":"SUCCESS"}']
     stage: "agent vuln_cves insert same package with different CVE without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2" AND cve = "CVE-2021-1002"'
-    output: ['ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1002","reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]']
+    output: ['ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","severity":"High","cvss2_score":8.2,"cvss3_score":9.35,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]']
     stage: "agent vuln_cves checking package with different CVE"
+    use_regex: "yes"
   -
     input: 'agent 000 vuln_cves update_status {"old_status":"PENDING",
                                                "new_status":"OBSOLETE"}'
@@ -157,8 +173,9 @@
     stage: 'agent vuln_cves checking remove cve'
   -
     input: 'agent 000 vuln_cves remove {"status":"PENDING"}'
-    output: ['ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]']
+    output: ['ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","cvss2_score":0,"cvss3_score":0,"reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]']
     stage: 'agent vuln_cves remove by status'
+    use_regex: "yes"
   -
     input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
     output: ['ok [{"status":"VALID"}]']

--- a/tests/integration/test_wazuh_db/data/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent_messages.yaml
@@ -11,7 +11,10 @@
                                         "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
                                         "type":"PACKAGE",
                                         "status":"VALID",
-                                        "check_pkg_existence":true}'
+                                        "check_pkg_existence":true,
+                                        "severity":null,
+                                        "cvss2_score":0,
+                                        "cvss3_score":0}'
     output: ['ok {"action":"INSERT","status":"PKG_NOT_FOUND"}']
     stage: "agent vuln_cves insert test_package when it does not exist in sys_programs"
   -
@@ -45,7 +48,7 @@
                                         "severity":"Medium",
                                         "cvss2_score":5.0,
                                         "cvss3_score":6.1}'
-    output: ['ok {"action":"UPDATE"}']
+    output: ['ok {"action":"UPDATE","status":"SUCCESS"}']
     stage: "agent vuln_cves update already inserted entry"
   -
     input: 'agent 000 sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,checksum,item_id)
@@ -64,7 +67,10 @@
                                         "reference":"777fef8cc434b597769d102361af718d29ef72c1",
                                         "type":"OS",
                                         "status":"PENDING",
-                                        "check_pkg_existence":true}'
+                                        "check_pkg_existence":true,
+                                        "severity":null,
+                                        "cvss2_score":0,
+                                        "cvss3_score":0}'
     output: ['ok {"action":"INSERT","status":"SUCCESS"}']
     stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs"
   -
@@ -188,7 +194,10 @@
                                         "reference":"777fef8cc434b597769d102361af718d29ef72c1",
                                         "type":"OS",
                                         "status":"PENDING",
-                                        "check_pkg_existence":true}'
+                                        "check_pkg_existence":true,
+                                        "severity":"Low",
+                                        "cvss2_score":3.2,
+                                        "cvss3_score":2.1}'
     output: ['ok {"action":"INSERT","status":"SUCCESS"}']
     stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs again"
   -


### PR DESCRIPTION
|Related issue|
|---|
|#1362|

## Description

This PR updates the Wazuh-DB integration tests for the `vuln_cves` table with the new fields:

- **severity**
- **cvss_score2**
- **cvss_score3**
- **detection_time**

## Tests

- [x] Proven that tests **pass** when they have to pass.
