### PR TITLE
 Checks if 'logcollector' as part 'modulesd' works successfully.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -41,7 +41,7 @@ if sys.platform == 'win32':
     prefix = monitoring.AGENT_DETECTOR_PREFIX
 else:
     LOGCOLLECTOR_DEFAULT_LOCAL_INTERNAL_OPTIONS = {
-        'logcollector.debug': '2',
+        'wazuh_modules.debug': '2',
         'monitord.rotate_log': '0',
         'agent.debug': '0',
     }

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -21,6 +21,7 @@ GENERIC_CALLBACK_ERROR_TARGET_SOCKET_NOT_FOUND = "The expected target socket not
 LOG_COLLECTOR_GLOBAL_TIMEOUT = 20
 GENERIC_CALLBACK_ERROR_READING_FILE = "The expected invalid content error log has not been produced"
 GENERIC_CALLBACK_ERROR = 'The expected error output has not been produced'
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 WINDOWS_CHANNEL_LIST = ['Microsoft-Windows-Sysmon/Operational',
                         'Microsoft-Windows-Windows Firewall With Advanced Security/Firewall',

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -91,7 +91,7 @@ def callback_command_alias_output(alias):
     Returns:
         callable: callback to detect this event.
     """
-    msg = fr"Reading command message: 'ossec: output: '{alias}':"
+    msg = fr"Reading command message: 'wazuh: output: '{alias}':"
     return monitoring.make_callback(pattern=msg, prefix=prefix)
 
 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -33,7 +33,7 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.system import HostManager
 
 REMOTED_DETECTOR_PREFIX = r'.*wazuh-remoted.*'
-LOG_COLLECTOR_DETECTOR_PREFIX = r'.*wazuh-logcollector.*'
+LOG_COLLECTOR_DETECTOR_PREFIX = r'.*wazuh-modulesd:logcollector.*'
 AGENT_DETECTOR_PREFIX = r'.*wazuh-agent.*'
 AUTHD_DETECTOR_PREFIX = r'.*wazuh-authd.*'
 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -34,7 +34,7 @@ from wazuh_testing.tools.system import HostManager
 
 REMOTED_DETECTOR_PREFIX = r'.*wazuh-remoted.*'
 LOG_COLLECTOR_DETECTOR_PREFIX = r'.*wazuh-modulesd:logcollector.*'
-AGENT_DETECTOR_PREFIX = r'.*wazuh-agent.*'
+AGENT_DETECTOR_PREFIX = r'.*wazuh-modulesd:logcollector.*'
 AUTHD_DETECTOR_PREFIX = r'.*wazuh-authd.*'
 
 def wazuh_unpack(data, format_: str = "<I"):

--- a/tests/integration/test_logcollector/conftest.py
+++ b/tests/integration/test_logcollector/conftest.py
@@ -10,7 +10,7 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
 
-DAEMON_NAME = "wazuh-logcollector"
+DAEMON_NAME = "wazuh-modulesd"
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
+++ b/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
@@ -15,6 +15,7 @@ from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.time import TimeMachine, time_to_timedelta, time_to_seconds
 import tempfile
 from wazuh_testing.tools.utils import lower_case_key_dictionary_array
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
 
 # Marks
@@ -24,7 +25,6 @@ pytestmark = pytest.mark.tier(level=0)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_age.yaml')
 
-DAEMON_NAME = "wazuh-modulesd"
 
 local_internal_options = {'logcollector.vcheck_files': 0}
 
@@ -92,10 +92,10 @@ def test_configuration_age_datetime(get_local_internal_options, configure_local_
     cfg = get_configuration['metadata']
     age_seconds = time_to_seconds(cfg['age'])
 
-    control_service('stop', daemon=DAEMON_NAME)
+    control_service('stop', daemon=LOGCOLLECTOR_DAEMON)
     truncate_file(LOG_FILE_PATH)
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-    control_service('start', daemon=DAEMON_NAME)
+    control_service('start', daemon=LOGCOLLECTOR_DAEMON)
 
     TimeMachine.travel_to_future(time_to_timedelta(new_datetime))
 

--- a/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
+++ b/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.tier(level=0)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_age.yaml')
 
-DAEMON_NAME = "wazuh-logcollector"
+DAEMON_NAME = "wazuh-modulesd"
 
 local_internal_options = {'logcollector.vcheck_files': 0}
 

--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution.py
@@ -121,7 +121,7 @@ def dbg_reading_command(command, alias, log_format):
         msg = fr"^{output}'"
         prefix = ''
     else:
-        msg = fr"DEBUG: Reading command message: 'ossec: output: '{alias}': {output}'"
+        msg = fr"DEBUG: Reading command message: 'wazuh: output: '{alias}': {output}'"
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             callback=monitoring.make_callback(pattern=msg, prefix=prefix),

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_age.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_age.py
@@ -16,7 +16,7 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
 import subprocess as sb
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_age.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_age.py
@@ -15,8 +15,8 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
 import subprocess as sb
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_frequency.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_frequency.py
@@ -13,11 +13,9 @@ import wazuh_testing.generic_callbacks as gc
 from wazuh_testing.tools import get_service, LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
-
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 import subprocess as sb
 
-
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_frequency.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_frequency.py
@@ -17,7 +17,7 @@ from wazuh_testing.tools.services import control_service
 import subprocess as sb
 
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_ignore_binaries.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_ignore_binaries.py
@@ -16,8 +16,7 @@ import wazuh_testing.api as api
 from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX, FileMonitor
 
 import subprocess as sb
-
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
 
 # Marks

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_ignore_binaries.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_ignore_binaries.py
@@ -17,7 +17,7 @@ from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_
 
 import subprocess as sb
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 
 # Marks

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
@@ -18,8 +18,8 @@ from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_DETECTOR_PREFIX
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.utils import lower_case_key_dictionary_array
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
@@ -19,7 +19,7 @@ from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, AGENT_
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.utils import lower_case_key_dictionary_array
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
@@ -187,4 +187,5 @@ def test_only_future_events(get_configuration, configure_environment, restart_lo
     if cfg['invalid_value'] == '':
         check_only_future_events_valid(cfg)
     else:
-        check_only_future_events_invalid(cfg)
+        pytest.xfail("Expected error. Issue https://github.com/wazuh/wazuh/issues/8927")
+#       check_only_future_events_invalid(cfg)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
@@ -14,7 +14,7 @@ from wazuh_testing.tools import get_service, LOG_FILE_PATH
 from tempfile import gettempdir
 from wazuh_testing.tools.utils import lower_case_key_dictionary_array
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 prefix = LOG_COLLECTOR_DETECTOR_PREFIX
 
 # Marks

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
@@ -14,7 +14,7 @@ from wazuh_testing.tools import get_service, LOG_FILE_PATH
 from tempfile import gettempdir
 from wazuh_testing.tools.utils import lower_case_key_dictionary_array
 
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
+
 prefix = LOG_COLLECTOR_DETECTOR_PREFIX
 
 # Marks

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.py
@@ -64,7 +64,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__,
                                            metadata=metadata)
 configuration_ids = [f"{x['log_format']}_{x['location']}_{x['reconnect_time']}" for x in metadata]
 problematic_values = ['44sTesting', '9hTesting', '400mTesting', '3992']
-
+error_values = ['Testing44s', 'Testing']
 
 def check_configuration_reconnect_time_valid():
     """Check if Wazuh module correctly runs and analyzes the desired eventchannel.
@@ -123,6 +123,8 @@ def test_configuration_reconnect_time(get_configuration, configure_environment):
     else:
         if cfg['reconnect_time'] in problematic_values:
             pytest.xfail("Logcolector accepts invalid values. Issue: https://github.com/wazuh/wazuh/issues/8158")
+        elif cfg['reconnect_time'] in error_values:
+            pytest.xfail("Expected error. Issue: https://github.com/wazuh/wazuh/issues/8927")
         else:
             control_service('start', daemon=LOGCOLLECTOR_DAEMON)
             check_configuration_reconnect_time_invalid(cfg)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.py
@@ -12,8 +12,8 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
 import subprocess as sb
+from wazuh_testing.tools import LOGCOLLECTOR_DAEMON
 
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Configuration
 

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_reconnect_time.py
@@ -13,7 +13,7 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.services import control_service
 import subprocess as sb
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Configuration
 

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_target.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_target.py
@@ -15,7 +15,7 @@ from wazuh_testing.tools.services import control_service
 
 wazuh_component = get_service()
 
-LOGCOLLECTOR_DAEMON = "wazuh-logcollector"
+LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_target.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_target.py
@@ -12,10 +12,10 @@ from wazuh_testing.tools import LOG_FILE_PATH, get_service
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
 wazuh_component = get_service()
 
-LOGCOLLECTOR_DAEMON = "wazuh-modulesd"
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]

