### PR TITLE
 CVEs alerts inventory for Vulnerability Detector: full scan type

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -490,9 +490,7 @@ def update_package(version, package, agent="000"):
         package (str): package name
         agent (str): id of the agent
     """
-    path = os.path.join(DB_PATH, f"{agent}.db")
-    update_query_string = f'UPDATE sys_programs SET version="{version}" WHERE name="{package}"'
-    make_query(path, [update_query_string])
+    query_wdb(f"agent {agent} sql UPDATE sys_programs SET version='{version}' WHERE name='{package}'")
 
 
 def delete_package(package, agent="000"):
@@ -504,9 +502,7 @@ def delete_package(package, agent="000"):
         package (str): package name
         agent (str): id of the agent
     """
-    path = os.path.join(DB_PATH, f"{agent}.db")
-    delete_query_string = f'DELETE FROM sys_programs WHERE name="{package}"'
-    make_query(path, [delete_query_string])
+    query_wdb(f"agent {agent} sql DELETE FROM sys_programs WHERE name='{package}'")
 
 
 def delete_vulnerability(cveid):
@@ -965,6 +961,18 @@ def create_simulated_agent(manager_address="localhost", operating_system="debian
     agent.set_module_status('fim', 'disabled')
     sender, injector = ag.connect(agent)
     return agent.id, sender, injector
+
+
+def modify_agent_scan_timestamp(agent="000", timestamp=0, full_scan=True):
+    """Function to modify the timestamp of the agent scans in the vuln_metadata table.
+
+    Args:
+        agent (str, optional) = Id of the agent. Defaults to "000".
+        timestamp (int, optional): The new timestamp value to set. Defaults to 0.
+        full_scan (bool, optional): True for set LAST_FULL_SCAN or False to set LAST_SCAN. Defaults to True.
+    """
+    scan_type = "LAST_FULL_SCAN" if full_scan else "LAST_PARTIAL_SCAN"
+    query_wdb(f"agent {agent} sql UPDATE vuln_metadata SET {scan_type}={timestamp}")
 
 
 def delete_mocked_agent(agent_id):

--- a/docs/tests/integration/test_vulnerability_detector/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/index.md
@@ -86,6 +86,13 @@ Test that adds a simulated agent to the system with a test package containing a 
 a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability. 
 It then launches a `PARTIAL_SCAN` and checks that the alert has only been generated for the last package installed.
   
+- **[test_full_scan_type](test_scan_types/test_full_scan_type.md#test-full-scan-type)**:
+Test that adds a simulated agent to the system with two test packages containing vulnerabilities then starts 
+a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability and updates 
+the second package to a non-vulnerable version. It then launches a `FULL_SCAN` and checks that alerts 
+have been generated for both the installed package and the updated package, the latter due to the removal 
+of the vulnerability associated with it. 
+  
 ---
 
 ### Tier 1

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/index.md
@@ -7,18 +7,21 @@ expected. These are the general scan types:
 
 - `BASELINE`
 - `PARTIAL_SCAN`
+- `FULL_SCAN`
 
 ## General info
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 0 | 2 | 0:04:25  |
+| 0 | 3 | 0:05:53 |
 
 ## Expected behavior
 
 - `BASELINE`: No alerts should be generated for vulnerabilities detected during this kind of scanning.
 - `PARTIAL_SCAN`: Alerts should be generated only for vulnerabilities detected in new packages installed during 
   this kind of scanning.
+- `FULL_SCAN`: Alerts should be generated for the newly detected vulnerabilities and the ones that no longer 
+  affect the agent after the database has been updated with new information.
 
 ## Testing
 
@@ -33,4 +36,11 @@ expected. These are the general scan types:
   Test that adds a simulated agent to the system with a test package containing a vulnerability then starts 
   a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability. 
   It then launches a `PARTIAL_SCAN` and checks that the alert has only been generated for the last package installed.
+  
+- **[test_full_scan_type](test_full_scan_type.md#test-full-scan-type)**:
+  Test that adds a simulated agent to the system with two test packages containing vulnerabilities then starts 
+  a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability and updates 
+  the second package to a non-vulnerable version. It then launches a `FULL_SCAN` and checks that alerts 
+  have been generated for both the installed package and the updated package, the latter due to the removal 
+  of the vulnerability associated with it. 
   

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.md
@@ -1,0 +1,34 @@
+# Test full scan type
+
+The test will check if the Vulnerability Detector module performs the `FULL_SCAN` type correctly.
+
+## General info
+
+|Tier | Number of tests | Time spent| Test file | 
+|:--:|:--:|:--:|:--:| 
+| 0 | 1 | 1m28s | test_full_scan_type.py |
+
+## Test logic
+
+The manager is configured to use custom feeds that include vulnerabilities associated with the test packages. 
+Two test packages are added to the database of the simulated agent and, after enrollment of the agent, 
+the vulnerability detector must launch the first scan on it, which is of `BASELINE` type.
+
+When the `BASELINE` scan has been performed, an additional package will be inserted, and the second package
+installed on the tested agent will be updated to a non-vulnerable version, then the necessary conditions
+to launch a `FULL_SCAN` scan type will be triggered.
+
+Once the full scan is complete, we will verify that two vulnerabilities remain in the `vuln_cves` table
+and two alerts have been generated (one for the vulnerability detected and another for the vulnerability
+removed by the update). This will be confirmed by checking the log and alert files respectively.
+
+## Checks
+
+- [x] The `BASELINE` and `FULLL_SCAN` scan startup, checking messages in the logs file.
+- [x] The NVD vulnerabilities for the test packages are detected during the scans, checking messages in the logs file.
+- [x] Completion of the scans, checking messages in the logs file.
+- [x] Alerts are generated for the vulnerabilities detected during `FULL_SCAN`, checking messages in the alerts file.
+
+## Code documentation
+
+::: tests.integration.test_vulnerability_detector.test_scan_types.test_full_scan_type

--- a/tests/integration/test_vulnerability_detector/test_scan_types/data/wazuh_full_scan_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/data/wazuh_full_scan_type.yaml
@@ -1,0 +1,45 @@
+- tags:
+    - full_scan_type
+  apply_to_modules:
+    - test_full_scan_type
+  sections:
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: "20s"
+        - min_full_scan_interval:
+            value: '0s'
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: 'debian'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: BUSTER_FEED_PATH
+                  value: 'buster'
+              - path:
+                  value: DEBIAN_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: NVD_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import datetime
+import os
+import time
+
+import pytest
+
+import wazuh_testing.vulnerability_detector as vd
+from wazuh_testing.tools import ALERT_FILE_PATH, LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+
+# Marks
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
+
+local_internal_options = {
+    'wazuh_modules.debug': 2,
+    'monitord.rotate_log': 0
+}
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+configurations_path = os.path.join(test_data_path, 'wazuh_full_scan_type.yaml')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_alert_monitor = FileMonitor(ALERT_FILE_PATH)
+test_packet_vendor = 'WazuhIntegrationTests'
+test_packet_version = '1.0.0'
+test_packet_version_not_vulnerable = '2.1.0'
+test_packet_0_name = 'wazuhintegrationpackage-0'
+test_packet_1_name = 'wazuhintegrationpackage-1'
+test_packet_2_name = 'wazuhintegrationpackage-2'
+test_packet_0_cve = 'CVE-000'
+test_packet_1_cve = 'CVE-001'
+test_packet_2_cve = 'CVE-002'
+
+# Offline feeds
+buster_oval_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_OVAL_FEED)
+debian_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_JSON_FEED)
+nvd_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_NVD_FEED)
+parameters = [{
+    'BUSTER_FEED_PATH': buster_oval_feed_path,
+    'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
+    'NVD_JSON_FEED_PATH': nvd_json_feed_path
+}]
+metadata = parameters
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# fixtures
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="function")
+def add_simulated_agent(get_configuration):
+    """Add a simulated agent to the system with basic functionality.
+
+    For this purpose, it adds a dummy agent, inserts in its database (sys_programs table) a test package,
+    and configures its database to appear to be up to date (sync_info table)."""
+    agent_id, sender, injector = vd.create_simulated_agent()
+    vd.insert_package(agent=agent_id, name=test_packet_0_name, vendor=test_packet_vendor,
+                      version=test_packet_version, source='NULL')
+    vd.insert_package(agent=agent_id, name=test_packet_1_name, vendor=test_packet_vendor,
+                      version=test_packet_version, source='NULL')
+    vd.update_sync_info(agent=agent_id)
+    yield agent_id
+    injector.stop_receive()
+    vd.delete_simulated_agent(agent_id)
+
+
+def test_full_scan_type(configure_local_internal_options, get_configuration, configure_environment,
+                        restart_modulesd, add_simulated_agent):
+    """Check if the Vulnerability Detector module performs the full scan type correctly.
+
+    For this purpose, the manager is configured to use custom feeds that include vulnerabilities associated
+    with test packages. Two packages are added to the database of the simulated agent and, after enrollment
+    of the agent, the vulnerability detector must launch the first scan on it, which is of BASELINE type.
+
+    When the BASELINE scan has been performed, an additional package will be inserted and the second package
+    installed on the tested agent will be updated to a non-vulnerable version, then the necessary conditions
+    to launch a FULL_SCAN scan type will be triggered.
+
+    Once the full scan is complete, we will verify that two vulnerabilities remain in the "vuln_cves" table
+    and two alerts have been generated (one for the vulnerability detected and another for the vulnerability
+    removed by the update). This will be confirmed by checking the log and alert files respectively.
+
+    Args:
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_modulesd (fixture): Reset ossec.log and start a new monitor.
+        add_simulated_agent (fixture): Add a simulated agent to the manager for testing.
+    """
+    check_apply_test({'full_scan_type'}, get_configuration['tags'])
+    agent_id = add_simulated_agent
+
+    # Callbacks
+    callback_detect_baseline_scan_start = vd.make_vuln_callback(f"A baseline scan will be run on agent '{agent_id}'")
+    callback_detect_full_scan_start = vd.make_vuln_callback(f"A full scan will be run on agent '{agent_id}'")
+    callback_detect_scan_end = vd.make_vuln_callback(f"Finished vulnerability assessment for agent '{agent_id}'")
+    callback_detect_test_package_0_vuln = vd.make_vuln_callback(
+        pattern=f"Package '{test_packet_0_name}' inserted into the vulnerability '{test_packet_0_cve}'.")
+    callback_detect_test_package_1_vuln_removal = vd.make_vuln_callback(
+        pattern=f"Package '{test_packet_1_name}' not vulnerable to '{test_packet_1_cve}'.")
+    callback_detect_test_package_2_vuln = vd.make_vuln_callback(
+        pattern=f"Package '{test_packet_2_name}' inserted into the vulnerability '{test_packet_2_cve}'.")
+    callback_detect_test_package_1_alert_removal = vd.make_vuln_callback(
+        pattern=f"{test_packet_1_cve} affecting {test_packet_1_name} was eliminated", prefix='.*')
+    callback_detect_test_package_2_alert_add = vd.make_vuln_callback(
+        pattern=f"{test_packet_2_cve} affects {test_packet_2_name}", prefix='.*')
+
+    # Detect the baseline scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_baseline_scan_start,
+                            error_message='No baseline scan start has been detected in the log.')
+
+    # Check if the NVD vulnerabilities are detected.
+    vd.check_detected_vulnerabilities_number(agent=agent_id,
+                                             wazuh_log_monitor=wazuh_log_monitor,
+                                             expected_vulnerabilities_number=2,
+                                             feed_source='NVD', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
+
+    # Detect baseline scan completion.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_scan_end,
+                            error_message='No baseline scan end has been detected in the log.')
+
+    # Update test package 1 to a non-vulnerable version.
+    vd.update_package(agent=agent_id, package=test_packet_1_name, version=test_packet_version_not_vulnerable)
+
+    # Insert the test package 2.
+    vd.insert_package(agent=agent_id, name=test_packet_2_name, vendor=test_packet_vendor,
+                      version=test_packet_version, source='NULL')
+
+    # Set LAST_FULL_SCAN to the lowest possible value on the VULN_METADATA table of agent DB to force a full scan.
+    vd.modify_agent_scan_timestamp(agent=agent_id, timestamp=1)
+
+    # Detect a full scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_full_scan_start,
+                            error_message='No full scan start has been detected in the log.')
+
+    # Ensure that the vulnerability of package 0 is detected in the full scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT, update_position=False,
+                            callback=callback_detect_test_package_0_vuln,
+                            error_message='No vulnerability for test package 0 was detected in the log.')
+
+    # Ensure that the vulnerability removal of package 1 is detected in the full scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_test_package_1_vuln_removal,
+                            error_message='No vulnerability removal for test package 1 was detected in the log.')
+
+    # Ensure that the vulnerability of package 2 is detected in the full scan.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT, update_position=False,
+                            callback=callback_detect_test_package_2_vuln,
+                            error_message='No vulnerability for test package 2 was detected in the log.')
+
+    # Detect a full scan completion.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_scan_end,
+                            error_message='No full scan end has been detected in the log.')
+
+    # Ensure test package 1 does generate an alert at vulnerability removal.
+    wazuh_alert_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT, update_position=False,
+                              callback=callback_detect_test_package_1_alert_removal,
+                              error_message='No alert for test package 1 has been detected in the log.')
+
+    # Ensure the test package 2 does generate an alert.
+    wazuh_alert_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                              callback=callback_detect_test_package_2_alert_add,
+                              error_message='No alert for test package 2 has been detected in the log.')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1437|


## Description

This PR adds a test to verify if the `FULL_SCAN` scan type of vulnerability detector works correctly as part of #1261.

## Test results

### Manager
#### Tested on CentOS 8 (local)

![manager](https://user-images.githubusercontent.com/80053749/121649085-7c0d0580-ca98-11eb-9db0-b0173d7887db.png)

#### Tested on CentOS 7 (Jenkins)

![jenkins_centos7](https://user-images.githubusercontent.com/80053749/121666003-183f0880-caa9-11eb-9bf2-86dc076fbe34.png)

## Documentation

![docu](https://user-images.githubusercontent.com/80053749/121649104-816a5000-ca98-11eb-85e9-23baca20ad9d.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.