### PR TITLE
Fix FIM registry sync IT

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1036,15 +1036,15 @@ def callback_detect_integrity_event(line):
 
 
 def callback_detect_registry_integrity_state_event(line):
-    match = re.match(r'.*Sending integrity control message: {"component":"fim_registry","type":"state","data":(.+)}', line)
-    if match:
-        return json.loads(match.group(1))
+    event = callback_detect_integrity_event(line)
+    if event and event['component'] == 'fim_registry' and event['type'] == 'state':
+        return event['data']
     return None
 
 
 def callback_detect_registry_integrity_clear_event(line):
-    match = re.match(r'.*Sending integrity control message: {"component":"fim_registry","type":"integrity_clear".*', line)
-    if match:
+    event = callback_detect_integrity_event(line)
+    if event and event['component'] == 'fim_registry' and event['type'] == 'integrity_clear':
         return True
     return None
 

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1035,10 +1035,17 @@ def callback_detect_integrity_event(line):
     return None
 
 
-def callback_detect_registry_integrity_event(line):
+def callback_detect_registry_integrity_state_event(line):
     match = re.match(r'.*Sending integrity control message: {"component":"fim_registry","type":"state","data":(.+)}', line)
     if match:
         return json.loads(match.group(1))
+    return None
+
+
+def callback_detect_registry_integrity_clear_event(line):
+    match = re.match(r'.*Sending integrity control message: {"component":"fim_registry","type":"integrity_clear".*', line)
+    if match:
+        return True
     return None
 
 

--- a/docs/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.md
+++ b/docs/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.md
@@ -2,32 +2,25 @@
 
 This test performs several tests that check if the registry synchronization is performed properly.
 
-The first test checks that synchronization is performed after changes after the baseline scan.
-The second test checks that if a modification occurs when the Windows agent is down, the synchronization is triggered with the new values.
+The test checks that if a modification occurs when the Windows agent is down, the synchronization is triggered with the new values.
 
 
 ## General info
 
 | Tier | Platforms | Time spent| Test file |
 |:--:|:--:|:--:|:--:|
-| 1 | Windows | 00:13:00 | [test_registry_responses.py](../../../../../../tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py)|
+| 1 | Windows | 00:02:00 | [test_registry_responses.py](../../../../../../tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py)|
 
 ## Test logic
 
-### test_registry_responses
-- The test waits for the baseline scan.
-- Then, the test will create several sub-keys inside a monitored key and values inside the monitored key and the sub-keys.
-- Finally, it will change the system clock and expect the synchronization event for the created keys/values.
 
-
-### test_registry_sync_after_restart
+- First, the test will remove any monitored key and restart the agent. This removes the entry of the key used for the test from the manager's database.
 - The test waits until the first synchronization is completed.
-- Then, the test stops the Windows agent and creates values inside a monitored key.
+- Then, the test stops the Windows agent and creates key and values inside a monitored key.
 - Finally, the test starts the agent and will check that the synchronization is performed with the new values.
 
 ## Checks
 
-- [x] Check that FIM perform the registry synchronization after the baseline scan.
 - [x] Check that FIM perform the registry synchronization when changes occurs while the agent is down.
 - [x] Check that FIM perform properly the registry synchronization when using keys/values starting with `:`.
 - [x] Check that FIM perform properly the registry synchronization when using keys/values ending with `:`.
@@ -37,14 +30,15 @@ The second test checks that if a modification occurs when the Windows agent is d
 
 ```
 python -m pytest test_synchronization\test_registry_responses_win32.py
-=================================================================== test session starts ===================================================================
+================================================= test session starts =================================================
 platform win32 -- Python 3.7.3, pytest-5.1.2, py-1.8.0, pluggy-0.13.0
 rootdir: C:\Users\jmv74211\Desktop\wazuh-qa\tests\integration, inifile: pytest.ini
 plugins: html-2.0.1, metadata-1.11.0, testinfra-5.0.0
-collected 18 items
-test_synchronization\test_registry_responses_win32.py s.................                                                                             [100%]
+collected 9 items
 
-======================================================== 17 passed, 1 skipped in 808.74s (0:13:28) ========================================================
+test_synchronization\test_registry_responses_win32.py .........                                                  [100%]
+
+============================================ 9 passed in 137.78s (0:02:17) ============================================
 ```
 
 ## Code documentation

--- a/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py
@@ -4,11 +4,12 @@
 
 import os
 import pytest
-from wazuh_testing import global_parameters
 import wazuh_testing.fim as fim
+from wazuh_testing import global_parameters
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import truncate_file
 
 # Marks
 
@@ -20,7 +21,7 @@ subkey = "SOFTWARE\\random_key"
 
 sync_interval = 20
 max_events = 20
-test_regs = [os.path.join(key, subkey)]
+
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_registry_responses_win32.yaml')
 conf_params = {'WINDOWS_REGISTRY': os.path.join(key, subkey), 'SYNC_INTERVAL': sync_interval}
@@ -58,7 +59,7 @@ def get_sync_msgs(tout, new_data=True):
     for _ in range(0, max_events):
         try:
             sync_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                                 callback=fim.callback_detect_registry_integrity_event,
+                                                 callback=fim.callback_detect_registry_integrity_state_event,
                                                  accum_results=1,
                                                  error_message='Did not receive expected '
                                                                'Sending integrity control message"').result()
@@ -102,75 +103,28 @@ def find_value_in_event_list(key_path, value_name, event_list):
 
     return None
 
