### PR TITLE
Fix NameError on logcollector.py

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -614,7 +614,7 @@ def wait_statistics_file(timeout=LOG_COLLECTOR_GLOBAL_TIMEOUT):
                            defined by "logcollector.state_interval".
     """
     for _ in range(timeout):
-        if path.isfile(LOGCOLLECTOR_STATISTICS_FILE):
+        if os.path.isfile(LOGCOLLECTOR_STATISTICS_FILE):
             break
         else:
             sleep(1)


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/assigned/spothound|

Just a small fix for a failed reference on our integration tests for logcollector.

Tests


- ubuntu manager https://ci.wazuh.info/job/Test_integration/5597/console
- centos manager https://ci.wazuh.info/job/Test_integration/5593/console
- manager and agents https://ci.wazuh.info/job/Test_integration/5601/console

