### PR TITLE
Stabilize remoted IT tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -383,7 +383,7 @@ def detect_archives_log_event(archives_monitor, callback, error_message=None, up
                            error_message=error_message)
 
 
-def check_syslog_event(wazuh_archives_log_monitor, message, port, protocol, timeout=10):
+def check_syslog_event(wazuh_archives_log_monitor, message, port, protocol, timeout=20):
     """Check if a syslog event is properly received by the manager.
 
     Args:

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1706,7 +1706,7 @@ def create_agents(agents_number, manager_address, cypher='aes', fim_eps=100, aut
 
     return agents
 
-
+@retry(AttributeError, attempts=3, delay=15, delay_multiplier=1)
 def connect(agent,  manager_address='localhost', protocol=TCP, manager_port='1514'):
     """Connects an agent to the manager
 

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -92,9 +92,10 @@ def validate_agent_manager_protocol_communication(num_agents=2, manager_port=151
         # Save the search pattern to check it later
         search_patterns.append(search_pattern)
 
-        # Create sender event threads
-        send_event_threads.append(ThreadExecutor(send_event, {'event': event, 'protocol': protocol,
-                                                              'manager_port': manager_port, 'agent': agent}))
+        # Create multiple sender event threads
+        for _ in range(3):
+            send_event_threads.append(ThreadExecutor(send_event, {'event': event, 'protocol': protocol,
+                                                                  'manager_port': manager_port, 'agent': agent}))
 
     # Create socket monitor thread and start it
     socket_monitor_thread = ThreadExecutor(rd.check_queue_socket_event, {'raw_events': search_patterns})

--- a/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
@@ -74,7 +74,14 @@ def test_request(get_configuration, configure_environment, remove_shared_files,
 
         msg_request = f'{agent.id} {command_request}'
 
-        response = send_request(msg_request)
+        retries = 3
+        response = ''
+        while retries > 0:
+            retries -= 1
+            try:
+                response = send_request(msg_request)
+            except (AttributeError, ValueError, ConnectionRefusedError):
+                pass
 
         assert expected_answer in response, "Remoted unexpected answer"
 

--- a/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_syslog_message.py
@@ -83,8 +83,8 @@ def test_syslog_message(message, get_configuration, configure_environment, resta
 
     # Check if remoted correctly started with the new conf
     log_callback = remote.callback_detect_remoted_started(port=port, protocol=protocol, connection_type='syslog')
-    wazuh_log_monitor.start(timeout=5, callback=log_callback, update_position=False,
+    wazuh_log_monitor.start(timeout=50, callback=log_callback, update_position=False,
                             error_message="Wazuh remoted didn't start as expected.")
 
     # Check if wazuh-remoted receives syslog messages
-    remote.check_syslog_event(wazuh_archives_log_monitor, syslog_messages[message], port, protocol)
+    remote.check_syslog_event(wazuh_archives_log_monitor, syslog_messages[message], port, protocol, timeout=30)


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1411|


## Description

We have found some issues with remoted integration tests on production. Multiple false positive failures that need to be solved.

## Problem with the simulated agent's connection
```
00:11:42.565  self = <wazuh_testing.tools.agent_simulator.Agent object at 0x7f3f27368518>
00:11:42.565  
00:11:42.565      @retry(AttributeError, attempts=10, delay=2, delay_multiplier=1)
00:11:42.565      def wait_status_active(self):
00:11:42.565          """Wait until agent status is active in global.db.
00:11:42.565      
00:11:42.565          Raises:
00:11:42.565              AttributeError: If the agent is not active. Combined with the retry decorator makes a wait loop
00:11:42.565                  until the agent is active.
00:11:42.565          """
00:11:42.565          status = self.get_connection_status()
00:11:42.565      
00:11:42.565          if status == 'active':
00:11:42.565              return
00:11:42.565  >       raise AttributeError(f"Agent is not active yet: {status}")
00:11:42.565  E       AttributeError: Agent is not active yet: never_connected
```
It seems that sometimes the simulated agent can not connect with the manager, probably due to a race condition related to remoted/manager restart. We've solved it by adding a retry decorator to the connect function from the agent simulator

![image](https://user-images.githubusercontent.com/15269938/122350111-35625400-cf4d-11eb-8668-6fc30bb3ab11.png)


## Empty response from the socket on UDP

```
00:12:42.326  _socket = <socket.socket fd=11, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=queue/sockets/request>
00:12:42.326  size = 100
00:12:42.326  
00:12:42.326      @retry(ValueError)
00:12:42.326      def recv_response(_socket, size):
00:12:42.326          answer = _socket.recv(size).decode()
00:12:42.326          if answer == '':
00:12:42.326  >           raise ValueError
00:12:42.326  E           ValueError
00:12:42.326  
```

The reason may be that the package or the response is lost for networking (UDP) issues. A solution to avoid this problem is to send more than one message (identical messages) and wait for the first response to came.

![image](https://user-images.githubusercontent.com/15269938/122350913-eec12980-cf4d-11eb-92f1-38464765bb33.png)
![image](https://user-images.githubusercontent.com/15269938/122351141-27610300-cf4e-11eb-8e14-803d886a0ecf.png)

Tests
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/709/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/710/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/711/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/712/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/713/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/714/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/715/console
https://devel.ci.wazuh.info/view/Tests/job/Test_integration/716/console
