### PR TITLE
Full Yellow Local - Fix WPK tests in 4.2

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -276,8 +276,7 @@ def callback_detect_upgrade_ack_event(event_log):
     Returns:
         String: Upgrade result.
     """
-    msg = ".*Sending upgrade ACK event: '(.*)'"
-    match = re.match(msg, event_log)
+    match = re.match(".*Sending upgrade ACK event: '(.*)'", event_log)
     return None if not match else match.group(1)
 
 

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -7,10 +7,13 @@ import platform
 import re
 import socket
 import ssl
+import json
 
 from wazuh_testing.fim import change_internal_options
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 from wazuh_testing.tools import monitoring
+from wazuh_testing import logger
+
 
 DEFAULT_VALUES = {
     'enabled': 'yes',
@@ -277,7 +280,14 @@ def callback_detect_upgrade_ack_event(event_log):
         String: Upgrade result.
     """
     match = re.match(".*Sending upgrade ACK event: '(.*)'", event_log)
-    return None if not match else match.group(1)
+    if not match:
+        return None
+    else:
+        try:
+            json_event = json.loads(match.group(1))
+            return json_event
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.warning(f"Couldn't load a log line into json object. Reason {e}")
 
 
 def callback_upgrade_module_up():

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -10,7 +10,7 @@ import ssl
 
 from wazuh_testing.fim import change_internal_options
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
-import wazuh_testing.tools.monitoring as monitoring
+from wazuh_testing.tools import monitoring
 
 DEFAULT_VALUES = {
     'enabled': 'yes',

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -278,8 +278,6 @@ def callback_detect_upgrade_ack_event(event_log):
     """
     msg = ".*Sending upgrade ACK event: '(.*)'"
     match = re.match(msg, event_log)
-    if match:
-        return match.group(1)
     return None if not match else match.group(1)
 
 
@@ -292,10 +290,17 @@ def callback_upgrade_module_up():
     Returns:
         callable: callback to detect this event.
     """
-    msg = 'Module Agent Upgrade started'
-    return monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-modulesd.*')
+    return monitoring.make_callback(pattern='Module Agent Upgrade started', 
+    prefix=r'.*wazuh-modulesd.*')
 
 
-def callback_agent_stop():
-    msg = 'Exit Cleaning'
-    return monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*')
+def callback_exit_cleaning():
+    """Detect exit cleaning message.
+
+    Args:
+        callable: callback to detect this event.
+    
+    Returns:
+        callable: callback to detect this event.
+    """
+    return monitoring.make_callback(pattern='Exit Cleaning', prefix=r'.*wazuh-agentd.*')

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -283,7 +283,7 @@ def callback_detect_upgrade_ack_event(event_log):
     return None if not match else match.group(1)
 
 
-def callback_upgrade_module_up(event_log):
+def callback_upgrade_module_up():
     """Detect module agent upgrade started event.
 
     Args:
@@ -292,10 +292,10 @@ def callback_upgrade_module_up(event_log):
     Returns:
         callable: callback to detect this event.
     """
-    msg = '.*Module Agent Upgrade started.*'
-    return monitoring.make_callback(pattern=msg)
+    msg = 'Module Agent Upgrade started'
+    return monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-modulesd.*')
 
 
-def callback_agent_stop(event_log):
+def callback_agent_stop():
     msg = 'Exit Cleaning'
     return monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*')

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -269,10 +269,10 @@ def set_state_interval(interval, internal_file_path):
 
 def callback_detect_upgrade_ack_event(event_log):
     """Detect sending upgrade ACK event returning upgrade process result.
-    
+
     Args:
         event_log (str): Event line logs.
-    
+
     Returns:
         String: Upgrade result.
     """
@@ -286,12 +286,11 @@ def callback_upgrade_module_up():
 
     Args:
         event_log (str): Event line logs.
-    
+
     Returns:
         callable: callback to detect this event.
     """
-    return monitoring.make_callback(pattern='Module Agent Upgrade started', 
-    prefix=r'.*wazuh-modulesd.*')
+    return monitoring.make_callback(pattern='Module Agent Upgrade started', prefix=monitoring.MODULESD_DETECTOR_PREFIX)
 
 
 def callback_exit_cleaning():
@@ -299,8 +298,8 @@ def callback_exit_cleaning():
 
     Args:
         callable: callback to detect this event.
-    
+
     Returns:
         callable: callback to detect this event.
     """
-    return monitoring.make_callback(pattern='Exit Cleaning', prefix=r'.*wazuh-agentd.*')
+    return monitoring.make_callback(pattern='Exit Cleaning', prefix=monitoring.AGENT_DETECTOR_PREFIX)

--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -294,3 +294,8 @@ def callback_upgrade_module_up(event_log):
     """
     msg = '.*Module Agent Upgrade started.*'
     return monitoring.make_callback(pattern=msg)
+
+
+def callback_agent_stop(event_log):
+    msg = 'Exit Cleaning'
+    return monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*')

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -47,6 +47,7 @@ else:
     LOGCOLLECTOR_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-logcollector.state')
     REMOTE_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-remoted.state')
     ANALYSIS_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'var', 'run', 'wazuh-analysisd.state')
+    UPGRADE_PATH = os.path.join(WAZUH_PATH, 'var', 'upgrade')
 
     try:
         import grp

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -21,6 +21,8 @@ if sys.platform == 'win32':
     LOGCOLLECTOR_STATISTICS_FILE = os.path.join(WAZUH_PATH, 'wazuh-logcollector.state')
     REMOTE_STATISTICS_FILE = None
     ANALYSIS_STATISTICS_FILE = None
+    UPGRADE_PATH = os.path.join(WAZUH_PATH, 'upgrade')
+
 
 else:
 
@@ -95,8 +97,8 @@ QUEUE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
 CLUSTER_SOCKET_PATH = os.path.join(WAZUH_PATH, 'queue', 'cluster')
 
 
-ANALYSISD_ANALISIS_SOCKET_PATH= os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
-ANALYSISD_QUEUE_SOCKET_PATH= os.path.join(QUEUE_SOCKETS_PATH, 'queue')
+ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
+ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
 AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -540,7 +540,7 @@ class Agent:
                         sender.send_event(self.create_event(f'#!-req {req_code} {{"error":0, '
                                                             f'"message":"{self.sha_key}", "data":[]}}'))
             else:
-                raise ValueError(f'WPK SHA key should be configured in agent')
+                raise ValueError('WPK SHA key should be configured in agent')
 
         elif command == 'upgrade':
             if self.upgrade_exec_result:

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -274,3 +274,20 @@ def set_file_owner_and_group(file_path, owner, group):
         gid = getgrnam(group).gr_gid
 
         os.chown(file_path, uid, gid)
+
+
+def count_file_lines(filepath):
+    """Count number of lines of a specified file.
+
+    Args:
+        filepath (str): Absolute path of the file.
+    
+    Returns:
+        Integer: Number of lines of the file.
+    """
+    file = open(filepath, "r")
+    nonempty_lines = [line.strip("\n") for line in file if line != "\n"]
+    line_count = len(nonempty_lines)
+    file.close()
+    return line_count
+

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -286,6 +286,4 @@ def count_file_lines(filepath):
         Integer: Number of lines of the file.
     """
     with open(filepath, "r") as file:
-        line_count = sum(1 for line in file if line.strip())
-        return line_count
-
+        return sum(1 for line in file if line.strip())

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -285,9 +285,7 @@ def count_file_lines(filepath):
     Returns:
         Integer: Number of lines of the file.
     """
-    file = open(filepath, "r")
-    nonempty_lines = [line.strip("\n") for line in file if line != "\n"]
-    line_count = len(nonempty_lines)
-    file.close()
-    return line_count
+    with open(filepath, "r") as file:
+        line_count = sum(1 for line in file if line.strip())
+        return line_count
 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -36,6 +36,7 @@ REMOTED_DETECTOR_PREFIX = r'.*wazuh-remoted.*'
 LOG_COLLECTOR_DETECTOR_PREFIX = r'.*wazuh-logcollector.*'
 AGENT_DETECTOR_PREFIX = r'.*wazuh-agent.*'
 AUTHD_DETECTOR_PREFIX = r'.*wazuh-authd.*'
+MODULESD_DETECTOR_PREFIX = r'.*wazuh-modulesd.*'
 
 def wazuh_unpack(data, format_: str = "<I"):
     """Unpack data with a given header. Using Wazuh header by default.

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -34,7 +34,7 @@ from wazuh_testing.tools.system import HostManager
 
 REMOTED_DETECTOR_PREFIX = r'.*wazuh-remoted.*'
 LOG_COLLECTOR_DETECTOR_PREFIX = r'.*wazuh-logcollector.*'
-AGENT_DETECTOR_PREFIX = r'.*wazuh-agent.*'
+AGENT_DETECTOR_PREFIX = r'.*wazuh-agentd.*'
 AUTHD_DETECTOR_PREFIX = r'.*wazuh-authd.*'
 MODULESD_DETECTOR_PREFIX = r'.*wazuh-modulesd.*'
 

--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -11,7 +11,7 @@ import threading
 import time
 import zlib
 from struct import pack
-from wazuh_testing import global_parameters, logger
+from wazuh_testing import logger
 
 from Crypto.Cipher import AES, Blowfish
 from Crypto.Util.Padding import pad
@@ -248,7 +248,7 @@ class RemotedSimulator:
     def send_com_message(self, client_address, connection, command, payload=None, interruption_time=None):
         """
         Create a COM message
-        
+
         Args:
             - client_address: client of the connection
             - connection: established connection (tcp only)

--- a/deps/wazuh_testing/wazuh_testing/tools/sockets.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/sockets.py
@@ -63,7 +63,8 @@ class WazuhSocket:
             response = recv_response(wazuh_socket, response_size)
             wazuh_socket.close()
 
-            return response
+
+            return json.loads(response)
 
         except Exception:
             raise ConnectionError

--- a/deps/wazuh_testing/wazuh_testing/tools/sockets.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/sockets.py
@@ -47,11 +47,7 @@ class WazuhSocket:
                 raise ValueError
             return recv_msg
 
-        try:
-            msg_json = msg.loads()
-        except AttributeError:
-            msg_json = json.dumps(msg)
-
+        msg_json = json.dumps(msg)
 
         try:
             wazuh_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -62,7 +58,6 @@ class WazuhSocket:
             send_msg(wazuh_socket, request_msg)
             response = recv_response(wazuh_socket, response_size)
             wazuh_socket.close()
-
 
             return json.loads(response)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/sockets.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/sockets.py
@@ -49,7 +49,7 @@ class WazuhSocket:
 
         try:
             msg_json = msg.loads()
-        except ValueError:
+        except AttributeError:
             msg_json = json.dumps(msg)
 
 

--- a/deps/wazuh_testing/wazuh_testing/tools/sockets.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/sockets.py
@@ -4,6 +4,7 @@
 import socket
 import struct
 import time
+import json
 from os import path
 from wazuh_testing.tools import WAZUH_PATH, ACTIVE_RESPONSE_SOCKET_PATH
 from wazuh_testing.tools.utils import retry
@@ -47,8 +48,14 @@ class WazuhSocket:
             return recv_msg
 
         try:
+            msg_json = msg.loads()
+        except ValueError:
+            msg_json = json.dumps(msg)
+
+
+        try:
             wazuh_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            encoded_msg = msg.encode('utf-8')
+            encoded_msg = msg_json.encode('utf-8')
             request_msg = struct.pack("<I", len(encoded_msg)) + encoded_msg
 
             connection(wazuh_socket, self.file)
@@ -60,7 +67,6 @@ class WazuhSocket:
 
         except Exception:
             raise ConnectionError
-
 
 
 def send_request(msg_request, response_size=100, wazuh_socket=request_socket):

--- a/deps/wazuh_testing/wazuh_testing/tools/sockets.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/sockets.py
@@ -12,7 +12,58 @@ request_socket = path.join(WAZUH_PATH, 'queue', 'sockets', 'request')
 request_protocol = "tcp"
 
 
-def send_request(msg_request, response_size=100):
+class WazuhSocket:
+    def __init__(self, socket_file=request_socket):
+        """Encapsulate wazuh-socket communication (header with message size)
+
+        Args:
+            socket_file (str): Path of the file socket.
+        """
+        self.file = socket_file
+
+    def send(self, msg, response_size=4):
+        """Send and receive data to wazuh-socket (header with message size)
+
+        Args:
+            msg (str): data to send
+
+        Returns:
+            str: received data
+        """
+        try:
+            wazuh_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            encoded_msg = msg.encode('utf-8')
+            request_msg = struct.pack("<I", len(encoded_msg)) + encoded_msg
+
+            @retry(socket.error)
+            def connection(_socket, request):
+                _socket.connect(request)
+
+            @retry(socket.error)
+            def send_msg(_socket, msg):
+                _socket.send(msg)
+
+            @retry(ValueError)
+            def recv_response(_socket, size):
+                size = struct.unpack("<I", _socket.recv(size, socket.MSG_WAITALL))[0]
+                recv_msg = _socket.recv(size, socket.MSG_WAITALL)
+                if recv_msg == '':
+                    raise ValueError
+                return recv_msg
+
+            connection(wazuh_socket, self.file)
+            send_msg(wazuh_socket, request_msg)
+            response = recv_response(wazuh_socket, response_size)
+            wazuh_socket.close()
+
+            return response
+
+        except Exception:
+            raise ConnectionError
+
+
+
+def send_request(msg_request, response_size=100, wazuh_socket=request_socket):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     request_msg = struct.pack('<I', len(msg_request)) + msg_request.encode()
 
@@ -31,7 +82,7 @@ def send_request(msg_request, response_size=100):
             raise ValueError
         return answer
 
-    connection(sock, request_socket)
+    connection(sock, wazuh_socket)
     send_msg(sock, request_msg)
     response = recv_response(sock, response_size)
 

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -71,55 +71,6 @@ wait_upgrade_process_timeout = 240
 
 
 test_metadata = [
-    # 1. Upgrade from initial_version to new version
-    {
-        'protocol': PROTOCOL,
-        'initial_version': _agent_version,
-        'agent_version': version_to_upgrade,
-        'use_http': False,
-        'upgrade_script': DEFAULT_UPGRADE_SCRIPT,
-        'chunk_size': 16384,
-        'simulate_interruption': False,
-        'simulate_rollback': False,
-        'results': {
-            'upgrade_ok': True,
-            'result_code': 0,
-            'receive_notification': True,
-            'status': 'Done',
-        }
-    },
-    # 2. False upgrade script parameter
-    {
-        'protocol': PROTOCOL,
-        'initial_version': _agent_version,
-        'agent_version': version_to_upgrade,
-        'use_http': False,
-        'upgrade_script': 'fake_upgrade.sh',
-        'chunk_size': 16384,
-        'simulate_interruption': False,
-        'simulate_rollback': False,
-        'results': {
-            'upgrade_ok': False,
-            'error_message': error_msg,
-            'receive_notification': False,
-        }
-    },
-    # 3. Simulate an interruption
-    {
-        'protocol': PROTOCOL,
-        'initial_version': _agent_version,
-        'agent_version': version_to_upgrade,
-        'use_http': False,
-        'upgrade_script': DEFAULT_UPGRADE_SCRIPT,
-        'chunk_size': 16384,
-        'simulate_interruption': True,
-        'simulate_rollback': False,
-        'results': {
-            'upgrade_ok': False,
-            'error_message': 'Request confirmation never arrived',
-            'receive_notification': False,
-        }
-    }
 ]
 
 if _agent_version == 'v3.13.2':
@@ -390,18 +341,15 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
 
         if metadata['simulate_rollback']:
 
+            if sys_platform not in ['win32', 'Windows']:
+                wazuh_log_monitor.start(timeout=200,
+                                        error_message="Error agentd not stopped",
+                                        callback=callback_agent_stop())
  
-            wazuh_log_monitor.start(timeout=200,
-                                    error_message="Error agentd not stopped",
-                                    callback=callback_agent_stop)
- 
-            wazuh_log_monitor.start(timeout=200,
-                                    error_message="Agent did not receives req 384 message",
-                                    callback=callback_agent_req)
 
             wazuh_log_monitor.start(timeout=200,
                                     error_message="Upgrade module did not start",
-                                    callback=callback_upgrade_module_up)
+                                    callback=callback_upgrade_module_up())
 
                                     
             remoted_simulator.change_default_listener = True

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -388,7 +388,7 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
  
          if metadata['simulate_rollback']:
             msg = 'Exit Cleaning'
-            callback = monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*', escape=True)
+            callback = make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*', escape=True)
             wazuh_log_monitor.start(timeout=200,
                                     error_message="Error agentd not stopped",
                                     callback=callback)
@@ -398,7 +398,7 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                                     error_message="Error wazuh-agent does not stop",
                                     callback=callback_upgrade_module_up)
 
-                                    
+
                                     
             remoted_simulator.change_default_listener = True
 

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -10,7 +10,10 @@ import requests
 import subprocess
 import yaml
 import json
+import re
 
+from wazuh_testing import tools
+from wazuh_testing.tools.monitoring import make_callback, FileMonitor
 from configobj import ConfigObj
 from datetime import datetime
 from wazuh_testing.tools import WAZUH_PATH, get_version
@@ -19,6 +22,8 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.remoted_sim import RemotedSimulator
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools.file import read_file_lines
+
 from wazuh_testing import global_parameters
 
 
@@ -27,7 +32,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0),
 
 sys_platform = platform.system()
 
-folder = 'etc' if sys_platform == 'Linux' else 'upgrade'
+folder = 'etc' if sys_platform == 'Linux' else '.'
 
 upgrade_result_folder = 'var/upgrade' if sys_platform == 'Linux' else 'upgrade'
 
@@ -183,6 +188,16 @@ configurations = load_wazuh_configurations(configurations_path, __name__,
 remoted_simulator = None
 
 
+def callback_detect_upgrade_ack_event(event_log):
+    print("Callback")
+    msg = ".*Sending upgrade ACK event: '(.*)'"
+    match = re.match(msg, event_log)
+    if match:
+        print(match.group(1))
+        return match.group(1)
+    return None if not match else match.group(1)
+
+
 @pytest.fixture(scope="module", params=configurations)
 def get_configuration(request):
     """Get configurations from the module"""
@@ -206,8 +221,10 @@ def start_agent(request, get_configuration):
                                          client_keys=CLIENT_KEYS_PATH)
 
     ver_split = _agent_version.replace("v", "").split(".")
+    ver_major = ver_split[0]
+    ver_minor = ver_split[1]
     if int(ver_split[0]) >= 4 and int(ver_split[1]) >= 1:
-        remoted_simulator.set_wcom_message_version('4.1')
+        remoted_simulator.set_wcom_message_version(f"{ver_major}.{ver_minor}")
     else:
         remoted_simulator.set_wcom_message_version(None)
 
@@ -337,6 +354,7 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                    configure_environment, start_agent):
     metadata = get_configuration['metadata']
     expected = metadata['results']
+    wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
 
     # Extract initial Wazuh Agent version
     assert get_version() == metadata["initial_version"], \
@@ -363,8 +381,28 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
             upgrade_exec_message = str(exp_json['message'])
         assert upgrade_exec_message == expected['error_message'], \
                f'Expected error message does not match'
+
     if upgrade_process_result and expected['receive_notification']:
-        result = remoted_simulator.wait_upgrade_notification(timeout=180)
+
+        lines = read_file_lines(tools.LOG_FILE_PATH) 
+        while lines != 0:
+            time.sleep(1) 
+            lines = read_file_lines(tools.LOG_FILE_PATH) 
+
+        wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
+
+        if metadata['simulate_rollback']:
+            msg = r"SIGNAL [(15)-(Terminated)] Received. Exit Cleaning..."
+            callback = make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*', escape=True)
+            wazuh_log_monitor.start(timeout=120,
+                                    error_message="Error agentd not stopped",
+                                    callback=callback)
+                                    
+            remoted_simulator.agent_restarted = True
+
+        result = json.loads(wazuh_log_monitor.start(timeout=120, error_message="ACK event not received", callback=callback_detect_upgrade_ack_event).result())['parameters']
+
+
         if result is not None:
             status = result['status']
             assert status == expected['status'], \

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -67,9 +67,7 @@ time_to_sleep_until_stop = 1
 wait_upgrade_process_timeout = 240
 timeout_ack_response = 300
 timeout_agent_exit = 100
-timeout_upgrade_module_start= 100
-
-
+timeout_upgrade_module_start = 200
 
 test_metadata = [
     # 1. Upgrade from initial_version to new version
@@ -408,12 +406,9 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
             assert status == expected['status'], \
                    'Notification status did not match expected'
         else:
-            assert not expected['receive_notification'], \
-                   'Notification was expected but was not received'
+            assert not expected['receive_notification'], 'Notification was expected but was not received'
 
     if expected['upgrade_ok'] and not metadata['simulate_rollback']:
-        assert get_version() == metadata['agent_version'], \
-                'End version does not match expected!'
+        assert get_version() == metadata['agent_version'], 'End version does not match expected!'
     else:
-        assert get_version() == metadata['initial_version'], \
-                'End version does not match expected!'
+        assert get_version() == metadata['initial_version'], 'End version does not match expected!'

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from wazuh_testing.tools import WAZUH_PATH, get_version
 from wazuh_testing.tools.authd_sim import AuthdSimulator
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.file import truncate_file, read_file_lines
+from wazuh_testing.tools.file import truncate_file, count_file_lines
 from wazuh_testing.tools.remoted_sim import RemotedSimulator
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.agent import callback_detect_upgrade_ack_event, callback_upgrade_module_up
@@ -373,10 +373,10 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
 
     if upgrade_process_result and expected['receive_notification']:
         if sys_platform not in ['win32', 'Windows']:
-            lines = read_file_lines(tools.LOG_FILE_PATH) 
+            lines = count_file_lines(tools.LOG_FILE_PATH) 
             while lines != 0:
                 time.sleep(1) 
-                lines = read_file_lines(tools.LOG_FILE_PATH) 
+                lines = count_file_lines(tools.LOG_FILE_PATH) 
 
             wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
 

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -71,6 +71,55 @@ wait_upgrade_process_timeout = 240
 
 
 test_metadata = [
+       # 1. Upgrade from initial_version to new version
+    {
+        'protocol': PROTOCOL,
+        'initial_version': _agent_version,
+        'agent_version': version_to_upgrade,
+        'use_http': False,
+        'upgrade_script': DEFAULT_UPGRADE_SCRIPT,
+        'chunk_size': 16384,
+        'simulate_interruption': False,
+        'simulate_rollback': False,
+        'results': {
+            'upgrade_ok': True,
+            'result_code': 0,
+            'receive_notification': True,
+            'status': 'Done',
+        }
+    },
+    # 2. False upgrade script parameter
+    {
+        'protocol': PROTOCOL,
+        'initial_version': _agent_version,
+        'agent_version': version_to_upgrade,
+        'use_http': False,
+        'upgrade_script': 'fake_upgrade.sh',
+        'chunk_size': 16384,
+        'simulate_interruption': False,
+        'simulate_rollback': False,
+        'results': {
+            'upgrade_ok': False,
+            'error_message': error_msg,
+            'receive_notification': False,
+        }
+    },
+    # 3. Simulate an interruption
+    {
+        'protocol': PROTOCOL,
+        'initial_version': _agent_version,
+        'agent_version': version_to_upgrade,
+        'use_http': False,
+        'upgrade_script': DEFAULT_UPGRADE_SCRIPT,
+        'chunk_size': 16384,
+        'simulate_interruption': True,
+        'simulate_rollback': False,
+        'results': {
+            'upgrade_ok': False,
+            'error_message': 'Request confirmation never arrived',
+            'receive_notification': False,
+        }
+    }
 ]
 
 if _agent_version == 'v3.13.2':

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -169,7 +169,7 @@ params = [
 
 def load_tests(path):
     """ Loads a yaml file from a path.
-    
+
     Args:
         String: Full path of yaml file.
     """
@@ -185,6 +185,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__,
                                            metadata=test_metadata)
 
 remoted_simulator = None
+
 
 def callback_agent_req(id_req):
     msg = '#! req {id_req}'
@@ -371,8 +372,7 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
         if _agent_version == version_to_upgrade and not metadata['simulate_interruption']:
             exp_json = json.loads(upgrade_exec_message)
             upgrade_exec_message = str(exp_json['message'])
-        assert upgrade_exec_message == expected['error_message'], f'Expected error message does not match'
-
+        assert upgrade_exec_message == expected['error_message'], 'Expected error message does not match'
 
     if upgrade_process_result and expected['receive_notification']:
         if sys_platform not in ['win32', 'Windows']:
@@ -386,8 +386,6 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
         else:
             truncate_file(tools.LOG_FILE_PATH)
 
-
-
         wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
 
         if metadata['simulate_rollback']:
@@ -396,15 +394,15 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                 wazuh_log_monitor.start(timeout=timeout_agent_exit,
                                         error_message="Error agentd not stopped",
                                         callback=callback_exit_cleaning())
- 
+
             wazuh_log_monitor.start(timeout=timeout_upgrade_module_start,
                                     error_message="Upgrade module did not start",
                                     callback=callback_upgrade_module_up())
-                        
+
             remoted_simulator.change_default_listener = True
 
-        event = json.loads(wazuh_log_monitor.start(timeout=timeout_ack_response, error_message='ACK event not received', 
-                                                   callback=callback_detect_upgrade_ack_event).result())
+        event = wazuh_log_monitor.start(timeout=timeout_ack_response, error_message='ACK event not received',
+                                                   callback=callback_detect_upgrade_ack_event).result()
         result = event['parameters']
 
         if result is not None:

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -13,7 +13,6 @@ import json
 
 from wazuh_testing import tools
 from wazuh_testing.tools.monitoring import make_callback, FileMonitor
-from configobj import ConfigObj
 from datetime import datetime
 from wazuh_testing.tools import WAZUH_PATH, get_version
 from wazuh_testing.tools.authd_sim import AuthdSimulator
@@ -171,10 +170,10 @@ params = [
 
 
 def load_tests(path):
-    """ Loads a yaml file from a path
-    Return
-    ----------
-    yaml structure
+    """ Loads a yaml file from a path.
+    
+    Args:
+        String: Full path of yaml file.
     """
     with open(path) as f:
         return yaml.safe_load(f)
@@ -394,15 +393,14 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                                         error_message="Error agentd not stopped",
                                         callback=callback_exit_cleaning())
  
