### PR TITLE
Add new integration test for the API timeout setting

### DIFF
--- a/docs/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.md
+++ b/docs/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.md
@@ -1,0 +1,3 @@
+## Code documentation
+
+::: tests.integration.test_api.test_config.test_request_timeout.test_request_timeout

--- a/docs/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.md
+++ b/docs/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.md
@@ -1,3 +1,23 @@
+# Test intervals:request_timeout API's option
+
+## Overview 
+
+Check that the `request_timeout` option of the API does not cause any bug in the API itself and ensures its functionality.
+
+## Objective
+
+Check the correct functionality of the `request_timeout` option.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 1 | 17.51s |
+
+## Expected behavior
+
+- Fail if a timeout error is not returned.
+
 ## Code documentation
 
 ::: tests.integration.test_api.test_config.test_request_timeout.test_request_timeout

--- a/tests/integration/test_api/test_config/test_request_timeout/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_request_timeout/data/conf.yaml
@@ -1,0 +1,6 @@
+---
+- tags:
+  - config1
+  configuration:
+    intervals:
+      request_timeout: 0

--- a/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
+++ b/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+from json import loads
+
+import pytest
+import requests
+
+from wazuh_testing.api import API_PROTOCOL, API_HOST, API_PORT, API_LOGIN_ENDPOINT, \
+    API_USER, API_PASS, get_login_headers
+from wazuh_testing.tools.configuration import check_apply_test, get_api_conf
+
+# Marks
+
+pytestmark = pytest.mark.server
+
+# Configurations
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'conf.yaml')
+configuration = get_api_conf(configurations_path)
+
+
+# Fixtures
+
+@pytest.fixture(scope='module', params=configuration)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# Tests
+
+@pytest.mark.parametrize('tags_to_apply', [
+    {'config1'},
+])
+def test_request_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
+                         wait_for_start, get_api_details):
+    """Check that the blocking time for IPs detected as brute-force attack works.
+
+    Provoke a block, make a request before the blocking
+    time finishes and one after the blocking time.
+
+    Parameters
+    ----------
+    tags_to_apply : set
+        Run test if match with a configuration identifier, skip otherwise.
+    """
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+    get_response = requests.get(f'{API_PROTOCOL}://{API_HOST}:{API_PORT}{API_LOGIN_ENDPOINT}',
+                                headers=get_login_headers(API_USER, API_PASS), verify=False)
+
+    assert get_response.status_code == 500, f'Expected status code was 500, ' \
+                                            f'but {get_response.status_code} was returned. \n' \
+                                            f'Full response: {get_response.text}'
+    assert loads(get_response.text)['error'] == 3021  # Timeout error

--- a/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
+++ b/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
@@ -8,8 +8,7 @@ from json import loads
 import pytest
 import requests
 
-from wazuh_testing.api import API_PROTOCOL, API_HOST, API_PORT, API_LOGIN_ENDPOINT, \
-    API_USER, API_PASS, get_login_headers
+import wazuh_testing.api as api
 from wazuh_testing.tools.configuration import check_apply_test, get_api_conf
 
 # Marks
@@ -38,10 +37,9 @@ def get_configuration(request):
 ])
 def test_request_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                          wait_for_start, get_api_details):
-    """Check that the blocking time for IPs detected as brute-force attack works.
+    """Check that the maximum request time for an API request works.
 
-    Provoke a block, make a request before the blocking
-    time finishes and one after the blocking time.
+    Make a request to check the timeout error.
 
     Parameters
     ----------
@@ -49,8 +47,8 @@ def test_request_timeout(tags_to_apply, get_configuration, configure_api_environ
         Run test if match with a configuration identifier, skip otherwise.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    get_response = requests.get(f'{API_PROTOCOL}://{API_HOST}:{API_PORT}{API_LOGIN_ENDPOINT}',
-                                headers=get_login_headers(API_USER, API_PASS), verify=False)
+    get_response = requests.get(f'{api.API_PROTOCOL}://{api.API_HOST}:{api.API_PORT}{api.API_LOGIN_ENDPOINT}',
+                                headers=api.get_login_headers(api.API_USER, api.API_PASS), verify=False)
 
     assert get_response.status_code == 500, f'Expected status code was 500, ' \
                                             f'but {get_response.status_code} was returned. \n' \


### PR DESCRIPTION
|Related issue|
|---|
|#8799|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

In this PR we have added a test to check the correct functionality of the new API timeout option.

Regards

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs example

<!--
Paste here related logs and alerts
-->

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.