### PR TITLE
Add tests for invalid config of github and office365 modules

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/github.py
+++ b/deps/wazuh_testing/wazuh_testing/github.py
@@ -2,8 +2,6 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import os
-
 
 def callback_detect_enabled_err(line):
     if 'wm_github_read(): ERROR: Invalid content for tag \'enabled\' at module \'github\'.' in line:

--- a/deps/wazuh_testing/wazuh_testing/github.py
+++ b/deps/wazuh_testing/wazuh_testing/github.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+
+def callback_detect_enabled_err(line):
+    if 'wm_github_read(): ERROR: Invalid content for tag \'enabled\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_only_future_events_err(line):
+    if 'wm_github_read(): ERROR: Invalid content for tag \'only_future_events\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_interval_err(line):
+    if 'wm_github_read(): ERROR: Invalid content for tag \'interval\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_curl_max_size_err(line):
+    if 'wm_github_read(): ERROR: Invalid content for tag \'curl_max_size\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_time_delay_err(line):
+    if 'wm_github_read(): ERROR: Invalid content for tag \'time_delay\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_org_name_err(line):
+    if 'wm_github_read(): ERROR: Empty content for tag \'org_name\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_api_token_err(line):
+    if 'wm_github_read(): ERROR: Empty content for tag \'api_token\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_event_type_err(line):
+    if 'wm_github_read(): ERROR: Invalid content for tag \'event_type\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_read_err(line):
+    if 'wm_github_read(): ERROR: Empty content for tag \'api_auth\' at module \'github\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_start_github(line):
+    if 'wm_github_main(): INFO: Module GitHub started.' in line:
+        return line
+    return None
+
+
+def detect_github_start(file_monitor):
+    """Detect module github starts after restarting Wazuh.
+
+    Args:
+        file_monitor (FileMonitor): File log monitor to detect events
+    """
+    file_monitor.start(timeout=60, callback=callback_detect_start_github)

--- a/deps/wazuh_testing/wazuh_testing/github.py
+++ b/deps/wazuh_testing/wazuh_testing/github.py
@@ -24,7 +24,8 @@ def callback_detect_interval_err(line):
 
 
 def callback_detect_curl_max_size_err(line):
-    if 'wm_github_read(): ERROR: Invalid content for tag \'curl_max_size\' at module \'github\'.' in line:
+    if 'wm_github_read(): ERROR: Invalid content for tag \'curl_max_size\' at module \'github\'. '\
+       'The minimum value allowed is 1KB.' in line:
         return line
     return None
 

--- a/deps/wazuh_testing/wazuh_testing/office365.py
+++ b/deps/wazuh_testing/wazuh_testing/office365.py
@@ -2,8 +2,6 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import os
-
 
 def callback_detect_enabled_err(line):
     if 'wm_office365_read(): ERROR: Invalid content for tag \'enabled\' at module \'office365\'.' in line:

--- a/deps/wazuh_testing/wazuh_testing/office365.py
+++ b/deps/wazuh_testing/wazuh_testing/office365.py
@@ -25,7 +25,8 @@ def callback_detect_interval_err(line):
 
 
 def callback_detect_curl_max_size_err(line):
-    if 'wm_office365_read(): ERROR: Invalid content for tag \'curl_max_size\' at module \'office365\'.' in line:
+    if 'wm_office365_read(): ERROR: Invalid content for tag \'curl_max_size\' at module \'office365\'. '\
+       'The minimum value allowed is 1KB.' in line:
         return line
     return None
 

