### PR TITLE
Change plugin path for `test_fim/test_files/test_audit/test_audit.py`

### DIFF
--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -294,6 +294,9 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
         ValueError: If the time before the and after the restart are equal when auditd has been restarted or if the time
                     before and after the restart are different when auditd hasn't been restarted
     """
+    logger.info('Applying the test configuration')
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
     # We need to retry get_audit_creation_time in case syscheckd didn't have
     # enough time to boot auditd    
     @retry(Exception, attempts=2, delay=3, delay_multiplier=1)
@@ -315,9 +318,6 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
         remove_file(plugin_path)
     else:
         raise Exception('The path could not be found because auditd was not running')
-
-    logger.info('Applying the test configuration')
-    check_apply_test(tags_to_apply, get_configuration['tags'])
 
     time_before_restart = get_audit_creation_time()
     control_service('restart')

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -307,15 +307,14 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
     audisp_path = '/etc/audisp/plugins.d/af_wazuh.conf'
     audit_path = '/etc/audit/plugins.d/af_wazuh.conf'
 
-    stdout = subprocess.check_output(['auditctl', '-v'])
-    auditctl_version_output = stdout.decode('utf8').strip().split()
-
-    if auditctl_version_output[2].startswith('3'):
+    if os.path.exists(audisp_path):
+        plugin_path = audisp_path
+        remove_file(plugin_path)
+    elif os.path.exists(audit_path):
         plugin_path = audit_path
         remove_file(plugin_path)
     else:
-        plugin_path = audisp_path
-        remove_file(plugin_path)
+        raise Exception('The path could not be found because auditd was not running')
 
     logger.info('Applying the test configuration')
     check_apply_test(tags_to_apply, get_configuration['tags'])

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -301,13 +301,13 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
                 return proc.create_time()
         pytest.fail("Auditd is not running")
 
-    audit2_path = "/etc/audisp/plugins.d/af_wazuh.conf"
-    audit3_path = "/etc/audit/plugins.d/af_wazuh.conf"
-    
-    if os.path.exists(audit2_path):
-        plugin_path = audit2_path
-    elif os.path.exists(audit3_path):
-        plugin_path = audit3_path
+    audisp_path = "/etc/audisp/plugins.d/af_wazuh.conf"
+    audit_path = "/etc/audit/plugins.d/af_wazuh.conf"
+
+    if os.path.exists(audisp_path):
+        plugin_path = audisp_path
+    elif os.path.exists(audit_path):
+        plugin_path = audit_path
     else:
         raise Exception('Audit plugin not found')
 

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -303,6 +303,7 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
 
     audit2_path = "/etc/audisp/plugins.d/af_wazuh.conf"
     audit3_path = "/etc/audit/plugins.d/af_wazuh.conf"
+    
     if os.path.exists(audit2_path):
         plugin_path = audit2_path
     elif os.path.exists(audit3_path):

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -301,7 +301,14 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
                 return proc.create_time()
         pytest.fail("Auditd is not running")
 
-    plugin_path = "/etc/audisp/plugins.d/af_wazuh.conf"
+    audit2_path = "/etc/audisp/plugins.d/af_wazuh.conf"
+    audit3_path = "/etc/audit/plugins.d/af_wazuh.conf"
+    if os.path.exists(audit2_path):
+        plugin_path = audit2_path
+    elif os.path.exists(audit3_path):
+        plugin_path = audit3_path
+    else:
+        raise Exception('Audit plugin not found')
 
     logger.info('Applying the test configuration')
     check_apply_test(tags_to_apply, get_configuration['tags'])

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -293,7 +293,6 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
         ValueError: If the time before the and after the restart are equal when auditd has been restarted or if the time
                     before and after the restart are different when auditd hasn't been restarted
     """
-
     def get_audit_creation_time():
         for proc in psutil.process_iter(attrs=['name']):
             if proc.name() == "auditd":
@@ -301,8 +300,8 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
                 return proc.create_time()
         pytest.fail("Auditd is not running")
 
-    audisp_path = "/etc/audisp/plugins.d/af_wazuh.conf"
-    audit_path = "/etc/audit/plugins.d/af_wazuh.conf"
+    audisp_path = '/etc/audisp/plugins.d/af_wazuh.conf'
+    audit_path = '/etc/audit/plugins.d/af_wazuh.conf'
 
     if os.path.exists(audisp_path):
         plugin_path = audisp_path

