### PR TITLE
 Checks if 'syscheckd ' as part 'modulesd' works successfully. 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -41,7 +41,7 @@ else:
     WAZUH_CONF = os.path.join(WAZUH_PATH, WAZUH_CONF_RELATIVE)
     WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')
     WAZUH_SECURITY_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'security.yaml')
-    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'wazuh.log')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
     CLUSTER_LOG_PATH = os.path.join(WAZUH_PATH, 'logs', 'cluster.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
     ARCHIVES_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'archives', 'archives.log')

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -41,7 +41,7 @@ else:
     WAZUH_CONF = os.path.join(WAZUH_PATH, WAZUH_CONF_RELATIVE)
     WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')
     WAZUH_SECURITY_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security', 'security.yaml')
-    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'wazuh.log')
     CLUSTER_LOG_PATH = os.path.join(WAZUH_PATH, 'logs', 'cluster.log')
     API_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'api.log')
     ARCHIVES_LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'archives', 'archives.log')

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -28,7 +28,7 @@ def restart_wazuh_daemon(daemon):
     subprocess.check_call([f'{daemon_path}/{daemon}'])
 
 
-def restart_wazuh_with_new_conf(new_conf, daemon='wazuh-syscheckd'):
+def restart_wazuh_with_new_conf(new_conf, daemon='wazuh-modulesd'):
     """
     Restart Wazuh service applying a new ossec.conf
 

--- a/docs/tests/integration/setting_up_test_environment.md
+++ b/docs/tests/integration/setting_up_test_environment.md
@@ -47,7 +47,6 @@ yum install python36 python3-pip python36-devel -y
 
 ```
 # Enable debug 2
-echo 'syscheck.debug=2' >> $wazuh_path/etc/local_internal_options.conf
 echo 'wazuh_modules.debug=2' >> $wazuh_path/etc/local_internal_options.conf
 echo 'wazuh_db.debug=2' >> $wazuh_path/etc/local_internal_options.conf
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -52,7 +52,7 @@ pip3 install pytest freezegun jq jsonschema pyyaml==5.4 psutil paramiko distro p
 
 ```shell script
 # Enable debug 2
-echo 'syscheck.debug=2' >> $wazuh_path/etc/local_internal_options.conf
+echo 'wazuh_modules.debug=2' >> $wazuh_path/etc/local_internal_options.conf
 
 # Avoid agent disconnections when travelling in time (only for agents)
 sed -i "s:<time-reconnect>60</time-reconnect>:<time-reconnect>99999999999</time-reconnect>:g" /var/ossec/etc/ossec.conf
@@ -125,7 +125,7 @@ pip3 install pytest freezegun jq jsonschema pyyaml==5.4 psutil paramiko distro p
 ```shell script
 
 # Enable debug 2
-echo 'syscheck.debug=2' >> /Library/Ossec/etc/local_internal_options.conf
+echo 'wazuh_modules.debug=2' >> /Library/Ossec/etc/local_internal_options.conf
 
 # Avoid agent disconnections when travelling in time
 brew install gnu-sed

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_linux_yaml.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/yaml_generators/generate_linux_yaml.py
@@ -144,8 +144,8 @@ def generate_analysisd_yaml(n_events, modify_events):
     analysis_queue = mitm_analysisd.queue
     mitm_analysisd.start()
 
-    control_service('start', daemon='wazuh-syscheckd', debug_mode=True)
-    check_daemon_status(running=True, daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd', debug_mode=True)
+    check_daemon_status(running=True, daemon='wazuh-modulesd')
 
     # Wait for initial scan
     detect_initial_scan(file_monitor)
@@ -185,7 +185,7 @@ def generate_analysisd_yaml(n_events, modify_events):
 
 
 def kill_daemons():
-    for daemon in ['wazuh-analysisd', 'wazuh-db', 'wazuh-syscheckd']:
+    for daemon in ['wazuh-analysisd', 'wazuh-db', 'wazuh-modulesd']:
         control_service('stop', daemon=daemon)
         check_daemon_status(running=False, daemon=daemon)
 

--- a/tests/integration/test_fim/test_files/conftest.py
+++ b/tests/integration/test_fim/test_files/conftest.py
@@ -15,11 +15,11 @@ def restart_syscheckd(get_configuration, request):
     """
     Reset wazuh.log and start a new monitor.
     """
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
@@ -154,6 +154,7 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
                      time_travel=scheduled,
                      min_timeout=global_parameters.default_timeout, triggers_event=True)
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folders, tags_to_apply', [
     ([testdir, subdir], {'ambiguous_report_changes'})
@@ -216,6 +217,7 @@ def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_e
                      min_timeout=global_parameters.default_timeout, triggers_event=True,
                      validators_after_update=[no_report_changes_validator])
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folders, tags_to_apply', [
     ([testdir, subdir], {'ambiguous_tags'})
@@ -246,6 +248,7 @@ def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_env
     regular_file_cud(folders[1], wazuh_log_monitor,
                      time_travel=scheduled,
                      min_timeout=global_parameters.default_timeout, validators_after_cud=[tag_validator])
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('dirname, recursion_level, tags_to_apply', [
@@ -290,6 +293,7 @@ def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_config
                         scheduled=scheduled,
                         min_timeout=global_parameters.default_timeout, triggers_event=False)
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('dirnames, recursion_level, triggers_event, tags_to_apply', [
     ([testdir_recursion_tag, testdir_recursion_no_tag], 2, True, {'ambiguous_recursion_tag'}),
@@ -329,6 +333,7 @@ def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags
                         recursion_subdir=recursion_subdir,
                         scheduled=scheduled, min_timeout=global_parameters.default_timeout,
                         triggers_event=triggers_event, validators_after_cud=[no_tag_validator])
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('tags_to_apply', [

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
@@ -118,6 +118,7 @@ def _test_recursion_cud(ini, fin, path, recursion_subdir, scheduled,
 
 
 # tests
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folders, tags_to_apply', [
     ([testdir, subdir], {'ambiguous_restrict'})
 ])
@@ -153,7 +154,7 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
                      time_travel=scheduled,
                      min_timeout=global_parameters.default_timeout, triggers_event=True)
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folders, tags_to_apply', [
     ([testdir, subdir], {'ambiguous_report_changes'})
 ])
@@ -215,7 +216,7 @@ def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_e
                      min_timeout=global_parameters.default_timeout, triggers_event=True,
                      validators_after_update=[no_report_changes_validator])
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folders, tags_to_apply', [
     ([testdir, subdir], {'ambiguous_tags'})
 ])
@@ -246,7 +247,7 @@ def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_env
                      time_travel=scheduled,
                      min_timeout=global_parameters.default_timeout, validators_after_cud=[tag_validator])
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('dirname, recursion_level, tags_to_apply', [
     (testdir_recursion, 1, {'ambiguous_recursion_over'}),
     (testdir_recursion, 4, {'ambiguous_recursion'})
@@ -289,7 +290,7 @@ def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_config
                         scheduled=scheduled,
                         min_timeout=global_parameters.default_timeout, triggers_event=False)
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('dirnames, recursion_level, triggers_event, tags_to_apply', [
     ([testdir_recursion_tag, testdir_recursion_no_tag], 2, True, {'ambiguous_recursion_tag'}),
     ([testdir_recursion_tag, testdir_recursion_no_tag], 2, False, {'ambiguous_no_recursion_tag'})
@@ -329,7 +330,7 @@ def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags
                         scheduled=scheduled, min_timeout=global_parameters.default_timeout,
                         triggers_event=triggers_event, validators_after_cud=[no_tag_validator])
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('tags_to_apply', [
     {'ambiguous_check'}
 ])

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -21,8 +21,9 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_conf_ignore_restrict_win32.yaml' if sys.platform == 'win32'
-else 'wazuh_conf_ignore_restrict.yaml')
+configurations_path = os.path.join(test_data_path,
+                                   'wazuh_conf_ignore_restrict_win32.yaml' if sys.platform == 'win32'
+                                   else 'wazuh_conf_ignore_restrict.yaml')
 
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]
 testdir1, testdir2 = test_directories

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -41,7 +41,7 @@ def get_configuration(request):
 
 
 # tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
 ])
@@ -66,7 +66,7 @@ def test_audit_health_check(tags_to_apply, get_configuration,
     wazuh_log_monitor.start(timeout=20, callback=fim.callback_audit_health_check,
                             error_message='Health check failed')
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
 ])
@@ -99,7 +99,7 @@ def test_added_rules(tags_to_apply, get_configuration,
     assert testdir2 in events, f'{testdir2} not detected in scan'
     assert testdir3 in events, f'{testdir3} not detected in scan'
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
 ])
@@ -139,7 +139,7 @@ def test_readded_rules(tags_to_apply, get_configuration,
 
         assert dir_ in events, f'{dir_} not in {events}'
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
 ])
@@ -182,7 +182,7 @@ def test_readded_rules_on_restart(tags_to_apply, get_configuration,
     assert testdir2 in events, f'{testdir2} not in {events}'
     assert testdir3 in events, f'{testdir3} not in {events}'
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
 ])
@@ -223,7 +223,7 @@ def test_move_rules_realtime(tags_to_apply, get_configuration,
     p = subprocess.Popen(["service", "auditd", "start"])
     p.wait()
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('audit_key, path', [
     ("custom_audit_key", "/testdir1")
 ])
@@ -270,7 +270,7 @@ def test_audit_key(audit_key, path, get_configuration, configure_environment, re
     # Remove watch rule
     os.system("auditctl -W " + path + " -p wa -k " + audit_key)
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply, should_restart', [
     ({'audit_key'}, True),
     ({'restart_audit_false'}, False)

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -66,6 +66,7 @@ def test_audit_health_check(tags_to_apply, get_configuration,
     wazuh_log_monitor.start(timeout=20, callback=fim.callback_audit_health_check,
                             error_message='Health check failed')
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
@@ -98,6 +99,7 @@ def test_added_rules(tags_to_apply, get_configuration,
     assert testdir1 in events, f'{testdir1} not detected in scan'
     assert testdir2 in events, f'{testdir2} not detected in scan'
     assert testdir3 in events, f'{testdir3} not detected in scan'
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
@@ -138,6 +140,7 @@ def test_readded_rules(tags_to_apply, get_configuration,
                                                        'modification').result()
 
         assert dir_ in events, f'{dir_} not in {events}'
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
@@ -182,6 +185,7 @@ def test_readded_rules_on_restart(tags_to_apply, get_configuration,
     assert testdir2 in events, f'{testdir2} not in {events}'
     assert testdir3 in events, f'{testdir3} not in {events}'
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'config1'})
@@ -222,6 +226,7 @@ def test_move_rules_realtime(tags_to_apply, get_configuration,
     # Start Audit
     p = subprocess.Popen(["service", "auditd", "start"])
     p.wait()
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('audit_key, path', [
@@ -269,6 +274,7 @@ def test_audit_key(audit_key, path, get_configuration, configure_environment, re
 
     # Remove watch rule
     os.system("auditctl -W " + path + " -p wa -k " + audit_key)
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1441')
 @pytest.mark.parametrize('tags_to_apply, should_restart', [

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_db_inode_check.py
@@ -52,11 +52,11 @@ def restart_syscheck_function(get_configuration, request):
     """
     Reset wazuh.log and start a new monitor.
     """
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(fim.LOG_FILE_PATH)
     file_monitor = FileMonitor(fim.LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='function')

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_delete_folder.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_delete_folder.py
@@ -45,7 +45,7 @@ def get_configuration(request):
 
 
 # tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, file_list, filetype, tags_to_apply', [
     (testdir1, ['regular0', 'regular1', 'regular2'], REGULAR, {'ossec_conf'},),
     (testdir2, ['regular0', 'regular1', 'regular2'], REGULAR, {'ossec_conf'},)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_delete_folder.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_delete_folder.py
@@ -80,8 +80,8 @@ def test_delete_folder(folder, file_list, filetype, tags_to_apply,
 
     check_time_travel(scheduled, monitor=wazuh_log_monitor)
     events = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
-                                     accum_results=len(file_list), error_message='Did not receive expected '
-                                                                                 '"Sending FIM event: ..." event').result()
+                                     accum_results=len(file_list),
+                                     error_message='Did not receive expected "Sending FIM event: ..." event').result()
     for ev in events:
         validate_event(ev, mode=mode)
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_move_dir.py
@@ -60,7 +60,7 @@ def extra_configuration_after_yield():
     shutil.rmtree(os.path.join(PREFIX, 'subdir'), ignore_errors=True)
     shutil.rmtree(testdir4, ignore_errors=True)
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('source_folder, target_folder, subdir, tags_to_apply, \
                 triggers_delete_event, triggers_add_event', [
     (testdir4, testdir2, 'subdir', {'ossec_conf'}, False, True),

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_move_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_move_dir.py
@@ -60,6 +60,7 @@ def extra_configuration_after_yield():
     shutil.rmtree(os.path.join(PREFIX, 'subdir'), ignore_errors=True)
     shutil.rmtree(testdir4, ignore_errors=True)
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('source_folder, target_folder, subdir, tags_to_apply, \
                 triggers_delete_event, triggers_add_event', [

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_rename.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_rename.py
@@ -58,7 +58,7 @@ def clean_directories(request):
 
 
 # tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, tags_to_apply', [
     (testdir1, {'ossec_conf'}),
     (testdir2, {'ossec_conf'})

--- a/tests/integration/test_fim/test_files/test_benchmark/test_benchmark.py
+++ b/tests/integration/test_fim/test_files/test_benchmark/test_benchmark.py
@@ -50,6 +50,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1449')
 @pytest.mark.benchmark
 @pytest.mark.parametrize('files, folder, tags_to_apply', [
     (file_list[0:10], testdir1, {'ossec_conf'}),

--- a/tests/integration/test_fim/test_files/test_benchmark/test_report_changes_big.py
+++ b/tests/integration/test_fim/test_files/test_benchmark/test_report_changes_big.py
@@ -181,6 +181,7 @@ def write_csv(data):
     df.to_csv(metrics_path, sep='\t', mode='a', index=False, header=(not os.path.exists(metrics_path)))
 
 
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1449')
 @pytest.mark.benchmark
 @pytest.mark.parametrize('tags_to_apply', [
     {'ossec_conf'}

--- a/tests/integration/test_fim/test_files/test_checks/test_check_all.py
+++ b/tests/integration/test_fim/test_files/test_checks/test_check_all.py
@@ -118,8 +118,8 @@ else:
 def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                    wait_for_fim_start):
     """
