### PR TITLE
Add system test to check that agent-files are deleted when agent is removed

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -229,3 +229,18 @@ class HostManager:
             stdout (str): The output of the command execution.
         """
         return self.get_host(host).ansible("command", cmd, check=check)["stdout"]
+
+    def run_shell(self, host: str, cmd: str, check: bool = False):
+        """Run a shell command on the specified host and return its stdout.
+
+        The difference with run_command is that here, shell symbols like &, |, etc. are interpreted.
+
+        Args:
+            host (str) : Hostname
+            cmd (str): Shell command to execute
+            check (bool, optional): Ansible check mode("Dry Run")(https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html), by default it is enabled so no changes will be applied. Default `False`
+
+        Returns:
+            stdout (str): The output of the command execution.
+        """
+        return self.get_host(host).ansible("shell", cmd, check=check)["stdout"]

--- a/docs/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
+++ b/docs/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
@@ -1,19 +1,21 @@
 # Test whether agent files are being deleted in managers
 ## Overview
 This test checks that, when an agent is removed/unregistered, the files related to it that exist on the master and worker nodes are removed. Those files are:
-- {wazuh_path}/queue/diff/{name}
-- {wazuh_path}/queue/agent-groups/{id}
-- {wazuh_path}/queue/rids/{id}
-- {wazuh_path}/var/db/agents/{name}-{id}.db
-- {wazuh_path}/queue/db/{id}.db)
+
+- `{wazuh_path}/queue/diff/{name}`
+- `{wazuh_path}/queue/agent-groups/{id}`
+- `{wazuh_path}/queue/rids/{id}`
+- `{wazuh_path}/var/db/agents/{name}-{id}.db`
+- `{wazuh_path}/queue/db/{id}.db)`
 
 It is also verified that the information related to the unregistered agent is deleted from the following tables (inside `global.db`): 
+
 - agent
 - belongs
 
 ## Objective
 
-To confirm that no remaining files are left after deleting registered agents. 
+To confirm that no remaining files are left in the managers after deleting registered agents. 
 
 ## General info
 

--- a/docs/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
+++ b/docs/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
@@ -1,0 +1,33 @@
+# Test whether agent files are being deleted in managers
+## Overview
+This test checks that, when an agent is removed/unregistered, the files related to it that exist on the master and worker nodes are removed. Those files are:
+- {wazuh_path}/queue/diff/{name}
+- {wazuh_path}/queue/agent-groups/{id}
+- {wazuh_path}/queue/rids/{id}
+- {wazuh_path}/var/db/agents/{name}-{id}.db
+- {wazuh_path}/queue/db/{id}.db)
+
+It is also verified that the information related to the unregistered agent is deleted from the following tables (inside `global.db`): 
+- agent
+- belongs
+
+## Objective
+
+To confirm that no remaining files are left after deleting registered agents. 
+
+## General info
+
+| Number of tests | Time spent |
+|:--|:--:|
+| 1 | 106s |
+
+## Expected behavior
+
+- Fail if any of the agent files cannot be found when it has not yet been unregistered.
+- Fail if there are no information of the agent in `global.db` when it has not yet been unregistered.
+- Fail if after unregistering the agent, any of the expected files are not removed. 
+- Fail if after unregistering the agent, any of the expected information in `global.db` can be queried.
+
+## Code documentation
+
+::: tests.system.test_cluster.test_agent_files_deletion.test_agent_files_deletion

--- a/docs/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
+++ b/docs/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
@@ -1,4 +1,4 @@
-# Test whether agent files are being deleted in managers
+# Test that agent-files are deleted after unregistering agents
 ## Overview
 This test checks that, when an agent is removed/unregistered, the files related to it that exist on the master and worker nodes are removed. Those files are:
 
@@ -6,7 +6,7 @@ This test checks that, when an agent is removed/unregistered, the files related 
 - `{wazuh_path}/queue/agent-groups/{id}`
 - `{wazuh_path}/queue/rids/{id}`
 - `{wazuh_path}/var/db/agents/{name}-{id}.db`
-- `{wazuh_path}/queue/db/{id}.db)`
+- `{wazuh_path}/queue/db/{id}.db`
 
 It is also verified that the information related to the unregistered agent is deleted from the following tables (inside `global.db`): 
 
@@ -25,8 +25,8 @@ To confirm that no remaining files are left in the managers after deleting regis
 
 ## Expected behavior
 
-- Fail if any of the agent files cannot be found when it has not yet been unregistered.
-- Fail if there are no information of the agent in `global.db` when it has not yet been unregistered.
+- Fail if any of the agent files cannot be found when it has not been unregistered yet.
+- Fail if there are no information of the agent in `global.db` when it has not been unregistered yet.
 - Fail if after unregistering the agent, any of the expected files are not removed. 
 - Fail if after unregistering the agent, any of the expected information in `global.db` can be queried.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -522,6 +522,7 @@ nav:
         - Test cluster:
           - tests/system/test_cluster/index.md
           - Test agent info sync: tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.md
+          - Test agent files deletion: tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.md
           - Test agent enrollment:  tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.md
           - Test agent key polling: tests/system/test_cluster/test_agent_key_polling/test_agent_key_polling.md
           - Test integrity sync: tests/system/test_cluster/test_integrity_sync/test_integrity_sync.md

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -112,6 +112,7 @@ required an specific testing environment located in `wazuh-qa/tests/system/provi
 | test_cluster/test_agent_enrollment  | enrollment_cluster   |
 | test_cluster/test_agent_info_sync   | basic_cluster        |
 | test_cluster/test_agent_key_polling | basic_cluster        |
+| test_agent_files_deletion           | basic_cluster        |
 | test_cluster/test_integrity_sync    | agentless_cluster    |
 | test_jwt_invalidation               | agentless_cluster    |
 

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -107,14 +107,14 @@ our [testing environment guide](#setting-up-a-test-environment).
 Our cluster system tests are located in `wazuh-qa/tests/system/`. They are organized by functionalities and each one may
 required an specific testing environment located in `wazuh-qa/tests/system/provisioning`:
 
-| Functionality                       | Required environment |
-|-------------------------------------|----------------------|
-| test_cluster/test_agent_enrollment  | enrollment_cluster   |
-| test_cluster/test_agent_info_sync   | basic_cluster        |
-| test_cluster/test_agent_key_polling | basic_cluster        |
-| test_agent_files_deletion           | basic_cluster        |
-| test_cluster/test_integrity_sync    | agentless_cluster    |
-| test_jwt_invalidation               | agentless_cluster    |
+| Functionality                          | Required environment |
+|----------------------------------------|----------------------|
+| test_cluster/test_agent_enrollment     | enrollment_cluster   |
+| test_cluster/test_agent_info_sync      | basic_cluster        |
+| test_cluster/test_agent_key_polling    | basic_cluster        |
+| test_cluster/test_agent_files_deletion | basic_cluster        |
+| test_cluster/test_integrity_sync       | agentless_cluster    |
+| test_jwt_invalidation                  | agentless_cluster    |
 
 ### Test structure
 

--- a/tests/system/test_agent_files_deletion/test_agent_files_deletion.py
+++ b/tests/system/test_agent_files_deletion/test_agent_files_deletion.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from os.path import join, dirname, abspath
+from time import sleep
+
+import pytest
+
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.system import HostManager
+
+master_host = 'wazuh-master'
+worker_host = 'wazuh-worker2'
+agent_host = 'wazuh-agent3'
+managers_hosts = [master_host, worker_host]
+inventory_path = join(dirname(dirname(abspath(__file__))), 'provisioning', 'basic_cluster', 'inventory.yml')
+host_manager = HostManager(inventory_path)
+time_to_sync = 60
+
+# Each file should exist in all hosts specified in 'hosts'.
+files = [{'path': join(WAZUH_PATH, 'queue', 'rids', '{id}'), 'hosts': managers_hosts},
+         {'path': join(WAZUH_PATH, 'queue', 'agent-groups', '{id}'), 'hosts': managers_hosts},
+         {'path': join(WAZUH_PATH, 'var', 'db', 'agents', '{id}-{name}.db'), 'hosts': managers_hosts},
+         {'path': join(WAZUH_PATH, 'queue', 'diff', '{name}'), 'hosts': [worker_host]},
+         {'path': join(WAZUH_PATH, 'queue', 'db', '{id}.db'), 'hosts': [worker_host]}]
+db_queries = ["select * from agent where id={id}",
+              "select * from belongs where id_agent={id}"]
+
+
+@pytest.fixture(scope='function')
+def register_agent():
+    """Restart the removed agent to trigger auto-enrollment."""
+    yield
+    host_manager.get_host(agent_host).ansible('command', f'service wazuh-agent restart', check=False)
+
+
+def test_agent_files_deletion(register_agent):
+    """Check that when an agent is deleted, all its related files in managers are also removed."""
+    # Get the current ID and name of the agent that is reporting to worker_host.
+    master_token = host_manager.get_api_token(master_host)
+    response = host_manager.make_api_call(host=master_host, method='GET', token=master_token,
+                                          endpoint=f'/agents?select=id,name&q=manager={worker_host}')
+    assert response['status'] == 200, f'Failed when trying to obtain agent ID: {response}'
+    try:
+        agent_id = response['json']['data']['affected_items'][0]['id']
+        agent_name = response['json']['data']['affected_items'][0]['name']
+    except IndexError as e:
+        pytest.fail(f"Could not find any agent reporting to {worker_host}: {response['json']}")
+
+    # Check that expected files exist in each node before removing the agent.
+    for file in files:
+        for host in file['hosts']:
+            result = host_manager.run_shell(
+                host, f'test -e {file["path"].format(id=agent_id, name=agent_name)} && echo "exists"'
+            )
+            assert result, f'This file should exist in {host} but could not be found: ' \
+                           f'{file["path"].format(id=agent_id, name=agent_name)}'
+
+    # Check that agent information exists in global.db
+    for host in managers_hosts:
+        for query in db_queries:
+            result = host_manager.run_command(
+                host,
+                f'sqlite3 {join(WAZUH_PATH, "queue", "db", "global.db")} "{query.format(id=agent_id, name=agent_name)}"'
+            )
+            assert result, f'This db query should have returned something in {host}, but it did not: ' \
+                           f'{query.format(id=agent_id, name=agent_name)}'
+
+    response = host_manager.make_api_call(host=master_host, method='DELETE', token=master_token,
+                                          endpoint=f'/agents?agents_list={agent_id}&status=all&older_than=0s')
+    assert response['status'] == 200, f'Failed when trying to remove agent {agent_id}: {response}'
+
+    # Wait until information is synced to all workers
+    sleep(time_to_sync)
+
+    # Check that agent-related files where removed from each node.
+    for file in files:
+        for host in file['hosts']:
+            result = host_manager.run_shell(
+                host, f'test -e {file["path"].format(id=agent_id, name=agent_name)} && echo "exists"'
+            )
+            assert not result, f'This file should not exist in {host} but it was found: ' \
+                               f'{file["path"].format(id=agent_id, name=agent_name)}'
+
+    # Check that agent information does not exist anymore in global.db
+    for host in managers_hosts:
+        for query in db_queries:
+            result = host_manager.run_command(
+                host,
+                f'sqlite3 {join(WAZUH_PATH, "queue", "db", "global.db")} "{query.format(id=agent_id, name=agent_name)}"'
+            )
+            assert not result, f'This db query should have not returned anything in {host}, but it did: ' \
+                               f'{query.format(id=agent_id, name=agent_name)} -> {result}'

--- a/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.py
+++ b/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.py
@@ -14,7 +14,7 @@ master_host = 'wazuh-master'
 worker_host = 'wazuh-worker2'
 agent_host = 'wazuh-agent3'
 managers_hosts = [master_host, worker_host]
-inventory_path = join(dirname(dirname(abspath(__file__))), 'provisioning', 'basic_cluster', 'inventory.yml')
+inventory_path = join(dirname(dirname(dirname(abspath(__file__)))), 'provisioning', 'basic_cluster', 'inventory.yml')
 host_manager = HostManager(inventory_path)
 time_to_sync = 60
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1315 |

## Description

Hello team,

As requested in #1315, a new system test has been added. It does the following:
1. Checks that there are agent-related files in worker and master of a specific connected agent. Content of `global.db` is also reviewed.
2. The agent is removed.
3. It is checked that the files reviewed in the step #1 does not exist any more. The same is done with the information in `global.db`.

It takes about 100 seconds to complete. The environment required is [basic_cluster](https://github.com/wazuh/wazuh-qa/tree/master/tests/system/provisioning/basic_cluster).

## Output example

```
============================================================ test session starts =============================================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh-qa/tests/system
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                                                                                                                             

test_agent_files_deletion/test_agent_files_deletion.py .

========================================================= 1 passed in 106.20 seconds =========================================================

```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.

Regards,
Selu.