### PR TITLE
Fix `test_agentd_state_config.py` for Windows

### DIFF
--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -35,6 +35,8 @@ with open(test_data_file) as f:
     test_cases = yaml.safe_load(f)
 
 # Variables
+wait_daemon_control = 1
+
 if sys.platform == 'win32':
     state_file_path = os.path.join(WAZUH_PATH, 'wazuh-agent.state')
     internal_options = os.path.join(WAZUH_PATH, 'internal_options.conf')
@@ -102,6 +104,9 @@ def test_agentd_state_config(test_case, set_local_internal_options):
             control_service('start')
     else:
         control_service('start', 'wazuh-agentd')
+        # Sleep enough time to Wazuh load agent.state_interval configuration and
+        # boot wazuh-agentd
+        time.sleep(wait_daemon_control) 
         assert (test_case['agentd_ends']
                     is not check_if_process_is_running('wazuh-agentd'))
     

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -79,7 +79,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-def test_agentd_state_config(test_case: list, set_local_internal_options):
+def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')
 
@@ -95,11 +95,11 @@ def test_agentd_state_config(test_case: list, set_local_internal_options):
     if sys.platform == 'win32':
         if test_case['agentd_ends']:
             with pytest.raises(ValueError):
-                control_service('start', 'wazuh-agentd')
+                control_service('start')
             assert (test_case['agentd_ends']
                     is not check_if_process_is_running('wazuh-agentd'))
         else:
-            control_service('start', 'wazuh-agentd')
+            control_service('start')
     else:
         control_service('start', 'wazuh-agentd')
         assert (test_case['agentd_ends']

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -72,7 +72,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-def test_agentd_state_config(configure_environment, test_case: list):
+def test_agentd_state_config(test_case: list):
 
     control_service('stop', 'wazuh-agentd')
 

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -105,7 +105,7 @@ def test_agentd_state_config(test_case, set_local_internal_options):
         assert (test_case['agentd_ends']
                     is not check_if_process_is_running('wazuh-agentd'))
     
-    # Check if test require checking state file existance
+    # Check if the test requires checking state file existence
     if 'state_file_exist' in test_case:
         if test_case['state_file_exist']:
             # Wait until state file was dumped


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1588 |

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi

### local_internal_options.conf

#### Agent
```
agent.debug=2
execd.debug=2
monitord.rotate_log=0
```

### pytest_args
` -v tests/integration/test_agentd/test_agentd_state_config.py"`
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

After research #1493, we could see that some `agentd` tests were failing. In issue #1521 we specified which tests were failing and why. Then we created different issues for each error.
This test was failing because it wasn't managing Windows' errors correctly. Then, the test wasn't setting the `local_internal_options.conf` properly, and also, it was trying to connect the agent to a non-existent manager.

The test might keep failing because of issue https://github.com/wazuh/wazuh/issues/8746.

## Tests results

```
================================================= test session starts =================================================
platform win32 -- Python 3.7.4, pytest-6.2.2, py-1.10.0, pluggy-0.13.0 -- C:\Python37\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.7.4', 'Platform': 'Windows-10-10.0.14393-SP0', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', '
pluggy': '0.13.0'}, 'Plugins': {'html': '2.0.1', 'metadata': '1.8.0', 'testinfra': '5.0.0'}}
rootdir: C:\Windows\system32\wazuh-qa\tests\integration, configfile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0, testinfra-5.0.0
collected 6 items

tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED [ 16
%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASS
ED [ 33%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] PA
SSED [ 50%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED  [ 66%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED [ 83%
]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED [100%
]

================================================= 6 passed in 19.13s ==================================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.