### PR TITLE
Adapt the JSON event schema to parse WIN perms in JSON.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/syscheck_event_windows.json
+++ b/deps/wazuh_testing/wazuh_testing/data/syscheck_event_windows.json
@@ -149,12 +149,72 @@
             },
             "perm": {
               "$id": "#/properties/data/properties/attributes/properties/perm",
-              "type": "string",
-              "default": "",
-              "examples": [
-                "rw-r--r--"
-              ],
-              "pattern": "^(.*)$"
+              "type": "object",
+              "patternProperties": {
+                 "^S-[-0-9]*": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "$id": "#/properties/data/properties/attributes/properties/perm/name",
+                            "type": "string"
+                        },
+                        "allowed": {
+                            "$id": "#/properties/data/properties/attributes/properties/perm/allowed",
+                            "type": "array",
+                            "items": {
+                                "$id": "#/properties/data/properties/attributes/properties/perm/allowed/items",
+                                "type": "string",
+                                "enum": [
+                                    "generic_read",
+                                    "generic_write",
+                                    "generic_execute",
+                                    "generic_all",
+                                    "delete",
+                                    "read_control",
+                                    "write_dac",
+                                    "write_owner",
+                                    "synchronize",
+                                    "read_data",
+                                    "write_data",
+                                    "append_data",
+                                    "read_ea",
+                                    "write_ea",
+                                    "execute",
+                                    "read_attributes",
+                                    "write_attributes"
+                                ]
+                            }
+                        },
+                        "denied": {
+                            "$id": "#/properties/data/properties/attributes/properties/perm/denied",
+                            "type": "array",
+                            "items": {
+                                "$id": "#/properties/data/properties/attributes/properties/perm/denied/items",
+                                "type": "string",
+                                "enum": [
+                                    "generic_read",
+                                    "generic_write",
+                                    "generic_execute",
+                                    "generic_all",
+                                    "delete",
+                                    "read_control",
+                                    "write_dac",
+                                    "write_owner",
+                                    "synchronize",
+                                    "read_data",
+                                    "write_data",
+                                    "append_data",
+                                    "read_ea",
+                                    "write_ea",
+                                    "execute",
+                                    "read_attributes",
+                                    "write_attributes"
+                                  ]
+                            }
+                          }
+                      }
+                  }
+              }
             },
             "uid": {
               "$id": "#/properties/data/properties/attributes/properties/uid",


### PR DESCRIPTION
|Related issue|
|---|
|#1401|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team!!

The changes introduced in https://github.com/wazuh/wazuh/issues/8585 broke the FIM event validator in windows. This PR aims to introduce the necessary changes for make them work again as expected
Closes #1401
## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.