### PR TITLE
Bump requests dependency due to conflicts with urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pyOpenSSL==19.1.0
 pytest-html==3.1.1
 pytest==6.2.3
 pyyaml==5.4
-requests==2.23.0
+requests>=2.25.0
 scipy>=1.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 seaborn>=0.11.1; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 setuptools~=56.0.0


### PR DESCRIPTION
This PRs updates the `requests` dependency version due to the following conflict:

```
requests 2.23.0 requires urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1, but you'll have urllib3 1.26.5 which is incompatible
```

Regards.