### PR TITLE
Fix `test_fim/test_files/test_prefilter_cmd.py`

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -2398,3 +2398,18 @@ def get_fim_mode_param(mode, key='FIM_MODE'):
         return {key: {'whodata': 'yes'}}, metadata
     else:
         return None, None
+
+
+def check_fim_start(file_monitor):
+    """Check if realtime starts, whodata starts or ends the initial FIM scan.
+
+    Args:
+        file_monitor (FileMonitor): file log monitor to detect events.
+    """
+    mode = global_parameters.current_configuration['metadata']['fim_mode']
+    if mode == 'realtime':
+        detect_realtime_start(file_monitor)
+    elif mode == 'whodata':
+        detect_whodata_start(file_monitor)
+    else:
+        detect_initial_scan(file_monitor)

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -2413,3 +2413,4 @@ def check_fim_start(file_monitor):
         detect_whodata_start(file_monitor)
     else:
         detect_initial_scan(file_monitor)
+        

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/data/wazuh_conf.yaml
@@ -3,7 +3,7 @@
 - tags:
   - prefilter_cmd
   apply_to_modules:
-  - test_prefilter_cmd
+  - test_prefilter_cmd_conf
   sections:
   - section: syscheck
     elements:

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/data/wazuh_prefilter_cmd_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/data/wazuh_prefilter_cmd_conf.yaml
@@ -1,5 +1,4 @@
 ---
-# conf 1
 - tags:
   - prefilter_cmd
   apply_to_modules:
@@ -10,7 +9,7 @@
     - disabled:
         value: 'no'
     - directories:
-        value: "/testdir1"
+        value: TEST_DIRECTORIES
         attributes:
         - FIM_MODE
     - prefilter_cmd:

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
@@ -13,6 +13,7 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1), pytest.mark.agent, pytest.mark.server]
 
 #Variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -47,7 +48,7 @@ def get_configuration(request):
 
 
 @pytest.fixture(scope='session')
-def check_prelink():
+def install_prelink():
     # Call script to install prelink if it is not installed
     path = os.path.dirname(os.path.abspath(__file__))
     dist_list = ['centos', 'fedora', 'rhel']
@@ -67,5 +68,5 @@ def test_prefilter_cmd_conf(get_configuration, configure_environment, install_pr
         check_fim_start(wazuh_log_monitor)
     else:
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_configuration_error,
-                                    error_message=f"The expected 'Configuration error at...' "
+                                    error_message=f"The expected 'Configuration error at etc/ossec.conf' "
                                                   f"message has not been produced")

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
@@ -59,7 +59,7 @@ def check_prelink():
 @pytest.mark.parametrize('tags_to_apply', [
     ({'prefilter_cmd'})
 ])
-def test_prefilter_cmd(tags_to_apply, get_configuration, configure_environment, check_prelink, restart_syscheckd):
+def test_prefilter_cmd_conf(tags_to_apply, get_configuration, configure_environment, check_prelink, restart_syscheckd):
     """
     Check if prelink is installed and syscheck works. If prelink is not installed, checks if an error log is received.
 

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
@@ -64,7 +64,7 @@ def test_prefilter_cmd_conf(get_configuration, configure_environment, install_pr
 
     This test will have to updated if prefilter_cmd is updated as well.
     """
-    if os.path.exists(prefilter.split(' ')[0]):
+    if os.path.exists(prefilter.split()[0]):
         check_fim_start(wazuh_log_monitor)
     else:
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_configuration_error,


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1448|

### Environment

|OS|
|:--:|
|CentOS 8|
### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm

### local_internal_options.conf

#### Manager
```
syscheck.debug=2
analysisd.debug=2
monitord.rotate_log=0
```

#### Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

### pytest_args
`-v --tier 0 --tier 1 --tier 2 --fim_mode="realtime" --fim_mode="whodata"`
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description

After research #1493, we could see that some `FIM` tests were failing. In issue #1539 we specified which tests were failing and why. Then we created different issues for each error. 
This test was failing because `prelink` wasn't being installed in CentOS 8 and `FIM` wasn't starting as expected. To fix this, we have included to the test that if `prelink` isn't installed, an error log should be received. Also, we have renamed the test to match what is being tested.

## Tests results

```
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-centos-7.9.2009-Core', 'Packages': {'pytest': '5.3.5', 'py': '1.8.1', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.8.0', 'html': '2.0.1', 'testinfra': '6.0.0'}}
rootdir: /home/centos/wazuh-qa/tests/integration, inifile: pytest.ini
plugins: metadata-1.8.0, html-2.0.1, testinfra-6.4.0, testinfra-6.0.0
collected 2 items                                                                                                                                            

tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py::test_prefilter_cmd_conf[get_configuration0-tags_to_apply0] PASSED [ 50%]
tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py::test_prefilter_cmd_conf[get_configuration1-tags_to_apply0] PASSED [100%]

===================================================================== 2 passed in 45.64s =====================================================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->