### PR TITLE
Added IT for wazuh-logcollector.state in macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python cache
 __pycache__
+.pytest_cache/
 
 venv
 wazuh_testing.egg-info

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -600,9 +600,12 @@ def local_internal_options_to_dict(local_internal_options):
     dict_local_internal_options = {}
     no_comments_options = [line.strip() for line in local_internal_options
                            if not (line.startswith('#') or line == '\n')]
-    for line in no_comments_options:
-        key, value = line.split('=')
-        dict_local_internal_options[key.rstrip("\n")] = value
+    try:
+        for line in no_comments_options:
+            key, value = line.split('=')
+            dict_local_internal_options[key.rstrip('\n')] = value
+    except ValueError:
+        raise ValueError('Invalid local_internal_options.conf file.')
 
     return dict_local_internal_options
 

--- a/docs/tests/integration/test_logcollector/test_statistics/test_statistics.md
+++ b/docs/tests/integration/test_logcollector/test_statistics/test_statistics.md
@@ -17,7 +17,7 @@ and saves the corresponding information in the `wazuh-logcollector.state` file.
 
 ## Expected behavior
 
-- Pass if find macOS statistics on a Darwin system with the `<log_format>macos</log_format>` in the `localfile` block.
+- Pass if macOS statistics on a Darwin system are found with the `<log_format>macos</log_format>` in the `localfile` block.
 
 ## Code documentation
 

--- a/docs/tests/integration/test_logcollector/test_statistics/test_statistics.md
+++ b/docs/tests/integration/test_logcollector/test_statistics/test_statistics.md
@@ -1,0 +1,24 @@
+# Test statistics
+
+## Overview 
+
+Check if Wazuh is working properly when monitoring log files (via `logcollector`), 
+and saves the corresponding information in the `wazuh-logcollector.state` file.
+
+## Objective
+
+- To confirm that `logcollector` saves the statistics of the files it is monitoring.
+
+## General info
+
+|Tier | Number of tests | Time spent |
+|:--:|:--:|:--:|
+| 0 | 1 | 6s |
+
+## Expected behavior
+
+- Pass if find macOS statistics on a Darwin system with the `<log_format>macos</log_format>` in the `localfile` block.
+
+## Code documentation
+
+::: tests.integration.test_logcollector.test_statistics.test_statistics

--- a/docs/tests/integration/test_logcollector/test_statistics/test_statistics_macos.md
+++ b/docs/tests/integration/test_logcollector/test_statistics/test_statistics_macos.md
@@ -1,4 +1,4 @@
-# Test statistics
+# Test statistics - macOS
 
 ## Overview 
 
@@ -21,4 +21,4 @@ and saves the corresponding information in the `wazuh-logcollector.state` file.
 
 ## Code documentation
 
-::: tests.integration.test_logcollector.test_statistics.test_statistics
+::: tests.integration.test_logcollector.test_statistics.test_statistics_macos

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -488,6 +488,7 @@ nav:
                 - Overview: tests/integration/test_logcollector/test_options/index.md
                 - Test state interval: tests/integration/test_logcollector/test_options/test_options_state_interval.md
                 - Test state interval no file: tests/integration/test_logcollector/test_options/test_options_state_interval_no_file.md
+            - Test statistics: tests/integration/test_logcollector/test_statistics/test_statistics.md
         - Logtest:
           - tests/integration/test_logtest/index.md
           - Test invalid token: tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.md

--- a/tests/integration/test_logcollector/test_statistics/data/wazuh_statistics_macos.yaml
+++ b/tests/integration/test_logcollector/test_statistics/data/wazuh_statistics_macos.yaml
@@ -1,0 +1,13 @@
+- tags:
+  - test_statistics_macos
+  apply_to_modules:
+  - test_statistics_macos
+  sections:
+  - section: localfile
+    attributes:
+      - name: 'testing files'
+    elements:
+    - log_format:
+        value: LOG_FORMAT
+    - location:
+        value: LOCATION

--- a/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
+++ b/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
@@ -39,6 +39,7 @@ configuration_ids = [f"{x['LOCATION']}_{x['LOG_FORMAT']}" for x in parameters]
 
 local_internal_options = {'logcollector.state_interval': 1}
 
+
 # Fixtures
 @pytest.fixture(scope="module")
 def get_local_internal_options():
