### PR TITLE
Full Yellow Local - Fix Agent simulator Rootcheck class in 4.2

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -648,7 +648,7 @@ class Agent:
     def init_rootcheck(self):
         """Initialize rootcheck module."""
         if self.rootcheck is None:
-            self.rootcheck = Rootcheck(self.rootcheck_sample, self.name, self.id)
+            self.rootcheck = Rootcheck(os = self.os, agent_name = self.name, agent_id = self.id, rootcheck_sample = self.rootcheck_sample)
 
     def init_fim(self):
         """Initialize fim module."""
@@ -934,8 +934,6 @@ class SCA:
 
 
 class Rootcheck:
-    def __init__(self, os, agent_name, agent_id, rootcheck_sample=None):
-        self.os = os
     """This class allows the generation of rootcheck events.
 
     Creates rootcheck events by sequentially repeating the events of a sample file file.
@@ -945,7 +943,8 @@ class Rootcheck:
         agent_id (str): Id of the agent.
         rootcheck_sample (str): File with the rootcheck events that are going to be used.
     """
-    def __init__(self, agent_name, agent_id, rootcheck_sample=None):
+    def __init__(self, os, agent_name, agent_id, rootcheck_sample=None):
+        self.os = os
         self.agent_name = agent_name
         self.agent_id = agent_id
         self.rootcheck_tag = 'rootcheck'
@@ -966,7 +965,7 @@ class Rootcheck:
             line = fp.readline()
             while line:
                 if not line.startswith("#"):
-                    msg = "{0}:{1}:{2}".format(self.ROOTCHECK_MQ, self.ROOTCHECK, line.strip("\n"))
+                    msg = "{0}:{1}:{2}".format(self.rootcheck_mq, self.rootcheck_tag, line.strip("\n"))
                     self.messages_list.append(msg)
                 line = fp.readline()
 


### PR DESCRIPTION
|Related issue|
|---|
|#1520, #1580 |

## Description

This PR closes #1580 and closes #1520  issue. Fixing agent Rootcheck class in simulator module rootcheck tests work correctly.

## Testing

### CentOS Manager

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm

#### Local

- [x] [R1](https://github.com/wazuh/wazuh-qa/files/6768560/r1_rootcheck.log) :green_circle: 
- [x] [R2](https://github.com/wazuh/wazuh-qa/files/6768561/r2_rootcheck.log) :green_circle: 
- [x] [R3](https://github.com/wazuh/wazuh-qa/files/6768562/r3_rootcheck.log) :green_circle: 

## Documentation

It is not necessary to add new documentation due to this fix only change the defined `Rootcheck` class in the agent simulator module.