### PR TITLE
Change year of feed update in `test_download_feeds.py`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -31,7 +31,7 @@ provider_info = {
             'system_log': 'JSON Red Hat Enterprise Linux',
         },
         'os': ['5', '6', '7', '8'],
-        'update_from_year': 1999,
+        'update_from_year': 2020,
         'system_log': 'Red Hat Enterprise Linux',
         'download_timeout': 1800
     },
@@ -49,13 +49,13 @@ provider_info = {
     },
     'nvd': {
         'os': [],
-        'update_from_year': 2002,
+        'update_from_year': 2020,
         'system_log': 'National Vulnerability Database',
         'download_timeout': 1800
     },
     'msu': {
         'os': [],
-        'update_from_year': 2002,
+        'update_from_year': 2020,
         'system_log': 'Microsoft Security Update',
         'download_timeout': 360
     }

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -161,12 +161,6 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                                                 the interval update")
 
     finally:
-        control_service('stop', daemon='wazuh-db')
-
         # Clean NVD tables when the download has finished
         vd.clean_vuln_and_sys_programs_tables()
 
-        # Wait for cleaning NVD tables
-        sleep(5)
-
-        control_service('start', daemon='wazuh-db')


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1542|

## Description

This PR modifies the `test_download_feeds` test to reduce its running time. For this purpose, **2020** has been set as the minimum update year for the feeds:
  - redhat 
  - nvd
  - msu

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
wazuh_modules.debug=2
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.