-
             wazuh_log_monitor.start(timeout=timeout_upgrade_module_start,
                                     error_message="Upgrade module did not start",
                                     callback=callback_upgrade_module_up())
-
-                                    
+                        
             remoted_simulator.change_default_listener = True
 
-        event = json.loads(wazuh_log_monitor.start(timeout=timeout_ack_response, error_message="ACK event not received", callback=callback_detect_upgrade_ack_event).result())
+        event = json.loads(wazuh_log_monitor.start(timeout=timeout_ack_response, error_message='ACK event not received', 
+                                                   callback=callback_detect_upgrade_ack_event).result())
         result = event['parameters']
 
         if result is not None:

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -377,15 +377,17 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
             while lines != 0:
                 time.sleep(1) 
                 lines = count_file_lines(tools.LOG_FILE_PATH) 
+        else:
+            truncate_file(tools.LOG_FILE_PATH)
+        wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
 
-            wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
 
         if metadata['simulate_rollback']:
             wazuh_log_monitor.start(timeout=200,
                                     error_message="Error wazuh-agent does not stop",
                                     callback=callback_upgrade_module_up)
                                     
-            remoted_simulator.agent_restarted = True
+            remoted_simulator.change_default_listener = True
 
         result = json.loads(wazuh_log_monitor.start(timeout=300, error_message="ACK event not received", callback=callback_detect_upgrade_ack_event).result())['parameters']
         #result = remoted_simulator.wait_upgrade_notification(timeout=180)

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -66,6 +66,10 @@ else:
 time_to_sleep_until_backup = 10
 time_to_sleep_until_stop = 1
 wait_upgrade_process_timeout = 240