-    Test the functionality of `check_all` option when used in conjunction with more than one check on the same directory,
-    having "check_all" to "yes" and the other ones to "no".
+    Test the functionality of `check_all` option when used in conjunction with more than one check on the same
+    directory, having "check_all" to "yes" and the other ones to "no".
 
     Example:
         check_all="yes" check_sum="no" check_md5sum="no"

--- a/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
@@ -26,10 +26,12 @@ dir1, dir2, dir3, dir4 = test_directories
 
 # Check big environment variables ending with backslash
 if sys.platform == 'win32':
-    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + [os.path.join(dir2, "test.txt"),
+                                                                          os.path.join(dir3, "test.txt")]
     test_env = "%TEST_NODIFF_ENV%"
 else:
-    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [os.path.join(dir2, "test.txt"),
+                                                                           os.path.join(dir3, "test.txt")]
     test_env = "$TEST_NODIFF_ENV"
 
 multiple_env_var = os.pathsep.join(paths)

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_default.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_default.py
@@ -61,7 +61,8 @@ def test_file_limit_default(tags_to_apply, get_configuration, configure_environm
     file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                                callback=callback_value_file_limit,
                                                error_message='Did not receive expected '
-                                                             '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
+                                                             '"DEBUG: ...: Maximum number of entries to '
+                                                             'be monitored: ..." event'
                                                ).result()
 
     if file_limit_value:

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_full.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_full.py
@@ -85,7 +85,8 @@ def test_file_limit_full(tags_to_apply, get_configuration, configure_environment
 
     wazuh_log_monitor.start(timeout=40, callback=callback_file_limit_full_database,
                             error_message='Did not receive expected '
-                                          '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
+                                          '"DEBUG: ...: Couldn\'t insert \'...\' '
+                                          'entry into DB. The DB is full, ..." event')
 
     entries, path_count = wazuh_log_monitor.start(timeout=40, callback=callback_entries_path_count,
                                                   error_message='Did not receive expected '

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_values.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_values.py
@@ -75,7 +75,8 @@ def test_file_limit_values(tags_to_apply, get_configuration, configure_environme
     file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                                callback=callback_value_file_limit,
                                                error_message='Did not receive expected '
-                                                             '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
+                                                             '"DEBUG: ...: Maximum number of entries '
+                                                             'to be monitored: ..." event'
                                                ).result()
 
     if file_limit_value:

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target_with_nested_directory.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target_with_nested_directory.py
@@ -21,8 +21,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.sunos5, pytest.mark.darwin, pytest.
 
 # configurations
 
-conf_params, conf_metadata = fim.generate_params(extra_params={'FOLLOW_MODE': 'yes'},
-                                             modes=['scheduled'])
+conf_params, conf_metadata = fim.generate_params(extra_params={'FOLLOW_MODE': 'yes'}, modes=['scheduled'])
 configurations = load_wazuh_configurations(configurations_path, __name__,
                                            params=conf_params,
                                            metadata=conf_metadata

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_symlink_dir_inside_monitored_dir.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_symlink_dir_inside_monitored_dir.py
@@ -83,7 +83,8 @@ def test_symlink_dir_inside_monitored_dir(tags_to_apply, checkers, get_configura
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 
     # Alerts from the pointed directory should have all checks except size
-    fim.regular_file_cud(testdir_target, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, options=checkers,
-                     time_travel=scheduled)
+    fim.regular_file_cud(testdir_target, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                         options=checkers, time_travel=scheduled)
     # Alerts from the main directory should have all checks
-    fim.regular_file_cud(testdir, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, time_travel=scheduled)
+    fim.regular_file_cud(testdir, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
+                         time_travel=scheduled)

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_symlink_to_dir_between_scans.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_symlink_to_dir_between_scans.py
@@ -69,8 +69,8 @@ def test_symlink_to_dir_between_scans(tags_to_apply, get_configuration, configur
                                       wait_for_fim_start):
     """Replace a link with a directory between scans.
 
-    This test monitors a link with `follow_symbolic_link` enabled. After the first scan, it is replaced with a directory,
-    the new directory should send alerts during a second scan.
+    This test monitors a link with `follow_symbolic_link` enabled. After the first scan, it is replaced with
+    a directory, the new directory should send alerts during a second scan.
 
     Args:
         tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.

--- a/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
@@ -49,7 +49,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, filename, content, triggers_event, tags_to_apply', [
     (testdir1, 'testfile', "Sample content", True, {'valid_regex', 'valid_no_regex'}),
     (testdir1, 'btestfile', b"Sample content", True, {'valid_regex', 'valid_no_regex'}),

--- a/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
@@ -50,7 +50,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, filename, content, triggers_event, tags_to_apply', [
     (testdir1, 'testfile', "Sample content", True, {'valid_regex', 'valid_no_regex'}),
     (testdir1, 'btestfile', b"Sample content", True, {'valid_regex', 'valid_no_regex'}),

--- a/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
+++ b/tests/integration/test_fim/test_files/test_ignore/test_ignore_valid.py
@@ -49,6 +49,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, filename, content, triggers_event, tags_to_apply', [
     (testdir1, 'testfile', "Sample content", True, {'valid_regex', 'valid_no_regex'}),

--- a/tests/integration/test_fim/test_files/test_inotify/test_num_watches.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_num_watches.py
@@ -59,7 +59,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope='function')
 def restart_syscheckd_each_time(request):
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
@@ -68,7 +68,7 @@ def restart_syscheckd_each_time(request):
         for directory in test_directories:
             os.mkdir(directory)
 
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
     detect_initial_scan(file_monitor)
 
 

--- a/tests/integration/test_fim/test_files/test_inotify/test_num_watches.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_num_watches.py
@@ -82,7 +82,7 @@ def extra_configuration_after_yield():
 
 # Tests
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('realtime_enabled, decreases_num_watches, rename_folder', [
     (True, True, False),
     (True, True, True),

--- a/tests/integration/test_fim/test_files/test_inotify/test_remove_rename_folder.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_remove_rename_folder.py
@@ -53,7 +53,7 @@ def extra_configuration_after_yield():
 
 @pytest.fixture(scope='function')
 def restart_syscheckd_each_time(request):
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
@@ -61,7 +61,7 @@ def restart_syscheckd_each_time(request):
     if not os.path.exists(testdir):
         os.mkdir(testdir)
 
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
     detect_initial_scan(file_monitor)
 
 

--- a/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
+++ b/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
@@ -46,6 +46,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, filename, content, hidden_content, tags_to_apply', [
     (testdir1, 'testfile', "Sample content", False, {'valid_regex', 'valid_no_regex'}),

--- a/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
+++ b/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
@@ -47,7 +47,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, filename, content, hidden_content, tags_to_apply', [
     (testdir1, 'testfile', "Sample content", False, {'valid_regex', 'valid_no_regex'}),
     (testdir1, 'btestfile', b"Sample content", False, {'valid_regex', 'valid_no_regex'}),

--- a/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
+++ b/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
@@ -46,7 +46,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder, filename, content, hidden_content, tags_to_apply', [
     (testdir1, 'testfile', "Sample content", False, {'valid_regex', 'valid_no_regex'}),
     (testdir1, 'btestfile', b"Sample content", False, {'valid_regex', 'valid_no_regex'}),

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd.py
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd.py
@@ -55,6 +55,7 @@ def check_prelink():
 # tests
 
 
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1448')
 @pytest.mark.parametrize('tags_to_apply', [
     ({'prefilter_cmd'})
 ])

--- a/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
@@ -42,7 +42,6 @@ def get_configuration(request):
 
 
 # tests
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if the wazuh-modulesd service priority is updated correctly using
        <process_priority> tag in ossec.conf.

--- a/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
@@ -42,7 +42,7 @@ def get_configuration(request):
 
 
 # tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if the wazuh-modulesd service priority is updated correctly using
        <process_priority> tag in ossec.conf.

--- a/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
@@ -44,13 +44,13 @@ def get_configuration(request):
 # tests
 
 def test_process_priority(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check if the wazuh-syscheckd service priority is updated correctly using
+    """Check if the wazuh-modulesd service priority is updated correctly using
        <process_priority> tag in ossec.conf.
     """
     check_apply_test({'ossec_conf'}, get_configuration['tags'])
 
     priority = int(get_configuration['metadata']['process_priority'])
-    process_name = 'wazuh-syscheckd'
+    process_name = 'wazuh-modulesd'
     syscheckd_process = get_process(process_name)
 
     assert syscheckd_process is not None, f'Process {process_name} not found'

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
@@ -65,8 +65,8 @@ def test_diff_size_limit_default(tags_to_apply, get_configuration, configure_env
 
     diff_size_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                               callback=callback_diff_size_limit_value,
-                                              error_message='Did not receive expected '
-                                                            '"Maximum file size limit configured to \'... KB\'..." event'
+                                              error_message='Did not receive expected "Maximum file size '
+                                                            'limit configured to \'... KB\'..." event'
                                               ).result()
 
     if diff_size_value:

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
@@ -60,8 +60,8 @@ def test_diff_size_limit_default(tags_to_apply, get_configuration, configure_env
 
     diff_size_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                               callback=callback_diff_size_limit_value,
-                                              error_message='Did not receive expected '
-                                                            '"Maximum file size limit configured to \'... KB\'..." event'
+                                              error_message='Did not receive expected "Maximum file size limit '
+                                                            'configured to \'... KB\'..." event'
                                               ).result()
 
     if diff_size_value:

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_default.py
@@ -60,8 +60,8 @@ def test_disk_quota_default(tags_to_apply, get_configuration, configure_environm
 
     disk_quota_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                                callback=callback_disk_quota_default,
-                                               error_message='Did not receive expected '
-                                                             '"Maximum disk quota size limit configured to \'... KB\'." event'
+                                               error_message='Did not receive expected "Maximum disk quota '
+                                                             'size limit configured to \'... KB\'." event'
                                                ).result()
 
     if disk_quota_value:

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
@@ -96,5 +96,5 @@ def test_disk_quota_values(tags_to_apply, get_configuration, configure_environme
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout * 25, callback=callback_disk_quota_limit_reached,
-                            error_message='Did not receive expected '
-                                          '"The maximum configured size for the ... folder has been reached, ..." event.')
+                            error_message='Did not receive expected "The maximum configured '
+                                          'size for the ... folder has been reached, ..." event.')

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
@@ -78,7 +78,7 @@ def extra_configuration_after_yield():
 
 
 # Tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('tags_to_apply', [
     {'ossec_conf_diff'}
 ])

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
@@ -109,8 +109,8 @@ def test_file_size_default(tags_to_apply, filename, folder, get_configuration, c
     check_time_travel(scheduled)
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_file_size_limit_reached,
-                            error_message='Did not receive expected '
-                                          '"File ... is too big for configured maximum size to perform diff operation" event.')
+                            error_message='Did not receive expected "File ... is too '
+                                          'big for configured maximum size to perform diff operation" event.')
 
     if os.path.exists(diff_file_path):
         pytest.raises(FileExistsError(f"{diff_file_path} found. It should not exist after incresing the size."))

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_values.py
@@ -126,5 +126,5 @@ def test_file_size_values(tags_to_apply, filename, folder, get_configuration, co
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                             callback=callback_file_size_limit_reached,
-                            error_message='Did not receive expected '
-                                          '"File ... is too big for configured maximum size to perform diff operation" event.')
+                            error_message='Did not receive expected "File ... is too big for '
+                                          'configured maximum size to perform diff operation" event.')

--- a/tests/integration/test_fim/test_files/test_restrict/test_restrict_valid.py
+++ b/tests/integration/test_fim/test_files/test_restrict/test_restrict_valid.py
@@ -49,6 +49,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder', test_directories)
 @pytest.mark.parametrize('filename, mode, content, triggers_event, tags_to_apply', [

--- a/tests/integration/test_fim/test_files/test_restrict/test_restrict_valid.py
+++ b/tests/integration/test_fim/test_files/test_restrict/test_restrict_valid.py
@@ -49,7 +49,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder', test_directories)
 @pytest.mark.parametrize('filename, mode, content, triggers_event, tags_to_apply', [
     ('.restricted', 'w', "Sample content", True, {'valid_regex1'}),

--- a/tests/integration/test_fim/test_files/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_files/test_skip/test_skip.py
@@ -136,6 +136,7 @@ def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, 
             event = wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_state)
             raise AttributeError(f'Unexpected event {event}')
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /sys when setting 'skip_sys="yes"'."""
@@ -168,6 +169,7 @@ def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, w
         with pytest.raises(TimeoutError):
             event = wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_state)
             raise AttributeError(f'Unexpected event {event}')
+
 
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('directory, tags_to_apply', [

--- a/tests/integration/test_fim/test_files/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_files/test_skip/test_skip.py
@@ -89,7 +89,7 @@ def extra_configuration_before_yield():
 
 
 # tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /proc when setting 'skip_proc="yes"'."""
     check_apply_test({'skip_proc'}, get_configuration['tags'])
@@ -136,7 +136,7 @@ def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, 
             event = wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_state)
             raise AttributeError(f'Unexpected event {event}')
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /sys when setting 'skip_sys="yes"'."""
     check_apply_test({'skip_sys'}, get_configuration['tags'])
@@ -169,7 +169,7 @@ def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, w
             event = wazuh_log_monitor.start(timeout=3, callback=callback_detect_integrity_state)
             raise AttributeError(f'Unexpected event {event}')
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('directory, tags_to_apply', [
     (os.path.join('/', 'dev'), {'skip_dev'})
 ])
@@ -193,6 +193,7 @@ def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration
     regular_file_cud(directory, wazuh_log_monitor, time_travel=True, min_timeout=3, triggers_event=trigger)
 
 
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('directory,  tags_to_apply', [
     (os.path.join('/', 'nfs-mount-point'), {'skip_nfs'})
 ])

--- a/tests/integration/test_fim/test_files/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_files/test_skip/test_skip.py
@@ -89,7 +89,6 @@ def extra_configuration_before_yield():
 
 
 # tests
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /proc when setting 'skip_proc="yes"'."""
     check_apply_test({'skip_proc'}, get_configuration['tags'])
@@ -137,7 +136,6 @@ def test_skip_proc(get_configuration, configure_environment, restart_syscheckd, 
             raise AttributeError(f'Unexpected event {event}')
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     """Check if syscheckd skips /sys when setting 'skip_sys="yes"'."""
     check_apply_test({'skip_sys'}, get_configuration['tags'])
@@ -171,7 +169,6 @@ def test_skip_sys(get_configuration, configure_environment, restart_syscheckd, w
             raise AttributeError(f'Unexpected event {event}')
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('directory, tags_to_apply', [
     (os.path.join('/', 'dev'), {'skip_dev'})
 ])
@@ -195,7 +192,6 @@ def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration
     regular_file_cud(directory, wazuh_log_monitor, time_travel=True, min_timeout=3, triggers_event=trigger)
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('directory,  tags_to_apply', [
     (os.path.join('/', 'nfs-mount-point'), {'skip_nfs'})
 ])

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -542,6 +542,7 @@ def real_test(test_type, real_df, integrity_df, string_configuration, configurat
     if process:
         process.join()
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('number_files', [
     '1', '1000', '100000'

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -543,7 +543,7 @@ def real_test(test_type, real_df, integrity_df, string_configuration, configurat
         process.join()
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1449')
 @pytest.mark.parametrize('number_files', [
     '1', '1000', '100000'
 ])

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -1,3 +1,4 @@
+
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
@@ -24,7 +25,7 @@ from wazuh_testing.tools.services import control_service, check_daemon_status
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=3), pytest.mark.server]
 
 root_dir = '/test'
-tested_daemon = 'wazuh-syscheckd'
+tested_daemon = 'wazuh-modulesd'
 state_collector_time = 1
 state_path = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-agentd.state')
 performance_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'stats', 'performance')
@@ -32,7 +33,7 @@ fim_db_path = os.path.join(WAZUH_PATH, 'queue', 'fim', 'db')
 # local_internal_options configuration
 state_configuration = {
     "agentd.state_interval": state_collector_time,
-    "syscheck.debug": 2
+    "wazuh_modules.debug": 2
 }
 
 

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_FIM_performance.py
@@ -542,7 +542,7 @@ def real_test(test_type, real_df, integrity_df, string_configuration, configurat
     if process:
         process.join()
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('number_files', [
     '1', '1000', '100000'
 ])

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_stats_integrity_sync.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_stats_integrity_sync.py
@@ -717,7 +717,7 @@ def clean_environment():
             os.unlink(os.path.join(state_path, file))
 
 
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/1449')
 @pytest.mark.parametrize('case, modify_file, modify_all, restore_all', [
     (Cases.case0.value, False, False, True),
     (Cases.case1.value, True, False, False),

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_stats_integrity_sync.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_stats_integrity_sync.py
@@ -716,7 +716,7 @@ def clean_environment():
         if file.endswith('.state'):
             os.unlink(os.path.join(state_path, file))
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('case, modify_file, modify_all, restore_all', [
     (Cases.case0.value, False, False, True),
     (Cases.case1.value, True, False, False),

--- a/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_stats_integrity_sync.py
+++ b/tests/integration/test_fim/test_files/test_stats_integrity_sync/test_stats_integrity_sync.py
@@ -716,6 +716,7 @@ def clean_environment():
         if file.endswith('.state'):
             os.unlink(os.path.join(state_path, file))
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('case, modify_file, modify_all, restore_all', [
     (Cases.case0.value, False, False, True),

--- a/tests/integration/test_fim/test_files/test_tags/test_tags.py
+++ b/tests/integration/test_fim/test_files/test_tags/test_tags.py
@@ -50,7 +50,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder', test_directories)
 @pytest.mark.parametrize('name, content', [
     ('file1', 'Sample content'),

--- a/tests/integration/test_fim/test_files/test_tags/test_tags.py
+++ b/tests/integration/test_fim/test_files/test_tags/test_tags.py
@@ -50,6 +50,7 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 @pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('folder', test_directories)
 @pytest.mark.parametrize('name, content', [

--- a/tests/integration/test_fim/test_registry/conftest.py
+++ b/tests/integration/test_fim/test_registry/conftest.py
@@ -15,11 +15,11 @@ def restart_syscheckd(get_configuration, request):
     """
     Reset wazuh.log and start a new monitor.
     """
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_delete_registry.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_delete_registry.py
@@ -89,7 +89,8 @@ def test_delete_registry(key, subkey, arch, value_list,
     check_time_travel(scheduled, monitor=wazuh_log_monitor)
     events = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
                                      accum_results=len(value_list) + 1, error_message='Did not receive expected '
-                                                                                      '"Sending FIM event: ..." event').result()
+                                                                                      '"Sending FIM event: ..." '
+                                                                                      'event').result()
     for ev in events:
         validate_registry_value_event(ev, mode=mode)
 

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_baseline_generation.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_baseline_generation.py
@@ -48,11 +48,11 @@ registry_list = [(key, sub_key_1, KEY_WOW64_64KEY),
 
 @pytest.fixture(scope='function')
 def restart_syscheckd_each_time(request):
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='module', params=configurations)

--- a/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_full.py
+++ b/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_full.py
@@ -100,8 +100,8 @@ def test_file_limit_full(tags_to_apply, get_configuration, configure_environment
     RegCloseKey(reg1_handle)
 
     wazuh_log_monitor.start(timeout=40, callback=callback_file_limit_full_database,
-                            error_message='Did not receive expected '
-                                          '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
+                            error_message='Did not receive expected "DEBUG: ...: Couldn\'t insert \'...\' '
+                                          'entry into DB. The DB is full, ..." event')
 
     entries = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                       callback=callback_registry_count_entries,

--- a/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_values.py
+++ b/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_values.py
@@ -83,8 +83,8 @@ def test_file_limit_values(tags_to_apply, get_configuration, configure_environme
 
     file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                                callback=callback_value_file_limit,
-                                               error_message='Did not receive expected '
-                                                             '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
+                                               error_message='Did not receive expected "DEBUG: ...: Maximum '
+                                                             'number of entries to be monitored: ..." event'
                                                ).result()
 
     if file_limit_value:

--- a/tests/integration/test_fim/test_registry/test_registry_multiple_registries/test_multiple_keys.py
+++ b/tests/integration/test_fim/test_registry/test_registry_multiple_registries/test_multiple_keys.py
@@ -70,8 +70,8 @@ def test_multiple_keys(tags_to_apply, get_configuration, configure_environment, 
 
     discarded = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                         callback=callback_max_registry_monitored,
-                                        error_message='Did not receive expected '
-                                                      '"Maximum number of registries to be monitored..." event.').result()
+                                        error_message='Did not receive expected "Maximum number '
+                                                      'of registries to be monitored..." event.').result()
 
     assert discarded == expected_discarded, f'Discarded registry keys are not the expected ones.'
 

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
@@ -89,9 +89,8 @@ def test_disk_quota_default(key, subkey, arch, value_name, tags_to_apply,
 
     disk_quota_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                                callback=callback_disk_quota_default,
-                                               error_message='Did not receive expected '
-                                                             '"Maximum disk quota size limit configured to \'... KB\'." event'
-                                               ).result()
+                                               error_message='Did not receive expected "Maximum disk quota size '
+                                                             'limit configured to \'... KB\'." event').result()
     if disk_quota_value:
         assert disk_quota_value == str(DEFAULT_SIZE), 'Wrong value for disk_quota'
     else:

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
@@ -46,11 +46,11 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='function')
 def restart_syscheckd_each_time(request):
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='module', params=configurations)

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
@@ -46,11 +46,11 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='function')
 def restart_syscheckd_each_time(request):
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='module', params=configurations)

--- a/tests/integration/test_fim/test_synchronization/conftest.py
+++ b/tests/integration/test_fim/test_synchronization/conftest.py
@@ -15,11 +15,11 @@ def restart_syscheckd(get_configuration, request):
     """
     Reset wazuh.log and start a new monitor.
     """
-    control_service('stop', daemon='wazuh-syscheckd')
+    control_service('stop', daemon='wazuh-modulesd')
     truncate_file(LOG_FILE_PATH)
     file_monitor = FileMonitor(LOG_FILE_PATH)
     setattr(request.module, 'wazuh_log_monitor', file_monitor)
-    control_service('start', daemon='wazuh-syscheckd')
+    control_service('start', daemon='wazuh-modulesd')
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_fim/test_synchronization/test_response_timeout.py
+++ b/tests/integration/test_fim/test_synchronization/test_response_timeout.py
@@ -51,7 +51,7 @@ def get_configuration(request):
 
 
 # Tests
-
+@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('num_files', [1, 100])
 def test_response_timeout(num_files, get_configuration, configure_environment, restart_syscheckd):
     """Verify that synchronization checks take place at the expected time given INTERVAL and RESPONSE_TIMEOUT

--- a/tests/integration/test_fim/test_synchronization/test_response_timeout.py
+++ b/tests/integration/test_fim/test_synchronization/test_response_timeout.py
@@ -51,7 +51,6 @@ def get_configuration(request):
 
 
 # Tests
-@pytest.mark.xfail(reason='Expected error. Issue https://github.com/wazuh/wazuh/issues/8948')
 @pytest.mark.parametrize('num_files', [1, 100])
 def test_response_timeout(num_files, get_configuration, configure_environment, restart_syscheckd):
     """Verify that synchronization checks take place at the expected time given INTERVAL and RESPONSE_TIMEOUT

--- a/tests/integration/test_fim/test_synchronization/test_response_timeout.py
+++ b/tests/integration/test_fim/test_synchronization/test_response_timeout.py
@@ -78,7 +78,7 @@ def test_response_timeout(num_files, get_configuration, configure_environment, r
         truncate_agent_log()
         start_time = datetime.now()
         while datetime.now() < start_time + timedelta(seconds=time_out):
-            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command (f"sudo cat {LOG_FILE_PATH}")
+            ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command(f"sudo cat {LOG_FILE_PATH}")
             for line in ssh_stdout.read().decode('ascii').splitlines():
                 if callback_detect_end_scan(line):
                     return


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1199|

## Description

- Replaced wazuh-syscheckd daemon to wazuh-modulesd

- Replaced syscheck.debug to wazuh-modulesd.debug

- Some test fails by added issue with this unification. 
     [Issue - Syscheck.max_depth is set to 0 when reading the configuration ](https://github.com/wazuh/wazuh/issues/8948)
     
- Some test fails because we need to do refactoring. (4.x - 5.0):
     [Issue - test_audit.py not working when audit 3 is installed](https://github.com/wazuh/wazuh-qa/issues/1441)
     [Issue - test prefilter cmd failing in Centos8](https://github.com/wazuh/wazuh-qa/issues/1448)
     [Issue - Delete FIM tests deprecated](https://github.com/wazuh/wazuh-qa/issues/1449)
 
## Logs example

![imagen](https://user-images.githubusercontent.com/3978434/121751076-e4350900-cae3-11eb-881e-04f37fb5db89.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751116-f4e57f00-cae3-11eb-97a2-2485dfb4e279.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751158-03cc3180-cae4-11eb-9bde-d41f5c384c1c.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751198-12b2e400-cae4-11eb-8937-e8ecf25c7f15.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751232-1e9ea600-cae4-11eb-802d-f68e6054afcc.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751272-3118df80-cae4-11eb-991a-4d111f4f86b4.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751315-42fa8280-cae4-11eb-8d9a-eb0c1be58ce4.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751353-5279cb80-cae4-11eb-887c-bc2bdba8d6e8.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751378-60c7e780-cae4-11eb-8ae7-03e6dbaaa8fa.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751408-70473080-cae4-11eb-8fb0-5f5447b1cded.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751437-81903d00-cae4-11eb-8135-17f7c2cd9000.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751451-8c4ad200-cae4-11eb-9563-64679a173276.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751478-9967c100-cae4-11eb-81c5-94c5185928b0.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751504-a5538300-cae4-11eb-9e0b-60efb3edb5f3.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751528-b2707200-cae4-11eb-809b-c629d37558e2.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751543-c1572480-cae4-11eb-93f5-35f97b4c177f.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751579-d16f0400-cae4-11eb-9505-5b3ed2862dcb.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751597-de8bf300-cae4-11eb-81b4-e267591e6aff.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751632-ef3c6900-cae4-11eb-9f74-ace8b9086153.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751663-fbc0c180-cae4-11eb-99f0-116c8cd92f23.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751727-17c46300-cae5-11eb-81a6-0847f22177aa.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751763-2e6aba00-cae5-11eb-9e33-02312fa76240.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751796-3a567c00-cae5-11eb-9d2d-32fb22f60daa.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751811-45a9a780-cae5-11eb-9db9-b107b08d96e0.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751828-522e0000-cae5-11eb-8598-07fcd73a8fd0.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751882-6a058400-cae5-11eb-98ff-4e05b57d0225.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751902-7689dc80-cae5-11eb-92d6-c0f8fee3e68e.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751925-830e3500-cae5-11eb-808e-207f5d99a922.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751957-902b2400-cae5-11eb-812e-e3d2f9bde4de.png)
![imagen](https://user-images.githubusercontent.com/3978434/121751983-9e794000-cae5-11eb-89c7-82af01908aa1.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752004-a802a800-cae5-11eb-84bc-200513a574bf.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752044-bb157800-cae5-11eb-9ca9-125d4e2b25e4.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752087-ca94c100-cae5-11eb-8db3-abf19848b4be.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752109-d5e7ec80-cae5-11eb-843b-14c6bcfbc045.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752127-e009eb00-cae5-11eb-8216-d25c84e78f2b.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752161-f021ca80-cae5-11eb-94c8-9e9bbe683c1f.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752181-fb74f600-cae5-11eb-9d52-89c2b72b9121.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752219-0e87c600-cae6-11eb-9aab-70a2f47d8a3b.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752242-18a9c480-cae6-11eb-8ecf-72c12bc33340.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752268-26f7e080-cae6-11eb-97ae-aa013d60080a.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752282-31b27580-cae6-11eb-9a04-91dbf5e0f0ae.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752303-3d05a100-cae6-11eb-840b-c4a03500e6c3.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752344-4e4ead80-cae6-11eb-8726-d1edbf3a1988.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752360-59a1d900-cae6-11eb-9f26-890e824bca63.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752380-63c3d780-cae6-11eb-8aa3-8a267df30a50.png)
![imagen](https://user-images.githubusercontent.com/3978434/121752405-6faf9980-cae6-11eb-971d-51ba6a6b958d.png)

![imagen](https://user-images.githubusercontent.com/3978434/122069068-471bee00-cdcb-11eb-86c0-535627f6ca35.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.