### PR TITLE
Bump urllib3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ setuptools~=56.0.0
 testinfra==5.0.0
 jq==1.1.2; platform_system == "Linux" or platform_system == "MacOS"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-urllib3~=1.25.11
+urllib3>=1.26.5


### PR DESCRIPTION
This PR aims to bump the urllib3 version to avoid any security issues.