+timeout_ack_response = 300
+timeout_agent_exit = 100
+timeout_upgrade_module_start= 100
+
 
 
 test_metadata = [
@@ -386,21 +390,21 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
         if metadata['simulate_rollback']:
 
             if sys_platform not in ['win32', 'Windows']:
-                wazuh_log_monitor.start(timeout=200,
+                wazuh_log_monitor.start(timeout=timeout_agent_exit,
                                         error_message="Error agentd not stopped",
                                         callback=callback_exit_cleaning())
  
 
-            wazuh_log_monitor.start(timeout=200,
+            wazuh_log_monitor.start(timeout=timeout_upgrade_module_start,
                                     error_message="Upgrade module did not start",
                                     callback=callback_upgrade_module_up())
 
                                     
             remoted_simulator.change_default_listener = True
 
-        event = json.loads(wazuh_log_monitor.start(timeout=300, error_message="ACK event not received", callback=callback_detect_upgrade_ack_event).result())
+        event = json.loads(wazuh_log_monitor.start(timeout=timeout_ack_response, error_message="ACK event not received", callback=callback_detect_upgrade_ack_event).result())
         result = event['parameters']
-        
+
         if result is not None:
             status = result['status']
             assert status == expected['status'], \

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -376,7 +376,7 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
 
     if upgrade_process_result and expected['receive_notification']:
         if sys_platform not in ['win32', 'Windows']:
-            int max_retries_truncate_file = 100
+            max_retries_truncate_file = 100
             lines = count_file_lines(tools.LOG_FILE_PATH)
             truncate_file_lines = lines
             while truncate_file_lines >= lines and max_retries_truncate_file > 0:

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -26,6 +26,7 @@ from wazuh_testing.agent import callback_detect_upgrade_ack_event, callback_upgr
 from wazuh_testing import global_parameters
 
 
+
 pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0),
               pytest.mark.agent]
 
@@ -383,9 +384,21 @@ def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
 
 
         if metadata['simulate_rollback']:
+
+ 
+         if metadata['simulate_rollback']:
+            msg = 'Exit Cleaning'
+            callback = monitoring.make_callback(pattern=msg, prefix=r'.*wazuh-agentd.*', escape=True)
+            wazuh_log_monitor.start(timeout=200,
+                                    error_message="Error agentd not stopped",
+                                    callback=callback)
+
+            wazuh_log_monitor = FileMonitor(tools.LOG_FILE_PATH)
             wazuh_log_monitor.start(timeout=200,
                                     error_message="Error wazuh-agent does not stop",
                                     callback=callback_upgrade_module_up)
+
+                                    
                                     
             remoted_simulator.change_default_listener = True
 

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -15,7 +15,7 @@ import requests
 import platform
 
 from configobj import ConfigObj
-from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, get_version
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, UPGRADE_PATH, get_version
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.agent_simulator import Sender, Injector
 from wazuh_testing.tools.services import control_service

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -931,7 +931,7 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
     time.sleep(time_until_registration_key_avaible)
 
     # Send upgrade request
-    response = json.loads(upgrade_socket.send(json.dumps(data)))
+    response = upgrade_socket.send(data)
 
     if metadata.get('checks') and (('use_http' in metadata.get('checks')) or ('version' in metadata.get('checks'))):
         # Checking version or http in logs
@@ -1009,19 +1009,19 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
 
             time.sleep(time_until_ask_upgrade_result)
 
-            response = json.loads(task_socket.send(json.dumps(data)))
+            response = task_socket.send(data)
             retries = 0
             while (response['data'][0]['status'] != metadata.get('first_attempt')) \
                     and (retries < 10):
                 time.sleep(time_until_ask_upgrade_result)
-                response = json.loads(task_socket.send(json.dumps(data)))
+                response = task_socket.send(data)
                 retries += 1
             assert metadata.get('first_attempt') == response['data'][0]['status'], \
                 f'First upgrade status did not match expected! ' \
                 f'Expected {metadata.get("first_attempt")} obtained {response["data"][0]["status"]}'
 
         # send upgrade request again
-        response = json.loads(upgrade_socket.send(json.dumps(repeat_message)))
+        response = upgrade_socket.send(repeat_message)
 
     if metadata.get('expected_response') == 'Success':
         # Chech that result is expected
@@ -1042,13 +1042,13 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
                 }
             }
             time.sleep(time_until_ask_upgrade_result)
