### PR TITLE
Modify integration tests for Vulnerability Detector: SUSE support dependencies

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -362,7 +362,7 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
 
 
 def insert_dependency(id="2009116126", name="sled-release",
-                      operation="equals", operation_value="12.0", installed="0", package_id="0"):
+                      operation="equals", operation_value="12.0", target="SLED11",installed="0", package_id="0"):
     """Insert a new dependency in the dependency database, with the parameters given as arguments
 
     Args:
@@ -374,14 +374,14 @@ def insert_dependency(id="2009116126", name="sled-release",
         package_id (str): the id to relate the dependency to a package
     """
     query_string = f'''INSERT INTO dependencies
-        (id, name, operation, operation_value, installed)
+        (id, name, operation, operation_value, target, installed)
         VALUES
-        ("{id}", "{name}", "{operation}", "{operation_value}", "{installed}")
+        ("{id}", "{name}", "{operation}", "{operation_value}", "{target}","{installed}")
         '''
     pkgs_deps_string = f'''INSERT INTO PKGS_DEPS
-        (pkg_id,dep_id)
+        (pkg_id, dep_id, pkg_dep_target)
         VALUES
-        ("{package_id}", "{id}")
+        ("{package_id}", "{id}", "{target}")
         '''
     make_query(CVE_DB_PATH, [query_string,pkgs_deps_string])
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -273,7 +273,9 @@ def clean_vd_tables(agent="000"):
         {"name": "bugzilla_references_info", "path": CVE_DB_PATH},
         {"name": "advisories_info", "path": CVE_DB_PATH},
         {"name": "metadata", "path": CVE_DB_PATH},
-        {"name": "variables", "path": CVE_DB_PATH}
+        {"name": "variables", "path": CVE_DB_PATH},
+        {"name": "pkg_deps", "path": CVE_DB_PATH},
+        {"name": "dependencies", "path": CVE_DB_PATH}
     ]
 
     # Clean providers and sys_programs tables