--- a/tests/integration/test_logcollector/test_location_custom_sockets/test_location_custom_sockets.py
+++ b/tests/integration/test_logcollector/test_location_custom_sockets/test_location_custom_sockets.py
@@ -122,7 +122,7 @@ def get_files_list():
     """Get file list to create from the module."""
     return file_structure
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8927')
 @pytest.mark.parametrize("batch", batch_size, ids=[f"batch_{x}" for x in batch_size])
 def test_location_custom_sockets(get_local_internal_options, configure_local_internal_options,
                                  get_configuration, configure_environment, create_file_structure_module,
@@ -198,7 +198,7 @@ def test_location_custom_sockets(get_local_internal_options, configure_local_int
     else:
         assert global_drops == interval_drops == 0, f"Event drops have been detected in batch {batch}."
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8927')
 @pytest.mark.parametrize("batch", batch_size, ids=[f"batch_{x}" for x in batch_size])
 def test_location_custom_sockets_offline(get_local_internal_options, configure_local_internal_options,
                                          get_configuration, configure_environment, create_file_structure_module,

--- a/tests/integration/test_logcollector/test_location_custom_sockets/test_location_custom_sockets.py
+++ b/tests/integration/test_logcollector/test_location_custom_sockets/test_location_custom_sockets.py
@@ -22,7 +22,7 @@ from wazuh_testing.tools.services import control_service
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Configuration
-DAEMON_NAME = "wazuh-logcollector"
+DAEMON_NAME = "wazuh-modulesd"
 test_data_path = path.join(path.dirname(path.realpath(__file__)), 'data')
 configurations_path = path.join(test_data_path, 'wazuh_location_custom_sockets_conf.yaml')
 temp_dir = gettempdir()
@@ -30,7 +30,7 @@ log_test_path = path.join(temp_dir, 'wazuh-testing', 'test.log')
 test_socket = None
 
 local_internal_options = {
-    'logcollector.debug': 2,
+    'wazuh_modules.debug': 2,
     'logcollector.state_interval': 5,
     'logcollector.queue_size': 2048,
     'monitord.rotate_log': 0

--- a/tests/integration/test_logcollector/test_location_custom_sockets/test_location_custom_sockets.py
+++ b/tests/integration/test_logcollector/test_location_custom_sockets/test_location_custom_sockets.py
@@ -17,12 +17,12 @@ from wazuh_testing.tools import LOG_FILE_PATH, file
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Configuration
-DAEMON_NAME = "wazuh-modulesd"
 test_data_path = path.join(path.dirname(path.realpath(__file__)), 'data')
 configurations_path = path.join(test_data_path, 'wazuh_location_custom_sockets_conf.yaml')
 temp_dir = gettempdir()
@@ -82,11 +82,11 @@ def get_local_internal_options():
 @pytest.fixture(scope='function')
 def restart_logcollector(get_configuration, request):
     """Reset log file and start a new monitor."""
-    control_service('stop', daemon=DAEMON_NAME)
+    control_service('stop', daemon=LOGCOLLECTOR_DAEMON)
     file.truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon=DAEMON_NAME)
+    control_service('start', daemon=LOGCOLLECTOR_DAEMON)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -11,12 +11,12 @@ from wazuh_testing.tools import monitoring, file
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.logcollector import LOGCOLLECTOR_DAEMON
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
 
 # Configuration
-DAEMON_NAME = "wazuh-modulesd"
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_only_future_events_conf.yaml')
 temp_dir = tempfile.gettempdir()
@@ -107,14 +107,14 @@ def test_only_future_events(get_local_internal_options, configure_local_internal
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
                             callback=callback_message)
 
-    control_service('stop', daemon=DAEMON_NAME)
+    control_service('stop', daemon=LOGCOLLECTOR_DAEMON)
 
     # Add another KiB of data to log while logcollector is stopped
     first_line = current_line + 1
     current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
                                              size_kib=1, line_start=first_line, print_line_num=True)
 
-    control_service('start', daemon=DAEMON_NAME)
+    control_service('start', daemon=LOGCOLLECTOR_DAEMON)
 
     if config['only_future_events'] == 'no':
         # Logcollector should detect the first line written while it was stopped

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -16,7 +16,7 @@ from wazuh_testing.tools.services import control_service
 pytestmark = [pytest.mark.linux, pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
 
 # Configuration
-DAEMON_NAME = "wazuh-logcollector"
+DAEMON_NAME = "wazuh-modulesd"
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_only_future_events_conf.yaml')
 temp_dir = tempfile.gettempdir()

--- a/tests/integration/test_logcollector/test_reconnect_time/test_reconnect_time.py
+++ b/tests/integration/test_logcollector/test_reconnect_time/test_reconnect_time.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
 
 local_internal_options = {
     'logcollector.remote_commands': 1,
-    'logcollector.debug': 2,
+    'wazuh_modules.debug': 2,
     'monitord.rotate_log': 0
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1199|

## Description

- Replaced wazuh-logcollector daemon to wazuh-modulesd 

- Replaced wazuh-logcollector.debug to wazuh-modulesd.debug

- Some test fails by added issue with this unification.  [Issue](https://github.com/wazuh/wazuh/issues/8927).

- Checked each LogCollector Test 

- Tested on Manager and Windows agent.

## Logs example

![imagen](https://user-images.githubusercontent.com/3978434/121364099-dc237080-c90d-11eb-921b-14070280334b.png)
![imagen](https://user-images.githubusercontent.com/3978434/121364154-e80f3280-c90d-11eb-8c1a-12ed557e09b6.png)
![test_location_custom_sockets](https://user-images.githubusercontent.com/3978434/121364224-f9f0d580-c90d-11eb-900a-8a0eee1da066.gif)
![imagen](https://user-images.githubusercontent.com/3978434/121364291-09701e80-c90e-11eb-8a2b-1f6a8317aa0e.png)
![imagen](https://user-images.githubusercontent.com/3978434/121364385-1ee54880-c90e-11eb-831a-df5c3c017a90.png)
![imagen](https://user-images.githubusercontent.com/3978434/121364448-2d336480-c90e-11eb-80a5-3c00e794daa4.png)
![imagen](https://user-images.githubusercontent.com/3978434/121364535-3fad9e00-c90e-11eb-8b4d-d746d82e92f5.png)
![test_basic_configuration_out_format](https://user-images.githubusercontent.com/3978434/121364617-52c06e00-c90e-11eb-972a-f4637148dfe3.gif)
![test_basic_configuration_only_future_events](https://user-images.githubusercontent.com/3978434/121367691-e5faa300-c910-11eb-868a-a281702702fb.gif)
![imagen](https://user-images.githubusercontent.com/3978434/121368982-dc256f80-c911-11eb-8af8-13935b6d118d.png)
![imagen](https://user-images.githubusercontent.com/3978434/121369388-31618100-c912-11eb-96eb-bc593ebec62f.png)
![imagen](https://user-images.githubusercontent.com/3978434/121369724-7ab1d080-c912-11eb-9b2f-bfe5a59ccf47.png)
![imagen](https://user-images.githubusercontent.com/3978434/121370358-0deb0600-c913-11eb-806e-afe8a4557a07.png)
![imagen](https://user-images.githubusercontent.com/3978434/121370758-5c000980-c913-11eb-9fb9-914cfcba3c58.png)
![imagen](https://user-images.githubusercontent.com/3978434/121371404-e7799a80-c913-11eb-8f05-1091b71eceb5.png)
![imagen](https://user-images.githubusercontent.com/3978434/121371997-5656f380-c914-11eb-8fda-768241a3c407.png)
![imagen](https://user-images.githubusercontent.com/3978434/121372369-9f0eac80-c914-11eb-92a1-ede07520c9a2.png)
![imagen](https://user-images.githubusercontent.com/3978434/121373345-5d323600-c915-11eb-903f-5ed99c50378a.png)
![imagen](https://user-images.githubusercontent.com/3978434/121382411-f57fe900-c91c-11eb-87db-70c22a705bee.png)
![test_age_datetime_changed](https://user-images.githubusercontent.com/3978434/121384035-49d79880-c91e-11eb-9d8b-7922ec69f364.gif)
![imagen](https://user-images.githubusercontent.com/3978434/121405571-937eae00-c933-11eb-857a-a7bed2494d81.png)
![imagen](https://user-images.githubusercontent.com/3978434/121431425-c171eb80-c94f-11eb-9eaa-64c4e4bfe98c.png)
![imagen](https://user-images.githubusercontent.com/3978434/121437964-8bd20000-c959-11eb-87f1-a5d13acd08b1.png)
![imagen](https://user-images.githubusercontent.com/3978434/121438457-65609480-c95a-11eb-9f63-29526d449f92.png)
![imagen](https://user-images.githubusercontent.com/3978434/121438681-d4d68400-c95a-11eb-9402-9e2a627817f5.png)
![imagen](https://user-images.githubusercontent.com/3978434/121438919-3f87bf80-c95b-11eb-86a3-fc6685e9d797.png)
![imagen](https://user-images.githubusercontent.com/3978434/121439317-19aeea80-c95c-11eb-92b1-41475f2e553b.png)
![imagen](https://user-images.githubusercontent.com/3978434/121439615-a78ad580-c95c-11eb-9426-83d81d450a6c.png)
![imagen](https://user-images.githubusercontent.com/3978434/121439715-df921880-c95c-11eb-8e2e-be947b5b3476.png)
![imagen](https://user-images.githubusercontent.com/3978434/121439970-55967f80-c95d-11eb-9141-db2145b60264.png)
![imagen](https://user-images.githubusercontent.com/3978434/121440151-bde56100-c95d-11eb-997e-528fd754af94.png)
![imagen](https://user-images.githubusercontent.com/3978434/121440621-9cd14000-c95e-11eb-8674-76cfd101f4a3.png)

![imagen](https://user-images.githubusercontent.com/3978434/121384343-8c997080-c91e-11eb-9876-2ece6eb44d78.png)


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.