### PR TITLE
Add timeout for the manager services to be ready in `test_active_response_send_ar.py`

### DIFF
--- a/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
@@ -70,16 +70,11 @@ def test_active_response_ar_sending(get_configuration, configure_environment, re
         agent.set_module_status('keepalive', 'enabled')
 
         # Time necessary until socket creation
-        time.sleep(1)
+        time.sleep(10)
 
-        sender = ag.Sender(manager_address, protocol=protocol, manager_port=manager_port)
-
-        injector = ag.Injector(sender, agent)
+        sender, injector = ag.connect(agent, manager_address, protocol, manager_port)
 
         try:
-            injector.run()
-            agent.wait_status_active()
-
             active_response_message = f"(local_source) [] NRN {agent.id} {remote.ACTIVE_RESPONSE_EXAMPLE_COMMAND}"
 
             send_active_response_message(active_response_message)


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1571 |

## Description

This PR modifies the `test_active_response_send_ar.py` of `remoted` tests to add a timeout for the manager services to be ready.

The test code has also been simplified by using the `connect` method of the `Agent` class.

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
remoted.debug=2
wazuh_database.interval=1
wazuh_db.commit_time=2
wazuh_db.commit_time_max=3
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.