@@ -52,7 +53,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_options_state_interval_no_file(get_local_internal_options, get_configuration, 
+def test_options_state_interval_no_file(get_local_internal_options, get_configuration,
                                         configure_environment, restart_logcollector):
     """Check if the monitorized file does appear in logcollector.state.
 

--- a/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
+++ b/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
@@ -2,27 +2,21 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
-import sys
-from json import load
-import tempfile
-
 import pytest
 import wazuh_testing.tools.configuration as conf
+
+from json import load
 from wazuh_testing import logcollector
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools import LOGCOLLECTOR_STATISTICS_FILE
-from wazuh_testing.tools import LOG_FILE_PATH
-from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-
-from time import sleep
+from wazuh_testing.tools.file import read_json
 
 # Marks
 pytestmark = [pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # Configuration
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'configuration')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_statistics_macos.yaml')
 
 parameters = [
@@ -55,18 +49,17 @@ def get_configuration(request):
 
 def test_options_state_interval_no_file(get_local_internal_options, get_configuration,
                                         configure_environment, restart_logcollector):
-    """Check if the monitorized file does appear in logcollector.state.
+    """Check if the monitored file appears in logcollector.state.
 
     Raises:
         AssertionError: If the elapsed time is different from the interval.
-        TimeoutError: If the expected callback is not generated.
+        TimeoutError: If the expected callback is not generated in the expected time.
     """
 
     # Ensure wazuh-logcollector.state is created
     logcollector.wait_statistics_file(timeout=10)
 
-    with open(LOGCOLLECTOR_STATISTICS_FILE, 'r') as json_file:
-        data = load(json_file)
+    data = read_json(LOGCOLLECTOR_STATISTICS_FILE)
 
     global_files = data['global']['files']
     interval_files = data['interval']['files']

--- a/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
+++ b/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
@@ -3,19 +3,17 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
 import pytest
-import wazuh_testing.tools.configuration as conf
 
-from json import load
-from wazuh_testing import logcollector
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools import LOGCOLLECTOR_STATISTICS_FILE
-from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.file import read_json
+from wazuh_testing import logcollector
 
 # Marks
 pytestmark = [pytest.mark.darwin, pytest.mark.tier(level=1)]
 
 # Configuration
+logcollector_stats_file_tout = 30
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_statistics_macos.yaml')
 
@@ -33,22 +31,19 @@ configuration_ids = [f"{x['LOCATION']}_{x['LOG_FORMAT']}" for x in parameters]
 
 local_internal_options = {'logcollector.state_interval': 1}
 
-
-# Fixtures
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get configurations from the module."""
-    return local_internal_options
+daemons_handler_configuration = {'daemons': ['wazuh-logcollector', 'wazuh-agentd', 'wazuh-execd'], 'ignore_errors': False}
 
 
-@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+@pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-def test_options_state_interval_no_file(get_local_internal_options, get_configuration,
-                                        configure_environment, restart_logcollector):
+def test_options_state_interval_no_file(configure_local_internal_options_module,
+                                        get_configuration,
+                                        configure_environment,
+                                        daemons_handler):
     """Check if the monitored file appears in logcollector.state.
 
     Raises:
@@ -57,7 +52,7 @@ def test_options_state_interval_no_file(get_local_internal_options, get_configur
     """
 
     # Ensure wazuh-logcollector.state is created
-    logcollector.wait_statistics_file(timeout=10)
+    logcollector.wait_statistics_file(timeout=logcollector_stats_file_tout)
 
     data = read_json(LOGCOLLECTOR_STATISTICS_FILE)
 

--- a/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
+++ b/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+import sys
+from json import load
+import tempfile
+
+import pytest
+import wazuh_testing.tools.configuration as conf
+from wazuh_testing import logcollector
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+from wazuh_testing.tools import LOGCOLLECTOR_STATISTICS_FILE
+from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.services import control_service
+
+from time import sleep
+
+# Marks
+pytestmark = [pytest.mark.darwin, pytest.mark.tier(level=1)]
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'configuration')
+configurations_path = os.path.join(test_data_path, 'wazuh_statistics_macos.yaml')
+
+parameters = [
+    {'LOCATION': 'macos', 'LOG_FORMAT': 'macos'},
+]
+
+metadata = [
+    {'location': 'macos', 'log_format': 'macos'}
+]
+
+# Configuration data
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"{x['LOCATION']}_{x['LOG_FORMAT']}" for x in parameters]
+
+local_internal_options = {'logcollector.state_interval': 1}
+
+# Fixtures
+@pytest.fixture(scope="module")
+def get_local_internal_options():
+    """Get configurations from the module."""
+    return local_internal_options
+
+
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+def test_options_state_interval_no_file(get_local_internal_options, get_configuration, 
+                                        configure_environment, restart_logcollector):
+    """Check if the monitorized file does appear in logcollector.state.
+
+    Raises:
+        AssertionError: If the elapsed time is different from the interval.
+        TimeoutError: If the expected callback is not generated.
+    """
+
+    # Ensure wazuh-logcollector.state is created
+    logcollector.wait_statistics_file(timeout=10)
+
+    with open(LOGCOLLECTOR_STATISTICS_FILE, 'r') as json_file:
+        data = load(json_file)
+
+    global_files = data['global']['files']
+    interval_files = data['interval']['files']
+
+    assert list(filter(lambda global_file: global_file['location'] == 'macos', global_files))
+    assert list(filter(lambda interval_file: interval_file['location'] == 'macos', interval_files))


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1463|

## Description

Tests are needed to ensure that the `wazuh-logcollector.state` file is updated with information from the macOS logs. Although it is not a localfile that collects logs from a file, there should be informed about the events that are collected from the `log stream` command.

- [x] Test to check `wazuh-logcollector.state` contain macOS information without macOS localfile.

## Logs example
```
# python3 -m pytest tests/integration/test_logcollector/test_statistics/test_statistics_macos.py 
======================================== test session starts ========================================
platform darwin -- Python 3.9.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /Users/vagrant/Wazuh/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-2.0.1, metadata-1.11.0, testinfra-5.0.0
collected 1 item                                                                                    

tests/integration/test_logcollector/test_statistics/test_statistics_macos.py .                [100%]

========================================= 1 passed in 6.11s =========================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.