### PR TITLE
CVEs alerts inventory for Vulnerability Detector: baseline scan type

### DIFF
--- a/docs/tests/integration/test_vulnerability_detector/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/index.md
@@ -77,6 +77,10 @@ Vulnerability Detector generates the alerts from NVD and providers feed.
 
 #### Test scan types
 
+- **[test_baseline_scan_type](test_scan_types/test_baseline_scan_type.md#test-baseline-scan-type)**:
+Test that launches a `BASELINE` scan on a simulated agent containing a test package. It is confirmed through 
+the logs that the vulnerability for the test package is detected and no alert is generated for this vulnerability.
+
 - **[test_partial_scan_type](test_scan_types/test_partial_scan_type.md#test-partial-scan-type)**:
 Test that adds a simulated agent to the system with a test package containing a vulnerability then starts 
 a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability. 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/index.md
@@ -5,22 +5,29 @@
 The purpose of testing general settings is to check the scan types of the Vulnerability Detector module are working as
 expected. These are the general scan types:
 
+- `BASELINE`
 - `PARTIAL_SCAN`
 
 ## General info
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 0 | 1 | 0:02:40  |
+| 0 | 2 | 0:04:25  |
 
 ## Expected behavior
 
+- `BASELINE`: No alerts should be generated for vulnerabilities detected during this kind of scanning.
 - `PARTIAL_SCAN`: Alerts should be generated only for vulnerabilities detected in new packages installed during 
   this kind of scanning.
 
 ## Testing
 
 ### Generic tests
+
+- **[test_baseline_scan_type](test_baseline_scan_type.md#test-baseline-scan-type)**:
+  Test that launches a `BASELINE` scan on a simulated agent containing a test package. 
+  It is confirmed through the logs that the vulnerability for the test package is detected 
+  and no alert is generated for this vulnerability.
 
 - **[test_partial_scan_type](test_partial_scan_type.md#test-partial-scan-type)**:
   Test that adds a simulated agent to the system with a test package containing a vulnerability then starts 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
@@ -10,19 +10,19 @@ The test will check if the Vulnerability Detector module performs the `BASELINE`
 
 ## Test logic
 
-the manager is configured to use custom feeds that include a vulnerability associated with a test package. This package
+The manager is configured to use custom feeds that include a vulnerability associated with a test package. This package
 is added to the database of the simulated agent and, after enrollment of the agent, the vulnerability detector must
-launch the first scan on it, which is of BASELINE type.
+launch the first scan on it, which is of `BASELINE` type.
 
 When the scan is done, we verify the vulnerability has been detected and no alerts have been generated for such
 vulnerability in their respective logs.
 
 ## Checks
 
-- [x] The `BASELINE` scan startup, checking message in the logs file.
-- [x] The NVD vulnerability for the test package is detected during the scan, checking message in the logs file.
-- [x] Completion of baseline scan, checking message in the logs file.
-- [x] No alert is generated for the vulnerability detected during scanning, checking message in the alerts file.
+- [x] The `BASELINE` scan startup, checking messages in the logs file.
+- [x] The NVD vulnerability for the test package is detected during the scan, checking messages in the logs file.
+- [x] Completion of baseline scan, checking messages in the logs file.
+- [x] No alert is generated for the vulnerability detected during scanning, checking messages in the alerts file.
 
 ## Code documentation
 

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
@@ -1,0 +1,47 @@
+# Test baseline scan type
+
+The test will check if the Vulnerability Detector module performs the `BASELINE` scan type correctly.
+
+## General info
+
+|Tier | Number of tests | Time spent| Test file | 
+|:--:|:--:|:--:|:--:| 
+| 0 | 1 | 1m45s | test_baseline_scan_type.py |
+
+## Test logic
+
+the manager is configured to use custom feeds that include a vulnerability associated with a test package. This package
+is added to the database of the simulated agent and, after enrollment of the agent, the vulnerability detector must
+launch the first scan on it, which is of BASELINE type.
+
+When the scan is done, we verify the vulnerability has been detected and no alerts have been generated for such
+vulnerability in their respective logs.
+
+## Checks
+
+- [x] The `BASELINE` scan startup, checking `ossec.log` message.
+- [x] The NVD vulnerability for the test package is detected during the scan, checking `ossec.log` message.
+- [x] Completion of baseline scan, checking `ossec.log` message.
+- [x] No alert is generated for the vulnerability detected during scanning, checking `alerts.log` message.
+
+## Observed behavior
+
+The expected behavior is carried out.
+
+## Execution result
+
+```
+========================================= test session starts ==========================================
+platform linux -- Python 3.6.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
+rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
+plugins: metadata-1.11.0, html-3.1.1, testinfra-5.0.0
+collected 1 item                                                                                       
+
+test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py .                         [100%]
+
+==================================== 1 passed in 105.39s (0:01:45) =====================================
+```
+
+## Code documentation
+
+::: tests.integration.test_vulnerability_detector.test_scan_types.test_baseline_scan_type

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
@@ -19,28 +19,10 @@ vulnerability in their respective logs.
 
 ## Checks
 
-- [x] The `BASELINE` scan startup, checking `ossec.log` message.
-- [x] The NVD vulnerability for the test package is detected during the scan, checking `ossec.log` message.
-- [x] Completion of baseline scan, checking `ossec.log` message.
-- [x] No alert is generated for the vulnerability detected during scanning, checking `alerts.log` message.
-
-## Observed behavior
-
-The expected behavior is carried out.
-
-## Execution result
-
-```
-========================================= test session starts ==========================================
-platform linux -- Python 3.6.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
-rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
-plugins: metadata-1.11.0, html-3.1.1, testinfra-5.0.0
-collected 1 item                                                                                       
-
-test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py .                         [100%]
-
-==================================== 1 passed in 105.39s (0:01:45) =====================================
-```
+- [x] The `BASELINE` scan startup, checking message in the logs file.
+- [x] The NVD vulnerability for the test package is detected during the scan, checking message in the logs file.
+- [x] Completion of baseline scan, checking message in the logs file.
+- [x] No alert is generated for the vulnerability detected during scanning, checking message in the alerts file.
 
 ## Code documentation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
             - Test scan providers and nvd feed: tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.md
           - Tests SCAN types:
             - tests/integration/test_vulnerability_detector/test_scan_types/index.md
+            - Test baseline scan type: tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.md
             - Test partial scan type: tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.md
           - Tests Windows:
             - tests/integration/test_vulnerability_detector/test_windows/index.md

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+import time
 from datetime import datetime, timedelta
 
 import pytest
@@ -9,12 +10,10 @@ import pytest
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing import logger
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
-from wazuh_testing.tools import agent_simulator as ags
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.time import TimeMachine
 from wazuh_testing.tools.time import time_to_seconds
-from wazuh_testing.wazuh_db import query_wdb
 
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
@@ -110,6 +109,9 @@ def test_min_full_scan_interval(configure_local_internal_options, get_configurat
     min_full_scan_interval = time_to_seconds(config['min_full_scan_interval'])
     seconds_to_travel = min_full_scan_interval / 2
 
+    # Set LAST_UPDATE to the current time on NVD_METADATA of CVEs DB to simulate the feeds update.
+    vd.modify_nvd_metadata_vuldet(int(time.time()))
+
     # Detect baseline scan.
     wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_BASELINE_SCAN_TIMEOUT,
                             callback=callback_detect_baseline_scan_start,
@@ -125,6 +127,9 @@ def test_min_full_scan_interval(configure_local_internal_options, get_configurat
     TimeMachine.travel_to_future(timedelta(seconds=seconds_to_travel))
     logger.debug(f"Changing the system clock from {before} to {datetime.now()}")
 
+    # Set LAST_UPDATE to the current time on NVD_METADATA of CVEs DB to simulate the feeds update.
+    vd.modify_nvd_metadata_vuldet(int(time.time()))
+
     # Since the time set in "min_full_scan_interval" has not yet expired, the full scan should not be triggered.
     with pytest.raises(TimeoutError):
         wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
@@ -136,6 +141,9 @@ def test_min_full_scan_interval(configure_local_internal_options, get_configurat
     before = datetime.now()
     TimeMachine.travel_to_future(timedelta(seconds=seconds_to_travel))
     logger.debug(f"Changing the system clock from {before} to {datetime.now()}")
+
+    # Set LAST_UPDATE to the current time on NVD_METADATA of CVEs DB to simulate the feeds update.
+    vd.modify_nvd_metadata_vuldet(int(time.time()))
 
     wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
                             callback=callback_detect_full_scan_start,

--- a/tests/integration/test_vulnerability_detector/test_scan_types/data/wazuh_baseline_scan_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/data/wazuh_baseline_scan_type.yaml
@@ -1,0 +1,45 @@
+- tags:
+    - baseline_scan_type
+  apply_to_modules:
+    - test_baseline_scan_type
+  sections:
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: "20s"
+        - min_full_scan_interval:
+            value: '1h'
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: 'debian'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: BUSTER_FEED_PATH
+                  value: 'buster'
+              - path:
+                  value: DEBIAN_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: NVD_JSON_FEED_PATH
+              - update_interval:
+                  value: '10s'

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 import wazuh_testing.vulnerability_detector as vd
-from wazuh_testing.tools import ALERT_LOGS_PATH, LOG_FILE_PATH
+from wazuh_testing.tools import ALERT_FILE_PATH, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -24,7 +24,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
 configurations_path = os.path.join(test_data_path, 'wazuh_baseline_scan_type.yaml')
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-wazuh_alert_monitor = FileMonitor(ALERT_LOGS_PATH)
+wazuh_alert_monitor = FileMonitor(ALERT_FILE_PATH)
 
 # Offline feeds
 buster_oval_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_OVAL_FEED)
@@ -35,11 +35,7 @@ parameters = [{
     'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
     'NVD_JSON_FEED_PATH': nvd_json_feed_path
 }]
-metadata = [{
-    'BUSTER_FEED_PATH': buster_oval_feed_path,
-    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
-    'NVD_JSON_FEED_PATH': nvd_json_feed_path
-}]
+metadata = parameters
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -60,7 +56,9 @@ def get_local_internal_options():
 
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
-    """Add a dummy agent, inserts in its database (sys_programs table) a test package,
+    """Add a simulated agent to the system with basic functionality.
+
+    For this purpose, it adds a dummy agent, inserts in its database (sys_programs table) a test package,
     and configures its database to appear to be up to date (sync_info table)."""
     agent_id, sender, injector = vd.create_simulated_agent()
     vd.insert_package(agent=agent_id, name='wazuhintegrationpackage-0', vendor='WazuhIntegrationTests',
@@ -99,7 +97,7 @@ def test_baseline_scan_type(configure_local_internal_options, get_configuration,
     callback_detect_baseline_scan_start = vd.make_vuln_callback(f"A baseline scan will be run on agent '{agent_id}'")
     callback_detect_scan_end = vd.make_vuln_callback(f"Finished vulnerability assessment for agent '{agent_id}'")
     callback_detect_test_package_alert = vd.make_vuln_callback(pattern=f"CVE-000 affects wazuhintegrationpackage-0",
-                                                               prefix=vd.VULNERABILITY_DETECTOR_ALERT_PREFIX)
+                                                               prefix='.*')
 
     # Detect baseline scan.
     wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+
+import pytest
+
+import wazuh_testing.vulnerability_detector as vd
+from wazuh_testing.tools import ALERT_LOGS_PATH, LOG_FILE_PATH
+from wazuh_testing.tools import agent_simulator as ags
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.wazuh_db import query_wdb
+
+# Marks
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
+
+local_internal_options = {
+    'wazuh_modules.debug': 2,
+    'monitord.rotate_log': 0
+}
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+configurations_path = os.path.join(test_data_path, 'wazuh_baseline_scan_type.yaml')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_alert_monitor = FileMonitor(ALERT_LOGS_PATH)
+
+# Offline feeds
+buster_oval_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_OVAL_FEED)
+debian_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_JSON_FEED)
+nvd_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_NVD_FEED)
+parameters = [{
+    'BUSTER_FEED_PATH': buster_oval_feed_path,
+    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
+    'NVD_JSON_FEED_PATH': nvd_json_feed_path
+}]
+metadata = [{
+    'BUSTER_FEED_PATH': buster_oval_feed_path,
+    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
+    'NVD_JSON_FEED_PATH': nvd_json_feed_path
+}]
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# fixtures
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="function")
+def add_simulated_agent(get_configuration):
+    """Add a dummy agent, inserts in its database (sys_programs table) a test package,
+    and configures its database to appear to be up to date (sync_info table)."""
+    agent = ags.Agent(manager_address="localhost", os="debian10")
+    agent.set_module_status('syscollector', 'enabled')
+    agent.set_module_status('fim', 'disabled')
+    sender, injector = ags.connect(agent)
+    # Add the changes to the agent's database.
+    query_wdb(f"agent {agent.id} sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,"
+              f"vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,"
+              f"checksum,item_id) VALUES(0,'2021/04/07 22:00:00','deb','wazuhintegrationpackage-0','optional',"
+              f"'utils','7490','WazuhIntegrationTests',NULL,'1.0.0','amd64',NULL,NULL,'wazuhintegrationpackage-0',"
+              f"NULL,0,NULL,NULL,'e7dbc9bba5a0ee252866536225b952d3de7ea5cb',"
+              f"'777fef8cc434b597769d102361af718d29ef72c1')")
+    query_wdb(f"agent {agent.id} sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "
+              f"'syscollector-packages'")
+    yield agent.id
+    injector.stop_receive()
+    query_wdb(f"global delete-agent {agent.id}")
+
+
+def test_baseline_scan_type(configure_local_internal_options, get_configuration, configure_environment,
+                            restart_modulesd, add_simulated_agent):
+    """Check if the Vulnerability Detector module performs the baseline scan type correctly.
+
+    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
+    with a test package. This package is added to the database of the simulated agent and, after enrollment
+    of the agent, the vulnerability detector must launch the first scan on it, which is of BASELINE type.
+
+    When the scan is done, we verify the vulnerability has been detected and no alerts have been
+    generated for such vulnerability in their respective logs.
+
+    Args:
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_modulesd (fixture): Reset ossec.log and start a new monitor.
+        add_simulated_agent (fixture): Add a simulated agent to the manager for testing.
+    """
+    check_apply_test({'baseline_scan_type'}, get_configuration['tags'])
+    agent_id = add_simulated_agent
+
+    # Callbacks
+    callback_detect_baseline_scan_start = vd.make_vuln_callback(f"A baseline scan will be run on agent '{agent_id}'")
+    callback_detect_scan_end = vd.make_vuln_callback(f"Finished vulnerability assessment for agent '{agent_id}'")
+    callback_detect_test_package_alert = vd.make_vuln_callback(pattern=f"CVE-000 affects wazuhintegrationpackage-0",
+                                                               prefix=vd.VULNERABILITY_DETECTOR_ALERT_PREFIX)
+
+    # Detect baseline scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_baseline_scan_start,
+                            error_message='No baseline scan detected in log.')
+
+    # Check if the NVD vulnerability is detected.
+    vd.check_detected_vulnerabilities_number(agent=agent_id,
+                                             wazuh_log_monitor=wazuh_log_monitor,
+                                             expected_vulnerabilities_number=1,
+                                             feed_source='NVD', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
+
+    # Detect baseline scan completion.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_scan_end,
+                            error_message='No scan end detected in log.')
+
+    # Ensure the test package does not generate an alert.
+    with pytest.raises(TimeoutError):
+        wazuh_alert_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                                  callback=callback_detect_test_package_alert,
+                                  error_message='No alert detected in log.')

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
+import time
 
 import pytest
 
@@ -90,6 +91,9 @@ def test_baseline_scan_type(configure_local_internal_options, get_configuration,
     """
     check_apply_test({'baseline_scan_type'}, get_configuration['tags'])
     agent_id = add_simulated_agent
+
+    # Set LAST_UPDATE to the current time on NVD_METADATA of CVEs DB to simulate the feeds update.
+    vd.modify_nvd_metadata_vuldet(int(time.time()))
 
     # Callbacks
     callback_detect_baseline_scan_start = vd.make_vuln_callback(f"A baseline scan will be run on agent '{agent_id}'")

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -7,10 +7,8 @@ import pytest
 
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import ALERT_LOGS_PATH, LOG_FILE_PATH
-from wazuh_testing.tools import agent_simulator as ags
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.wazuh_db import query_wdb
 
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
@@ -63,22 +61,13 @@ def get_local_internal_options():
 def add_simulated_agent(get_configuration):
     """Add a dummy agent, inserts in its database (sys_programs table) a test package,
     and configures its database to appear to be up to date (sync_info table)."""
-    agent = ags.Agent(manager_address="localhost", os="debian10")
-    agent.set_module_status('syscollector', 'enabled')
-    agent.set_module_status('fim', 'disabled')
-    sender, injector = ags.connect(agent)
-    # Add the changes to the agent's database.
-    query_wdb(f"agent {agent.id} sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,"
-              f"vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,"
-              f"checksum,item_id) VALUES(0,'2021/04/07 22:00:00','deb','wazuhintegrationpackage-0','optional',"
-              f"'utils','7490','WazuhIntegrationTests',NULL,'1.0.0','amd64',NULL,NULL,'wazuhintegrationpackage-0',"
-              f"NULL,0,NULL,NULL,'e7dbc9bba5a0ee252866536225b952d3de7ea5cb',"
-              f"'777fef8cc434b597769d102361af718d29ef72c1')")
-    query_wdb(f"agent {agent.id} sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "
-              f"'syscollector-packages'")
-    yield agent.id
+    agent_id, sender, injector = vd.create_simulated_agent()
+    vd.insert_package(agent=agent_id, name='wazuhintegrationpackage-0', vendor='WazuhIntegrationTests',
+                      version='1.0.0', source='NULL')
+    vd.update_sync_info(agent=agent_id)
+    yield agent_id
     injector.stop_receive()
-    query_wdb(f"global delete-agent {agent.id}")
+    vd.delete_simulated_agent(agent_id)
 
 
 def test_baseline_scan_type(configure_local_internal_options, get_configuration, configure_environment,


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1409|


## Description

This PR adds a test to verify if the `BASELINE` scan type of vulnerability detector works correctly as part of #1261.

## Test results

### Manager
#### Tested on CentOS 8 (local)

![manager](https://user-images.githubusercontent.com/80053749/121157892-3a871b00-c84a-11eb-998a-25c6429d7d0d.png)

#### Tested on CentOS 7 (Jenkins)

![jenkins_centos7](https://user-images.githubusercontent.com/80053749/121162011-cea6b180-c84d-11eb-9ae1-8f218aacd309.png)

## Documentation

![docu](https://user-images.githubusercontent.com/80053749/121157924-41ae2900-c84a-11eb-829f-5068b0ea5b2f.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.