+
+@pytest.fixture(scope='function', params=configurations)
+def remove_key_and_restart(request):
+    """Fixture that removes the test key and restart the agent. The aim of this
+       fixture is to avoid false positives if the manager still has the test  key
+       in it's DB.
+    """
+    fim.delete_registry(fim.registry_parser[key], subkey, fim.KEY_WOW64_64KEY)
+    control_service('stop')
+    truncate_file(fim.LOG_FILE_PATH)
+    file_monitor = FileMonitor(fim.LOG_FILE_PATH)
+    setattr(request.module, 'wazuh_log_monitor', file_monitor)
+    control_service('start')
+
+
 # tests
 
-
 @pytest.mark.parametrize('tags_to_apply', [{'registry_sync_responses'}])
-@pytest.mark.parametrize('key_name', [None, ':subkey1', 'subkey2:', ':subkey3:'])
-@pytest.mark.parametrize('value_name', [None, ':value1', 'value2:', ':value3:'])
-def test_registry_responses(key_name, value_name, tags_to_apply,
-                            get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Test to check that the fields in synchronization events are decoded properly by the agent.
-    Params:
-        key_name (str): Name of the subkey that will be created in the test.
-        value_name (str): Name of the value that will be created in the test. If
-        tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
-        get_configuration (fixture): Gets the current configuration of the test.
-        configure_environment (fixture): Configure the environment for the execution of the test.
-        restart_syscheckd (fixture): Restarts syscheck.
-        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
-    Raises:
-        TimeoutError: If an expected event couldn't be captured.
-        ValueError: If a path or value are not in the sync event.
-    """
-    if key_name is None and value_name is None:
-        pytest.skip('key_name and value_name are None. Skipping')
-
-    check_apply_test(tags_to_apply, get_configuration['tags'])
-
-    # Wait for subkey sync messages only when it's expected
-    if key_name is not None:
-        fim.create_registry(fim.registry_parser[key], os.path.join(subkey, key_name), fim.KEY_WOW64_64KEY)
-        fim.check_time_travel(True, monitor=wazuh_log_monitor)
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=fim.callback_detect_end_scan,
-                                error_message='Did not receive expected "end_scan" event').result()
-
-        events = get_sync_msgs(sync_interval + 15)
-        # Parent key sync event
-        assert find_path_in_event_list(test_regs[0], events) is not None, f"No sync event was found for {test_regs[0]}"
-
-        # Subkey sync event
-        subkey_path = os.path.join(test_regs[0], key_name)
-        assert find_path_in_event_list(subkey_path, events) is not None, f'No sync event was found for {subkey_path}'
-
-    if value_name is not None:
-        if key_name is not None:
-            key_path = os.path.join(subkey, key_name)
-        else:
-            key_path = subkey
-
-        value_path = os.path.join(key, key_path, value_name)
-
-        key_handle = fim.RegOpenKeyEx(fim.registry_parser[key], key_path, 0, fim.KEY_ALL_ACCESS | fim.KEY_WOW64_64KEY)
-
-        fim.modify_registry_value(key_handle, value_name, fim.REG_SZ, 'This is a test')
-        fim.check_time_travel(True, monitor=wazuh_log_monitor)
-
-        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                callback=fim.callback_detect_end_scan,
-                                error_message='Did not receive expected "end_scan" event').result()
-
-        events = get_sync_msgs(sync_interval + 15)
-
-        assert find_value_in_event_list(
-               os.path.join(key, key_path), value_name, events) is not None, f"No sync event was found for {value_path}"
-
-
-@pytest.mark.parametrize('tags_to_apply', [{'registry_sync_responses'}])
-@pytest.mark.parametrize('key_name, value_name', [(':subkey1:', 'value1'), (':subkey2', ':value2')])
-def test_registry_sync_after_restart(key_name, value_name, tags_to_apply,
-                                     get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
+@pytest.mark.parametrize('key_name', [':subkey1', 'subkey2:', ':subkey3:'])
+@pytest.mark.parametrize('value_name', [':value1', 'value2:', ':value3:'])
+def test_registry_sync_after_restart(key_name, value_name, tags_to_apply, get_configuration, configure_environment,
+                                     remove_key_and_restart, wait_for_fim_start):
     """
     Test to check that FIM synchronizes the registry DB when a modification is performed while the agent is down.
 
@@ -187,20 +141,22 @@ def test_registry_sync_after_restart(key_name, value_name, tags_to_apply,
         ValueError: If a path or value are not in the sync event.
     """
     check_apply_test(tags_to_apply, get_configuration['tags'])
-
     key_path = os.path.join(subkey, key_name)
     value_path = os.path.join(key, key_path, value_name)
 
     # wait until the sync is done.
-    get_sync_msgs(sync_interval)
+    wazuh_log_monitor.start(timeout=sync_interval + 15, callback=fim.callback_detect_registry_integrity_clear_event,
+                            error_message='Did not receive expected "integrity clear" event')
+
     # stops syscheckd
     control_service('stop')
-
+    fim.create_registry(fim.registry_parser[key], subkey, fim.KEY_WOW64_64KEY)
     key_handle = fim.create_registry(fim.registry_parser[key], key_path, fim.KEY_WOW64_64KEY)
+
     fim.modify_registry_value(key_handle, value_name, fim.REG_SZ, 'This is a test with syscheckd down.')
     control_service('start')
 
-    events = get_sync_msgs(sync_interval + 15)
+    events = get_sync_msgs(sync_interval)
 
     assert find_value_in_event_list(
                os.path.join(key, key_path), value_name, events) is not None, f"No sync event was found for {value_path}"


### PR DESCRIPTION
|Related issue|
|---|
|#1343|

## Description
Hi team.

This PR aims to fix the test `test_registry_responses_win32.py` that was constantly failing.
Closes #1343 

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.