@@ -374,7 +376,7 @@ def insert_dependency(id="2009116126", name="sled-release",
         installed (str): flag that will be activated in the pre-scan as long as this dependency has been detected in the agent
         package_id (str): the id to relate the dependency to a package
     """
-    query_string = f'''INSERT INTO dependencies
+    query_string = f'''INSERT OR IGNORE INTO dependencies
         (id, name, operation, operation_value, target, installed)
         VALUES
         ("{id}", "{name}", "{operation}", "{operation_value}", "{target}","{installed}")

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -591,6 +591,19 @@ def get_num_vulnerabilities():
     return vulnerabilities_number
 
 
+def is_dependency_installed(id="2009116126"):
+    """Checks if a dependency is installed on the scanned agent, obtaining the field from the DEPENDENCIES table of CVE DB.
+
+    Returns:
+        bool: The dependency is installed or not in the agent scan
+    """
+    query_string = f'SELECT installed from DEPENDENCIES where id="{id}"'
+    query_result = get_query_result(CVE_DB_PATH, query_string)
+    dependency_installed = bool(query_result[0])
+
+    return dependency_installed
+
+
 def clean_vuln_and_sys_programs_tables(agent='000'):
     """Clean vulnerability detector and sys programs table/s
 

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -30,7 +30,7 @@ DEFAULT_VULNERABILITY_ID = "WVE-000"
 CLIENT_KEYS_PATH = '/var/ossec/etc/client.keys'
 
 MOCKED_AGENT_NAME = 'mocked_agent'
-CVE_NUM_TABLES = 24
+CVE_NUM_TABLES = 26
 
 REAL_NVD_FEED = 'real_nvd_feed.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'
@@ -370,6 +370,7 @@ def insert_dependency(id="2009116126", name="sled-release",
         name (str): name of the dependency. Defaults to sled-release
         operation (str): operator used to compare the version
         operation_value (str): version of the dependency
+        target (str): OS of the pkg
         installed (str): flag that will be activated in the pre-scan as long as this dependency has been detected in the agent
         package_id (str): the id to relate the dependency to a package
     """
@@ -378,12 +379,22 @@ def insert_dependency(id="2009116126", name="sled-release",
         VALUES
         ("{id}", "{name}", "{operation}", "{operation_value}", "{target}","{installed}")
         '''
-    pkgs_deps_string = f'''INSERT INTO PKGS_DEPS
-        (pkg_id, dep_id, pkg_dep_target)
+    make_query(CVE_DB_PATH, [query_string])
+
+def insert_pkg_dep(id="2009116126", target="SLED11",package_id="0"):
+    """Insert a new dependency in the dependency database, with the parameters given as arguments
+
+    Args:
+        id (str): id of the dependency
+        target (str): OS of the pkg
+        package_id (str): the id to relate the dependency to a package
+    """
+    pkg_deps_string = f'''INSERT INTO PKG_DEPS
+        (pkg_id, dep_id, target)
         VALUES
         ("{package_id}", "{id}", "{target}")
         '''
-    make_query(CVE_DB_PATH, [query_string,pkgs_deps_string])
+    make_query(CVE_DB_PATH, [pkg_deps_string])
 
 
 def insert_package(agent="000", scan_id=int(time()), format="rpm", name=DEFAULT_PACKAGE_NAME,

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -361,6 +361,25 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
     make_query(path, [query_string])
 
 
+def insert_dependency(id="oval:org.opensuse.security:tst:2009116126",name="sled-release",
+                      operation="equals",operation_value="12.0",installed="0"):
+    """Insert a new dependency in the dependency database, with the parameters given as arguments
+
+    Args:
+        id (str): id of the dependency
+        name (str): name of the dependency. Defaults to sled-release
+        operation (str): operator used to compare the version
+        operation_value (str): version of the dependency
+        installed (str): flag that will be activated in the pre-scan as long as this dependency has been detected in the agent
+    """
+    query_string = f'''INSERT INTO dependencies
+        (id, name, operation, operation_value, installed)
+        VALUES
+        ("{id}", "{name}", "{operation}", "{operation_value}", "{installed}")
+        '''
+    make_query(CVE_DB_PATH, [query_string])
+
+
 def insert_package(agent="000", scan_id=int(time()), format="rpm", name=DEFAULT_PACKAGE_NAME,
                    priority="", section="Unspecified", size=99, vendor="wazuhintegrationtests", version="1.0.0-1.el7",
                    architecture="x86_64", multiarch="", description="Wazuh Integration tests mock package",

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -361,8 +361,8 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
     make_query(path, [query_string])
 
 
-def insert_dependency(id="oval:org.opensuse.security:tst:2009116126",name="sled-release",
-                      operation="equals",operation_value="12.0",installed="0"):
+def insert_dependency(id="2009116126", name="sled-release",
+                      operation="equals", operation_value="12.0", installed="0", package_id="0"):
     """Insert a new dependency in the dependency database, with the parameters given as arguments
 
     Args:
@@ -371,13 +371,19 @@ def insert_dependency(id="oval:org.opensuse.security:tst:2009116126",name="sled-
         operation (str): operator used to compare the version
         operation_value (str): version of the dependency
         installed (str): flag that will be activated in the pre-scan as long as this dependency has been detected in the agent
+        package_id (str): the id to relate the dependency to a package
     """
     query_string = f'''INSERT INTO dependencies
         (id, name, operation, operation_value, installed)
         VALUES
         ("{id}", "{name}", "{operation}", "{operation_value}", "{installed}")
         '''
-    make_query(CVE_DB_PATH, [query_string])
+    pkgs_deps_string = f'''INSERT INTO PKGS_DEPS
+        (pkg_id,dep_id)
+        VALUES
+        ("{package_id}", "{id}")
+        '''
+    make_query(CVE_DB_PATH, [query_string,pkgs_deps_string])
 
 
 def insert_package(agent="000", scan_id=int(time()), format="rpm", name=DEFAULT_PACKAGE_NAME,
@@ -429,7 +435,7 @@ def insert_vulnerability(cveid=DEFAULT_VULNERABILITY_ID, target="RHEL7", target_
                          updated="", reference="https://github.com/wazuh/wazuh-qa", target_v="REDHAT", cvss="10.000000",
                          cvss_vector="AV:N/AC:L/Au:N/C:C/I:C/A:C", rationale="Wazuh integration test vulnerability",
                          cvss3="", bugzilla_reference="https://github.com/wazuh/wazuh-qa", cwe="WVE-000 -> WVE-001",
-                         advisory="RHSA-2010:0029", ref_target="RHEL"):
+                         advisory="RHSA-2010:0029", ref_target="RHEL", deps_id="0"):
     """Insert a new vulnerability in the database of vulnerabilities, with the parameters given as arguments.
 
     If used in conjunction with ``insert_package_in_db`` using the default arguments it will generate an alert.
@@ -455,12 +461,13 @@ def insert_vulnerability(cveid=DEFAULT_VULNERABILITY_ID, target="RHEL7", target_
         cwe (str): CWE id
         advisory (str): advisory ID
         ref_target (str): id of the target OS. Defaults to RHEL
+        deps_id (str): id of the dependencies related to the vulnerability.
     """
     vulnerabilities_query_string = f'''INSERT INTO VULNERABILITIES
-        (cveid, target, target_minor, package, operation, operation_value)
+        (cveid, target, target_minor, package, operation, operation_value, deps_id)
         VALUES
         ("{cveid}", "{target}", "{target_minor}", "{package}", "{operation}",
-        "{operation_value}")'''
+        "{operation_value}", "{deps_id}")'''
     query_vulnerabilities_info_query_string = f'''INSERT INTO VULNERABILITIES_INFO
         (ID, title, severity, published, updated, target, rationale, cvss, cvss_vector, CVSS3, cwe)
         VALUES

--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -363,7 +363,7 @@ def insert_osinfo(agent="000", scan_id=int(time()), scan_time=datetime.datetime.
     make_query(path, [query_string])
 
 
-def insert_dependency(id="2009116126", name="sled-release",
+def insert_dependency(id="oval:org.opensuse.security:tst:2009116126", name="sled-release",
                       operation="equals", operation_value="12.0", target="SLED11",installed="0", package_id="0"):
     """Insert a new dependency in the dependency database, with the parameters given as arguments
 
@@ -383,7 +383,7 @@ def insert_dependency(id="2009116126", name="sled-release",
         '''
     make_query(CVE_DB_PATH, [query_string])
 
-def insert_pkg_dep(id="2009116126", target="SLED11",package_id="0"):
+def insert_pkg_dep(id="oval:org.opensuse.security:tst:2009116126", target="SLED11",package_id="0"):
     """Insert a new dependency in the dependency database, with the parameters given as arguments
 
     Args:
@@ -590,18 +590,6 @@ def get_num_vulnerabilities():
 
     return vulnerabilities_number
 
-
-def is_dependency_installed(id="2009116126"):
-    """Checks if a dependency is installed on the scanned agent, obtaining the field from the DEPENDENCIES table of CVE DB.
-
-    Returns:
-        bool: The dependency is installed or not in the agent scan
-    """
-    query_string = f'SELECT installed from DEPENDENCIES where id="{id}"'
-    query_result = get_query_result(CVE_DB_PATH, query_string)
-    dependency_installed = bool(query_result[0])
-
-    return dependency_installed
 
 
 def clean_vuln_and_sys_programs_tables(agent='000'):

--- a/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.md
+++ b/docs/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.md
@@ -1,6 +1,6 @@
 # Test SUSE inventory SUSE feed
 
-These tests will mock SUSE systems and insert custom vulnerabilities and vulnerable packages to check if Vulnerability
+These tests will mock SUSE systems and insert custom vulnerabilities, vulnerable packages and its related dependencies to check if Vulnerability
 Detector generates the alerts from the SUSE provider feed.
 
 ## General info
@@ -20,16 +20,20 @@ SLED15, SLES15, SLED12, SLES12, SLED11, SLES11
 The tests will execute these actions:
 - Clean NVD, `vulnerabilities`, and `sys_programs tables`.
 - Mock the system.
-- Insert [SUSE custom feed and vulnerable packages](../../test_scan_results/data/suse_vulnerabilities.json).
+- Insert [SUSE custom feed, vulnerable packages and dependencies](../../test_scan_results/data/suse_vulnerabilities.json).
 - Import NVD vulnerabilities from [custom NVD feed](../../test_scan_results/data/real_nvd_feed.json).
-- Check this event in `ossec.log`:
+- Check these events in `ossec.log`:
   ```
   The '{package}' package .* from agent .* is vulnerable to '{cve}'
+  ```
+  ```
+  Package '{package}' not vulnerable to '{cve}'.
   ```
 
 ## Checks
 
 - [x] A report of the corresponding vulnerabilities is generated in the `ossec.log`.
+- [x] A report of non-vulnerable packages is generated in the `ossec.log`.
 
 ## Observed behavior
 

--- a/tests/integration/test_vulnerability_detector/data/feeds/custom_suse_oval_feed.xml
+++ b/tests/integration/test_vulnerability_detector/data/feeds/custom_suse_oval_feed.xml
@@ -115,6 +115,18 @@
 		<object object_ref="oval:org.opensuse.security:obj:2009051684"/>
 		<state state_ref="oval:org.opensuse.security:ste:2009110829"/>
 	</rpminfo_test>
+    	<rpminfo_test id="oval:org.opensuse.security:tst:2009258803" version="1" comment="SLES_SAP-release is ==12.3" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+		<object object_ref="oval:org.opensuse.security:obj:2009047546"/>
+		<state state_ref="oval:org.opensuse.security:ste:2009052091"/>
+	</rpminfo_test>
+    	<rpminfo_test id="oval:org.opensuse.security:tst:2009258804" version="1" comment="SLES_SAP-release is ==12.4" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+		<object object_ref="oval:org.opensuse.security:obj:2009047546"/>
+		<state state_ref="oval:org.opensuse.security:ste:2009066428"/>
+	</rpminfo_test>
+    	<rpminfo_test id="oval:org.opensuse.security:tst:2009258650" version="1" comment="sle-we-release is ==12.5" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+		<object object_ref="oval:org.opensuse.security:obj:2009039405"/>
+		<state state_ref="oval:org.opensuse.security:ste:2009068902"/>
+	</rpminfo_test>
 </tests>
 <objects>
 	<rpminfo_object id="oval:org.opensuse.security:obj:2009051686" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
@@ -134,6 +146,12 @@
 	</rpminfo_object>
 	<rpminfo_object id="oval:org.opensuse.security:obj:2009051684" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
 		<name>caribou-lang</name>
+	</rpminfo_object>
+    <rpminfo_object id="oval:org.opensuse.security:obj:2009047546" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+		<name>SLES_SAP-release</name>
+	</rpminfo_object>
+    <rpminfo_object id="oval:org.opensuse.security:obj:2009039405" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+		<name>sle-we-release</name>
 	</rpminfo_object>
 </objects>
 <states>
@@ -160,6 +178,15 @@
   <rpminfo_state id="oval:org.opensuse.security:ste:2009086787" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
    <arch datatype="string" operation="pattern match">(noarch)</arch>
    <evr datatype="evr_string" operation="less than">0:3.12.67-60.64.21</evr>
+  </rpminfo_state>
+  <rpminfo_state id="oval:org.opensuse.security:ste:2009052091" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+   <version operation="equals">12.3</version>
+  </rpminfo_state>
+  <rpminfo_state id="oval:org.opensuse.security:ste:2009066428" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+   <version operation="equals">12.4</version>
+  </rpminfo_state>
+  <rpminfo_state id="oval:org.opensuse.security:ste:2009068902" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+   <version operation="equals">12.5</version>
   </rpminfo_state>
 </states>
 </oval_definitions>

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -7,21 +7,13 @@
         "name": "Desktop11",
         "vulnerabilities": [
             {
-                "package": [
-                    {
+                "package" :
+                {
                         "name": "krb5",
                         "version": "1.5.0",
                         "format": "rpm",
                         "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "11.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                    
-                ],
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -45,20 +37,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "kdelibs4",
-                        "version": "4.3.5-0.12.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "11.3",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "kdelibs4",
+                    "version": "4.3.5-0.12.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -82,20 +67,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "libecpg6",
-                        "version": "3.25.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "11.4",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "libecpg6",
+                    "version": "3.25.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -112,20 +90,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "openssl",
-                        "version": "0.6.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "11.3",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "openssl",
+                    "version": "0.6.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -142,20 +113,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "monodoc-core",
-                        "version": "2.0.12",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "11.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "monodoc-core",
+                    "version": "2.0.12",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -170,13 +134,42 @@
                         "operation": "equals",
                         "operation_value": "11.3",
                         "installed": "0"
-                    }  
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2009-0689",
                     "operation": "less than",
                     "operation_value": "2.6.7-0.16"
                  }
+            }
+        ],
+        "agent_dependencies": [
+            {
+                "package":
+                {
+                    "name": "sled-release",
+                    "version": "11.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sled-release",
+                    "version": "11.3",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sled-release",
+                    "version": "11.4",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
             }
         ]
     },
@@ -188,20 +181,13 @@
         "name": "Server11",
         "vulnerabilities": [
             {
-                "package": [
-                    {
-                        "name": "tar",
-                        "version": "1.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "11.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "tar",
+                    "version": "1.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -218,20 +204,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "squid3",
-                        "version": "2.1.3",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "11.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "squid3",
+                    "version": "2.1.3",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -248,20 +227,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "openssh-openssl1",
-                        "version": "2.8",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "11.3",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "openssh-openssl1",
+                    "version": "2.8",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -278,20 +250,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "wireshark",
-                        "version": "1.7",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "11.4",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "wireshark",
+                    "version": "1.7",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -308,20 +273,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "ruby",
-                        "version": "1.3.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "11.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "ruby",
+                    "version": "1.3.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -337,6 +295,44 @@
                     "operation_value": "1.8.7.p357-0.7"
                  }
             }
+        ],
+        "agent_dependencies": [
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "11.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "11.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "11.3",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "11.4",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            }
         ]
     },
     {
@@ -347,20 +343,13 @@
         "name": "Desktop12",
         "vulnerabilities": [
             {
-                "package": [
-                    {
-                        "name": "krb5-client",
-                        "version": "1.11.4",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "12.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "krb5-client",
+                    "version": "1.11.4",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -384,20 +373,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "hplip",
-                        "version": "3.14",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "12.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "hplip",
+                    "version": "3.14",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -428,20 +410,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "cron",
-                        "version": "3.3",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "12.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "cron",
+                    "version": "3.3",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -479,20 +454,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "coolkey",
-                        "version": "1.1.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "12.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "coolkey",
+                    "version": "1.1.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -530,20 +498,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "qemu",
-                        "version": "1.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sled-release",
-                        "version": "12.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "qemu",
+                    "version": "1.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sled-release",
@@ -559,6 +520,35 @@
                     "operation_value": "2.0.0-40"
                  }
             }
+        ],
+        "agent_dependencies": [
+            {
+                "package":
+                {
+                    "name": "sled-release",
+                    "version": "12.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sled-release",
+                    "version": "12.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sled-release",
+                    "version": "12.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            }
         ]
     },
     {
@@ -569,20 +559,13 @@
         "name": "Server12",
         "vulnerabilities": [
             {
-                "package": [
-                    {
-                        "name": "gimp",
-                        "version": "0.98.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-we-release",
-                        "version": "12.3",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "gimp",
+                    "version": "0.98.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-we-release",
@@ -599,20 +582,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "libecpg6",
-                        "version": "1.0.8",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "12.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "libecpg6",
+                    "version": "1.0.8",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -636,20 +612,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "mariadb",
-                        "version": "9.9",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "12.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "mariadb",
+                    "version": "9.9",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -666,20 +635,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "curl",
-                        "version": "6.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "12.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "curl",
+                    "version": "6.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -696,20 +658,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "krb5",
-                        "version": "1.1.5",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sles-release",
-                        "version": "12.5",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "krb5",
+                    "version": "1.1.5",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sles-release",
@@ -725,6 +680,44 @@
                     "operation_value": "1.12.5-40.37"
                 }
             }
+        ],
+        "agent_dependencies": [
+            {
+                "package":
+                {
+                    "name": "sle-we-release",
+                    "version": "12.3",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "12.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "12.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sles-release",
+                    "version": "12.5",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            }
         ]
     },
     {
@@ -735,20 +728,13 @@
         "name": "Desktop15",
         "vulnerabilities": [
             {
-                "package": [
-                    {
-                        "name": "krb5",
-                        "version": "0.98.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "krb5",
+                    "version": "0.98.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -765,20 +751,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "openssl",
-                        "version": "1.0.8",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "openssl",
+                    "version": "1.0.8",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -795,20 +774,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "python3-bind",
-                        "version": "9.10",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "python3-bind",
+                    "version": "9.10",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -825,20 +797,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "pam_ssh",
-                        "version": "1.2",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "pam_ssh",
+                    "version": "1.2",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -869,20 +834,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "git",
-                        "version": "1.0.5",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-development-tools-release",
-                        "version": "15.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "git",
+                    "version": "1.0.5",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-development-tools-release",
@@ -898,6 +856,35 @@
                     "operation_value": "2.16.4-3.9"
                 }
             }
+        ],
+        "agent_dependencies": [
+            {
+                "package":
+                {
+                    "name": "sle-module-basesystem-release",
+                    "version": "15",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sle-module-basesystem-release",
+                    "version": "15.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sle-module-development-tools-release",
+                    "version": "15.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            }
         ]
     },
     {
@@ -908,20 +895,13 @@
         "name": "Server15",
         "vulnerabilities": [
             {
-                "package": [
-                    {
-                        "name": "krb5",
-                        "version": "0.98.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "krb5",
+                    "version": "0.98.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -938,20 +918,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "php7",
-                        "version": "6.0.8",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-web-scripting-release",
-                        "version": "15.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "php7",
+                    "version": "6.0.8",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-web-scripting-release",
@@ -968,20 +941,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "python",
-                        "version": "1.9",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "python",
+                    "version": "1.9",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -1005,20 +971,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "openssl",
-                        "version": "1.0.0",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-basesystem-release",
-                        "version": "15.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "openssl",
+                    "version": "1.0.0",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
@@ -1035,20 +994,13 @@
                 }
             },
             {
-                "package": [
-                    {
-                        "name": "apache2",
-                        "version": "2.1.5",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    },
-                    {
-                        "name": "sle-module-server-application-release",
-                        "version": "15.1",
-                        "format": "rpm",
-                        "vendor": "SUSE LLC <https://www.suse.com/>"
-                    }
-                ],
+                "package":
+                {
+                    "name": "apache2",
+                    "version": "2.1.5",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                },
                 "dependency": [
                     {
                         "name": "sle-module-server-application-release",
@@ -1062,6 +1014,44 @@
                     "cveid": "CVE-2009-0023",
                     "operation": "less than",
                     "operation_value": "2.4.33-3.15"
+                }
+            }
+        ],
+        "agent_dependencies": [
+            {
+                "package":
+                {
+                    "name": "sle-module-basesystem-release",
+                    "version": "15",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sle-module-basesystem-release",
+                    "version": "15.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sle-module-web-scripting-release",
+                    "version": "15.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
+                }
+            },
+            {
+                "package":
+                {
+                    "name": "sle-module-server-application-release",
+                    "version": "15.1",
+                    "format": "rpm",
+                    "vendor": "SUSE LLC <https://www.suse.com/>"
                 }
             }
         ]

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -9,13 +9,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "krb5",
                             "version": "1.5.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "11.2",
                             "format": "rpm",
@@ -29,13 +29,15 @@
                             "name": "sled-release",
                             "test_ref": "2009073771",
                             "operation": "equals",
-                            "operation_value": "11.2"
+                            "operation_value": "11.2",
+                            "installed": "0"
                         },
                         "1":{
                             "name": "sled-release",
                             "test_ref": "2009077540",
                             "operation": "equals",
-                            "operation_value": "11.3"
+                            "operation_value": "11.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -48,13 +50,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "kdelibs4",
                             "version": "4.3.5-0.12.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "11.3",
                             "format": "rpm",
@@ -68,13 +70,15 @@
                             "name": "sled-release",
                             "test_ref": "2009073771",
                             "operation": "equals",
-                            "operation_value": "11.2"
+                            "operation_value": "11.2",
+                            "installed": "0"
                         },
                         "1":{
                             "name": "sled-release",
                             "test_ref": "2009077540",
                             "operation": "equals",
-                            "operation_value": "11.3"
+                            "operation_value": "11.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -87,13 +91,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "libecpg6",
                             "version": "3.25.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "11.4",
                             "format": "rpm",
@@ -107,7 +111,8 @@
                             "name": "sled-release",
                             "test_ref": "2009117401",
                             "operation": "equals",
-                            "operation_value": "11.4"
+                            "operation_value": "11.4",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -120,13 +125,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "openssl",
                             "version": "0.6.1",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "11.3",
                             "format": "rpm",
@@ -140,7 +145,8 @@
                             "name": "sled-release",
                             "test_ref": "2009077540",
                             "operation": "equals",
-                            "operation_value": "11.3"
+                            "operation_value": "11.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -153,13 +159,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "monodoc-core",
                             "version": "2.0.12",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "11.2",
                             "format": "rpm",
@@ -173,13 +179,15 @@
                             "name": "sled-release",
                             "test_ref": "2009073771",
                             "operation": "equals",
-                            "operation_value": "11.2"
+                            "operation_value": "11.2",
+                            "installed": "0"
                         },
                         "1":{
                             "name": "sled-release",
                             "test_ref": "2009077540",
                             "operation": "equals",
-                            "operation_value": "11.3"
+                            "operation_value": "11.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -201,13 +209,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "tar",
                             "version": "1.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "11.1",
                             "format": "rpm",
@@ -221,7 +229,8 @@
                             "name": "sles-release",
                             "test_ref": "2009060800",
                             "operation": "equals",
-                            "operation_value": "11.1"
+                            "operation_value": "11.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -234,13 +243,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "squid3",
                             "version": "2.1.3",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "11.2",
                             "format": "rpm",
@@ -254,7 +263,8 @@
                             "name": "sles-release",
                             "test_ref": "2009073771",
                             "operation": "equals",
-                            "operation_value": "11.2"
+                            "operation_value": "11.2",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -267,13 +277,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "openssh-openssl1",
                             "version": "2.8",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "11.3",
                             "format": "rpm",
@@ -287,7 +297,8 @@
                             "name": "sles-release",
                             "test_ref": "2009117400",
                             "operation": "greater than or equal",
-                            "operation_value": "11.3"
+                            "operation_value": "11.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -300,13 +311,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "wireshark",
                             "version": "1.7",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "11.4",
                             "format": "rpm",
@@ -320,7 +331,8 @@
                             "name": "sles-release",
                             "test_ref": "2009117413",
                             "operation": "equals",
-                            "operation_value": "11.4"
+                            "operation_value": "11.4",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -333,13 +345,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "ruby",
                             "version": "1.3.2",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "11.2",
                             "format": "rpm",
@@ -353,7 +365,8 @@
                             "name": "sles-release",
                             "test_ref": "2009073673",
                             "operation": "equals",
-                            "operation_value": "11.2"
+                            "operation_value": "11.2",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -375,13 +388,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "krb5-client",
                             "version": "1.11.4",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "12.2",
                             "format": "rpm",
@@ -395,13 +408,15 @@
                             "name": "sled-release",
                             "test_ref": "2009128016",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         },
                         "1":{
                             "name": "sled-release",
                             "test_ref": "2009159517",
                             "operation": "equals",
-                            "operation_value": "12.3"
+                            "operation_value": "12.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -414,13 +429,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "hplip",
                             "version": "3.14",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "12.0",
                             "format": "rpm",
@@ -434,19 +449,22 @@
                             "name": "sled-release",
                             "test_ref": "2009116183",
                             "operation": "equals",
-                            "operation_value": "12.0"
+                            "operation_value": "12.0",
+                            "installed": "0"
                         },
                         "1": {
                             "name": "sled-release",
                             "test_ref": "2009118774",
                             "operation": "equals",
-                            "operation_value": "12.1"
+                            "operation_value": "12.1",
+                            "installed": "0"
                         },
                         "2": {
                             "name": "sled-release",
                             "test_ref": "2009128016",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -459,13 +477,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "cron",
                             "version": "3.3",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "12.1",
                             "format": "rpm",
@@ -479,25 +497,29 @@
                             "name": "sled-release",
                             "test_ref": "2009118774",
                             "operation": "equals",
-                            "operation_value": "12.1"
+                            "operation_value": "12.1",
+                            "installed": "0"
                         },
                         "1":{
                             "name": "sled-release",
                             "test_ref": "2009128016",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         },
                         "2":{
                             "name": "sled-release",
                             "test_ref": "2009159517",
                             "operation": "equals",
-                            "operation_value": "12.3"
+                            "operation_value": "12.3",
+                            "installed": "0"
                         },
                         "3":{
                             "name": "sled-release",
                             "test_ref": "2009239879",
                             "operation": "equals",
-                            "operation_value": "12.4"
+                            "operation_value": "12.4",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -510,13 +532,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "coolkey",
                             "version": "1.1.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "12.0",
                             "format": "rpm",
@@ -530,25 +552,29 @@
                             "name": "sled-release",
                             "test_ref": "2009116183",
                             "operation": "equals",
-                            "operation_value": "12.0"
+                            "operation_value": "12.0",
+                            "installed": "0"
                         },
                         "1": {
                             "name": "sled-release",
                             "test_ref": "2009118774",
                             "operation": "equals",
-                            "operation_value": "12.1"
+                            "operation_value": "12.1",
+                            "installed": "0"
                         },
                         "2":{
                             "name": "sled-release",
                             "test_ref": "2009128016",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         },
                         "3":{
                             "name": "sled-release",
                             "test_ref": "2009159517",
                             "operation": "equals",
-                            "operation_value": "12.3"
+                            "operation_value": "12.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -561,13 +587,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "qemu",
                             "version": "1.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sled-release",
                             "version": "12.0",
                             "format": "rpm",
@@ -581,7 +607,8 @@
                             "name": "sled-release",
                             "test_ref": "2009116183",
                             "operation": "equals",
-                            "operation_value": "12.0"
+                            "operation_value": "12.0",
+                            "installed": "0"
                         }
                     }    
                 ],               
@@ -603,13 +630,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "gimp",
                             "version": "0.98.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-we-release",
                             "version": "12.3",
                             "format": "rpm",
@@ -623,7 +650,8 @@
                             "name": "sle-we-release",
                             "test_ref": "2009159844",
                             "operation": "equals",
-                            "operation_value": "12.3"
+                            "operation_value": "12.3",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -636,13 +664,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "libecpg6",
                             "version": "1.0.8",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "12.2",
                             "format": "rpm",
@@ -656,13 +684,15 @@
                             "name": "sles-release",
                             "test_ref": "2009128018",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         },
                         "1": {
                             "name": "sles-release",
                             "test_ref": "2009128018",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -675,13 +705,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "mariadb",
                             "version": "9.9",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "12.2",
                             "format": "rpm",
@@ -695,7 +725,8 @@
                             "name": "sles-release",
                             "test_ref": "2009116126",
                             "operation": "equals",
-                            "operation_value": "12.2"
+                            "operation_value": "12.2",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -708,13 +739,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "curl",
                             "version": "6.2",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "12.0",
                             "format": "rpm",
@@ -728,7 +759,8 @@
                             "name": "sles-release",
                             "test_ref": "2009116126",
                             "operation": "equals",
-                            "operation_value": "12.0"
+                            "operation_value": "12.0",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -741,13 +773,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "krb5",
                             "version": "1.1.5",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sles-release",
                             "version": "12.5",
                             "format": "rpm",
@@ -761,7 +793,8 @@
                             "name": "sles-release",
                             "test_ref": "2009258033",
                             "operation": "equals",
-                            "operation_value": "12.5"
+                            "operation_value": "12.5",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -783,13 +816,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "krb5",
                             "version": "0.98.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15",
                             "format": "rpm",
@@ -803,7 +836,8 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009223735",
                             "operation": "equals",
-                            "operation_value": "15"
+                            "operation_value": "15",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -816,13 +850,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "openssl",
                             "version": "1.0.8",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15.1",
                             "format": "rpm",
@@ -836,7 +870,8 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009254629",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -849,13 +884,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "python3-bind",
                             "version": "9.10",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15.1",
                             "format": "rpm",
@@ -869,7 +904,8 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009254629",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -882,13 +918,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "pam_ssh",
                             "version": "1.2",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15",
                             "format": "rpm",
@@ -902,19 +938,22 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009223735",
                             "operation": "equals",
-                            "operation_value": "15"
+                            "operation_value": "15",
+                            "installed": "0"
                         },
                         "1": {
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009254629",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         },
                         "2": {
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009281315",
                             "operation": "equals",
-                            "operation_value": "15.2"
+                            "operation_value": "15.2",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -927,13 +966,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "git",
                             "version": "1.0.5",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-development-tools-release",
                             "version": "15.1",
                             "format": "rpm",
@@ -947,7 +986,8 @@
                             "name": "sle-module-development-tools-release",
                             "test_ref": "2009255446",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -969,13 +1009,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "krb5",
                             "version": "0.98.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15",
                             "format": "rpm",
@@ -989,7 +1029,8 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009223735",
                             "operation": "equals",
-                            "operation_value": "15"
+                            "operation_value": "15",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -1002,13 +1043,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "php7",
                             "version": "6.0.8",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-web-scripting-release",
                             "version": "15.1",
                             "format": "rpm",
@@ -1022,7 +1063,8 @@
                             "name": "sle-module-web-scripting-release",
                             "test_ref": "2009255622",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -1035,13 +1077,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "python",
                             "version": "1.9",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15",
                             "format": "rpm",
@@ -1055,13 +1097,15 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009223735",
                             "operation": "equals",
-                            "operation_value": "15"
+                            "operation_value": "15",
+                            "installed": "0"
                         },
                         "1": {
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009254629",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -1074,13 +1118,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "openssl",
                             "version": "1.0.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-basesystem-release",
                             "version": "15.1",
                             "format": "rpm",
@@ -1094,7 +1138,8 @@
                             "name": "sle-module-basesystem-release",
                             "test_ref": "2009254629",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],
@@ -1107,13 +1152,13 @@
             {
                 "package": [
                     {
-                        "0":{
+                        "pkg":{
                             "name": "apache2",
                             "version": "2.1.5",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
-                        "1": {
+                        "dep": {
                             "name": "sle-module-server-application-release",
                             "version": "15.1",
                             "format": "rpm",
@@ -1127,7 +1172,8 @@
                             "name": "sle-module-server-application-release",
                             "test_ref": "2009255508",
                             "operation": "equals",
-                            "operation_value": "15.1"
+                            "operation_value": "15.1",
+                            "installed": "0"
                         }
                     }    
                 ],

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -7,12 +7,22 @@
         "name": "Desktop11",
         "vulnerabilities": [
             {
-                "package": {
-                    "name": "krb5",
-                    "version": "1.5.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "krb5",
+                            "version": "1.5.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "11.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -36,12 +46,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "mailx",
-                    "version": "10.3",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "mailx",
+                            "version": "10.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "11.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0":{
@@ -59,12 +79,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "libecpg6",
-                    "version": "3.25.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "libecpg6",
+                            "version": "3.25.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "11.4",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -82,12 +112,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "openssl",
-                    "version": "0.6.1",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "openssl",
+                            "version": "0.6.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "11.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0":{
@@ -105,12 +145,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "monodoc-core",
-                    "version": "2.0.12",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "monodoc-core",
+                            "version": "2.0.12",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "11.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -143,12 +193,22 @@
         "name": "Server11",
         "vulnerabilities": [
             {
-                "package": {
-                    "name": "tar",
-                    "version": "1.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "tar",
+                            "version": "1.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "11.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -166,12 +226,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "squid3",
-                    "version": "2.1.3",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "squid3",
+                            "version": "2.1.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "11.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -189,12 +259,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "openssh-openssl1",
-                    "version": "2.8",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "openssh-openssl1",
+                            "version": "2.8",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "11.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -212,12 +292,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "wireshark",
-                    "version": "1.7",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "wireshark",
+                            "version": "1.7",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "11.4",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -235,12 +325,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "ruby",
-                    "version": "1.3.2",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "ruby",
+                            "version": "1.3.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "11.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -267,12 +367,22 @@
         "name": "Desktop12",
         "vulnerabilities": [
             {
-                "package": {
-                    "name": "krb5-client",
-                    "version": "1.11.4",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "krb5-client",
+                            "version": "1.11.4",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "12.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -296,12 +406,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "mailx",
-                    "version": "3.7",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "mailx",
+                            "version": "3.7",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "12.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -319,12 +439,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "cron",
-                    "version": "3.3",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "cron",
+                            "version": "3.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "12.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -360,12 +490,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "perl-tk",
-                    "version": "802.030",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "perl-tk",
+                            "version": "802.030",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "12.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -407,12 +547,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "qemu",
-                    "version": "1.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "qemu",
+                            "version": "1.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "version": "12.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -439,12 +589,22 @@
         "name": "Server12",
         "vulnerabilities": [
             {
-                "package": {
-                    "name": "gimp",
-                    "version": "0.98.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "gimp",
+                            "version": "0.98.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-we-release",
+                            "version": "12.3",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -462,12 +622,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "libecpg6",
-                    "version": "1.0.8",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "libecpg6",
+                            "version": "1.0.8",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "12.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -491,12 +661,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "mariadb",
-                    "version": "9.9",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "mariadb",
+                            "version": "9.9",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "12.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -514,12 +694,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "curl",
-                    "version": "6.2",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "curl",
+                            "version": "6.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "12.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -537,12 +727,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "krb5",
-                    "version": "1.1.5",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "krb5",
+                            "version": "1.1.5",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "version": "12.5",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -569,12 +769,22 @@
         "name": "Desktop15",
         "vulnerabilities": [
             {
-                "package": {
-                    "name": "krb5",
-                    "version": "0.98.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "krb5",
+                            "version": "0.98.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -592,12 +802,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "openssl",
-                    "version": "1.0.8",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "openssl",
+                            "version": "1.0.8",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -615,12 +835,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "python3-bind",
-                    "version": "9.10",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "python3-bind",
+                            "version": "9.10",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -638,12 +868,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "pam_ssh",
-                    "version": "1.2",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "pam_ssh",
+                            "version": "1.2",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -673,12 +913,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "git",
-                    "version": "1.0.5",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "git",
+                            "version": "1.0.5",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-development-tools-release",
+                            "version": "15.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -705,12 +955,22 @@
         "name": "Server15",
         "vulnerabilities": [
             {
-                "package": {
-                    "name": "krb5",
-                    "version": "0.98.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "krb5",
+                            "version": "0.98.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -728,12 +988,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "php7",
-                    "version": "6.0.8",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "php7",
+                            "version": "6.0.8",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-web-scripting-release",
+                            "version": "15.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -751,12 +1021,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "python",
-                    "version": "1.9",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "python",
+                            "version": "1.9",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -780,12 +1060,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "openssl",
-                    "version": "1.0.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "openssl",
+                            "version": "1.0.0",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "version": "15.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {
@@ -803,12 +1093,22 @@
                 }
             },
             {
-                "package": {
-                    "name": "apache2",
-                    "version": "2.1.5",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                },
+                "package": [
+                    {
+                        "0":{
+                            "name": "apache2",
+                            "version": "2.1.5",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        },
+                        "1": {
+                            "name": "sle-module-server-application-release",
+                            "version": "15.1",
+                            "format": "rpm",
+                            "vendor": "SUSE LLC <https://www.suse.com/>"
+                        }
+                    }
+                ],
                 "dependency": [
                     {
                         "0": {

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -17,14 +17,14 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009073771",
+                        "test_ref": "oval:org.opensuse.security:tst:2009073771",
                         "operation": "equals",
                         "operation_value": "11.2",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009077540",
+                        "test_ref": "oval:org.opensuse.security:tst:2009077540",
                         "operation": "equals",
                         "operation_value": "11.3",
                         "installed": "0"
@@ -47,14 +47,14 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009073771",
+                        "test_ref": "oval:org.opensuse.security:tst:2009073771",
                         "operation": "equals",
                         "operation_value": "11.2",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009077540",
+                        "test_ref": "oval:org.opensuse.security:tst:2009077540",
                         "operation": "equals",
                         "operation_value": "11.3",
                         "installed": "0"
@@ -77,7 +77,7 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009117401",
+                        "test_ref": "oval:org.opensuse.security:tst:2009117401",
                         "operation": "equals",
                         "operation_value": "11.4",
                         "installed": "0"
@@ -100,7 +100,7 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009077540",
+                        "test_ref": "oval:org.opensuse.security:tst:2009077540",
                         "operation": "equals",
                         "operation_value": "11.3",
                         "installed": "0"
@@ -123,14 +123,14 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009073771",
+                        "test_ref": "oval:org.opensuse.security:tst:2009073771",
                         "operation": "equals",
                         "operation_value": "11.2",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009077540",
+                        "test_ref": "oval:org.opensuse.security:tst:2009077540",
                         "operation": "equals",
                         "operation_value": "11.3",
                         "installed": "0"
@@ -149,24 +149,6 @@
                 {
                     "name": "sled-release",
                     "version": "11.2",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sled-release",
-                    "version": "11.3",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sled-release",
-                    "version": "11.4",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 }
@@ -191,10 +173,10 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009060800",
+                        "test_ref": "oval:org.opensuse.security:tst:2009060800",
                         "operation": "equals",
                         "operation_value": "11.1",
-                        "installed": "0"
+                        "installed": "1"
                     }   
                 ],
                 "cve": {
@@ -214,7 +196,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009073771",
+                        "test_ref": "oval:org.opensuse.security:tst:2009073771",
                         "operation": "equals",
                         "operation_value": "11.2",
                         "installed": "0"
@@ -237,7 +219,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009117400",
+                        "test_ref": "oval:org.opensuse.security:tst:2009117400",
                         "operation": "greater than or equal",
                         "operation_value": "11.3",
                         "installed": "0"
@@ -260,7 +242,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009117413",
+                        "test_ref": "oval:org.opensuse.security:tst:2009117413",
                         "operation": "equals",
                         "operation_value": "11.4",
                         "installed": "0"
@@ -283,7 +265,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009073673",
+                        "test_ref": "oval:org.opensuse.security:tst:2009073673",
                         "operation": "equals",
                         "operation_value": "11.2",
                         "installed": "0"
@@ -302,33 +284,6 @@
                 {
                     "name": "sles-release",
                     "version": "11.1",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sles-release",
-                    "version": "11.2",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sles-release",
-                    "version": "11.3",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sles-release",
-                    "version": "11.4",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 }
@@ -353,14 +308,14 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009128016",
+                        "test_ref": "oval:org.opensuse.security:tst:2009128016",
                         "operation": "equals",
                         "operation_value": "12.2",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009159517",
+                        "test_ref": "oval:org.opensuse.security:tst:2009159517",
                         "operation": "equals",
                         "operation_value": "12.3",
                         "installed": "0"
@@ -383,24 +338,24 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009116183",
+                        "test_ref": "oval:org.opensuse.security:tst:2009116183",
                         "operation": "equals",
                         "operation_value": "12.0",
                         "installed": "0"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009118774",
+                        "test_ref": "oval:org.opensuse.security:tst:2009118774",
                         "operation": "equals",
                         "operation_value": "12.1",
                         "installed": "0"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009128016",
+                        "test_ref": "oval:org.opensuse.security:tst:2009128016",
                         "operation": "equals",
                         "operation_value": "12.2",
-                        "installed": "0"
+                        "installed": "1"
                     }
                 ],
                 "cve": {
@@ -420,28 +375,28 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009118774",
+                        "test_ref": "oval:org.opensuse.security:tst:2009118774",
                         "operation": "equals",
                         "operation_value": "12.1",
                         "installed": "0"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009128016",
+                        "test_ref": "oval:org.opensuse.security:tst:2009128016",
                         "operation": "equals",
                         "operation_value": "12.2",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009159517",
+                        "test_ref": "oval:org.opensuse.security:tst:2009159517",
                         "operation": "equals",
                         "operation_value": "12.3",
                         "installed": "0"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009239879",
+                        "test_ref": "oval:org.opensuse.security:tst:2009239879",
                         "operation": "equals",
                         "operation_value": "12.4",
                         "installed": "0"
@@ -464,28 +419,28 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009116183",
+                        "test_ref": "oval:org.opensuse.security:tst:2009116183",
                         "operation": "equals",
                         "operation_value": "12.0",
                         "installed": "0"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009118774",
+                        "test_ref": "oval:org.opensuse.security:tst:2009118774",
                         "operation": "equals",
                         "operation_value": "12.1",
                         "installed": "0"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009128016",
+                        "test_ref": "oval:org.opensuse.security:tst:2009128016",
                         "operation": "equals",
                         "operation_value": "12.2",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sled-release",
-                        "test_ref": "2009159517",
+                        "test_ref": "oval:org.opensuse.security:tst:2009159517",
                         "operation": "equals",
                         "operation_value": "12.3",
                         "installed": "0"
@@ -508,7 +463,7 @@
                 "dependency": [
                     {
                         "name": "sled-release",
-                        "test_ref": "2009116183",
+                        "test_ref": "oval:org.opensuse.security:tst:2009116183",
                         "operation": "equals",
                         "operation_value": "12.0",
                         "installed": "0"
@@ -522,24 +477,6 @@
             }
         ],
         "agent_dependencies": [
-            {
-                "package":
-                {
-                    "name": "sled-release",
-                    "version": "12.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sled-release",
-                    "version": "12.1",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
             {
                 "package":
                 {
@@ -569,10 +506,10 @@
                 "dependency": [
                     {
                         "name": "sle-we-release",
-                        "test_ref": "2009159844",
+                        "test_ref": "oval:org.opensuse.security:tst:2009159844",
                         "operation": "equals",
                         "operation_value": "12.3",
-                        "installed": "0"
+                        "installed": "1"
                     }
                 ],
                 "cve": {
@@ -592,17 +529,17 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009128018",
+                        "test_ref": "oval:org.opensuse.security:tst:2009128018",
                         "operation": "equals",
                         "operation_value": "12.2",
                         "installed": "0"
                     },
                     {
                         "name": "sles-release",
-                        "test_ref": "2009158922",
+                        "test_ref": "oval:org.opensuse.security:tst:2009158922",
                         "operation": "equals",
                         "operation_value": "12.3",
-                        "installed": "0"
+                        "installed": "1"
                     } 
                 ],
                 "cve": {
@@ -622,7 +559,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009116126",
+                        "test_ref": "oval:org.opensuse.security:tst:2009116126",
                         "operation": "equals",
                         "operation_value": "12.2",
                         "installed": "0"
@@ -645,7 +582,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009116126",
+                        "test_ref": "oval:org.opensuse.security:tst:2009116126",
                         "operation": "equals",
                         "operation_value": "12.0",
                         "installed": "0"
@@ -668,7 +605,7 @@
                 "dependency": [
                     {
                         "name": "sles-release",
-                        "test_ref": "2009258033",
+                        "test_ref": "oval:org.opensuse.security:tst:2009258033",
                         "operation": "equals",
                         "operation_value": "12.5",
                         "installed": "0"
@@ -687,33 +624,6 @@
                 {
                     "name": "sle-we-release",
                     "version": "12.3",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sles-release",
-                    "version": "12.0",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sles-release",
-                    "version": "12.2",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sles-release",
-                    "version": "12.5",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 }
@@ -738,10 +648,10 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009223735",
+                        "test_ref": "oval:org.opensuse.security:tst:2009223735",
                         "operation": "equals",
                         "operation_value": "15",
-                        "installed": "0"
+                        "installed": "1"
                     }  
                 ],
                 "cve": {
@@ -761,7 +671,7 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009254629",
+                        "test_ref": "oval:org.opensuse.security:tst:2009254629",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -784,7 +694,7 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009254629",
+                        "test_ref": "oval:org.opensuse.security:tst:2009254629",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -807,21 +717,21 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009223735",
+                        "test_ref": "oval:org.opensuse.security:tst:2009223735",
                         "operation": "equals",
                         "operation_value": "15",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009254629",
+                        "test_ref": "oval:org.opensuse.security:tst:2009254629",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
                     },
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009281315",
+                        "test_ref": "oval:org.opensuse.security:tst:2009281315",
                         "operation": "equals",
                         "operation_value": "15.2",
                         "installed": "0"
@@ -844,7 +754,7 @@
                 "dependency": [
                     {
                         "name": "sle-module-development-tools-release",
-                        "test_ref": "2009255446",
+                        "test_ref": "oval:org.opensuse.security:tst:2009255446",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -863,24 +773,6 @@
                 {
                     "name": "sle-module-basesystem-release",
                     "version": "15",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sle-module-basesystem-release",
-                    "version": "15.1",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sle-module-development-tools-release",
-                    "version": "15.1",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 }
@@ -905,10 +797,10 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009223735",
+                        "test_ref": "oval:org.opensuse.security:tst:2009223735",
                         "operation": "equals",
                         "operation_value": "15",
-                        "installed": "0"
+                        "installed": "1"
                     } 
                 ],
                 "cve": {
@@ -928,7 +820,7 @@
                 "dependency": [
                     {
                         "name": "sle-module-web-scripting-release",
-                        "test_ref": "2009255622",
+                        "test_ref": "oval:org.opensuse.security:tst:2009255622",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -951,14 +843,14 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009223735",
+                        "test_ref": "oval:org.opensuse.security:tst:2009223735",
                         "operation": "equals",
                         "operation_value": "15",
-                        "installed": "0"
+                        "installed": "1"
                     },
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009254629",
+                        "test_ref": "oval:org.opensuse.security:tst:2009254629",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -981,7 +873,7 @@
                 "dependency": [
                     {
                         "name": "sle-module-basesystem-release",
-                        "test_ref": "2009254629",
+                        "test_ref": "oval:org.opensuse.security:tst:2009254629",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -1004,7 +896,7 @@
                 "dependency": [
                     {
                         "name": "sle-module-server-application-release",
-                        "test_ref": "2009255508",
+                        "test_ref": "oval:org.opensuse.security:tst:2009255508",
                         "operation": "equals",
                         "operation_value": "15.1",
                         "installed": "0"
@@ -1023,33 +915,6 @@
                 {
                     "name": "sle-module-basesystem-release",
                     "version": "15",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sle-module-basesystem-release",
-                    "version": "15.1",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sle-module-web-scripting-release",
-                    "version": "15.1",
-                    "format": "rpm",
-                    "vendor": "SUSE LLC <https://www.suse.com/>"
-                }
-            },
-            {
-                "package":
-                {
-                    "name": "sle-module-server-application-release",
-                    "version": "15.1",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 }

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -9,37 +9,34 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "krb5",
-                            "version": "1.5.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "11.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "krb5",
+                        "version": "1.5.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "11.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
+                    
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009073771",
-                            "operation": "equals",
-                            "operation_value": "11.2",
-                            "installed": "0"
-                        },
-                        "1":{
-                            "name": "sled-release",
-                            "test_ref": "2009077540",
-                            "operation": "equals",
-                            "operation_value": "11.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009073771",
+                        "operation": "equals",
+                        "operation_value": "11.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009077540",
+                        "operation": "equals",
+                        "operation_value": "11.3",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
@@ -50,37 +47,33 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "kdelibs4",
-                            "version": "4.3.5-0.12.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "11.3",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "kdelibs4",
+                        "version": "4.3.5-0.12.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "11.3",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0":{
-                            "name": "sled-release",
-                            "test_ref": "2009073771",
-                            "operation": "equals",
-                            "operation_value": "11.2",
-                            "installed": "0"
-                        },
-                        "1":{
-                            "name": "sled-release",
-                            "test_ref": "2009077540",
-                            "operation": "equals",
-                            "operation_value": "11.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009073771",
+                        "operation": "equals",
+                        "operation_value": "11.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009077540",
+                        "operation": "equals",
+                        "operation_value": "11.3",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2012-4515",
@@ -91,30 +84,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "libecpg6",
-                            "version": "3.25.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "11.4",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "libecpg6",
+                        "version": "3.25.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "11.4",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009117401",
-                            "operation": "equals",
-                            "operation_value": "11.4",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009117401",
+                        "operation": "equals",
+                        "operation_value": "11.4",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2007-4772",
@@ -125,30 +114,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "openssl",
-                            "version": "0.6.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "11.3",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "openssl",
+                        "version": "0.6.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "11.3",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0":{
-                            "name": "sled-release",
-                            "test_ref": "2009077540",
-                            "operation": "equals",
-                            "operation_value": "11.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009077540",
+                        "operation": "equals",
+                        "operation_value": "11.3",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2009-5146",
@@ -159,37 +144,33 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "monodoc-core",
-                            "version": "2.0.12",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "11.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "monodoc-core",
+                        "version": "2.0.12",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "11.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009073771",
-                            "operation": "equals",
-                            "operation_value": "11.2",
-                            "installed": "0"
-                        },
-                        "1":{
-                            "name": "sled-release",
-                            "test_ref": "2009077540",
-                            "operation": "equals",
-                            "operation_value": "11.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009073771",
+                        "operation": "equals",
+                        "operation_value": "11.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009077540",
+                        "operation": "equals",
+                        "operation_value": "11.3",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2009-0689",
@@ -209,30 +190,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "tar",
-                            "version": "1.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "11.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "tar",
+                        "version": "1.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "11.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009060800",
-                            "operation": "equals",
-                            "operation_value": "11.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009060800",
+                        "operation": "equals",
+                        "operation_value": "11.1",
+                        "installed": "0"
+                    }   
                 ],
                 "cve": {
                     "cveid": "CVE-2001-1267",
@@ -243,30 +220,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "squid3",
-                            "version": "2.1.3",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "11.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "squid3",
+                        "version": "2.1.3",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "11.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009073771",
-                            "operation": "equals",
-                            "operation_value": "11.2",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009073771",
+                        "operation": "equals",
+                        "operation_value": "11.2",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2005-0094",
@@ -277,30 +250,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "openssh-openssl1",
-                            "version": "2.8",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "11.3",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "openssh-openssl1",
+                        "version": "2.8",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "11.3",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009117400",
-                            "operation": "greater than or equal",
-                            "operation_value": "11.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009117400",
+                        "operation": "greater than or equal",
+                        "operation_value": "11.3",
+                        "installed": "0"
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2006-0225",
@@ -311,30 +280,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "wireshark",
-                            "version": "1.7",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "11.4",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "wireshark",
+                        "version": "1.7",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "11.4",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009117413",
-                            "operation": "equals",
-                            "operation_value": "11.4",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009117413",
+                        "operation": "equals",
+                        "operation_value": "11.4",
+                        "installed": "0"
+                    }   
                 ],
                 "cve": {
                     "cveid": "CVE-2006-4805",
@@ -345,30 +310,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "ruby",
-                            "version": "1.3.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "11.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "ruby",
+                        "version": "1.3.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "11.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009073673",
-                            "operation": "equals",
-                            "operation_value": "11.2",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009073673",
+                        "operation": "equals",
+                        "operation_value": "11.2",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2006-3694",
@@ -388,37 +349,33 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "krb5-client",
-                            "version": "1.11.4",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "12.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "krb5-client",
+                        "version": "1.11.4",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "12.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009128016",
-                            "operation": "equals",
-                            "operation_value": "12.2",
-                            "installed": "0"
-                        },
-                        "1":{
-                            "name": "sled-release",
-                            "test_ref": "2009159517",
-                            "operation": "equals",
-                            "operation_value": "12.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009128016",
+                        "operation": "equals",
+                        "operation_value": "12.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009159517",
+                        "operation": "equals",
+                        "operation_value": "12.3",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
@@ -429,44 +386,40 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "hplip",
-                            "version": "3.14",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "12.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "hplip",
+                        "version": "3.14",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "12.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009116183",
-                            "operation": "equals",
-                            "operation_value": "12.0",
-                            "installed": "0"
-                        },
-                        "1": {
-                            "name": "sled-release",
-                            "test_ref": "2009118774",
-                            "operation": "equals",
-                            "operation_value": "12.1",
-                            "installed": "0"
-                        },
-                        "2": {
-                            "name": "sled-release",
-                            "test_ref": "2009128016",
-                            "operation": "equals",
-                            "operation_value": "12.2",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009116183",
+                        "operation": "equals",
+                        "operation_value": "12.0",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009118774",
+                        "operation": "equals",
+                        "operation_value": "12.1",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009128016",
+                        "operation": "equals",
+                        "operation_value": "12.2",
+                        "installed": "0"
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2004-0801",
@@ -477,51 +430,47 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "cron",
-                            "version": "3.3",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "12.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "cron",
+                        "version": "3.3",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "12.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009118774",
-                            "operation": "equals",
-                            "operation_value": "12.1",
-                            "installed": "0"
-                        },
-                        "1":{
-                            "name": "sled-release",
-                            "test_ref": "2009128016",
-                            "operation": "equals",
-                            "operation_value": "12.2",
-                            "installed": "0"
-                        },
-                        "2":{
-                            "name": "sled-release",
-                            "test_ref": "2009159517",
-                            "operation": "equals",
-                            "operation_value": "12.3",
-                            "installed": "0"
-                        },
-                        "3":{
-                            "name": "sled-release",
-                            "test_ref": "2009239879",
-                            "operation": "equals",
-                            "operation_value": "12.4",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009118774",
+                        "operation": "equals",
+                        "operation_value": "12.1",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009128016",
+                        "operation": "equals",
+                        "operation_value": "12.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009159517",
+                        "operation": "equals",
+                        "operation_value": "12.3",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009239879",
+                        "operation": "equals",
+                        "operation_value": "12.4",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2006-2607",
@@ -532,51 +481,47 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "coolkey",
-                            "version": "1.1.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "12.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "coolkey",
+                        "version": "1.1.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "12.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009116183",
-                            "operation": "equals",
-                            "operation_value": "12.0",
-                            "installed": "0"
-                        },
-                        "1": {
-                            "name": "sled-release",
-                            "test_ref": "2009118774",
-                            "operation": "equals",
-                            "operation_value": "12.1",
-                            "installed": "0"
-                        },
-                        "2":{
-                            "name": "sled-release",
-                            "test_ref": "2009128016",
-                            "operation": "equals",
-                            "operation_value": "12.2",
-                            "installed": "0"
-                        },
-                        "3":{
-                            "name": "sled-release",
-                            "test_ref": "2009159517",
-                            "operation": "equals",
-                            "operation_value": "12.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009116183",
+                        "operation": "equals",
+                        "operation_value": "12.0",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009118774",
+                        "operation": "equals",
+                        "operation_value": "12.1",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009128016",
+                        "operation": "equals",
+                        "operation_value": "12.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sled-release",
+                        "test_ref": "2009159517",
+                        "operation": "equals",
+                        "operation_value": "12.3",
+                        "installed": "0"
+                    }   
                 ],
                 "cve": {
                     "cveid": "CVE-2007-4129",
@@ -587,30 +532,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "qemu",
-                            "version": "1.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sled-release",
-                            "version": "12.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "qemu",
+                        "version": "1.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sled-release",
+                        "version": "12.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sled-release",
-                            "test_ref": "2009116183",
-                            "operation": "equals",
-                            "operation_value": "12.0",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sled-release",
+                        "test_ref": "2009116183",
+                        "operation": "equals",
+                        "operation_value": "12.0",
+                        "installed": "0"
+                    }
                 ],               
                 "cve": {
                     "cveid": "CVE-2008-0928",
@@ -630,30 +571,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "gimp",
-                            "version": "0.98.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-we-release",
-                            "version": "12.3",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "gimp",
+                        "version": "0.98.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-we-release",
+                        "version": "12.3",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-we-release",
-                            "test_ref": "2009159844",
-                            "operation": "equals",
-                            "operation_value": "12.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-we-release",
+                        "test_ref": "2009159844",
+                        "operation": "equals",
+                        "operation_value": "12.3",
+                        "installed": "0"
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2007-3126",
@@ -664,37 +601,33 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "libecpg6",
-                            "version": "1.0.8",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "12.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "libecpg6",
+                        "version": "1.0.8",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "12.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009128018",
-                            "operation": "equals",
-                            "operation_value": "12.2",
-                            "installed": "0"
-                        },
-                        "1": {
-                            "name": "sles-release",
-                            "test_ref": "2009158922",
-                            "operation": "equals",
-                            "operation_value": "12.3",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009128018",
+                        "operation": "equals",
+                        "operation_value": "12.2",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sles-release",
+                        "test_ref": "2009158922",
+                        "operation": "equals",
+                        "operation_value": "12.3",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2007-4772",
@@ -705,30 +638,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "mariadb",
-                            "version": "9.9",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "12.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "mariadb",
+                        "version": "9.9",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "12.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009116126",
-                            "operation": "equals",
-                            "operation_value": "12.2",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009116126",
+                        "operation": "equals",
+                        "operation_value": "12.2",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2007-5970",
@@ -739,30 +668,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "curl",
-                            "version": "6.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "12.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "curl",
+                        "version": "6.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "12.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009116126",
-                            "operation": "equals",
-                            "operation_value": "12.0",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009116126",
+                        "operation": "equals",
+                        "operation_value": "12.0",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2009-0037",
@@ -773,30 +698,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "krb5",
-                            "version": "1.1.5",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sles-release",
-                            "version": "12.5",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "krb5",
+                        "version": "1.1.5",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sles-release",
+                        "version": "12.5",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sles-release",
-                            "test_ref": "2009258033",
-                            "operation": "equals",
-                            "operation_value": "12.5",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sles-release",
+                        "test_ref": "2009258033",
+                        "operation": "equals",
+                        "operation_value": "12.5",
+                        "installed": "0"
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2009-0846",
@@ -816,30 +737,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "krb5",
-                            "version": "0.98.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "krb5",
+                        "version": "0.98.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009223735",
-                            "operation": "equals",
-                            "operation_value": "15",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009223735",
+                        "operation": "equals",
+                        "operation_value": "15",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
@@ -850,30 +767,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "openssl",
-                            "version": "1.0.8",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "openssl",
+                        "version": "1.0.8",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009254629",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009254629",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2006-7250",
@@ -884,30 +797,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "python3-bind",
-                            "version": "9.10",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "python3-bind",
+                        "version": "9.10",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009254629",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009254629",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    }
                 ],
                 "cve": {
                     "cveid": "CVE-2009-0696",
@@ -918,44 +827,40 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "pam_ssh",
-                            "version": "1.2",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "pam_ssh",
+                        "version": "1.2",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009223735",
-                            "operation": "equals",
-                            "operation_value": "15",
-                            "installed": "0"
-                        },
-                        "1": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009254629",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        },
-                        "2": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009281315",
-                            "operation": "equals",
-                            "operation_value": "15.2",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009223735",
+                        "operation": "equals",
+                        "operation_value": "15",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009254629",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009281315",
+                        "operation": "equals",
+                        "operation_value": "15.2",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2009-1273",
@@ -966,30 +871,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "git",
-                            "version": "1.0.5",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-development-tools-release",
-                            "version": "15.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "git",
+                        "version": "1.0.5",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-development-tools-release",
+                        "version": "15.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-development-tools-release",
-                            "test_ref": "2009255446",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-development-tools-release",
+                        "test_ref": "2009255446",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2005-4900",
@@ -1009,30 +910,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "krb5",
-                            "version": "0.98.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "krb5",
+                        "version": "0.98.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009223735",
-                            "operation": "equals",
-                            "operation_value": "15",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009223735",
+                        "operation": "equals",
+                        "operation_value": "15",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
@@ -1043,30 +940,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "php7",
-                            "version": "6.0.8",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-web-scripting-release",
-                            "version": "15.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "php7",
+                        "version": "6.0.8",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-web-scripting-release",
+                        "version": "15.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-web-scripting-release",
-                            "test_ref": "2009255622",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-web-scripting-release",
+                        "test_ref": "2009255622",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2006-7243",
@@ -1077,36 +970,32 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "python",
-                            "version": "1.9",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "python",
+                        "version": "1.9",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009223735",
-                            "operation": "equals",
-                            "operation_value": "15",
-                            "installed": "0"
-                        },
-                        "1": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009254629",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009223735",
+                        "operation": "equals",
+                        "operation_value": "15",
+                        "installed": "0"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009254629",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
                     }    
                 ],
                 "cve": {
@@ -1118,30 +1007,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "openssl",
-                            "version": "1.0.0",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-basesystem-release",
-                            "version": "15.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "openssl",
+                        "version": "1.0.0",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-basesystem-release",
+                        "version": "15.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-basesystem-release",
-                            "test_ref": "2009254629",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-basesystem-release",
+                        "test_ref": "2009254629",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    } 
                 ],
                 "cve": {
                     "cveid": "CVE-2006-7250",
@@ -1152,30 +1037,26 @@
             {
                 "package": [
                     {
-                        "pkg":{
-                            "name": "apache2",
-                            "version": "2.1.5",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        },
-                        "dep": {
-                            "name": "sle-module-server-application-release",
-                            "version": "15.1",
-                            "format": "rpm",
-                            "vendor": "SUSE LLC <https://www.suse.com/>"
-                        }
+                        "name": "apache2",
+                        "version": "2.1.5",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
+                    },
+                    {
+                        "name": "sle-module-server-application-release",
+                        "version": "15.1",
+                        "format": "rpm",
+                        "vendor": "SUSE LLC <https://www.suse.com/>"
                     }
                 ],
                 "dependency": [
                     {
-                        "0": {
-                            "name": "sle-module-server-application-release",
-                            "test_ref": "2009255508",
-                            "operation": "equals",
-                            "operation_value": "15.1",
-                            "installed": "0"
-                        }
-                    }    
+                        "name": "sle-module-server-application-release",
+                        "test_ref": "2009255508",
+                        "operation": "equals",
+                        "operation_value": "15.1",
+                        "installed": "0"
+                    }  
                 ],
                 "cve": {
                     "cveid": "CVE-2009-0023",

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -13,6 +13,22 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009073771",
+                            "operation": "equals",
+                            "operation_value": "11.2"
+                        },
+                        "1":{
+                            "name": "sled-release",
+                            "test_ref": "2009077540",
+                            "operation": "equals",
+                            "operation_value": "11.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
                     "operation": "less than",
@@ -26,6 +42,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0":{
+                            "name": "sled-release",
+                            "test_ref": "2009077540",
+                            "operation": "equals",
+                            "operation_value": "11.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2004-2771",
                     "operation": "less than",
@@ -38,7 +64,17 @@
                     "version": "3.25.0",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009117401",
+                            "operation": "equals",
+                            "operation_value": "11.4"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2007-4772",
                     "operation": "less than",
@@ -51,7 +87,17 @@
                     "version": "0.6.1",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0":{
+                            "name": "sled-release",
+                            "test_ref": "2009077540",
+                            "operation": "equals",
+                            "operation_value": "11.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-5146",
                     "operation": "less than",
@@ -65,6 +111,22 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009073771",
+                            "operation": "equals",
+                            "operation_value": "11.2"
+                        },
+                        "1":{
+                            "name": "sled-release",
+                            "test_ref": "2009077540",
+                            "operation": "equals",
+                            "operation_value": "11.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-0689",
                     "operation": "less than",
@@ -87,6 +149,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009060800",
+                            "operation": "equals",
+                            "operation_value": "11.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2001-1267",
                     "operation": "less than",
@@ -100,6 +172,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009073771",
+                            "operation": "equals",
+                            "operation_value": "11.2"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2005-0094",
                     "operation": "less than",
@@ -112,7 +194,17 @@
                     "version": "2.8",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009117400",
+                            "operation": "greater than or equal",
+                            "operation_value": "11.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-0225",
                     "operation": "less than",
@@ -125,7 +217,17 @@
                     "version": "1.7",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009117413",
+                            "operation": "equals",
+                            "operation_value": "11.4"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-4805",
                     "operation": "less than",
@@ -139,6 +241,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009073673",
+                            "operation": "equals",
+                            "operation_value": "11.2"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-3694",
                     "operation": "less than",
@@ -161,6 +273,22 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009128016",
+                            "operation": "equals",
+                            "operation_value": "12.2"
+                        },
+                        "1":{
+                            "name": "sled-release",
+                            "test_ref": "2009159517",
+                            "operation": "equals",
+                            "operation_value": "12.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
                     "operation": "less than",
@@ -174,6 +302,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009116183",
+                            "operation": "equals",
+                            "operation_value": "12.0"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2004-2771",
                     "operation": "less than",
@@ -186,7 +324,35 @@
                     "version": "3.3",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009118774",
+                            "operation": "equals",
+                            "operation_value": "12.1"
+                        },
+                        "1":{
+                            "name": "sled-release",
+                            "test_ref": "2009128016",
+                            "operation": "equals",
+                            "operation_value": "12.2"
+                        },
+                        "2":{
+                            "name": "sled-release",
+                            "test_ref": "2009159517",
+                            "operation": "equals",
+                            "operation_value": "12.3"
+                        },
+                        "3":{
+                            "name": "sled-release",
+                            "test_ref": "2009239879",
+                            "operation": "equals",
+                            "operation_value": "12.4"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-2607",
                     "operation": "less than",
@@ -199,7 +365,41 @@
                     "version": "802.030",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009116183",
+                            "operation": "equals",
+                            "operation_value": "12.0"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "test_ref": "2009118774",
+                            "operation": "equals",
+                            "operation_value": "12.1"
+                        },
+                        "2":{
+                            "name": "sled-release",
+                            "test_ref": "2009128016",
+                            "operation": "equals",
+                            "operation_value": "12.2"
+                        },
+                        "3":{
+                            "name": "sled-release",
+                            "test_ref": "2009159517",
+                            "operation": "equals",
+                            "operation_value": "12.3"
+                        },
+                        "4":{
+                            "name": "sled-release",
+                            "test_ref": "2009239879",
+                            "operation": "equals",
+                            "operation_value": "12.4"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-4484",
                     "operation": "less than",
@@ -213,6 +413,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sled-release",
+                            "test_ref": "2009116183",
+                            "operation": "equals",
+                            "operation_value": "12.0"
+                        }
+                    }    
+                ],               
                 "cve": {
                     "cveid": "CVE-2008-0928",
                     "operation": "less than",
@@ -235,6 +445,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-we-release",
+                            "test_ref": "2009159844",
+                            "operation": "equals",
+                            "operation_value": "12.3"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2007-3126",
                     "operation": "less than",
@@ -248,6 +468,22 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009128018",
+                            "operation": "equals",
+                            "operation_value": "12.2"
+                        },
+                        "1": {
+                            "name": "sles-release",
+                            "test_ref": "2009128018",
+                            "operation": "equals",
+                            "operation_value": "12.2"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2007-4772",
                     "operation": "less than",
@@ -260,7 +496,17 @@
                     "version": "9.9",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009116126",
+                            "operation": "equals",
+                            "operation_value": "12.2"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2007-5970",
                     "operation": "less than",
@@ -273,7 +519,17 @@
                     "version": "6.2",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009116126",
+                            "operation": "equals",
+                            "operation_value": "12.0"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-0037",
                     "operation": "less than",
@@ -287,6 +543,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sles-release",
+                            "test_ref": "2009258033",
+                            "operation": "equals",
+                            "operation_value": "12.5"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-0846",
                     "operation": "less than",
@@ -309,6 +575,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009223735",
+                            "operation": "equals",
+                            "operation_value": "15"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
                     "operation": "less than",
@@ -322,6 +598,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009254629",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-7250",
                     "operation": "less than",
@@ -334,7 +620,17 @@
                     "version": "9.10",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009254629",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-0696",
                     "operation": "less than",
@@ -347,7 +643,29 @@
                     "version": "1.2",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009223735",
+                            "operation": "equals",
+                            "operation_value": "15"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009254629",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        },
+                        "2": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009281315",
+                            "operation": "equals",
+                            "operation_value": "15.2"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-1273",
                     "operation": "less than",
@@ -361,6 +679,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-development-tools-release",
+                            "test_ref": "2009255446",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2005-4900",
                     "operation": "less than",
@@ -383,6 +711,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009223735",
+                            "operation": "equals",
+                            "operation_value": "15"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2002-2443",
                     "operation": "less than",
@@ -396,6 +734,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-web-scripting-release",
+                            "test_ref": "2009255622",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-7243",
                     "operation": "less than",
@@ -408,7 +756,23 @@
                     "version": "1.9",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009223735",
+                            "operation": "equals",
+                            "operation_value": "15"
+                        },
+                        "1": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009254629",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2007-2052",
                     "operation": "less than",
@@ -421,7 +785,17 @@
                     "version": "1.0.0",
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
-            },
+                },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-basesystem-release",
+                            "test_ref": "2009254629",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2006-7250",
                     "operation": "less than",
@@ -435,6 +809,16 @@
                     "format": "rpm",
                     "vendor": "SUSE LLC <https://www.suse.com/>"
                 },
+                "dependency": [
+                    {
+                        "0": {
+                            "name": "sle-module-server-application-release",
+                            "test_ref": "2009255508",
+                            "operation": "equals",
+                            "operation_value": "15.1"
+                        }
+                    }    
+                ],
                 "cve": {
                     "cveid": "CVE-2009-0023",
                     "operation": "less than",

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -689,9 +689,9 @@
                         },
                         "1": {
                             "name": "sles-release",
-                            "test_ref": "2009128018",
+                            "test_ref": "2009158922",
                             "operation": "equals",
-                            "operation_value": "12.2",
+                            "operation_value": "12.3",
                             "installed": "0"
                         }
                     }    

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/suse_vulnerabilities.json
@@ -49,8 +49,8 @@
                 "package": [
                     {
                         "0":{
-                            "name": "mailx",
-                            "version": "10.3",
+                            "name": "kdelibs4",
+                            "version": "4.3.5-0.12.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
@@ -66,6 +66,12 @@
                     {
                         "0":{
                             "name": "sled-release",
+                            "test_ref": "2009073771",
+                            "operation": "equals",
+                            "operation_value": "11.2"
+                        },
+                        "1":{
+                            "name": "sled-release",
                             "test_ref": "2009077540",
                             "operation": "equals",
                             "operation_value": "11.3"
@@ -73,9 +79,9 @@
                     }    
                 ],
                 "cve": {
-                    "cveid": "CVE-2004-2771",
+                    "cveid": "CVE-2012-4515",
                     "operation": "less than",
-                    "operation_value": "12.5-1.7"
+                    "operation_value": "4.3.5-0.12.1"
                 }
             },
             {
@@ -409,8 +415,8 @@
                 "package": [
                     {
                         "0":{
-                            "name": "mailx",
-                            "version": "3.7",
+                            "name": "hplip",
+                            "version": "3.14",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
@@ -429,13 +435,25 @@
                             "test_ref": "2009116183",
                             "operation": "equals",
                             "operation_value": "12.0"
+                        },
+                        "1": {
+                            "name": "sled-release",
+                            "test_ref": "2009118774",
+                            "operation": "equals",
+                            "operation_value": "12.1"
+                        },
+                        "2": {
+                            "name": "sled-release",
+                            "test_ref": "2009128016",
+                            "operation": "equals",
+                            "operation_value": "12.2"
                         }
                     }    
                 ],
                 "cve": {
-                    "cveid": "CVE-2004-2771",
+                    "cveid": "CVE-2004-0801",
                     "operation": "less than",
-                    "operation_value": "12.5-22"
+                    "operation_value": "3.14.6-3.14"
                 }
             },
             {
@@ -493,8 +511,8 @@
                 "package": [
                     {
                         "0":{
-                            "name": "perl-tk",
-                            "version": "802.030",
+                            "name": "coolkey",
+                            "version": "1.1.0",
                             "format": "rpm",
                             "vendor": "SUSE LLC <https://www.suse.com/>"
                         },
@@ -531,19 +549,13 @@
                             "test_ref": "2009159517",
                             "operation": "equals",
                             "operation_value": "12.3"
-                        },
-                        "4":{
-                            "name": "sled-release",
-                            "test_ref": "2009239879",
-                            "operation": "equals",
-                            "operation_value": "12.4"
                         }
                     }    
                 ],
                 "cve": {
-                    "cveid": "CVE-2006-4484",
+                    "cveid": "CVE-2007-4129",
                     "operation": "less than",
-                    "operation_value": "804.031-3"
+                    "operation_value": "1.1.0-147.71"
                 }
             },
             {

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -79,22 +79,23 @@ def test_suse_vulnerabilities_report(get_configuration, configure_environment, r
     """
     vulnerabilities_number = len(mock_vulnerability_scan['vulnerabilities'])
 
+    # Check the vulnerabilities of packages inserted
+    for item in mock_vulnerability_scan['vulnerabilities']:
+        vulnerable = False
+        for deps in item['dependency']:
+            if deps['installed'] == "1":
+                vulnerable = True
+                break
+        if not vulnerable:
+            vulnerabilities_number-=1
+        else:
+            vd.check_vulnerability_scan_event(wazuh_log_monitor=wazuh_log_monitor, package=item['package']['name'],
+                                            cve=item['cve']['cveid'])
+
     # Check that the number of OVAL vulnerabilities is the expected
     vd.check_detected_vulnerabilities_number(wazuh_log_monitor=wazuh_log_monitor,
                                              expected_vulnerabilities_number=vulnerabilities_number,
                                              feed_source='OVAL', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
 
-    # Check the vulnerabilities of packages inserted
-    for item in mock_vulnerability_scan['vulnerabilities']:
-        vulnerable = False
-        for deps in item['dependency']:
-            if vd.is_dependency_installed(deps['test_ref']):
-                vulnerable = True
-                break
-        if not vulnerable:
-            log_event = f"Package '{item['package']['name']}' not vulnerable to '{item['cve']['cveid']}'."
-            vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event)
-        else:
-            vd.check_vulnerability_scan_event(wazuh_log_monitor=wazuh_log_monitor, package=item['package']['name'],
-                                            cve=item['cve']['cveid'])
+
     vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -56,7 +56,8 @@ def mock_vulnerability_scan(request, mock_agent):
     # Add custom vulnerabilities and feeds
     id=1
     for vulnerability in request.param['vulnerabilities']:
-        vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
+        for package in vulnerability['package']:
+            vd.insert_package(**package, agent=mock_agent, source=package['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
                                 target=request.param['target'], deps_id=id)
         for dependency in vulnerability['dependency']:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -55,6 +55,7 @@ def mock_vulnerability_scan(request, mock_agent):
 
     # Add custom vulnerabilities and feeds
     id=1
+    
     for vulnerability in request.param['vulnerabilities']:
         for package in vulnerability['package']:
             vd.insert_package(**package, agent=mock_agent, source=package['name'])
@@ -62,7 +63,7 @@ def mock_vulnerability_scan(request, mock_agent):
                                 target=request.param['target'], deps_id=id)
         for dependency in vulnerability['dependency']:
             vd.insert_dependency(id=dependency['test_ref'], name=dependency['name'], operation=dependency['operation'], 
-                                 operation_value=dependency['operation_value'], package_id=id)
+                                 operation_value=dependency['operation_value'], target=request.param['target'], installed=dependency['installed'], package_id=id)
         id+=1
 
 
@@ -83,9 +84,6 @@ def test_suse_vulnerabilities_report(get_configuration, configure_environment, r
         for packg in item['package']:
             vulnerable = False
             for deps in item['dependency']:
-                if deps['name'] in packg['name']:
-                    vulnerable = True
-                    break
                 if '1' in deps['installed']:
                     vulnerable = True
                     break

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -57,16 +57,19 @@ def mock_vulnerability_scan(request, mock_agent):
     id=1
     
     for vulnerability in request.param['vulnerabilities']:
-        for package in vulnerability['package']:
-            vd.insert_package(**package, agent=mock_agent, source=package['name'])
-            vd.insert_vulnerability(**vulnerability['cve'], package=package['name'],
-                                    target=request.param['target'], deps_id=id)
-            for dep in vulnerability['dependency']:
-                vd.insert_pkg_dep(id=dep['test_ref'], target=request.param['target'], package_id=id)
-            id+=1
         for dependency in vulnerability['dependency']:
-                vd.insert_dependency(id=dependency['test_ref'], name=dependency['name'], operation=dependency['operation'], 
-                                     operation_value=dependency['operation_value'], target=request.param['target'], installed=dependency['installed'])
+            vd.insert_dependency(id=dependency['test_ref'], name=dependency['name'], operation=dependency['operation'],
+                                operation_value=dependency['operation_value'], target=request.param['target'], installed=dependency['installed'])
+
+        vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
+        vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
+                                target=request.param['target'], deps_id=id)
+        for dep in vulnerability['dependency']:
+            vd.insert_pkg_dep(id=dep['test_ref'], target=request.param['target'], package_id=id)
+        id+=1
+
+    for agent_dependencies in request.param['agent_dependencies']:
+        vd.insert_package(**agent_dependencies['package'], agent=mock_agent, source=agent_dependencies['package']['name'])
 
 
 def test_suse_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
@@ -83,16 +86,15 @@ def test_suse_vulnerabilities_report(get_configuration, configure_environment, r
 
     # Check the vulnerabilities of packages inserted
     for item in mock_vulnerability_scan['vulnerabilities']:
-        for packg in item['package']:
-            vulnerable = False
-            for deps in item['dependency']:
-                if '1' in deps['installed']:
-                    vulnerable = True
-                    break
-            if not vulnerable:
-                log_event = f"Package '{packg['name']}' not vulnerable to '{item['cve']['cveid']}'."
-                vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event)
-            else:
-                vd.check_vulnerability_scan_event(wazuh_log_monitor=wazuh_log_monitor, package=packg['name'],
-                                                cve=item['cve']['cveid'])
+        vulnerable = False
+        for deps in item['dependency']:
+            if '1' in deps['installed']:
+                vulnerable = True
+                break
+        if not vulnerable:
+            log_event = f"Package '{item['package']['name']}' not vulnerable to '{item['cve']['cveid']}'."
+            vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event)
+        else:
+            vd.check_vulnerability_scan_event(wazuh_log_monitor=wazuh_log_monitor, package=item['package']['name'],
+                                            cve=item['cve']['cveid'])
     vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -80,6 +80,11 @@ def test_suse_vulnerabilities_report(get_configuration, configure_environment, r
 
     # Check the vulnerabilities of packages inserted
     for item in mock_vulnerability_scan['vulnerabilities']:
-        vd.check_vulnerability_scan_event(wazuh_log_monitor=wazuh_log_monitor, package=item['package']['name'],
-                                          cve=item['cve']['cveid'])
+        for packg in item['package']:
+            if 'sle' in packg['name']:
+                log_event = f"Package '{packg['name']}' not vulnerable to '{item['cve']['cveid']}'."
+                vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event)
+            else:
+                vd.check_vulnerability_scan_event(wazuh_log_monitor=wazuh_log_monitor, package=packg['name'],
+                                                cve=item['cve']['cveid'])
     vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -54,10 +54,15 @@ def mock_vulnerability_scan(request, mock_agent):
                      os_minor=request.param['os_minor'], name=vd.MOCKED_AGENT_NAME)
 
     # Add custom vulnerabilities and feeds
+    id=1
     for vulnerability in request.param['vulnerabilities']:
         vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
         vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
-                                target=request.param['target'])
+                                target=request.param['target'], deps_id=id)
+        for dependency in vulnerability['dependency']:
+            vd.insert_dependency(id=dependency['test_ref'], name=dependency['name'], operation=dependency['operation'], 
+                                 operation_value=dependency['operation_value'], package_id=id)
+        id+=1
 
 
 def test_suse_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -59,12 +59,14 @@ def mock_vulnerability_scan(request, mock_agent):
     for vulnerability in request.param['vulnerabilities']:
         for package in vulnerability['package']:
             vd.insert_package(**package, agent=mock_agent, source=package['name'])
-        vd.insert_vulnerability(**vulnerability['cve'], package=vulnerability['package']['name'],
-                                target=request.param['target'], deps_id=id)
+            vd.insert_vulnerability(**vulnerability['cve'], package=package['name'],
+                                    target=request.param['target'], deps_id=id)
+            for dep in vulnerability['dependency']:
+                vd.insert_pkg_dep(id=dep['test_ref'], target=request.param['target'], package_id=id)
+            id+=1
         for dependency in vulnerability['dependency']:
-            vd.insert_dependency(id=dependency['test_ref'], name=dependency['name'], operation=dependency['operation'], 
-                                 operation_value=dependency['operation_value'], target=request.param['target'], installed=dependency['installed'], package_id=id)
-        id+=1
+                vd.insert_dependency(id=dependency['test_ref'], name=dependency['name'], operation=dependency['operation'], 
+                                     operation_value=dependency['operation_value'], target=request.param['target'], installed=dependency['installed'])
 
 
 def test_suse_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -81,7 +81,15 @@ def test_suse_vulnerabilities_report(get_configuration, configure_environment, r
     # Check the vulnerabilities of packages inserted
     for item in mock_vulnerability_scan['vulnerabilities']:
         for packg in item['package']:
-            if 'sle' in packg['name']:
+            vulnerable = False
+            for deps in item['dependency']:
+                if deps['name'] in packg['name']:
+                    vulnerable = True
+                    break
+                if '1' in deps['installed']:
+                    vulnerable = True
+                    break
+            if not vulnerable:
                 log_event = f"Package '{packg['name']}' not vulnerable to '{item['cve']['cveid']}'."
                 vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event)
             else:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_suse_inventory_suse_feed.py
@@ -88,7 +88,7 @@ def test_suse_vulnerabilities_report(get_configuration, configure_environment, r
     for item in mock_vulnerability_scan['vulnerabilities']:
         vulnerable = False
         for deps in item['dependency']:
-            if '1' in deps['installed']:
+            if vd.is_dependency_installed(deps['test_ref']):
                 vulnerable = True
                 break
         if not vulnerable:


### PR DESCRIPTION
|Related issue|
|---|
|[#1526 ](https://github.com/wazuh/wazuh-qa/issues/1526)|


## Description

This PR modify the scan test for SUSE Linux Enterprise to take into account the dependencies of each package.

For `SLES 11, 12, 15` and `SLED 11, 12, 15`:

- [x] Modify test_scan_result data for SUSE to add dependencies for each package.
- [x] Add function to insert dependencies to the vulnerability DB.
- [x] Modify test_scan_result for SUSE to insert dependencies to the DB.
- [x] Modify test_scan_result for SUSE to check if packages are not vulnerable.

## Test results

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.