--- a/tests/integration/test_fim/test_files/test_audit/test_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_audit.py
@@ -9,7 +9,7 @@ import psutil
 import pytest
 import wazuh_testing.fim as fim
 
-from wazuh_testing import logger
+from wazuh_testing import global_parameters, logger
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.file import truncate_file, remove_file
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -322,7 +322,7 @@ def test_restart_audit(tags_to_apply, should_restart, get_configuration, configu
     time_before_restart = get_audit_creation_time()
     control_service('restart')
     try:
-        check_daemon_status(timeout=30)
+        check_daemon_status(timeout=global_parameters.default_timeout)
     except TimeoutError:
         pass
     time_after_restart = get_audit_creation_time()


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1441|

### Environment

|OS|
|:--:|
|CentOS 8 and CentOS 7 |
### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm

### local_internal_options.conf

#### Manager
```
syscheck.debug=2
analysisd.debug=2
monitord.rotate_log=0
```

#### Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

### pytest_args
`-v --tier 0 --tier 1 --tier 2 --fim_mode="realtime" --fim_mode="whodata"`
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description

After research #1493, we could see that some `FIM` tests were failing. In issue #1539 we specified which tests were failing and why. Then we created different issues for each error. 
This test was failing because it couldn't find the path of the plugin. We needed to change the plugin path for different versions because depending on the OS, the audit version could be different and the path would change.

## Tests results

```
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-193.19.1.el8_2.x86_64-x86_64-with-centos-8.2.2004-Core', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'testinfra': '5.0.0', 'html': '2.0.1'}}
rootdir: /home/centos/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-2.0.1
collected 24 items                                                                                                                                           

tests/integration/test_fim/test_files/test_audit/test_audit.py::test_audit_health_check[get_configuration0-tags_to_apply0] PASSED                      [  4%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_added_rules[get_configuration0-tags_to_apply0] PASSED                             [  8%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_readded_rules[get_configuration0-tags_to_apply0] PASSED                           [ 12%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_readded_rules_on_restart[get_configuration0-tags_to_apply0] PASSED                [ 16%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_move_rules_realtime[get_configuration0-tags_to_apply0] PASSED                     [ 20%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_audit_key[get_configuration0-custom_audit_key-/testdir1] SKIPPED (Does not ap...) [ 25%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_restart_audit[get_configuration0-tags_to_apply0-True] SKIPPED (Does not apply...) [ 29%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_restart_audit[get_configuration0-tags_to_apply1-False] SKIPPED (Does not appl...) [ 33%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_audit_health_check[get_configuration1-tags_to_apply0] SKIPPED (Does not apply...) [ 37%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_added_rules[get_configuration1-tags_to_apply0] SKIPPED (Does not apply to thi...) [ 41%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_readded_rules[get_configuration1-tags_to_apply0] SKIPPED (Does not apply to t...) [ 45%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_readded_rules_on_restart[get_configuration1-tags_to_apply0] SKIPPED (Does not...) [ 50%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_move_rules_realtime[get_configuration1-tags_to_apply0] SKIPPED (Does not appl...) [ 54%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_audit_key[get_configuration1-custom_audit_key-/testdir1] SKIPPED (Does not ap...) [ 58%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_restart_audit[get_configuration1-tags_to_apply0-True] PASSED                      [ 62%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_restart_audit[get_configuration1-tags_to_apply1-False] SKIPPED (Does not appl...) [ 66%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_audit_health_check[get_configuration2-tags_to_apply0] SKIPPED (Does not apply...) [ 70%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_added_rules[get_configuration2-tags_to_apply0] SKIPPED (Does not apply to thi...) [ 75%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_readded_rules[get_configuration2-tags_to_apply0] SKIPPED (Does not apply to t...) [ 79%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_readded_rules_on_restart[get_configuration2-tags_to_apply0] SKIPPED (Does not...) [ 83%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_move_rules_realtime[get_configuration2-tags_to_apply0] SKIPPED (Does not appl...) [ 87%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_audit_key[get_configuration2-custom_audit_key-/testdir1] SKIPPED (Does not ap...) [ 91%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_restart_audit[get_configuration2-tags_to_apply0-True] SKIPPED (Does not apply...) [ 95%]
tests/integration/test_fim/test_files/test_audit/test_audit.py::test_restart_audit[get_configuration2-tags_to_apply1-False] PASSED                     [100%]

========================================================== 7 passed, 17 skipped in 92.73s (0:01:32) ==========================================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->