### PR TITLE
Fix missing argument in test_macos_format_basic IT

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -761,6 +761,6 @@ def format_macos_message_pattern(process_name, message, type='log', subsystem=No
         elif type == 'activity':
             macos_message = f"{process_name}\[\d+\]: Created Activity ID.* Description: {message}"
 
-    assert macos_message is not None
+    assert macos_message is not None, 'Wrong type or process name selected for macos message pattern format.'
 
     return macos_message

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -752,6 +752,7 @@ def format_macos_message_pattern(process_name, message, type='log', subsystem=No
     Returns:
         string: Expected unified logging system event.
     """
+    macos_message = None
     if process_name == 'logger' or type == 'trace':
         macos_message = f"{process_name}\[\d+\]: {message}"
     else:
@@ -759,5 +760,7 @@ def format_macos_message_pattern(process_name, message, type='log', subsystem=No
             macos_message = f"{process_name}\[\d+\]: \[{subsystem}:{category}\] {message}"
         elif type == 'activity':
             macos_message = f"{process_name}\[\d+\]: Created Activity ID.* Description: {message}"
+
+    assert macos_message is not None
 
     return macos_message

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -479,6 +479,7 @@ def add_log_data(log_path, log_line_message, size_kib=1024, line_start=1, print_
         return line_start + lines - 1
     return 0
 
+
 def callback_invalid_format_value(line, option, location):
     """Create a callback to detect content values invalid in a log format file specific.
 

--- a/tests/integration/test_logcollector/test_macos/test_macos_format_basic.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_format_basic.py
@@ -42,7 +42,7 @@ def get_connection_configuration():
     return logcollector.DEFAULT_AUTHD_REMOTED_SIMULATOR_CONFIGURATION
 
 
-@pytest.mark.parametrize('macos_message', macos_log_messages, ids=[x['id'] for x in macos_log_messages])
+@pytest.mark.parametrize('macos_message', macos_log_messages, ids=[log_message['id'] for log_message in macos_log_messages])
 def test_macos_format_basic(get_configuration, configure_environment, get_connection_configuration,
                             init_authd_remote_simulator, macos_message, restart_logcollector):
 

--- a/tests/integration/test_logcollector/test_macos/test_macos_format_basic.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_format_basic.py
@@ -42,7 +42,8 @@ def get_connection_configuration():
     return logcollector.DEFAULT_AUTHD_REMOTED_SIMULATOR_CONFIGURATION
 
 
-@pytest.mark.parametrize('macos_message', macos_log_messages, ids=[log_message['id'] for log_message in macos_log_messages])
+@pytest.mark.parametrize('macos_message', macos_log_messages,
+                         ids=[log_message['id'] for log_message in macos_log_messages])
 def test_macos_format_basic(get_configuration, configure_environment, get_connection_configuration,
                             init_authd_remote_simulator, macos_message, restart_logcollector):
 
@@ -70,8 +71,8 @@ def test_macos_format_basic(get_configuration, configure_environment, get_connec
         logcollector.generate_macos_custom_log(macos_message['type'], macos_message['level'],
                                                macos_message['subsystem'], macos_message['category'])
         expected_macos_message = logcollector.format_macos_message_pattern(
-                                                        'custom_log',
-                                                        logcollector.TEMPLATE_OSLOG_MESSAGE, 'log', macos_message['subsystem'],
-                                                        macos_message['category'])
+                                                'custom_log', logcollector.TEMPLATE_OSLOG_MESSAGE,
+                                                subsystem=macos_message['subsystem'],
+                                                category=macos_message['category'])
 
     check_agent_received_message(remoted_simulator.rcv_msg_queue, expected_macos_message, timeout=40)


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-qa/issues/1469|


## Description
It seems that `format_macos_message_pattern`' function arguments changed recently and were not updated in `tests/integration/test_logcollector/test_macos/test_macos_format_basic.py` leading to a logic failure because of a missing specification of the log type. This PR aims to fix that problem.


## Configuration options


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.