--- a/deps/wazuh_testing/wazuh_testing/office365.py
+++ b/deps/wazuh_testing/wazuh_testing/office365.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+
+
+def callback_detect_enabled_err(line):
+    if 'wm_office365_read(): ERROR: Invalid content for tag \'enabled\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_only_future_events_err(line):
+    if 'wm_office365_read(): ERROR: Invalid content for tag \'only_future_events\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_interval_err(line):
+    if 'wm_office365_read(): ERROR: Invalid content for tag \'interval\' at module \'office365\'. The maximum value allowed is 1 day.' in line:
+        return line
+    return None
+
+
+def callback_detect_curl_max_size_err(line):
+    if 'wm_office365_read(): ERROR: Invalid content for tag \'curl_max_size\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_tenant_id_err(line):
+    if 'wm_office365_read(): ERROR: Empty content for tag \'tenant_id\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_client_id_err(line):
+    if 'wm_office365_read(): ERROR: Empty content for tag \'client_id\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_client_secret_err(line):
+    if 'wm_office365_read(): ERROR: Empty content for tag \'client_secret\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_subscription_err(line):
+    if 'wm_office365_read(): ERROR: Empty content for tag \'subscription\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_read_err(line):
+    if 'wm_office365_read(): ERROR: Empty content for tag \'api_auth\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
+def callback_detect_start_office365(line):
+    if 'wm_office365_main(): INFO: Module Office365 started.' in line:
+        return line
+    return None
+
+
+def detect_office365_start(file_monitor):
+    """Detect module office365 starts after restarting Wazuh.
+
+    Args:
+        file_monitor (FileMonitor): File log monitor to detect events
+    """
+    file_monitor.start(timeout=60, callback=callback_detect_start_office365)

--- a/deps/wazuh_testing/wazuh_testing/office365.py
+++ b/deps/wazuh_testing/wazuh_testing/office365.py
@@ -18,7 +18,8 @@ def callback_detect_only_future_events_err(line):
 
 
 def callback_detect_interval_err(line):
-    if 'wm_office365_read(): ERROR: Invalid content for tag \'interval\' at module \'office365\'. The maximum value allowed is 1 day.' in line:
+    if 'wm_office365_read(): ERROR: Invalid content for tag \'interval\' at module \'office365\'. '\
+       'The maximum value allowed is 1 day.' in line:
         return line
     return None
 

--- a/docs/tests/integration/test_github/index.md
+++ b/docs/tests/integration/test_github/index.md
@@ -1,0 +1,2 @@
+# Overview
+

--- a/docs/tests/integration/test_github/test_configuration/test_invalid.md
+++ b/docs/tests/integration/test_github/test_configuration/test_invalid.md
@@ -1,0 +1,3 @@
+## Code documentation
+
+<!-- ::: tests.integration.test_github.test_configuration.test_invalid -->

--- a/docs/tests/integration/test_office365/index.md
+++ b/docs/tests/integration/test_office365/index.md
@@ -1,0 +1,2 @@
+# Overview
+

--- a/docs/tests/integration/test_office365/test_configuration/test_invalid.md
+++ b/docs/tests/integration/test_office365/test_configuration/test_invalid.md
@@ -1,0 +1,3 @@
+## Code documentation
+
+<!-- ::: tests.integration.test_office365.test_configuration.test_invalid -->

--- a/tests/integration/test_github/conftest.py
+++ b/tests/integration/test_github/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+
+from wazuh_testing.github import detect_github_start
+
+
+@pytest.fixture(scope='module')
+def wait_for_github_start(get_configuration, request):
+    # Wait for module github starts
+    file_monitor = getattr(request.module, 'wazuh_log_monitor')
+    detect_github_start(file_monitor)

--- a/tests/integration/test_github/test_configuration/data/wazuh_conf.yaml
+++ b/tests/integration/test_github/test_configuration/data/wazuh_conf.yaml
@@ -1,0 +1,28 @@
+---
+- tags:
+  - github_integration
+  apply_to_modules:
+  - test_invalid
+  sections:
+  - section: github
+    elements:
+      - enabled:
+          value: 'ENABLED'
+      - only_future_events:
+          value: 'ONLY_FUTURE_EVENTS'
+      - interval:
+          value: 'INTERVAL'
+      - curl_max_size:
+          value: 'CURL_MAX_SIZE'
+      - time_delay:
+          value: 'TIME_DELAY'
+      - api_auth:
+          elements:
+          - org_name:
+              value: 'ORG_NAME'
+          - api_token:
+              value: 'API_TOKEN'
+      - api_parameters:
+          elements:
+          - event_type:
+              value: 'EVENT_TYPE'

