### PR TITLE
Increasing wait time until socket monitor is fully initialized in `test_multi_agent_protocols_communication.py`

### DIFF
--- a/docs/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.md
+++ b/docs/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.md
@@ -14,7 +14,7 @@ protocols simultaneously.
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 2 | 6 | 24s |
+| 2 | 6 | 65.72s |
 
 ## Expected behavior
 Success if the events have been found in the manager's `queue` socket after sending it from the agents, using different

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -100,8 +100,8 @@ def validate_agent_manager_protocol_communication(num_agents=2, manager_port=151
     socket_monitor_thread = ThreadExecutor(rd.check_queue_socket_event, {'raw_events': search_patterns})
     socket_monitor_thread.start()
 
-    # Wait 3 seconds until socket monitor is fully initialized
-    sleep(3)
+    # Wait 10 seconds until socket monitor is fully initialized
+    sleep(10)
 
     # Start sender event threads
     for thread in send_event_threads:


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1618 |

## Description

This PR modifies the `test_multi_agent_protocols_communication.py` of `remoted` tests to increase the time that the test waits until having the socket monitor is fully initialized.

In addition, this PR updates the documentation to reflect the increase of time duration.

## Configuration options

All the tests are run with the default test configuration and the following options in `local_internal_options.conf`

```
remoted.debug=2
wazuh_database.interval=1
wazuh_db.commit_time=2
wazuh_db.commit_time_max=3
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.
