### PR TITLE
CVEs alerts inventory for Vulnerability Detector: partial scan type

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -89,6 +89,7 @@ def get_service():
 _data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 WAZUH_LOGS_PATH = os.path.join(WAZUH_PATH, 'logs')
 ALERT_FILE_PATH = os.path.join(WAZUH_LOGS_PATH, 'alerts', 'alerts.json')
+ALERT_LOGS_PATH = os.path.join(WAZUH_LOGS_PATH, 'alerts', 'alerts.log')
 CLUSTER_LOGS_PATH = os.path.join(WAZUH_LOGS_PATH, 'cluster.log')
 
 QUEUE_SOCKETS_PATH = os.path.join(WAZUH_PATH, 'queue', 'sockets')
@@ -97,8 +98,8 @@ QUEUE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
 CLUSTER_SOCKET_PATH = os.path.join(WAZUH_PATH, 'queue', 'cluster')
 
 
-ANALYSISD_ANALISIS_SOCKET_PATH= os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
-ANALYSISD_QUEUE_SOCKET_PATH= os.path.join(QUEUE_SOCKETS_PATH, 'queue')
+ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
+ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
 AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
@@ -111,7 +112,7 @@ MODULESD_DOWNLOAD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'download')
 MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
 MODULESD_KREQUEST_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'krequest')
 MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(CLUSTER_SOCKET_PATH, 'c-internal.sock')
-ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_ALERTS_PATH,'ar')
+ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_ALERTS_PATH, 'ar')
 
 WAZUH_SOCKETS = {
     'wazuh-agentd': [],

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -819,15 +819,19 @@ def modify_nvd_metadata_vuldet(timestamp):
 
     Args:
         timestamp (int): The new timestamp value to set.
+
+    Raises:
+        sqlite3.OperationalError: If the modification has not been possible.
     """
     query_string = f"UPDATE NVD_METADATA SET LAST_UPDATE={timestamp};"
     for _ in range(VULN_DETECTOR_GLOBAL_TIMEOUT):
         try:
             make_query(CVE_DB_PATH, [query_string])
-            return
+            break
         except sqlite3.OperationalError:
             sleep(1)
-    raise sqlite3.OperationalError
+    else:
+        raise sqlite3.OperationalError
 
 
 def check_vulnerability_scan_event(wazuh_log_monitor, package, cve):

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -15,6 +15,7 @@ from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, GLOBAL_DB_PATH, CLIEN
 from wazuh_testing.tools import file
 from wazuh_testing.tools import agent_simulator as ag
 from wazuh_testing.tools.services import control_service, check_if_process_is_running
+from wazuh_testing.tools.utils import retry
 from wazuh_testing.wazuh_db import query_wdb
 
 VULN_DETECTOR_GLOBAL_TIMEOUT = 20
@@ -813,6 +814,22 @@ def modify_metadata_vuldet_feed(feed, timestamp):
     control_service('start', daemon='wazuh-db')
 
 
+def modify_nvd_metadata_vuldet(timestamp):
+    """Function to modify the timestamp value of the nvd_metadata table.
+
+    Args:
+        timestamp (int): The new timestamp value to set.
+    """
+    query_string = f"UPDATE NVD_METADATA SET LAST_UPDATE={timestamp};"
+    for _ in range(VULN_DETECTOR_GLOBAL_TIMEOUT):
+        try:
+            make_query(CVE_DB_PATH, [query_string])
+            return
+        except sqlite3.OperationalError:
+            sleep(1)
+    raise sqlite3.OperationalError
+
+
 def check_vulnerability_scan_event(wazuh_log_monitor, package, cve):
     """Check if inserted vulnerable packages are reported by vulnerability detector.
 
@@ -928,17 +945,18 @@ def create_mocked_agent(name="centos8-agent", ip="127.0.0.1", register_ip="127.0
     return agent_id_str
 
 
-def create_simulated_agent(manager_address="localhost", os="debian10"):
+@retry(AttributeError, attempts=2, delay=2, delay_multiplier=1)
+def create_simulated_agent(manager_address="localhost", operating_system="debian10"):
     """Create a new agent using the Agent class of agent_simulator module with a minimal functionality.
 
     Args:
         manager_address (str, optional): Manager address. Defaults to "localhost".
-        os (str, optional): Operating system of the simulated agent. Defaults to "Debian 10".
+        operating_system (str, optional): Operating system of the simulated agent. Defaults to "Debian 10".
 
     Returns:
         (str, Sender, Injector): A tuple with the id, the Sender and the Injector of the simulated agent.
     """
-    agent = ag.Agent(manager_address=manager_address, os=os)
+    agent = ag.Agent(manager_address=manager_address, os=operating_system)
     agent.set_module_status('syscollector', 'enabled')
     agent.set_module_status('fim', 'disabled')
     sender, injector = ag.connect(agent)

--- a/docs/tests/integration/test_vulnerability_detector/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/index.md
@@ -19,6 +19,9 @@ Vulnerability Detector in the configuration file.
 - **[test_scan_results](test_scan_results#test-scan-results)** Tests that check if Vulnerability Detector generates
 alerts in the right cases.
 
+- **[test_scan_types](test_scan_types#test-scan-types)** Tests that check if the scan types of the 
+Vulnerability Detector are working as expected.
+
 We can specify the set of tests that we want to launch, either individually, module, package or custom. Normally,
 the tests are selected in a personalized way called **tier**.
 
@@ -72,6 +75,13 @@ Detector generates the alerts from NVD feed.
 Tests mock RedHat, Ubuntu and Debian systems, and insert custom vulnerabilities and vulnerable packages to see if
 Vulnerability Detector generates the alerts from NVD and providers feed.
 
+#### Test scan types
+
+- **[test_partial_scan_type](test_scan_types/test_partial_scan_type.md#test-partial-scan-type)**:
+Test that adds a simulated agent to the system with a test package containing a vulnerability then starts 
+a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability. 
+It then launches a `PARTIAL_SCAN` and checks that the alert has only been generated for the last package installed.
+  
 ---
 
 ### Tier 1

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/index.md
@@ -1,0 +1,29 @@
+# Overview
+
+## Objective
+
+The purpose of testing general settings is to check the scan types of the Vulnerability Detector module are working as
+expected. These are the general scan types:
+
+- `PARTIAL_SCAN`
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 1 | 0:02:40  |
+
+## Expected behavior
+
+- `PARTIAL_SCAN`: Alerts should be generated only for vulnerabilities detected in new packages installed during 
+  this kind of scanning.
+
+## Testing
+
+### Generic tests
+
+- **[test_partial_scan_type](test_partial_scan_type.md#test-partial-scan-type)**:
+  Test that adds a simulated agent to the system with a test package containing a vulnerability then starts 
+  a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability. 
+  It then launches a `PARTIAL_SCAN` and checks that the alert has only been generated for the last package installed.
+  

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.md
@@ -1,0 +1,33 @@
+# Test partial scan type
+
+The test will check if the Vulnerability Detector module performs the `PARTIAL_SCAN` type correctly.
+
+## General info
+
+|Tier | Number of tests | Time spent| Test file | 
+|:--:|:--:|:--:|:--:| 
+| 0 | 1 | 2m40s | test_partial_scan_type.py |
+
+## Test logic
+
+The manager is configured to use custom feeds that include vulnerabilities associated with the test packages. 
+The first package is added to the database of the simulated agent and, after enrollment of the agent, 
+the vulnerability detector must launch the first scan on it, which is of `BASELINE` type.
+
+When the `BASELINE` scan is done, we will insert a new test package and wait for the `PARTIAL_SCAN` to start.
+Once the `PARTIAL_SCAN` is completed, it will check that a new vulnerability has been detected and an alert
+has been generated for that vulnerability by analyzing its respective logs. It will also be checked that
+no alerts have been generated for the first package that had already been previously analyzed by
+the `BASELINE` scan.
+
+
+## Checks
+
+- [x] The `BASELINE` and `PARTIAL_SCAN` scan startup, checking messages in the logs file.
+- [x] The NVD vulnerabilities for the test packages are detected during the scans, checking messages in the logs file.
+- [x] Completion of the scans, checking messages in the logs file.
+- [x] Alert is generated only for the vulnerability detected during `PARTIAL_SCAN` scanning, checking messages in the alerts file.
+
+## Code documentation
+
+::: tests.integration.test_vulnerability_detector.test_scan_types.test_partial_scan_type

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,9 @@ nav:
             - Test scan different cves:  tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.md
             - Test scan nvd feed: tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.md
             - Test scan providers and nvd feed: tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.md
+          - Tests SCAN types:
+            - tests/integration/test_vulnerability_detector/test_scan_types/index.md
+            - Test partial scan type: tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.md
           - Tests Windows:
             - tests/integration/test_vulnerability_detector/test_windows/index.md
             - Test CPE indexing: tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.md

--- a/tests/integration/test_vulnerability_detector/data/feeds/custom_nvd_feed.json
+++ b/tests/integration/test_vulnerability_detector/data/feeds/custom_nvd_feed.json
@@ -1,439 +1,534 @@
 {
-  "CVE_data_type" : "CVE",
-  "CVE_data_format" : "MITRE",
-  "CVE_data_version" : "4.0",
-  "CVE_data_numberOfCVEs" : "1",
-  "CVE_data_timestamp" : "2020-05-21T07:00Z",
-  "CVE_Items" : [ {
-    "cve" : {
-      "data_type" : "CVE",
-      "data_format" : "MITRE",
-      "data_version" : "4.0",
-      "CVE_data_meta" : {
-        "ID" : "CVE-000",
-        "ASSIGNER" : "WAZUH"
-      },
-      "affects" : {
-        "vendor" : {
-          "vendor_data" : [ {
-            "vendor_name" : "WazuhIntegrationTests",
-            "product" : {
-              "product_data" : [ {
-                "product_name" : "wazuhintegrationpackage-0",
-                "version" : {
-                  "version_data" : [ {
-                    "version_value" : "1.0.0",
-                    "version_affected" : "="
-                  } ]
+  "CVE_data_type": "CVE",
+  "CVE_data_format": "MITRE",
+  "CVE_data_version": "4.0",
+  "CVE_data_numberOfCVEs": "1",
+  "CVE_data_timestamp": "2020-05-21T07:00Z",
+  "CVE_Items": [
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-000",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-0",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
-              } ]
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
             }
-          } ]
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
         }
       },
-      "problemtype" : {
-        "problemtype_data" : [ {
-          "description" : [ {
-            "lang" : "en",
-            "value" : "CWE-200"
-          } ]
-        } ]
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-0:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
       },
-      "references" : {
-        "reference_data" : [ {
-          "url" : "https://github.com/wazuh/wazuh-qa/",
-          "name" : "WAZUH-INTEGRATION-WVE-000",
-          "refsource" : "WAZUH",
-          "tags" : [ ]
-        }]
-      },
-      "description" : {
-        "description_data" : [ {
-          "lang" : "en",
-          "value" : "Wazuh integration test NVD vulnerability"
-        } ]
-      }
-    },
-    "configurations" : {
-      "CVE_data_version" : "4.0",
-      "nodes" : [ {
-        "operator" : "OR",
-        "cpe_match" : [ {
-          "vulnerable" : true,
-          "cpe23Uri" : "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-0:*:*:*:*:*:*:x64:*",
-          "versionEndExcluding" : "2.0.0"
-        } ]
-      } ]
-    },
-    "impact" : {
-      "baseMetricV2" : {
-        "cvssV2" : {
-          "version" : "2.0",
-          "vectorString" : "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "accessVector" : "LOCAL",
-          "accessComplexity" : "LOW",
-          "authentication" : "NONE",
-          "confidentialityImpact" : "PARTIAL",
-          "integrityImpact" : "NONE",
-          "availabilityImpact" : "NONE",
-          "baseScore" : 10
-        },
-        "severity" : "CRITICAL",
-        "exploitabilityScore" : 10,
-        "impactScore" : 10,
-        "acInsufInfo" : false,
-        "obtainAllPrivilege" : false,
-        "obtainUserPrivilege" : false,
-        "obtainOtherPrivilege" : false,
-        "userInteractionRequired" : false
-      }
-    },
-    "publishedDate" : "2019-11-19T22:15Z",
-    "lastModifiedDate" : "2020-01-21T01:15Z"
-  }, {
-    "cve" : {
-      "data_type" : "CVE",
-      "data_format" : "MITRE",
-      "data_version" : "4.0",
-      "CVE_data_meta" : {
-        "ID" : "CVE-001",
-        "ASSIGNER" : "WAZUH"
-      },
-      "affects" : {
-        "vendor" : {
-          "vendor_data" : [ {
-            "vendor_name" : "WazuhIntegrationTests",
-            "product" : {
-              "product_data" : [ {
-                "product_name" : "wazuhintegrationpackage-1",
-                "version" : {
-                  "version_data" : [ {
-                    "version_value" : "1.0.0",
-                    "version_affected" : "="
-                  } ]
-                }
-              } ]
-            }
-          } ]
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
         }
       },
-      "problemtype" : {
-        "problemtype_data" : [ {
-          "description" : [ {
-            "lang" : "en",
-            "value" : "CWE-200"
-          } ]
-        } ]
-      },
-      "references" : {
-        "reference_data" : [ {
-          "url" : "https://github.com/wazuh/wazuh-qa/",
-          "name" : "WAZUH-INTEGRATION-WVE-000",
-          "refsource" : "WAZUH",
-          "tags" : [ ]
-        }]
-      },
-      "description" : {
-        "description_data" : [ {
-          "lang" : "en",
-          "value" : "Wazuh integration test NVD vulnerability"
-        } ]
-      }
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
     },
-    "configurations" : {
-      "CVE_data_version" : "4.0",
-      "nodes" : [ {
-        "operator" : "OR",
-        "cpe_match" : [ {
-          "vulnerable" : true,
-          "cpe23Uri" : "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-1:*:*:*:*:*:*:x64:*",
-          "versionEndExcluding" : "2.0.0"
-        } ]
-      } ]
-    },
-    "impact" : {
-      "baseMetricV2" : {
-        "cvssV2" : {
-          "version" : "2.0",
-          "vectorString" : "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "accessVector" : "LOCAL",
-          "accessComplexity" : "LOW",
-          "authentication" : "NONE",
-          "confidentialityImpact" : "PARTIAL",
-          "integrityImpact" : "NONE",
-          "availabilityImpact" : "NONE",
-          "baseScore" : 10
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-001",
+          "ASSIGNER": "WAZUH"
         },
-        "severity" : "CRITICAL",
-        "exploitabilityScore" : 10,
-        "impactScore" : 10,
-        "acInsufInfo" : false,
-        "obtainAllPrivilege" : false,
-        "obtainUserPrivilege" : false,
-        "obtainOtherPrivilege" : false,
-        "userInteractionRequired" : false
-      }
-    },
-    "publishedDate" : "2019-11-19T22:15Z",
-    "lastModifiedDate" : "2020-01-21T01:15Z"
-  }, {
-    "cve" : {
-      "data_type" : "CVE",
-      "data_format" : "MITRE",
-      "data_version" : "4.0",
-      "CVE_data_meta" : {
-        "ID" : "CVE-002",
-        "ASSIGNER" : "WAZUH"
-      },
-      "affects" : {
-        "vendor" : {
-          "vendor_data" : [ {
-            "vendor_name" : "WazuhIntegrationTests",
-            "product" : {
-              "product_data" : [ {
-                "product_name" : "wazuhintegrationpackage-2",
-                "version" : {
-                  "version_data" : [ {
-                    "version_value" : "1.0.0",
-                    "version_affected" : "="
-                  } ]
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-1",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
-              } ]
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
             }
-          } ]
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
         }
       },
-      "problemtype" : {
-        "problemtype_data" : [ {
-          "description" : [ {
-            "lang" : "en",
-            "value" : "CWE-200"
-          } ]
-        } ]
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-1:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
       },
-      "references" : {
-        "reference_data" : [ {
-          "url" : "https://github.com/wazuh/wazuh-qa/",
-          "name" : "WAZUH-INTEGRATION-WVE-000",
-          "refsource" : "WAZUH",
-          "tags" : [ ]
-        }]
-      },
-      "description" : {
-        "description_data" : [ {
-          "lang" : "en",
-          "value" : "Wazuh integration test NVD vulnerability"
-        } ]
-      }
-    },
-    "configurations" : {
-      "CVE_data_version" : "4.0",
-      "nodes" : [ {
-        "operator" : "OR",
-        "cpe_match" : [ {
-          "vulnerable" : true,
-          "cpe23Uri" : "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-2:*:*:*:*:*:*:x64:*",
-          "versionEndExcluding" : "2.0.0"
-        } ]
-      } ]
-    },
-    "impact" : {
-      "baseMetricV2" : {
-        "cvssV2" : {
-          "version" : "2.0",
-          "vectorString" : "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "accessVector" : "LOCAL",
-          "accessComplexity" : "LOW",
-          "authentication" : "NONE",
-          "confidentialityImpact" : "PARTIAL",
-          "integrityImpact" : "NONE",
-          "availabilityImpact" : "NONE",
-          "baseScore" : 10
-        },
-        "severity" : "CRITICAL",
-        "exploitabilityScore" : 10,
-        "impactScore" : 10,
-        "acInsufInfo" : false,
-        "obtainAllPrivilege" : false,
-        "obtainUserPrivilege" : false,
-        "obtainOtherPrivilege" : false,
-        "userInteractionRequired" : false
-      }
-    },
-    "publishedDate" : "2019-11-19T22:15Z",
-    "lastModifiedDate" : "2020-01-21T01:15Z"
-  }, {
-    "cve" : {
-      "data_type" : "CVE",
-      "data_format" : "MITRE",
-      "data_version" : "4.0",
-      "CVE_data_meta" : {
-        "ID" : "CVE-003",
-        "ASSIGNER" : "WAZUH"
-      },
-      "affects" : {
-        "vendor" : {
-          "vendor_data" : [ {
-            "vendor_name" : "WazuhIntegrationTests",
-            "product" : {
-              "product_data" : [ {
-                "product_name" : "wazuhintegrationpackage-3",
-                "version" : {
-                  "version_data" : [ {
-                    "version_value" : "1.0.0",
-                    "version_affected" : "="
-                  } ]
-                }
-              } ]
-            }
-          } ]
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
         }
       },
-      "problemtype" : {
-        "problemtype_data" : [ {
-          "description" : [ {
-            "lang" : "en",
-            "value" : "CWE-200"
-          } ]
-        } ]
-      },
-      "references" : {
-        "reference_data" : [ {
-          "url" : "https://github.com/wazuh/wazuh-qa/",
-          "name" : "WAZUH-INTEGRATION-WVE-000",
-          "refsource" : "WAZUH",
-          "tags" : [ ]
-        }]
-      },
-      "description" : {
-        "description_data" : [ {
-          "lang" : "en",
-          "value" : "Wazuh integration test NVD vulnerability"
-        } ]
-      }
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
     },
-    "configurations" : {
-      "CVE_data_version" : "4.0",
-      "nodes" : [ {
-        "operator" : "OR",
-        "cpe_match" : [ {
-          "vulnerable" : true,
-          "cpe23Uri" : "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-3:*:*:*:*:*:*:x64:*",
-          "versionEndExcluding" : "2.0.0"
-        } ]
-      } ]
-    },
-    "impact" : {
-      "baseMetricV2" : {
-        "cvssV2" : {
-          "version" : "2.0",
-          "vectorString" : "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "accessVector" : "LOCAL",
-          "accessComplexity" : "LOW",
-          "authentication" : "NONE",
-          "confidentialityImpact" : "PARTIAL",
-          "integrityImpact" : "NONE",
-          "availabilityImpact" : "NONE",
-          "baseScore" : 10
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-002",
+          "ASSIGNER": "WAZUH"
         },
-        "severity" : "CRITICAL",
-        "exploitabilityScore" : 10,
-        "impactScore" : 10,
-        "acInsufInfo" : false,
-        "obtainAllPrivilege" : false,
-        "obtainUserPrivilege" : false,
-        "obtainOtherPrivilege" : false,
-        "userInteractionRequired" : false
-      }
-    },
-    "publishedDate" : "2019-11-19T22:15Z",
-    "lastModifiedDate" : "2020-01-21T01:15Z"
-  }, {
-    "cve" : {
-      "data_type" : "CVE",
-      "data_format" : "MITRE",
-      "data_version" : "4.0",
-      "CVE_data_meta" : {
-        "ID" : "CVE-004",
-        "ASSIGNER" : "WAZUH"
-      },
-      "affects" : {
-        "vendor" : {
-          "vendor_data" : [ {
-            "vendor_name" : "WazuhIntegrationTests",
-            "product" : {
-              "product_data" : [ {
-                "product_name" : "wazuhintegrationpackage-4",
-                "version" : {
-                  "version_data" : [ {
-                    "version_value" : "1.0.0",
-                    "version_affected" : "="
-                  } ]
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-2",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
-              } ]
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
             }
-          } ]
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
         }
       },
-      "problemtype" : {
-        "problemtype_data" : [ {
-          "description" : [ {
-            "lang" : "en",
-            "value" : "CWE-200"
-          } ]
-        } ]
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-2:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
       },
-      "references" : {
-        "reference_data" : [ {
-          "url" : "https://github.com/wazuh/wazuh-qa/",
-          "name" : "WAZUH-INTEGRATION-WVE-000",
-          "refsource" : "WAZUH",
-          "tags" : [ ]
-        }]
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
       },
-      "description" : {
-        "description_data" : [ {
-          "lang" : "en",
-          "value" : "Wazuh integration test NVD vulnerability"
-        } ]
-      }
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
     },
-    "configurations" : {
-      "CVE_data_version" : "4.0",
-      "nodes" : [ {
-        "operator" : "OR",
-        "cpe_match" : [ {
-          "vulnerable" : true,
-          "cpe23Uri" : "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-4:*:*:*:*:*:*:x64:*",
-          "versionEndExcluding" : "2.0.0"
-        } ]
-      } ]
-    },
-    "impact" : {
-      "baseMetricV2" : {
-        "cvssV2" : {
-          "version" : "2.0",
-          "vectorString" : "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "accessVector" : "LOCAL",
-          "accessComplexity" : "LOW",
-          "authentication" : "NONE",
-          "confidentialityImpact" : "PARTIAL",
-          "integrityImpact" : "NONE",
-          "availabilityImpact" : "NONE",
-          "baseScore" : 10
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-003",
+          "ASSIGNER": "WAZUH"
         },
-        "severity" : "CRITICAL",
-        "exploitabilityScore" : 10,
-        "impactScore" : 10,
-        "acInsufInfo" : false,
-        "obtainAllPrivilege" : false,
-        "obtainUserPrivilege" : false,
-        "obtainOtherPrivilege" : false,
-        "userInteractionRequired" : false
-      }
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-3",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-3:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
     },
-    "publishedDate" : "2019-11-19T22:15Z",
-    "lastModifiedDate" : "2020-01-21T01:15Z"
-  }
- ]
+    {
+      "cve": {
+        "data_type": "CVE",
+        "data_format": "MITRE",
+        "data_version": "4.0",
+        "CVE_data_meta": {
+          "ID": "CVE-004",
+          "ASSIGNER": "WAZUH"
+        },
+        "affects": {
+          "vendor": {
+            "vendor_data": [
+              {
+                "vendor_name": "WazuhIntegrationTests",
+                "product": {
+                  "product_data": [
+                    {
+                      "product_name": "wazuhintegrationpackage-4",
+                      "version": {
+                        "version_data": [
+                          {
+                            "version_value": "1.0.0",
+                            "version_affected": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "problemtype": {
+          "problemtype_data": [
+            {
+              "description": [
+                {
+                  "lang": "en",
+                  "value": "CWE-200"
+                }
+              ]
+            }
+          ]
+        },
+        "references": {
+          "reference_data": [
+            {
+              "url": "https://github.com/wazuh/wazuh-qa/",
+              "name": "WAZUH-INTEGRATION-WVE-000",
+              "refsource": "WAZUH",
+              "tags": []
+            }
+          ]
+        },
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Wazuh integration test NVD vulnerability"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "operator": "OR",
+            "cpe_match": [
+              {
+                "vulnerable": true,
+                "cpe23Uri": "cpe:2.3:a:WazuhIntegrationTests:wazuhintegrationpackage-4:*:*:*:*:*:*:x64:*",
+                "versionEndExcluding": "2.0.0"
+              }
+            ]
+          }
+        ]
+      },
+      "impact": {
+        "baseMetricV2": {
+          "cvssV2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "accessVector": "LOCAL",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 10
+          },
+          "severity": "CRITICAL",
+          "exploitabilityScore": 10,
+          "impactScore": 10,
+          "acInsufInfo": false,
+          "obtainAllPrivilege": false,
+          "obtainUserPrivilege": false,
+          "obtainOtherPrivilege": false,
+          "userInteractionRequired": false
+        }
+      },
+      "publishedDate": "2019-11-19T22:15Z",
+      "lastModifiedDate": "2020-01-21T01:15Z"
+    }
+  ]
 }

--- a/tests/integration/test_vulnerability_detector/test_scan_types/data/wazuh_partial_scan_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/data/wazuh_partial_scan_type.yaml
@@ -1,0 +1,45 @@
+- tags:
+    - partial_scan_type
+  apply_to_modules:
+    - test_partial_scan_type
+  sections:
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: "20s"
+        - min_full_scan_interval:
+            value: '1h'
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: 'debian'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: BUSTER_FEED_PATH
+                  value: 'buster'
+              - path:
+                  value: DEBIAN_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: NVD_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 import wazuh_testing.vulnerability_detector as vd
-from wazuh_testing.tools import ALERT_LOGS_PATH, LOG_FILE_PATH
+from wazuh_testing.tools import ALERT_FILE_PATH, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -24,7 +24,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
 configurations_path = os.path.join(test_data_path, 'wazuh_partial_scan_type.yaml')
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-wazuh_alert_monitor = FileMonitor(ALERT_LOGS_PATH)
+wazuh_alert_monitor = FileMonitor(ALERT_FILE_PATH)
 test_packet_vendor = 'WazuhIntegrationTests'
 test_packet_version = '1.0.0'
 test_packet_0_name = 'wazuhintegrationpackage-0'
@@ -41,11 +41,7 @@ parameters = [{
     'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
     'NVD_JSON_FEED_PATH': nvd_json_feed_path
 }]
-metadata = [{
-    'BUSTER_FEED_PATH': buster_oval_feed_path,
-    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
-    'NVD_JSON_FEED_PATH': nvd_json_feed_path
-}]
+metadata = parameters
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -66,7 +62,9 @@ def get_local_internal_options():
 
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
-    """Add a dummy agent, inserts in its database (sys_programs table) a test package,
+    """Add a simulated agent to the system with basic functionality.
+
+    For this purpose, it adds a dummy agent, inserts in its database (sys_programs table) a test package,
     and configures its database to appear to be up to date (sync_info table)."""
     agent_id, sender, injector = vd.create_simulated_agent()
     vd.insert_package(agent=agent_id, name=test_packet_0_name, vendor=test_packet_vendor,
@@ -113,9 +111,9 @@ def test_partial_scan_type(configure_local_internal_options, get_configuration, 
     callback_detect_test_package_1_vuln = vd.make_vuln_callback(
         pattern=f"Package '{test_packet_1_name}' inserted into the vulnerability '{test_packet_1_cve}'.")
     callback_detect_test_package_0_alert = vd.make_vuln_callback(
-        pattern=f"{test_packet_0_cve} affects {test_packet_0_name}", prefix=vd.VULNERABILITY_DETECTOR_ALERT_PREFIX)
+        pattern=f"{test_packet_0_cve} affects {test_packet_0_name}", prefix='.*')
     callback_detect_test_package_1_alert = vd.make_vuln_callback(
-        pattern=f"{test_packet_1_cve} affects {test_packet_1_name}", prefix=vd.VULNERABILITY_DETECTOR_ALERT_PREFIX)
+        pattern=f"{test_packet_1_cve} affects {test_packet_1_name}", prefix='.*')
 
     # Detect the baseline scan.
     wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -1,0 +1,170 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+import time
+
+import pytest
+
+import wazuh_testing.vulnerability_detector as vd
+from wazuh_testing.tools import ALERT_LOGS_PATH, LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
+
+local_internal_options = {
+    'wazuh_modules.debug': 2,
+    'monitord.rotate_log': 0
+}
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+configurations_path = os.path.join(test_data_path, 'wazuh_partial_scan_type.yaml')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_alert_monitor = FileMonitor(ALERT_LOGS_PATH)
+test_packet_vendor = 'WazuhIntegrationTests'
+test_packet_version = '1.0.0'
+test_packet_0_name = 'wazuhintegrationpackage-0'
+test_packet_1_name = 'wazuhintegrationpackage-1'
+test_packet_0_cve = 'CVE-000'
+test_packet_1_cve = 'CVE-001'
+
+# Offline feeds
+buster_oval_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_OVAL_FEED)
+debian_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_JSON_FEED)
+nvd_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_NVD_FEED)
+parameters = [{
+    'BUSTER_FEED_PATH': buster_oval_feed_path,
+    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
+    'NVD_JSON_FEED_PATH': nvd_json_feed_path
+}]
+metadata = [{
+    'BUSTER_FEED_PATH': buster_oval_feed_path,
+    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
+    'NVD_JSON_FEED_PATH': nvd_json_feed_path
+}]
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# fixtures
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="function")
+def add_simulated_agent(get_configuration):
+    """Add a dummy agent, inserts in its database (sys_programs table) a test package,
+    and configures its database to appear to be up to date (sync_info table)."""
+    agent_id, sender, injector = vd.create_simulated_agent()
+    vd.insert_package(agent=agent_id, name=test_packet_0_name, vendor=test_packet_vendor,
+                      version=test_packet_version, source='NULL')
+    vd.update_sync_info(agent=agent_id)
+    yield agent_id
+    injector.stop_receive()
+    vd.delete_simulated_agent(agent_id)
+
+
+def test_partial_scan_type(configure_local_internal_options, get_configuration, configure_environment,
+                           restart_modulesd, add_simulated_agent):
+    """Check if the Vulnerability Detector module performs the partial scan type correctly.
+
+    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
+    with a test package. This package is added to the database of the simulated agent and, after enrollment
+    of the agent, the vulnerability detector must launch the first scan on it, which is of BASELINE type.
+
+    When the BASELINE scan is done, we will insert a new test package and wait for the partial scan to start.
+    Once the PARTIAL scan is completed, it will check that a new vulnerability has been detected and an alert
+    has been generated for that vulnerability by analyzing its respective logs. It will also be checked that
+    no alerts have been generated for the first package that had already been previously analyzed by
+    the BASELINE scan.
+
+    Args:
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_modulesd (fixture): Reset ossec.log and start a new monitor.
+        add_simulated_agent (fixture): Add a simulated agent to the manager for testing.
+    """
+    check_apply_test({'partial_scan_type'}, get_configuration['tags'])
+    agent_id = add_simulated_agent
+
+    # Set LAST_UPDATE to the current time on NVD_METADATA of CVEs DB to simulate the feeds update.
+    vd.modify_nvd_metadata_vuldet(int(time.time()))
+
+    # Callbacks
+    callback_detect_baseline_scan_start = vd.make_vuln_callback(f"A baseline scan will be run on agent '{agent_id}'")
+    callback_detect_partial_scan_start = vd.make_vuln_callback(f"A partial scan will be run on agent '{agent_id}'")
+    callback_detect_scan_end = vd.make_vuln_callback(f"Finished vulnerability assessment for agent '{agent_id}'")
+    callback_detect_test_package_0_vuln = vd.make_vuln_callback(
+        pattern=f"Package '{test_packet_0_name}' inserted into the vulnerability '{test_packet_0_cve}'.")
+    callback_detect_test_package_1_vuln = vd.make_vuln_callback(
+        pattern=f"Package '{test_packet_1_name}' inserted into the vulnerability '{test_packet_1_cve}'.")
+    callback_detect_test_package_0_alert = vd.make_vuln_callback(
+        pattern=f"{test_packet_0_cve} affects {test_packet_0_name}", prefix=vd.VULNERABILITY_DETECTOR_ALERT_PREFIX)
+    callback_detect_test_package_1_alert = vd.make_vuln_callback(
+        pattern=f"{test_packet_1_cve} affects {test_packet_1_name}", prefix=vd.VULNERABILITY_DETECTOR_ALERT_PREFIX)
+
+    # Detect the baseline scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_baseline_scan_start,
+                            error_message='No baseline scan start has been detected in the log.')
+
+    # Check if the NVD vulnerability is detected.
+    vd.check_detected_vulnerabilities_number(agent=agent_id,
+                                             wazuh_log_monitor=wazuh_log_monitor,
+                                             expected_vulnerabilities_number=1,
+                                             feed_source='NVD', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
+
+    # Detect baseline scan completion.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_scan_end,
+                            error_message='No baseline scan end has been detected in the log.')
+
+    # Insert the test package 1.
+    vd.insert_package(agent=agent_id, name=test_packet_1_name, vendor=test_packet_vendor,
+                      version=test_packet_version, source='NULL')
+
+    # Detect a partial scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_partial_scan_start,
+                            error_message='No partial scan start has been detected in the log.')
+
+    # Ensure that the vulnerability of package 0 is NOT detected in the partial scan.
+    with pytest.raises(TimeoutError):
+        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT, update_position=False,
+                                callback=callback_detect_test_package_0_vuln,
+                                error_message='No vulnerability for test package 0 was detected in the log.')
+
+    # Ensure that the vulnerability of package 1 is detected in the partial scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_test_package_1_vuln,
+                            error_message='No vulnerability for test package 1 was detected in the log.')
+
+    # Detect a partial scan completion.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_scan_end,
+                            error_message='No partial scan end has been detected in the log.')
+
+    # Ensure the test package 0 does NOT generate an alert.
+    with pytest.raises(TimeoutError):
+        wazuh_alert_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT, update_position=False,
+                                  callback=callback_detect_test_package_0_alert,
+                                  error_message='No alert for test package 0 has been detected in the log.')
+
+    # Ensure the test package 1 does generate an alert.
+    wazuh_alert_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                              callback=callback_detect_test_package_1_alert,
+                              error_message='No alert for test package 1 has been detected in the log.')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1425|


## Description

This PR adds a test to verify if the `PARTIAL_SCAN` type of vulnerability detector works correctly as part of #1261.

## Test results

### Manager
#### Tested on CentOS 8 (local)

![manager](https://user-images.githubusercontent.com/80053749/121217138-d718df80-c881-11eb-94fb-4497afcb8243.png)

#### Tested on CentOS 7 (Jenkins)

![jenkins_centos7](https://user-images.githubusercontent.com/80053749/121217981-9ff6fe00-c882-11eb-8704-b506eea27c9d.png)

## Documentation

![docu](https://user-images.githubusercontent.com/80053749/121217242-f152bd80-c881-11eb-9871-3be4eaaab232.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.