-            response = json.loads(task_socket.send(json.dumps(data)))
+            response = task_socket.send((data))
             retries = 0
 
             while response['data'][0]['status'] == 'Updating' and retries < max_upgrade_result_status_retries and \
                     response['data'][0]['status'] != expected_status[index]:
                 time.sleep(time_until_ask_upgrade_result)
-                response = json.loads(task_socket.send(json.dumps(data)))
+                response = task_socket.send(data)
                 retries += 1
 
             assert expected_status[index] == response['data'][0]['status'], \

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -28,7 +28,6 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 UPGRADE_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'upgrade')
 TASK_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'task')
-UPGRADE_PATH = os.path.join(WAZUH_PATH, 'var', 'upgrade')
 SERVER_ADDRESS = 'localhost'
 WPK_REPOSITORY_4x = 'packages-dev.wazuh.com/trash/wpk/'
 WPK_REPOSITORY_3x = 'packages.wazuh.com/wpk/'
@@ -737,7 +736,6 @@ cases = [
     }
 ]
 
-
 params = [case['params'] for case in cases]
 metadata = [case['metadata'] for case in cases]
 
@@ -774,16 +772,6 @@ def restart_service():
     control_service('restart')
 
     yield
-
-
-def send_message(data_object, socket_path):
-    upgrade_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    upgrade_sock.connect(socket_path)
-    msg_bytes = json.dumps(data_object).encode()
-    upgrade_sock.send(struct.pack("<I", len(msg_bytes)) + msg_bytes)
-    size = struct.unpack("<I", upgrade_sock.recv(4, socket.MSG_WAITALL))[0]
-    response = upgrade_sock.recv(size, socket.MSG_WAITALL)
-    return json.loads(response.decode())
 
 
 def clean_logs():
