### PR TITLE
Fix: Delete `Auto Negotation TLSv1_1` test case

### DIFF
--- a/tests/integration/test_agentd/data/wazuh_enrollment_tests.yaml
+++ b/tests/integration/test_agentd/data/wazuh_enrollment_tests.yaml
@@ -111,16 +111,6 @@
     agent_name: "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn" 
   expected_error: "ERROR: Invalid agent name"
 -
-  name: "SSL - Auto Negotiation"
-  description: "Try auto negotiation option"
-  enrollment:
-    response: "OSSEC K:'001 test_agent_1 any TopSecret'\n"
-    id: 1
-    protocol: "TLSv1_1"
-  configuration:
-    agent_name: "test_agent_1"
-    auto_method: "yes"
--
   name: "SSL - Auto Negotiation Negative"
   description: "Try TLSv1_1 without auto_negotiation"
   enrollment:


### PR DESCRIPTION
|Related issue|
|---|
|#1521|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

### Environment

|OS|
|:--:|
|CentOS 8, Windows|

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | msi (Windows) | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi 

### local_internal_options.conf

#### Agent
```
agent.debug=2
execd.debug=2
monitord.rotate_log=0
```

## Description

<!--
Add a clear description of how the problem has been solved.
-->
After research #1493, we could see that some `agentd` tests were failing. In issue #1521 we specified which tests were failing and why. 
We had some problems with the OpenSSL library and the test was failing. We have decided to delete this test case and we will implement it again when refactoring and issue #1585 are done.
This fix affects `test_agent_auth_enrollment.py` and `test_agendt_enrollment_params.py`.

## Tests results

||CentOS 8 Agent|Windows Agent|Reports|
|:--:|:--:|:--:|:--:|
|R1| 🟢  | 🟢  | [Tests results](https://github.com/wazuh/wazuh-qa/files/6862010/test_execution_1.zip)  |  
|R2| 🟢  | 🟢  | [Tests resutls](https://github.com/wazuh/wazuh-qa/files/6862013/test_execution_2.zip)  |  
|R3| 🟢  | 🟢  | [Tests results](https://github.com/wazuh/wazuh-qa/files/6862015/test_execution_3.zip)  |   

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