--- a/tests/integration/test_github/test_configuration/test_invalid.py
+++ b/tests/integration/test_github/test_configuration/test_invalid.py
@@ -9,8 +9,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.github import callback_detect_enabled_err, callback_detect_only_future_events_err, \
     callback_detect_interval_err, callback_detect_curl_max_size_err, callback_detect_time_delay_err, \
-    callback_detect_org_name_err, callback_detect_api_token_err, callback_detect_event_type_err, \
-    callback_detect_read_err
+    callback_detect_org_name_err, callback_detect_api_token_err, callback_detect_event_type_err
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -28,6 +27,10 @@ configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 force_restart_after_restoring = True
 
 # configurations
+
+local_internal_options = {
+    'wazuh_modules.debug': 2
+}
 
 cases = [
     # Case 1: Invalid enabled (version 4.3)
@@ -165,6 +168,20 @@ metadata = [case['metadata'] for case in cases]
 configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
 
 
+# callbacks
+
+callbacks = {
+                'invalid_enabled': callback_detect_enabled_err,
+                'invalid_only_future_events': callback_detect_only_future_events_err,
+                'invalid_interval': callback_detect_interval_err,
+                'invalid_curl_max_size': callback_detect_curl_max_size_err,
+                'invalid_time_delay': callback_detect_time_delay_err,
+                'invalid_org_name': callback_detect_org_name_err,
+                'invalid_api_token': callback_detect_api_token_err,
+                'invalid_event_type': callback_detect_event_type_err
+            }
+
+
 # fixtures
 
 @pytest.fixture(scope='module', params=configurations)
@@ -173,14 +190,28 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get internal configuration."""
+    return local_internal_options
+
+
 # tests
 
-def test_invalid(get_configuration, configure_environment, reset_ossec_log):
+def test_invalid(get_local_internal_options, configure_local_internal_options,
+                 get_configuration, configure_environment, reset_ossec_log):
     """
     Checks if an invalid configuration is detected
 
     Using invalid configurations with different attributes,
     expect an error message and github unable to start.
+
+    Args:
+        get_local_internal_options (fixture): Get internal configuration.
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        reset_ossec_log (fixture): Reset ossec.log and start a new monitor
     """
     # Configuration error -> ValueError raised
     try:
@@ -191,57 +222,8 @@ def test_invalid(get_configuration, configure_environment, reset_ossec_log):
     metadata = get_configuration.get('metadata')
     tags_to_apply = metadata['tags']
 
-    if tags_to_apply == 'invalid_enabled':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_enabled_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'Invalid element in the configuration').result()
-    elif tags_to_apply == 'invalid_only_future_events':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_only_future_events_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    elif tags_to_apply == 'invalid_interval':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_interval_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    elif tags_to_apply == 'invalid_curl_max_size':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_curl_max_size_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    elif tags_to_apply == 'invalid_time_delay':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_time_delay_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    elif tags_to_apply == 'invalid_org_name':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_org_name_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    elif tags_to_apply == 'invalid_api_token':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_api_token_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    elif tags_to_apply == 'invalid_event_type':
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_event_type_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'sched_scan_validate_parameters(): ERROR').result()
-    else:
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=callback_detect_read_err,
-                                accum_results=1,
-                                error_message='Did not receive expected '
-                                              'wm_gcp_read(): ERROR:').result()
+    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                            callback=callbacks[tags_to_apply],
+                            accum_results=1,
+                            error_message='Did not receive expected '
+                                          'Invalid element in the configuration').result()

--- a/tests/integration/test_github/test_configuration/test_invalid.py
+++ b/tests/integration/test_github/test_configuration/test_invalid.py
@@ -7,9 +7,10 @@ import sys
 
 import pytest
 from wazuh_testing import global_parameters
-from wazuh_testing.github import callback_detect_enabled_err, callback_detect_only_future_events_err, callback_detect_interval_err, \
-    callback_detect_curl_max_size_err, callback_detect_time_delay_err, callback_detect_org_name_err, callback_detect_api_token_err, \
-    callback_detect_event_type_err, callback_detect_read_err
+from wazuh_testing.github import callback_detect_enabled_err, callback_detect_only_future_events_err, \
+    callback_detect_interval_err, callback_detect_curl_max_size_err, callback_detect_time_delay_err, \
+    callback_detect_org_name_err, callback_detect_api_token_err, callback_detect_event_type_err, \
+    callback_detect_read_err
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor

--- a/tests/integration/test_github/test_configuration/test_invalid.py
+++ b/tests/integration/test_github/test_configuration/test_invalid.py
@@ -1,0 +1,246 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.github import callback_detect_enabled_err, callback_detect_only_future_events_err, callback_detect_interval_err, \
+    callback_detect_curl_max_size_err, callback_detect_time_delay_err, callback_detect_org_name_err, callback_detect_api_token_err, \
+    callback_detect_event_type_err, callback_detect_read_err
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+force_restart_after_restoring = True
+
+# configurations
+
+cases = [
+    # Case 1: Invalid enabled (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'invalid',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_enabled'
+        }
+    },
+    # Case 2: Invalid only_future_events (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'invalid',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_only_future_events'
+        }
+    },
+    # Case 3: Invalid interval (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '-5s',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_interval'
+        }
+    },
+    # Case 4: Invalid curl_max_size (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '-12',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_curl_max_size'
+        }
+    },
+    # Case 5: Invalid time_delay (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '7k',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_time_delay'
+        }
+    },
+    # Case 6: Invalid org_name (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': '',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_org_name'
+        }
+    },
+    # Case 7: Invalid api_token (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': '',
+            'EVENT_TYPE': 'all'
+        },
+        'metadata': {
+            'tags': 'invalid_api_token'
+        }
+    },
+    # Case 8: Invalid event_type (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TIME_DELAY': '1s',
+            'ORG_NAME': 'dummy',
+            'API_TOKEN': 'token',
+            'EVENT_TYPE': 'invalid'
+        },
+        'metadata': {
+            'tags': 'invalid_event_type'
+        }
+    }
+]
+params = [case['params'] for case in cases]
+metadata = [case['metadata'] for case in cases]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+def test_invalid(get_configuration, configure_environment, reset_ossec_log):
+    """
+    Checks if an invalid configuration is detected
+
+    Using invalid configurations with different attributes,
+    expect an error message and github unable to start.
+    """
+    # Configuration error -> ValueError raised
+    try:
+        control_service('restart')
+    except ValueError:
+        pass
+
+    metadata = get_configuration.get('metadata')
+    tags_to_apply = metadata['tags']
+
+    if tags_to_apply == 'invalid_enabled':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_enabled_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'Invalid element in the configuration').result()
+    elif tags_to_apply == 'invalid_only_future_events':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_only_future_events_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_interval':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_interval_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_curl_max_size':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_curl_max_size_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_time_delay':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_time_delay_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_org_name':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_org_name_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_api_token':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_api_token_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_event_type':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_event_type_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    else:
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_read_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'wm_gcp_read(): ERROR:').result()

--- a/tests/integration/test_office365/conftest.py
+++ b/tests/integration/test_office365/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import pytest
+
+from wazuh_testing.office365 import detect_office365_start
+
+
+@pytest.fixture(scope='module')
+def wait_for_office365_start(get_configuration, request):
+    # Wait for module office365 starts
+    file_monitor = getattr(request.module, 'wazuh_log_monitor')
+    detect_office365_start(file_monitor)

--- a/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
+++ b/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
@@ -1,0 +1,28 @@
+---
+- tags:
+  - offic365_integration
+  apply_to_modules:
+  - test_invalid
+  sections:
+  - section: office365
+    elements:
+      - enabled:
+          value: 'ENABLED'
+      - only_future_events:
+          value: 'ONLY_FUTURE_EVENTS'
+      - interval:
+          value: 'INTERVAL'
+      - curl_max_size:
+          value: 'CURL_MAX_SIZE'
+      - api_auth:
+          elements:
+          - tenant_id:
+              value: 'TENANT_ID'
+          - client_id:
+              value: 'CLIENT_ID'
+          - client_secret:
+              value: 'CLIENT_SECRET'
+      - subscriptions:
+          elements:
+          - subscription:
+              value: 'SUBSCRIPTION'

--- a/tests/integration/test_office365/test_configuration/test_invalid.py
+++ b/tests/integration/test_office365/test_configuration/test_invalid.py
@@ -7,9 +7,10 @@ import sys
 
 import pytest
 from wazuh_testing import global_parameters
-from wazuh_testing.office365 import callback_detect_enabled_err, callback_detect_only_future_events_err, callback_detect_interval_err, \
-    callback_detect_curl_max_size_err, callback_detect_tenant_id_err, callback_detect_client_id_err, callback_detect_client_secret_err, \
-    callback_detect_subscription_err, callback_detect_read_err
+from wazuh_testing.office365 import callback_detect_enabled_err, callback_detect_only_future_events_err, \
+    callback_detect_interval_err, callback_detect_curl_max_size_err, callback_detect_tenant_id_err, \
+    callback_detect_client_id_err, callback_detect_client_secret_err, callback_detect_subscription_err, \
+    callback_detect_read_err
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor

--- a/tests/integration/test_office365/test_configuration/test_invalid.py
+++ b/tests/integration/test_office365/test_configuration/test_invalid.py
@@ -1,0 +1,246 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+
+import pytest
+from wazuh_testing import global_parameters
+from wazuh_testing.office365 import callback_detect_enabled_err, callback_detect_only_future_events_err, callback_detect_interval_err, \
+    callback_detect_curl_max_size_err, callback_detect_tenant_id_err, callback_detect_client_id_err, callback_detect_client_secret_err, \
+    callback_detect_subscription_err, callback_detect_read_err
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+
+# Marks
+
+pytestmark = pytest.mark.tier(level=0)
+
+# variables
+
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+force_restart_after_restoring = True
+
+# configurations
+
+cases = [
+    # Case 1: Invalid enabled (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'invalid',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_enabled'
+        }
+    },
+    # Case 2: Invalid only_future_events (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'invalid',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_only_future_events'
+        }
+    },
+    # Case 3: Invalid interval (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '2d',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_interval'
+        }
+    },
+    # Case 4: Invalid curl_max_size (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '-12',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_curl_max_size'
+        }
+    },
+    # Case 5: Invalid tenant_id (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': '',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_tenant_id'
+        }
+    },
+    # Case 6: Invalid client_id (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': '',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_client_id'
+        }
+    },
+    # Case 7: Invalid client_secret (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': '',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_client_secret'
+        }
+    },
+    # Case 8: Invalid subscription (version 4.3)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'SUBSCRIPTION': ''
+        },
+        'metadata': {
+            'tags': 'invalid_subscription'
+        }
+    }
+]
+params = [case['params'] for case in cases]
+metadata = [case['metadata'] for case in cases]
+
+configurations = load_wazuh_configurations(configurations_path, __name__, params=params, metadata=metadata)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+
+def test_invalid(get_configuration, configure_environment, reset_ossec_log):
+    """
+    Checks if an invalid configuration is detected
+
+    Using invalid configurations with different attributes,
+    expect an error message and github unable to start.
+    """
+    # Configuration error -> ValueError raised
+    try:
+        control_service('restart')
+    except ValueError:
+        pass
+
+    metadata = get_configuration.get('metadata')
+    tags_to_apply = metadata['tags']
+
+    if tags_to_apply == 'invalid_enabled':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_enabled_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'Invalid element in the configuration').result()
+    elif tags_to_apply == 'invalid_only_future_events':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_only_future_events_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_interval':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_interval_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_curl_max_size':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_curl_max_size_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_tenant_id':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_tenant_id_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_client_id':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_client_id_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_client_secret':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_client_secret_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    elif tags_to_apply == 'invalid_subscription':
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_subscription_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'sched_scan_validate_parameters(): ERROR').result()
+    else:
+        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                callback=callback_detect_read_err,
+                                accum_results=1,
+                                error_message='Did not receive expected '
+                                              'wm_gcp_read(): ERROR:').result()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4983|

## Description

This PR includes:

- Tests for `github` module configuration.
- Tests for `office365` module configuration.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without 