@@ -981,7 +969,6 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
             log_monitor.start(timeout=600, callback=wait_downloaded)
         except TimeoutError as err:
             raise AssertionError("Finish download wpk log took too much!")
-        # time.sleep(60)
 
     if metadata.get('checks') and ('chunk_size' in metadata.get('checks')):
         # Checking version in logs

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -2,7 +2,6 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import json
 import os
 import pytest
 import time
@@ -868,7 +867,7 @@ def remove_current_wpk():
                 os.unlink(file_path)
         except Exception:
             raise Exception(f'Failed to remove {filename} file')
-            
+
 
 def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, configure_environment,
                      restart_service, configure_agents):
@@ -937,7 +936,7 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
         # Checking version or http in logs
         try:
             log_monitor.start(timeout=60, callback=wait_download)
-        except TimeoutError as err:
+        except TimeoutError:
             raise AssertionError("Download wpk log took too much!")
 
         last_log = log_monitor.result()
@@ -961,14 +960,14 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
         # let time to download wpk
         try:
             log_monitor.start(timeout=600, callback=wait_downloaded)
-        except TimeoutError as err:
+        except TimeoutError:
             raise AssertionError("Finish download wpk log took too much!")
 
     if metadata.get('checks') and ('chunk_size' in metadata.get('checks')):
         # Checking version in logs
         try:
             log_monitor.start(timeout=60, callback=wait_chunk_size)
