### PR TITLE
Added retry interval general settings tests

### DIFF
--- a/docs/tests/integration/test_vulnerability_detector/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/index.md
@@ -19,7 +19,7 @@ Vulnerability Detector in the configuration file.
 - **[test_scan_results](test_scan_results#test-scan-results)** Tests that check if Vulnerability Detector generates
 alerts in the right cases.
 
-- **[test_scan_types](test_scan_types#test-scan-types)** Tests that check if the scan types of the 
+- **[test_scan_types](test_scan_types#test-scan-types)** Tests that check if the scan types of the
 Vulnerability Detector are working as expected.
 
 We can specify the set of tests that we want to launch, either individually, module, package or custom. Normally,
@@ -46,18 +46,21 @@ Tests that modify the value of `enabled` tag in the configuration file and check
 - **[test_general_settings_min_full_scan_interval](test_general_settings/test_general_settings_min_full_scan_interval.md#test-general-settings-min-full-scan-interval)**:
 Tests that modify the value of `min_full_scan_interval` tag in the configuration file, set different intervals, and checking the result in
 the logs file.
-  
+
 - **[test_general_settings_interval](test_general_settings/test_general_settings_interval.md#test-general-settings-interval)**:
 Tests that modify the value of `interval` tag in the configuration file, set different times and check the result in the logs file.
 
 - **[test_general_settings_run_on_start](test_general_settings/test_general_settings_run_on_start.md#test-general-settings-run-on-start)**:
 Tests that modify the value of `run_on_start` tag in the configuration file and check the result in the logs file.
 
+- **[test_general_settings_retry_interval](test_general_settings/test_general_settings_retry_interval.md#test-general-settings-retry-interval)**:
+Tests that modify the value of `retry_interval` tag in the configuration file and check the result in the logs file.
+
 #### Test scan results
 
 - **[test_alert_vulnerability_removal](test_scan_results/test_alert_vulnerability_removal.md#test-alert-vulnerability-removal)**:
-Test that adds a simulated agent to the system with two test packages containing vulnerabilities then starts 
-a `BASELINE` scan and, after finishing it, removes the first package and updates the second one to a non-vulnerable 
+Test that adds a simulated agent to the system with two test packages containing vulnerabilities then starts
+a `BASELINE` scan and, after finishing it, removes the first package and updates the second one to a non-vulnerable
 version. It then launches a `PARTIAL_SCAN` and checks if alerts have been generated for these package operations.
 
 - **[test_debian_inventory_debian_feed](test_scan_results/test_debian_inventory_debian_feed.md#test-debian-inventory-debian-feed)**:
@@ -83,21 +86,21 @@ Vulnerability Detector generates the alerts from NVD and providers feed.
 #### Test scan types
 
 - **[test_baseline_scan_type](test_scan_types/test_baseline_scan_type.md#test-baseline-scan-type)**:
-Test that launches a `BASELINE` scan on a simulated agent containing a test package. It is confirmed through 
+Test that launches a `BASELINE` scan on a simulated agent containing a test package. It is confirmed through
 the logs that the vulnerability for the test package is detected and no alert is generated for this vulnerability.
 
 - **[test_partial_scan_type](test_scan_types/test_partial_scan_type.md#test-partial-scan-type)**:
-Test that adds a simulated agent to the system with a test package containing a vulnerability then starts 
-a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability. 
+Test that adds a simulated agent to the system with a test package containing a vulnerability then starts
+a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability.
 It then launches a `PARTIAL_SCAN` and checks that the alert has only been generated for the last package installed.
-  
+
 - **[test_full_scan_type](test_scan_types/test_full_scan_type.md#test-full-scan-type)**:
-Test that adds a simulated agent to the system with two test packages containing vulnerabilities then starts 
-a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability and updates 
-the second package to a non-vulnerable version. It then launches a `FULL_SCAN` and checks that alerts 
-have been generated for both the installed package and the updated package, the latter due to the removal 
-of the vulnerability associated with it. 
-  
+Test that adds a simulated agent to the system with two test packages containing vulnerabilities then starts
+a `BASELINE` scan and, after finishing it, adds a new test package with another vulnerability and updates
+the second package to a non-vulnerable version. It then launches a `FULL_SCAN` and checks that alerts
+have been generated for both the installed package and the updated package, the latter due to the removal
+of the vulnerability associated with it.
+
 ---
 
 ### Tier 1

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/index.md
@@ -9,6 +9,7 @@ expected. These are the general options:
 - `<min_full_scan_interval>`
 - `<interval>`
 - `<run_on_start>`
+- `<retry_interval>`
 
 ## General info
 
@@ -23,6 +24,7 @@ expected. These are the general options:
 - `interval`: Vulnerabilities scans should start every `<x>` specified time.
 - `run_on_start`: If it set to `yes`, vulnerabilities scans and providers feeds update must start when `wazuh-modulesd`
 process gets started.
+- `retry_interval`: Vulnerabilities scan retry on an agent should start after `<x>` specified time expires.
 
 ## Testing
 
@@ -34,11 +36,13 @@ Tests that modify the value of `enabled` tag in the configuration file and check
 - **[test_general_settings_min_full_scan_interval](test_general_settings_min_full_scan_interval.md#test-general-settings-min-full-scan-interval)**:
 Tests that modify the value of `min_full_scan_interval` tag in the configuration file, set different intervals and checking the result in
 the logs file.
-  
+
 - **[test_general_settings_interval](test_general_settings_interval.md#test-general-settings-interval)**:
 Tests that modify the value of `interval` tag in the configuration file, set different times and checking the result in
 the logs file.
 
 - **[test_general_settings_run_on_start](test_general_settings_run_on_start.md#test-general-settings-run-on-start)**:
 Tests that modify the value of `run_on_start` tag in the configuration file and check the result in the logs file.
-  
+
+- **[test_general_settings_retry_interval](test_general_settings_retry_interval.md#test-general-settings-retry-interval)**:
+Tests that modify the value of `retry_interval` tag in the configuration file and check the result in the logs file.

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/index.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/index.md
@@ -24,7 +24,7 @@ expected. These are the general options:
 - `interval`: Vulnerabilities scans should start every `<x>` specified time.
 - `run_on_start`: If it set to `yes`, vulnerabilities scans and providers feeds update must start when `wazuh-modulesd`
 process gets started.
-- `retry_interval`: Vulnerabilities scan retry on an agent should start after `<x>` specified time expires.
+- `retry_interval`:  The time to wait after a scan completes to retry the agents that had a problem to be scanned.
 
 ## Testing
 

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.md
@@ -1,7 +1,7 @@
 # Test general settings retry interval
 
 The tests will modify the value of `retry_interval` tag in the configuration file,
-set different intervals and check the result in the logs file.
+setting different intervals and checking the result in the logs file.
 
 ## General info
 

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.md
@@ -1,0 +1,50 @@
+# Test general settings retry interval
+
+The tests will modify the value of `retry_interval` tag in the configuration file,
+set different intervals and check the result in the logs file.
+
+## General info
+
+|Tier | Number of tests | Time spent| Test file |
+|:--:|:--:|:--:|:--:|
+| 0 | 6 | 3m14s | test_general_settings_retry_interval.py |
+
+## Test logic
+
+For different time units:
+
+```
+['s']
+```
+
+and the time values:
+
+```
+[20, 30, 40]
+```
+
+At first, the test will check in the logs file if the following message appears:
+
+```
+<vulnerability_detector_prefix> Going to sleep <value> seconds before retrying pending agents
+```
+
+And then the test will look into the log file for the following message:
+
+```
+<vulnerability_detector_prefix> Analyzing OVAL vulnerabilities for agent '<agent_id>'
+```
+
+To do so, a simulated agent is added to the system, as soon as it is detected, the Vulnerability Detector
+will attempt to start a (`BASELINE` scan) on it. Since the values in the table `sync_info` represent a not synced state
+of `sys_programs` table, the agent is skipped.
+The date when the agent was skipped plus the value set in `retry_interval` should be greater or equal to the date
+that the vulnerabilities analysis starts on the agent after a synced state is forced modifying the info in `sync_info`.
+
+## Checks
+
+- [x] Vulnerability Detector does not attempt to start a scan of the agent until the time set in `retry_interval` has expired.
+
+## Code documentation
+
+::: tests.integration.test_vulnerability_detector.test_general_settings.test_general_settings_retry_interval

--- a/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.md
@@ -35,11 +35,10 @@ And then the test will look into the log file for the following message:
 <vulnerability_detector_prefix> Analyzing OVAL vulnerabilities for agent '<agent_id>'
 ```
 
-To do so, a simulated agent is added to the system, as soon as it is detected, the Vulnerability Detector
-will attempt to start a (`BASELINE` scan) on it. Since the values in the table `sync_info` represent a not synced state
-of `sys_programs` table, the agent is skipped.
-The date when the agent was skipped plus the value set in `retry_interval` should be greater or equal to the date
-that the vulnerabilities analysis starts on the agent after a synced state is forced modifying the info in `sync_info`.
+To do so, a simulated agent is added to the system; as soon as it is detected, the Vulnerability Detector
+will attempt to start a (`BASELINE` scan) on it.
+The datetime when the agent was skipped plus the value set in `retry_interval` should be greater or equal
+to the actual datetime that the vulnerabilities analysis starts on the agent after a synced state is forced.
 
 ## Checks
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_retry_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_retry_interval.yaml
@@ -1,0 +1,39 @@
+- tags:
+    - retry_interval
+  apply_to_modules:
+    - test_general_settings_retry_interval
+  sections:
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: "20s"
+        - retry_interval:
+            value: RETRY_INTERVAL
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: 'debian'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: BUSTER_FEED_PATH
+                  value: 'buster'
+              - path:
+                  value: DEBIAN_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: NVD_JSON_FEED_PATH
+              - update_interval:
+                  value: '10s'

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
@@ -18,11 +18,6 @@ from wazuh_testing.tools.time import time_to_seconds
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
-local_internal_options = {
-    'wazuh_modules.debug': 2,
-    'monitord.rotate_log': 0
-}
-
 # variables
 CVE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'vulnerabilities', 'cve.db')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -60,12 +55,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get configurations from the module."""
-    return local_internal_options
-
-
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
     """Add a dummy agent, inserts in its database (sys_programs table) a test package,
@@ -79,8 +68,7 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_min_full_scan_interval(configure_local_internal_options, get_configuration, configure_environment,
-                                restart_modulesd, add_simulated_agent):
+def test_min_full_scan_interval(get_configuration, configure_environment, restart_modulesd, add_simulated_agent):
     """Check if the Vulnerability Detector module waits the minimal time set in "min_full_scan_interval"
     to perform FULL_SCAN type scanning.
 
@@ -91,7 +79,6 @@ def test_min_full_scan_interval(configure_local_internal_options, get_configurat
     the period set in "min_full_scan_interval" has expired, at which point the full scan should be triggered.
 
     Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
         get_configuration (fixture): Get configurations from the module.
         configure_environment (fixture): Configure a custom environment for testing.
         restart_modulesd (fixture): Reset ossec.log and start a new monitor.

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -27,7 +27,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
 configurations_path = os.path.join(test_data_path, 'wazuh_retry_interval.yaml')
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-retry_interval_values = [20, 30, 40]
+retry_interval_values = [25, 30, 35]
 retry_interval_units = ['s']
 parameters = []
 metadata = []
@@ -40,35 +40,32 @@ nvd_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_NVD_FEED)
 
 for value in retry_interval_values:
     for unit in retry_interval_units:
-        parameters.append({'RETRY_INTERVAL': f'{value}{unit}',
+        parameters.append({'RETRY_INTERVAL': f"{value}{unit}",
                            'BUSTER_FEED_PATH': buster_oval_feed_path,
                            'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
                            'NVD_JSON_FEED_PATH': nvd_json_feed_path})
-        metadata.append({'retry_interval': f'{value}{unit}'})
-        ids.append(f'{value}{unit}')
+        metadata.append({'retry_interval': f"{value}{unit}"})
+        ids.append(f"{value}{unit}")
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
-
-def pytest_namespace():
-    return {'first_scan_fail_time': None,
-            'scan_success_time': None}
-
 # fixtures
-@pytest.fixture(scope='module', params=configurations)
+@pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    """Get configurations from the module.
+    """
     return request.param
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def get_local_internal_options():
-    """Get configurations from the module."""
+    """Get configurations from the module.
+    """
     return local_internal_options
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
 
@@ -83,63 +80,19 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_retry_interval_skip_agent(configure_local_internal_options, get_configuration, configure_environment,
-                                   restart_modulesd, add_simulated_agent):
-    """Check if the Vulnerability Detector module skips an agent due to sys_collector database unsynced.
+def test_retry_interval(configure_local_internal_options, get_configuration, configure_environment,
+                        restart_modulesd, add_simulated_agent):
+    """Check if the Vulnerability Detector module retries the scan after a failure attempt when the value set in
+    retry_interval expires and the syscollector database is synced.
 
     For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
     with a test package. This package is added to the database of the simulated agent and, after enrollment
     of the agent, the vulnerability detector must attempt to launch the first scan on it.
 
-    As the sys_collector database is not synchronized (last_completion attribute in sync_info table does not match
+    As the syscollector database is not synchronized (last_completion attribute in sync_info table does not match
     with the last_attemp attribute) the scan on the agent is skipped.
 
-    Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset ossec.log and start a new monitor.
-        add_simulated_agent (fixture): Add a simulated agent to the manager for testing.
-    """
-    check_apply_test({'retry_interval'}, get_configuration['tags'])
-    agent_id = add_simulated_agent
-
-    # Callbacks
-    callback_detect_collecting_software = vd.make_vuln_callback(pattern=f"Collecting agent '{agent_id}' software.",
-                                                                prefix='.*')
-    log_line = "Going to sleep \\d+ seconds before retrying pending agents"
-    callback_detect_skip_agent_log = vd.make_vuln_callback(pattern=log_line,
-                                                           prefix='.*')
-
-    # Detect collection software log.
-    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
-                            callback=callback_detect_collecting_software,
-                            error_message='No collecting software detected in log.')
-
-    # Detect agent skipped log.
-    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
-                            callback=callback_detect_skip_agent_log,
-                            error_message='No skip agent log detected.')
-
-    pattern = "(\\d{4}/\\d{2}/\\d{2}\\s\\d{2}:\\d{2}:\\d{2}).*" + log_line + ""
-    file = open(LOG_FILE_PATH, "r")
-    lines = file.readlines()
-    for line in lines:
-        exist = re.search(pattern, line)
-        if exist:
-            pytest.first_scan_fail_time = datetime.strptime(exist.group(1), '%Y/%m/%d %H:%M:%S')
-    file.close()
-
-
-def test_retry_interval_scan_agent(configure_local_internal_options, get_configuration, configure_environment,
-                                   restart_modulesd, add_simulated_agent):
-    """Check if the Vulnerability Detector module performs the analysis of vulnerabilities correctly.
-
-    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
-    with a test package. This package is added to the database of the simulated agent and, after enrollment
-    of the agent, the vulnerability detector must attempt to launch the first scan on it.
-
-    As the sys_collector database is synchronized (last_completion attribute in sync_info table match
+    After the syscollector database is synchronized (last_completion attribute in sync_info table match
     with the last_attemp attribute) the scan on the agent is performed.
 
     Args:
@@ -151,37 +104,29 @@ def test_retry_interval_scan_agent(configure_local_internal_options, get_configu
     """
     check_apply_test({'retry_interval'}, get_configuration['tags'])
     agent_id = add_simulated_agent
+    retry_interval = time_to_seconds(get_configuration['metadata']['retry_interval'])
 
-    # Force sys_collector database synchronization.
+    def get_timestamp(log_line):
+        callback_log_line = vd.make_vuln_callback(pattern=log_line, prefix='.*')
+        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                                callback=callback_log_line,
+                                error_message='Log line not found.')
+
+        regex = f"(\\d{{4}}/\\d{{2}}/\\d{{2}}\\s\\d{{2}}:\\d{{2}}:\\d{{2}}).*{log_line}"
+        with open(LOG_FILE_PATH) as file:
+            lines = file.readlines()
+            for line in lines:
+                exist = re.search(regex, line)
+                if exist:
+                    return datetime.strptime(exist.group(1), '%Y/%m/%d %H:%M:%S')
+
+    first_scan_fail_time = get_timestamp('Going to sleep \\d+ seconds before retrying pending agents')
+
+    # Force syscollector database synchronization.
     vd.update_sync_info(agent=agent_id)
 
-    # Callbacks
-    callback_detect_collecting_software = vd.make_vuln_callback(pattern=f"Collecting agent '{agent_id}' software.",
-                                                                prefix='.*')
-    retry_interval = time_to_seconds(get_configuration['metadata']['retry_interval'])
-    log_line = f"Analyzing OVAL vulnerabilities for agent '{agent_id}'"
-    callback_detect_scan_agent_log = vd.make_vuln_callback(pattern=log_line,
-                                                           prefix='.*')
+    scan_success_time = get_timestamp(f"Analyzing OVAL vulnerabilities for agent '{agent_id}'")
 
-    # Detect collection software log.
-    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
-                            callback=callback_detect_collecting_software,
-                            error_message='No collecting software detected in log.')
-
-    # Detect vulnerabilities analysis log on agent.
-    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
-                            callback=callback_detect_scan_agent_log,
-                            error_message='No vulnerabilities analysis detected in log.')
-
-    pattern = "(\\d{4}/\\d{2}/\\d{2}\\s\\d{2}:\\d{2}:\\d{2}).*" + log_line + ""
-    file = open(LOG_FILE_PATH, "r")
-    lines = file.readlines()
-    for line in lines:
-        exist = re.search(pattern, line)
-        if exist:
-            pytest.scan_success_time = datetime.strptime(exist.group(1), '%Y/%m/%d %H:%M:%S')
-    file.close()
-
-    time_between_scan_retries = (pytest.scan_success_time - pytest.first_scan_fail_time).total_seconds()
+    time_between_scan_retries = (scan_success_time - first_scan_fail_time).total_seconds()
 
     assert math.trunc(time_between_scan_retries) >= retry_interval

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -73,7 +73,8 @@ def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
 
     For this purpose, it adds a dummy agent, inserts in its database (sys_programs table) a test package,
-    and configures its database to appear to be up to date (sync_info table)."""
+    and configures its database to appear to be up to date (sync_info table).
+    """
     agent_id, sender, injector = vd.create_simulated_agent()
     vd.insert_package(agent=agent_id, name='wazuhintegrationpackage-0', vendor='WazuhIntegrationTests',
                       version='1.0.0', source='NULL')

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+import time
+import re
+import math
+import pytest
+import wazuh_testing.vulnerability_detector as vd
+
+from datetime import datetime
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.time import time_to_seconds
+
+# Marks
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
+
+local_internal_options = {
+    'wazuh_modules.debug': 2,
+    'monitord.rotate_log': 0
+}
+
+# variables
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+configurations_path = os.path.join(test_data_path, 'wazuh_retry_interval.yaml')
+wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+retry_interval_values = [20, 30, 40]
+retry_interval_units = ['s']
+parameters = []
+metadata = []
+ids = []
+
+# Offline feeds
+buster_oval_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_OVAL_FEED)
+debian_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_DEBIAN_JSON_FEED)
+nvd_json_feed_path = os.path.join(test_feed_path, vd.CUSTOM_NVD_FEED)
+
+for value in retry_interval_values:
+    for unit in retry_interval_units:
+        parameters.append({'RETRY_INTERVAL': f'{value}{unit}',
+                           'BUSTER_FEED_PATH': buster_oval_feed_path,
+                           'DEBIAN_JSON_FEED_PATH': debian_json_feed_path,
+                           'NVD_JSON_FEED_PATH': nvd_json_feed_path})
+        metadata.append({'retry_interval': f'{value}{unit}'})
+        ids.append(f'{value}{unit}')
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+def pytest_namespace():
+    return {'first_scan_fail_time': None,
+            'scan_success_time': None}
+
+# fixtures
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="module")
+def add_simulated_agent(get_configuration):
+    """Add a simulated agent to the system with basic functionality.
+
+    For this purpose, it adds a dummy agent, inserts in its database (sys_programs table) a test package,
+    and configures its database to appear to be up to date (sync_info table)."""
+    agent_id, sender, injector = vd.create_simulated_agent()
+    vd.insert_package(agent=agent_id, name='wazuhintegrationpackage-0', vendor='WazuhIntegrationTests',
+                      version='1.0.0', source='NULL')
+    yield agent_id
+    injector.stop_receive()
+    vd.delete_simulated_agent(agent_id)
+
+
+def test_retry_interval_skip_agent(configure_local_internal_options, get_configuration, configure_environment,
+                                   restart_modulesd, add_simulated_agent):
+    """Check if the Vulnerability Detector module skips an agent due to sys_collector database unsynced.
+
+    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
+    with a test package. This package is added to the database of the simulated agent and, after enrollment
+    of the agent, the vulnerability detector must attempt to launch the first scan on it.
+
+    As the sys_collector database is not synchronized (last_completion attribute in sync_info table does not match
+    with the last_attemp attribute) the scan on the agent is skipped.
+
+    Args:
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_modulesd (fixture): Reset ossec.log and start a new monitor.
+        add_simulated_agent (fixture): Add a simulated agent to the manager for testing.
+    """
+    check_apply_test({'retry_interval'}, get_configuration['tags'])
+    agent_id = add_simulated_agent
+
+    # Callbacks
+    callback_detect_collecting_software = vd.make_vuln_callback(pattern=f"Collecting agent '{agent_id}' software.",
+                                                                prefix='.*')
+    log_line = "Going to sleep \\d+ seconds before retrying pending agents"
+    callback_detect_skip_agent_log = vd.make_vuln_callback(pattern=log_line,
+                                                           prefix='.*')
+
+    # Detect collection software log.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_collecting_software,
+                            error_message='No collecting software detected in log.')
+
+    # Detect agent skipped log.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_skip_agent_log,
+                            error_message='No skip agent log detected.')
+
+    pattern = "(\\d{4}/\\d{2}/\\d{2}\\s\\d{2}:\\d{2}:\\d{2}).*" + log_line + ""
+    file = open(LOG_FILE_PATH, "r")
+    lines = file.readlines()
+    for line in lines:
+        exist = re.search(pattern, line)
+        if exist:
+            pytest.first_scan_fail_time = datetime.strptime(exist.group(1), '%Y/%m/%d %H:%M:%S')
+    file.close()
+
+
+def test_retry_interval_scan_agent(configure_local_internal_options, get_configuration, configure_environment,
+                                   restart_modulesd, add_simulated_agent):
+    """Check if the Vulnerability Detector module performs the analysis of vulnerabilities correctly.
+
+    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
+    with a test package. This package is added to the database of the simulated agent and, after enrollment
+    of the agent, the vulnerability detector must attempt to launch the first scan on it.
+
+    As the sys_collector database is synchronized (last_completion attribute in sync_info table match
+    with the last_attemp attribute) the scan on the agent is performed.
+
+    Args:
+        configure_local_internal_options (fixture): Set internal configuration for testing.
+        get_configuration (fixture): Get configurations from the module.
+        configure_environment (fixture): Configure a custom environment for testing.
+        restart_modulesd (fixture): Reset ossec.log and start a new monitor.
+        add_simulated_agent (fixture): Add a simulated agent to the manager for testing.
+    """
+    check_apply_test({'retry_interval'}, get_configuration['tags'])
+    agent_id = add_simulated_agent
+
+    # Force sys_collector database synchronization.
+    vd.update_sync_info(agent=agent_id)
+
+    # Callbacks
+    callback_detect_collecting_software = vd.make_vuln_callback(pattern=f"Collecting agent '{agent_id}' software.",
+                                                                prefix='.*')
+    retry_interval = time_to_seconds(get_configuration['metadata']['retry_interval'])
+    log_line = f"Analyzing OVAL vulnerabilities for agent '{agent_id}'"
+    callback_detect_scan_agent_log = vd.make_vuln_callback(pattern=log_line,
+                                                           prefix='.*')
+
+    # Detect collection software log.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_collecting_software,
+                            error_message='No collecting software detected in log.')
+
+    # Detect vulnerabilities analysis log on agent.
+    wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                            callback=callback_detect_scan_agent_log,
+                            error_message='No vulnerabilities analysis detected in log.')
+
+    pattern = "(\\d{4}/\\d{2}/\\d{2}\\s\\d{2}:\\d{2}:\\d{2}).*" + log_line + ""
+    file = open(LOG_FILE_PATH, "r")
+    lines = file.readlines()
+    for line in lines:
+        exist = re.search(pattern, line)
+        if exist:
+            pytest.scan_success_time = datetime.strptime(exist.group(1), '%Y/%m/%d %H:%M:%S')
+    file.close()
+
+    time_between_scan_retries = (pytest.scan_success_time - pytest.first_scan_fail_time).total_seconds()
+
+    assert math.trunc(time_between_scan_retries) >= retry_interval

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -17,11 +17,6 @@ from wazuh_testing.tools.time import time_to_seconds
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
-local_internal_options = {
-    'wazuh_modules.debug': 2,
-    'monitord.rotate_log': 0
-}
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
@@ -59,13 +54,6 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='module')
-def get_local_internal_options():
-    """Get configurations from the module.
-    """
-    return local_internal_options
-
-
-@pytest.fixture(scope='module')
 def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
 
@@ -80,8 +68,7 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_retry_interval(configure_local_internal_options, get_configuration, configure_environment,
-                        restart_modulesd, add_simulated_agent):
+def test_retry_interval(get_configuration, configure_environment, restart_modulesd, add_simulated_agent):
     """Check if the Vulnerability Detector module retries the scan after a failure attempt when the value set in
     retry_interval expires and the syscollector database is synced.
 
@@ -96,7 +83,6 @@ def test_retry_interval(configure_local_internal_options, get_configuration, con
     with the last_attemp attribute) the scan on the agent is performed.
 
     Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
         get_configuration (fixture): Get configurations from the module.
         configure_environment (fixture): Configure a custom environment for testing.
         restart_modulesd (fixture): Reset ossec.log and start a new monitor.

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -48,8 +48,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 # fixtures
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module.
-    """
+    """Get configurations from the module."""
     return request.param
 
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_alert_vulnerability_removal.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_alert_vulnerability_removal.py
@@ -14,11 +14,6 @@ from wazuh_testing.tools.monitoring import FileMonitor
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
-local_internal_options = {
-    'wazuh_modules.debug': 2,
-    'monitord.rotate_log': 0
-}
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
@@ -55,12 +50,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get configurations from the module."""
-    return local_internal_options
-
-
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
@@ -78,8 +67,7 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_alert_vulnerability_removal(configure_local_internal_options, get_configuration, configure_environment,
-                                     restart_modulesd, add_simulated_agent):
+def test_alert_vulnerability_removal(get_configuration, configure_environment, restart_modulesd, add_simulated_agent):
     """Check if the Vulnerability Detector module generates an alert when a vulnerability is removed from the inventory.
 
     For this purpose, the manager is configured to use custom feeds that include vulnerabilities associated
@@ -94,7 +82,6 @@ def test_alert_vulnerability_removal(configure_local_internal_options, get_confi
     the alerts that should have been generated after the removal of the vulnerabilities are searched for.
 
     Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
         get_configuration (fixture): Get configurations from the module.
         configure_environment (fixture): Configure a custom environment for testing.
         restart_modulesd (fixture): Reset ossec.log and start a new monitor.

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -14,11 +14,6 @@ from wazuh_testing.tools.monitoring import FileMonitor
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
-local_internal_options = {
-    'wazuh_modules.debug': 2,
-    'monitord.rotate_log': 0
-}
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
@@ -48,12 +43,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get configurations from the module."""
-    return local_internal_options
-
-
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
@@ -69,8 +58,7 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_baseline_scan_type(configure_local_internal_options, get_configuration, configure_environment,
-                            restart_modulesd, add_simulated_agent):
+def test_baseline_scan_type(get_configuration, configure_environment, restart_modulesd, add_simulated_agent):
     """Check if the Vulnerability Detector module performs the baseline scan type correctly.
 
     For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
@@ -81,7 +69,6 @@ def test_baseline_scan_type(configure_local_internal_options, get_configuration,
     generated for such vulnerability in their respective logs.
 
     Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
         get_configuration (fixture): Get configurations from the module.
         configure_environment (fixture): Configure a custom environment for testing.
         restart_modulesd (fixture): Reset ossec.log and start a new monitor.

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
@@ -15,11 +15,6 @@ from wazuh_testing.tools.monitoring import FileMonitor
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
-local_internal_options = {
-    'wazuh_modules.debug': 2,
-    'monitord.rotate_log': 0
-}
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
@@ -58,12 +53,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get configurations from the module."""
-    return local_internal_options
-
-
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
@@ -81,8 +70,7 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_full_scan_type(configure_local_internal_options, get_configuration, configure_environment,
-                        restart_modulesd, add_simulated_agent):
+def test_full_scan_type(get_configuration, configure_environment, restart_modulesd, add_simulated_agent):
     """Check if the Vulnerability Detector module performs the full scan type correctly.
 
     For this purpose, the manager is configured to use custom feeds that include vulnerabilities associated
@@ -98,7 +86,6 @@ def test_full_scan_type(configure_local_internal_options, get_configuration, con
     removed by the update). This will be confirmed by checking the log and alert files respectively.
 
     Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
         get_configuration (fixture): Get configurations from the module.
         configure_environment (fixture): Configure a custom environment for testing.
         restart_modulesd (fixture): Reset ossec.log and start a new monitor.

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -14,11 +14,6 @@ from wazuh_testing.tools.monitoring import FileMonitor
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
-local_internal_options = {
-    'wazuh_modules.debug': 2,
-    'monitord.rotate_log': 0
-}
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_feed_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
@@ -54,12 +49,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get configurations from the module."""
-    return local_internal_options
-
-
 @pytest.fixture(scope="function")
 def add_simulated_agent(get_configuration):
     """Add a simulated agent to the system with basic functionality.
@@ -75,8 +64,7 @@ def add_simulated_agent(get_configuration):
     vd.delete_simulated_agent(agent_id)
 
 
-def test_partial_scan_type(configure_local_internal_options, get_configuration, configure_environment,
-                           restart_modulesd, add_simulated_agent):
+def test_partial_scan_type(get_configuration, configure_environment, restart_modulesd, add_simulated_agent):
     """Check if the Vulnerability Detector module performs the partial scan type correctly.
 
     For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
@@ -90,7 +78,6 @@ def test_partial_scan_type(configure_local_internal_options, get_configuration, 
     the BASELINE scan.
 
     Args:
-        configure_local_internal_options (fixture): Set internal configuration for testing.
         get_configuration (fixture): Get configurations from the module.
         configure_environment (fixture): Configure a custom environment for testing.
         restart_modulesd (fixture): Reset ossec.log and start a new monitor.


### PR DESCRIPTION
|Related issue|
|---|
|#1458|

## Description

As part of the issue [#8701](https://github.com/wazuh/wazuh/issues/8701) a new settings was added to prevent all the scan retries are completed before `sys_collector` updates the agent's database.
That being said, this PR adds a new integration tests that cover the functionality of this setting. 

## Dod
![2021-06-23_16-24](https://user-images.githubusercontent.com/13010397/123156370-9606fa80-d43f-11eb-9e82-096a6c2991b6.png)
<!--
Paste here related logs and alerts
-->

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.