### PR TITLE
Add timeout for remoted socket to be ready in `test_request_agent_info.py`

### DIFF
--- a/docs/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.md
@@ -14,7 +14,7 @@ group to reduce the time required by the test to make the checks.
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 0 | 1 | 126.41s |
+| 0 | 3 | 71.23s |
 
 ## Expected behavior
 

--- a/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_request_agent_info.py
@@ -2,7 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
-import time
+from time import sleep
 
 import pytest
 
@@ -19,15 +19,11 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_request_agent_info.yaml')
 
 parameters = [
-    {'PROTOCOL': 'udp,tcp'},
-    {'PROTOCOL': 'tcp'},
-    {'PROTOCOL': 'udp'},
+    {'PROTOCOL': 'udp,tcp'}
 ]
 
 metadata = [
-    {'PROTOCOL': 'udp,tcp'},
-    {'PROTOCOL': 'tcp'},
-    {'PROTOCOL': 'udp'},
+    {'PROTOCOL': 'udp,tcp'}
 ]
 
 # test cases
@@ -71,6 +67,8 @@ def test_request(get_configuration, configure_environment, remove_shared_files,
     for agent, protocol in zip(agents, protocols):
         if "disconnected" not in command_request:
             sender, injector = ag.connect(agent, manager_address, protocol)
+        else:
+            sleep(10) # Give time for the remoted socket to be ready.
 
         msg_request = f'{agent.id} {command_request}'
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1579 |

## Description

This PR modifies the `test_request_agent_info.py` of `remoted` tests to add a timeout for `remoted` socket to be ready. This timeout is only added in a specific use case, which is where the errors occur.

The number of use cases has also been reduced from nine to three, as those eliminated were redundant. 

Finally, the documentation has been updated to include the above changes.

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
remoted.debug=2
wazuh_database.interval=1
wazuh_db.commit_time=2
wazuh_db.commit_time_max=3
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.
