### PR TITLE
Clear log file before run each use case in `test_invalid_syntax_redhat_feed.py`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
@@ -84,6 +84,8 @@ def modify_feed(test_data, request):
 
     vd.clean_vuln_and_sys_programs_tables()
 
+    file.truncate_file(LOG_FILE_PATH)
+
     control_service('restart', daemon='wazuh-modulesd')
 
     vd.set_system(system='RHEL8')


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1547 |

## Description

This PR modifies the `test_invalid_syntax_redhat_feed.py` of `vulnerability detector` tests to clear the log file before running each use case. The purpose is to avoid `FileMonitor` having to handle a lot of messages in the log file due to the verbosity of the internal `wazuh_modules.debug=2` option. 

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
wazuh_modules.debug=2
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.