### PR TITLE
Fix check_daemon_status (tools/services.py) refactor

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -517,7 +517,7 @@ def configure_sockets_environment(request):
 
     # Stop wazuh-service and ensure all daemons are stopped
     control_service('stop')
-    check_daemon_status(running=False)
+    check_daemon_status(running_condition=False)
 
     monitored_sockets = list()
     mitm_list = list()

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_linux_yaml.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_linux_yaml.py
@@ -131,21 +131,21 @@ def generate_analysisd_yaml(n_events, modify_events):
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     control_service('stop')
-    check_daemon_status(running=False)
+    check_daemon_status(running_condition=False)
     remove_logs()
 
     control_service('start', daemon='wazuh-db', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-db')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-db')
 
     control_service('start', daemon='wazuh-analysisd', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-analysisd')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-analysisd')
 
     mitm_analysisd = ManInTheMiddle(address=analysis_path, family='AF_UNIX', connection_protocol='UDP')
     analysis_queue = mitm_analysisd.queue
     mitm_analysisd.start()
 
     control_service('start', daemon='wazuh-syscheckd', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-syscheckd')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-syscheckd')
 
     # Wait for initial scan
     detect_initial_scan(file_monitor)
@@ -187,7 +187,7 @@ def generate_analysisd_yaml(n_events, modify_events):
 def kill_daemons():
     for daemon in ['wazuh-analysisd', 'wazuh-db', 'wazuh-syscheckd']:
         control_service('stop', daemon=daemon)
-        check_daemon_status(running=False, daemon=daemon)
+        check_daemon_status(running_condition=False, target_daemon=daemon)
 
 
 def get_script_arguments():

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_windows_yaml.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_windows_yaml.py
@@ -78,22 +78,22 @@ def generate_analysisd_yaml(n_events, modify_events):
     # Restart syscheckd with the new configuration
     truncate_file(LOG_FILE_PATH)
     control_service('stop')
-    check_daemon_status(running=False)
+    check_daemon_status(running_condition=False)
 
     remove_logs()
 
     control_service('start', daemon='wazuh-db', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-db')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-db')
 
     control_service('start', daemon='wazuh-analysisd', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-analysisd')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-analysisd')
 
     mitm_analysisd = ManInTheMiddle(address=analysis_path, family='AF_UNIX', connection_protocol='UDP')
     analysis_queue = mitm_analysisd.queue
     mitm_analysisd.start()
 
     control_service('start', daemon='wazuh-remoted', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-remoted')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-remoted')
 
     analysis_monitor = QueueMonitor(analysis_queue)
 
@@ -136,7 +136,7 @@ def generate_analysisd_yaml(n_events, modify_events):
 def kill_daemons():
     for daemon in ['wazuh-remoted', 'wazuh-analysisd', 'wazuh-db']:
         control_service('stop', daemon=daemon)
-        check_daemon_status(running=False, daemon=daemon)
+        check_daemon_status(running_condition=False, target_daemon=daemon)
 
 
 def get_script_arguments():

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -350,13 +350,13 @@ def duplicate_name_agent_delete_test(server):
 def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure_environment,
                                      configure_sockets_environment, connect_to_sockets_module):
     control_service('stop', daemon='wazuh-authd')
-    check_daemon_status(running=False, daemon='wazuh-authd')
+    check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     time.sleep(1)
     clean_logs()
     clean_agents_ctx()
     time.sleep(1)
     control_service('start', daemon='wazuh-authd')
-    check_daemon_status(running=True, daemon='wazuh-authd')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-authd')
     wait_server_connection()
     time.sleep(1)
 
@@ -369,13 +369,13 @@ def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure
 def test_ossec_authd_agents_ctx_local(get_configuration, set_up_groups, configure_environment,
                                       configure_sockets_environment, connect_to_sockets_module):
     control_service('stop', daemon='wazuh-authd')
-    check_daemon_status(running=False, daemon='wazuh-authd')
+    check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     time.sleep(1)
     clean_logs()
     clean_agents_ctx()
     time.sleep(1)
     control_service('start', daemon='wazuh-authd')
-    check_daemon_status(running=True, daemon='wazuh-authd')
+    check_daemon_status(running_condition=True, target_daemon='wazuh-authd')
     wait_server_connection()
     time.sleep(1)
 

--- a/tests/integration/test_authd/test_authd_name_ip_pass.py
+++ b/tests/integration/test_authd/test_authd_name_ip_pass.py
@@ -131,7 +131,7 @@ def override_wazuh_conf(configuration, set_password):
     # Stop Wazuh
     control_service('stop', daemon='wazuh-authd')
     time.sleep(1)
-    check_daemon_status(running=False, daemon='wazuh-authd')
+    check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     truncate_file(LOG_FILE_PATH)
 
     # Configuration for testing

--- a/tests/integration/test_authd/test_authd_ssl_certs.py
+++ b/tests/integration/test_authd/test_authd_ssl_certs.py
@@ -89,7 +89,7 @@ def override_wazuh_conf(configuration):
     # Stop Wazuh
     control_service('stop', daemon='wazuh-authd')
     time.sleep(1)
-    check_daemon_status(running=False, daemon='wazuh-authd')
+    check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     truncate_file(LOG_FILE_PATH)
 
     # Configuration for testing

--- a/tests/integration/test_authd/test_authd_ssl_options.py
+++ b/tests/integration/test_authd/test_authd_ssl_options.py
@@ -82,7 +82,7 @@ def override_wazuh_conf(configuration):
     # Stop Wazuh
     control_service('stop', daemon='wazuh-authd')
     time.sleep(1)
-    check_daemon_status(running=False, daemon='wazuh-authd')
+    check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     truncate_file(LOG_FILE_PATH)
 
     # Configuration for testing

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -584,7 +584,7 @@ def test_performance(mode, file_size, eps, path_length, number_files, initial_cl
 
     # Stop Wazuh
     control_service(daemon=tested_daemon, action='stop')
-    check_daemon_status(daemon=tested_daemon, running=False)
+    check_daemon_status(target_daemon=tested_daemon, running_condition=False)
 
     # Create number_files
     path_name = create_long_path(path_length, "scan")
@@ -593,7 +593,7 @@ def test_performance(mode, file_size, eps, path_length, number_files, initial_cl
     # Start Wazuh
     truncate_file(LOG_FILE_PATH)
     control_service(daemon=tested_daemon, action='start')
-    check_daemon_status(daemon=tested_daemon, running=True)
+    check_daemon_status(target_daemon=tested_daemon, running_condition=True)
 
     # Start state collector
     state_process = Process(target=state_collector, args=(state_filename, fconfiguration, state_status,))


### PR DESCRIPTION
|Related issue|
|---|
|#1302 |
| Closes #1422|


## Description

Hi team!

This PR aims to update every use of `check_daemon_status` function (part of `tool/services.py`) with the new parameters names (`daemon` to `target_daemon` and `running` to `running_condition`). 

## Tests

- [X] ~Proven that tests **pass** when they have to pass.~
- [X] ~Proven that tests **fail** when they have to fail.~
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] ~Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.~
- [X] ~Python codebase is documented following the Google Style for Python docstrings.~
- [X] ~The test is documented in wazuh-qa/docs.~
- [X] ~`provision_documentation.sh` generate the docs without errors.~

Regards,
Nico