### PR TITLE
Fix test_authd_worker.py

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/cluster.py
+++ b/deps/wazuh_testing/wazuh_testing/cluster.py
@@ -73,17 +73,17 @@ def cluster_msg_build(command: bytes = None, counter: int = None, payload: bytes
     """
     cmd_len = len(command)
     if cmd_len > CLUSTER_CMD_HEADER_SIZE - len(DIVIDE_FLAG):
-        raise Exception("Length of command '{}' exceeds limit ({}/{}).".format(cmd, cmd_len,
+        raise Exception("Length of command '{}' exceeds limit ({}/{}).".format(command, cmd_len,
                                                                                CLUSTER_CMD_HEADER_SIZE - len(
                                                                                    DIVIDE_FLAG)))
 
     # Add - to command until it reaches cmd length
     command = command + b' ' + b'-' * (CLUSTER_CMD_HEADER_SIZE - cmd_len - 1)
     encrypted_data = _my_fernet.encrypt(payload) if encrypt else payload
-    message_size = self.header_len + len(encrypted_data)
+    message_size = CLUSTER_DATA_HEADER_SIZE + len(encrypted_data)
 
     # Message size is <= request_chunk, send the message
-    if message_size <= self.request_chunk:
+    if message_size <= REQUEST_CHUNK:
         msg = bytearray(message_size)
         msg[:CLUSTER_DATA_HEADER_SIZE] = struct.pack(CLUSTER_HEADER_FORMAT, counter, len(encrypted_data), command)
         msg[CLUSTER_DATA_HEADER_SIZE:message_size] = encrypted_data

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -8,7 +8,7 @@ import time
 
 import pytest
 import yaml
-from wazuh_testing.tools.key_polling_cluster import FERNET_KEY, CLUSTER_DATA_HEADER_SIZE, cluster_msg_build
+from wazuh_testing.cluster import FERNET_KEY, CLUSTER_DATA_HEADER_SIZE, cluster_msg_build
 from wazuh_testing.tools import WAZUH_PATH, CLUSTER_LOGS_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import ManInTheMiddle
@@ -44,8 +44,8 @@ class WorkerMID(ManInTheMiddle):
     def verify_message(self, data: bytes):
         if len(data) > CLUSTER_DATA_HEADER_SIZE:
             message = data[CLUSTER_DATA_HEADER_SIZE:]
-            response = cluster_msg_build(cmd=b'send_sync', counter=2, payload=bytes(self.cluster_output.encode()),
-                                         encrypt=False)
+            response = cluster_msg_build(command=b'send_sync', counter=2, payload=bytes(self.cluster_output.encode()),
+                                         encrypt=False)[0]
             print(f'Received message from wazuh-authd: {message}')
             print(f'Response to send: {self.cluster_output}')
             self.pause()

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -8,7 +8,7 @@ import time
 
 import pytest
 import yaml
-from wazuh_testing.cluster import FERNET_KEY, CLUSTER_DATA_HEADER_SIZE, cluster_msg_build
+from wazuh_testing.tools.key_polling_cluster import FERNET_KEY, CLUSTER_DATA_HEADER_SIZE, cluster_msg_build
 from wazuh_testing.tools import WAZUH_PATH, CLUSTER_LOGS_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import ManInTheMiddle


### PR DESCRIPTION
|Related issue|
|---|
|#1444|


## Description

This PR aims to fix the problem with `test_authd_worker` described in the issue #1444 
Closes #1444 

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
- [report.zip](https://github.com/wazuh/wazuh-qa/files/6647074/report.zip)
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.