-        except TimeoutError as err:
+        except TimeoutError:
             raise AssertionError("Chunk size log tooks too much!")
         chunk = metadata.get('chunk_size')
         last_log = log_monitor.result()
@@ -979,7 +978,7 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
         # Checking version in logs
         try:
             log_monitor.start(timeout=180, callback=wait_wpk_custom)
-        except TimeoutError as err:
+        except TimeoutError:
             raise AssertionError("Custom wpk log tooks too much!")
 
         last_log = log_monitor.result()

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -5,16 +5,10 @@
 import json
 import os
 import pytest
-import socket
-import subprocess
-import struct
-import threading
 import time
 import hashlib
 import requests
-import platform
 
-from configobj import ConfigObj
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, UPGRADE_PATH, get_version
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.agent_simulator import Sender, Injector

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -876,7 +876,19 @@ def get_sha_list(metadata):
     return sha_list
 
 
-def test_wpk_manager(set_debug_mode, get_configuration, configure_environment,
+@pytest.fixture(scope="function")
+def remove_current_wpk():
+    downloaded_wpk_path = '/var/ossec/var/upgrade/'
+    for filename in os.listdir(downloaded_wpk_path):
+        file_path = os.path.join(downloaded_wpk_path, filename)
+        try:
+            if os.path.isfile(file_path):
+                os.unlink(file_path)
+        except Exception:
+            raise Exception(f'Failed to remove {filename} file')
+            
+
+def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, configure_environment,
                      restart_service, configure_agents):
     metadata = get_configuration.get('metadata')
     protocol = metadata['protocol']

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -359,7 +359,7 @@ cases = [
             'upgrade_exec_result': ['0'],
             'upgrade_script_result': [0],
             'status': ['Legacy upgrade:' + \
-                       'check the result manually since the agent cannot report the result of the task'],
+                       ' check the result manually since the agent cannot report the result of the task'],
             'upgrade_notification': [False],
             'message_params': {'version': 'v3.13.1'},
             'expected_response': 'Success'

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -1030,6 +1030,7 @@ def test_wpk_manager(remove_current_wpk, set_debug_mode, get_configuration, conf
 
         # Continue with the test validations
         task_ids = [item.get('agent') for item in response['data']]
+        task_ids.sort()
         for index, agent_id in enumerate(task_ids):
             data = {
                 "origin": {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1528  |

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi


#### WPK

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh_agent_v4.2.0_linux_x86_64.wpk
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh_agent_v4.2.0_windows.wpk

### Local internal options

#### Linux Manager
```
wazuh_modules.debug=2
```

#### Linux Agent
```
wazuh_modules.debug=2
```

#### Windows Agent
```
windows.debug=2
```

### pytest_args
` test_wpk/test_wpk_agent.py  --wpk_version=v4.2.0`

## Description

After research #1493, we could see that some `wpk` tests have some false positive cases. Issue #1528 was created In order to fix these tests cases. In order to fix it, some changes have been applied to the manager (`test_manager_wpk`) and agent(`test_agent_wpk`). Also, the remote simulator(`remoted_sim`) has been changed to fix these false-positive cases. Some of these changes are the following:

- WPK Manager tests
  - Fix badly formatted callback in manager WPK tests.
  - Adds new fixture to remove download WPK file in WPK manager tests in order to avoid error in case of the WPK file in trash folder changes.
  - Remove hardcoded timeouts.
  - Fix badly formatted agent upgrade response.

-  WPK Agent test
   - Linux
     - Remove hardcoded timeout
     - Fix badly formatted agent upgrade response.
     - Remove timeout in upgrade_listener in case of rollback. Instead, it is used the agent's upgrade events to trigger the change of the remoted listener to default.
   - Windows 
     - Fix key folder
     - Remove timeout in upgrade_listener in case of rollback. Instead, it is used the agent's upgrade events to trigger the change of the remoted listener to default.

## Tests results

### Manager

| **Linux manager**  |  **Local**  |  **Status** 
|:--:|:--: |:--:|
|**Test Execution 1**|  [R1](https://github.com/wazuh/wazuh-qa/files/6861313/r1_wpk_manager.log) |  :green_circle:  
|**Test Execution 2**|  [R2](https://github.com/wazuh/wazuh-qa/files/6863284/r1_manager_wpk.log)  |   :green_circle: 
|**Test Execution 3**|   [R3](https://github.com/wazuh/wazuh-qa/files/6863286/r3_wpk_agent_linux.log) |  :green_circle: 


### Linux agent


| **Linux manager**  |  **Local**  |  **Status** 
|:--:|:--: |:--:|
|**Test Execution 1**|  [R1](https://github.com/wazuh/wazuh-qa/files/6861312/r1_wpk_agent_linux.log)  |  :green_circle:  
|**Test Execution 2**|  [R2](https://github.com/wazuh/wazuh-qa/files/6861314/r2_wpk_agent_linux.log) |   :green_circle:  
|**Test Execution 3**| [R3](https://github.com/wazuh/wazuh-qa/files/6861315/r3_wpk_agent_linux.log) |   :green_circle:   




### Windows agent

| **Linux manager**  |  **Local**  |  **Status** 
|:--:|:--: |:--:|
|**Test Execution 1**|  [R1](https://github.com/wazuh/wazuh-qa/files/6917293/r1_wpk_agent_windows.zip) |  :green_circle: 
|**Test Execution 2**|  [R2](https://github.com/wazuh/wazuh-qa/files/6917294/r2_wpk_agent_windows.zip) | :green_circle: 
|**Test Execution 3**|   [R3](https://github.com/wazuh/wazuh-qa/files/6917295/r3_wpk_agent_windows.zip) |  :green_circle: 
