### PR TITLE
Fix Vulnerability Detector IT - Tier 1 and 2

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
@@ -20,11 +20,12 @@ current_test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(current_test_path, '..', '..', 'data')
 configurations_path = os.path.join(test_data_path, 'configuration', 'test_feeds', vd.INVALID_ARCHLINUX_FEEDS_CONF)
 custom_archlinux_json_feed_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_ARCHLINUX_JSON_FEED)
+custom_archlinux_json_feed_config_path = os.path.join(test_data_path, 'feeds', vd.CUSTOM_ARCHLINUX_JSON_FEED+'$')
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 # Set configuration
-parameters = [{'ARCHLINUX_CUSTOM_FEED': custom_archlinux_json_feed_path}]
+parameters = [{'ARCHLINUX_CUSTOM_FEED': custom_archlinux_json_feed_config_path}]
 ids = ['ARCHLINUX_configuration']
 
 # Configuration data

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -188,7 +188,8 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
         else:
             if custom_feed != '/tmp/dummy.json':
                 vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor,
-                                   log_event=f"Couldn't get the Debian feed .*"
+                                   log_event=f"Couldn't get the Debian feed .*",
+                                   timeout=timeout
                                    )
 
         if expected_vulnerabilities_number > 0:


### PR DESCRIPTION
|Related issue|
|---|
|#1383|

## Description

With this PR, the following tests that failed in the master branch are fixed:

- `test_invalid_type_url_feeds`: After the increased timeout, these tests failures were largely avoided, but they still fail a few times. After thoroughly reviewing it, within the `check_log_event` function it did not have the timeout as a parameter, so that at the time of executing it, the timeout was assigned to the flag `VULN_DETECTOR_GLOBAL_TIMEOUT` that is 20s and there are times that it is not enough time. Now, when the timeout is added to the parameter, we use the new flag `VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT` so that it has time to detect the message and pass the test.

- `test_extra_tags_archlinux_feed`: 150 vulnerabilities were being detected instead of 50 that are those that the feed has and it was due to the fact that `custom_feed.json` was being passed to the configuration, so it detected all the feeds (`.json`, `.json.bz2` and `.json .gz`), parsing them and inserting them into the DB. It has already been fixed adding a $ to the end of the path so that the test knows when the path ends.

## Logs example

`test_invalid_type_url_feeds`:
```
================== 82 passed, 12 xfailed in 607.02s (0:10:07) ==================
================== 82 passed, 12 xfailed in 680.00s (0:11:19) ==================
================== 82 passed, 12 xfailed in 691.74s (0:11:31) ==================
================== 82 passed, 12 xfailed in 618.05s (0:10:18) ==================
================== 82 passed, 12 xfailed in 739.64s (0:12:19) ==================
================== 82 passed, 12 xfailed in 668.30s (0:11:08) ==================
================== 82 passed, 12 xfailed in 686.66s (0:11:26) ==================
```

Tier 2 (includes `test_extra_tags_archlinux_feed`):
```
==== 1593 passed, 383 skipped, 22 xfailed, 1 warning in 15414.25s (4:16:54) ====
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.