### PR TITLE
Full Yellow Local - Fix WazuhDB tests self-configuration in 4.2 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -3,36 +3,29 @@ import subprocess
 import subprocess as sb
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb
-import sqlite3
 
 
-def list_agents(fields=['id']):
-    global_db_conn = sqlite3.connect(f"{WAZUH_PATH}/queue/db/global.db")
-    selected_fields = ''.join(fields)
-    global_db_conn.row_factory = lambda cursor, row: row[0]
-    cursor = global_db_conn.cursor()
 
-    list_agents = []
-
-    try:
-        sqlite_response = cursor.execute(f"SELECT id FROM agent").fetchall()
-        sqlite_response.remove(0)
-        list_agents = sqlite_response 
-    except Exception:
-        list_agents = []
+def list_agents_ids():
+    wazuhdb_result = query_wdb("global get-all-agents last_id -1")
+    list_agents = [agent['id'] for agent in wazuhdb_result if not (0 == agent.get('id'))]
 
     return list_agents
 
 
-def remove_agents(agents_id, wazuh_script=True, wazuh_db_query=False):
+def remove_agents(agents_id, remove_option='wazuhdb'):
+    if remove_option not in ['wazuhdb','manage_agents']:
+        raise ValueError("Invalid type of agent removal: %s" % remove_option)
+
     if agents_id:
         for agent_id in agents_id:
-            if wazuh_script:
+            if remove_option == 'manage_agents':
                 subprocess.call([f"{WAZUH_PATH}/bin/manage_agents", "-r", f"{agent_id}"], stdout=open(os.devnull, "w"),
                                 stderr=subprocess.STDOUT)
-            if wazuh_db_query:
+            elif remove_option == 'wazuhdb':
                 result = query_wdb(f"global delete-agent {str(agent_id)}")
 
+
 def remove_all_agents():
-    agent_ids_list = list_agents(['id'])
+    agent_ids_list = list_agents_ids()
     remove_agents(agent_ids_list)

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -5,7 +5,6 @@ from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb
 
 
-
 def list_agents_ids():
     wazuhdb_result = query_wdb("global get-all-agents last_id -1")
     list_agents = [agent['id'] for agent in wazuhdb_result if not (0 == agent.get('id'))]
@@ -13,19 +12,19 @@ def list_agents_ids():
     return list_agents
 
 
-def remove_agents(agents_id, remove_option='wazuhdb'):
-    if remove_option not in ['wazuhdb','manage_agents']:
-        raise ValueError("Invalid type of agent removal: %s" % remove_option)
+def remove_agents(agents_id, remove_type='wazuhdb'):
+    if remove_type not in ['wazuhdb','manage_agents']:
+        raise ValueError("Invalid type of agent removal: %s" % remove_type)
 
     if agents_id:
         for agent_id in agents_id:
-            if remove_option == 'manage_agents':
+            if remove_type == 'manage_agents':
                 subprocess.call([f"{WAZUH_PATH}/bin/manage_agents", "-r", f"{agent_id}"], stdout=open(os.devnull, "w"),
                                 stderr=subprocess.STDOUT)
-            elif remove_option == 'wazuhdb':
+            elif remove_type == 'wazuhdb':
                 result = query_wdb(f"global delete-agent {str(agent_id)}")
 
 
-def remove_all_agents():
+def remove_all_agents(remove_type):
     agent_ids_list = list_agents_ids()
-    remove_agents(agent_ids_list)
+    remove_agents(agent_ids_list, remove_type)

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import subprocess as sb
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.wazuh_db import query_wdb
+import sqlite3
+import time
+
+
+def list_agents(fields=['id']):
+    global_db_conn = sqlite3.connect(f"{WAZUH_PATH}/queue/db/global.db")
+    selected_fields = ''.join(fields)
+    global_db_conn.row_factory = lambda cursor, row: row[0]
+    cursor = global_db_conn.cursor()
+    
+    sqlite_response = cursor.execute(f"SELECT id FROM agent").fetchall()
+    sqlite_response.remove(0)
+    return sqlite_response 
+
+
+def remove_agents(agents_id):
+    print(f"Removing {agents_id}")
+
+    if agents_id:
+        for agent_id in agents_id:
+           print(f"Removing {str(agent_id)}")
+           subprocess.call([f"{WAZUH_PATH}/bin/manage_agents", "-r", f"{agent_id}"], stdout=open(os.devnull, "w"), stderr=subprocess.STDOUT)
+           #result =  query_wdb(f"global delete-agent {str(agent_id)}")
+
+def remove_all_agents():
+    agent_ids_list = list_agents(['id'])
+    remove_agents(agent_ids_list)

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -4,7 +4,6 @@ import subprocess as sb
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb
 import sqlite3
-import time
 
 
 def list_agents(fields=['id']):
@@ -12,20 +11,27 @@ def list_agents(fields=['id']):
     selected_fields = ''.join(fields)
     global_db_conn.row_factory = lambda cursor, row: row[0]
     cursor = global_db_conn.cursor()
-    
-    sqlite_response = cursor.execute(f"SELECT id FROM agent").fetchall()
-    sqlite_response.remove(0)
-    return sqlite_response 
+
+    list_agents = []
+
+    try:
+        sqlite_response = cursor.execute(f"SELECT id FROM agent").fetchall()
+        sqlite_response.remove(0)
+        list_agents = sqlite_response 
+    except Exception:
+        list_agents = []
+
+    return list_agents
 
 
-def remove_agents(agents_id):
-    print(f"Removing {agents_id}")
-
+def remove_agents(agents_id, wazuh_script=True, wazuh_db_query=False):
     if agents_id:
         for agent_id in agents_id:
-           print(f"Removing {str(agent_id)}")
-           subprocess.call([f"{WAZUH_PATH}/bin/manage_agents", "-r", f"{agent_id}"], stdout=open(os.devnull, "w"), stderr=subprocess.STDOUT)
-           #result =  query_wdb(f"global delete-agent {str(agent_id)}")
+            if wazuh_script:
+                subprocess.call([f"{WAZUH_PATH}/bin/manage_agents", "-r", f"{agent_id}"], stdout=open(os.devnull, "w"),
+                                stderr=subprocess.STDOUT)
+            if wazuh_db_query:
+                result = query_wdb(f"global delete-agent {str(agent_id)}")
 
 def remove_all_agents():
     agent_ids_list = list_agents(['id'])

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -1,19 +1,18 @@
 import os
 import subprocess
-import subprocess as sb
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb
 
 
 def list_agents_ids():
-    wazuhdb_result = query_wdb("global get-all-agents last_id -1")
+    wazuhdb_result = query_wdb('global get-all-agents last_id -1')
     list_agents = [agent['id'] for agent in wazuhdb_result if not (0 == agent.get('id'))]
 
     return list_agents
 
 
 def remove_agents(agents_id, remove_type='wazuhdb'):
-    if remove_type not in ['wazuhdb','manage_agents']:
+    if remove_type not in ['wazuhdb', 'manage_agents']:
         raise ValueError("Invalid type of agent removal: %s" % remove_type)
 
     if agents_id:
@@ -26,5 +25,4 @@ def remove_agents(agents_id, remove_type='wazuhdb'):
 
 
 def remove_all_agents(remove_type):
-    agent_ids_list = list_agents_ids()
-    remove_agents(agent_ids_list, remove_type)
+    remove_agents(list_agents_ids(), remove_type)

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -64,9 +64,8 @@ def clean_registered_agents():
 
 
 @pytest.fixture(scope="module")
-def retart_wazuh():
+def restart_wazuh():
     control_service('restart')
-
 
 
 @pytest.fixture(scope="function")
@@ -93,7 +92,7 @@ def pre_insert_agents():
                               for module_data, module_name in module_tests
                               for case in module_data]
                          )
-def test_wazuh_db_messages(clean_registered_agents, retart_wazuh, configure_sockets_environment, connect_to_sockets_module, test_case):
+def test_wazuh_db_messages(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module, test_case):
     """Check that every input message in wazuh-db socket generates the adequate output to wazuh-db socket
 
     Parameters
@@ -117,7 +116,7 @@ def test_wazuh_db_messages(clean_registered_agents, retart_wazuh, configure_sock
             .format(index + 1, stage['stage'], expected, response)
 
 
-def test_wazuh_db_create_agent(clean_registered_agents, retart_wazuh, configure_sockets_environment, connect_to_sockets_module):
+def test_wazuh_db_create_agent(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module):
     """Check that Wazuh DB creates the agent database when a query with a new agent ID is sent"""
     test = {"name": "Create agent",
             "description": "Wazuh DB creates automatically the agent's database the first time a query with a new agent"
@@ -125,11 +124,11 @@ def test_wazuh_db_create_agent(clean_registered_agents, retart_wazuh, configure_
             "test_case": [{"input": "agent 999 syscheck integrity_check_left",
                            "output": "err Invalid FIM query syntax, near 'integrity_check_left'",
                            "stage": "Syscheck - Agent does not exits yet"}]}
-    test_wazuh_db_messages(clean_registered_agents, configure_sockets_environment, connect_to_sockets_module, test['test_case'])
+    test_wazuh_db_messages(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module, test['test_case'])
     assert os.path.exists(os.path.join(WAZUH_PATH, 'queue', 'db', "999.db"))
 
 
-def test_wazuh_db_chunks(clean_registered_agents, retart_wazuh, configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
+def test_wazuh_db_chunks(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
     """Check that commands by chunks work properly when agents amount exceed the response maximum size"""
 
     def send_chunk_command(command):

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -60,7 +60,8 @@ def regex_match(regex, string):
 
 @pytest.fixture(scope="module")
 def clean_registered_agents():
-    remove_all_agents()
+    remove_all_agents('wazuhdb')
+    time.sleep(5)
 
 
 @pytest.fixture(scope="module")
@@ -92,7 +93,7 @@ def pre_insert_agents():
                               for module_data, module_name in module_tests
                               for case in module_data]
                          )
-def test_wazuh_db_messages(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module, test_case):
+def test_wazuh_db_messages(restart_wazuh, clean_registered_agents, configure_sockets_environment, connect_to_sockets_module, test_case):
     """Check that every input message in wazuh-db socket generates the adequate output to wazuh-db socket
 
     Parameters
@@ -116,7 +117,7 @@ def test_wazuh_db_messages(clean_registered_agents, restart_wazuh, configure_soc
             .format(index + 1, stage['stage'], expected, response)
 
 
-def test_wazuh_db_create_agent(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module):
+def test_wazuh_db_create_agent(restart_wazuh, clean_registered_agents, configure_sockets_environment, connect_to_sockets_module):
     """Check that Wazuh DB creates the agent database when a query with a new agent ID is sent"""
     test = {"name": "Create agent",
             "description": "Wazuh DB creates automatically the agent's database the first time a query with a new agent"
@@ -128,7 +129,7 @@ def test_wazuh_db_create_agent(clean_registered_agents, restart_wazuh, configure
     assert os.path.exists(os.path.join(WAZUH_PATH, 'queue', 'db', "999.db"))
 
 
-def test_wazuh_db_chunks(clean_registered_agents, restart_wazuh, configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
+def test_wazuh_db_chunks(restart_wazuh, clean_registered_agents, configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
     """Check that commands by chunks work properly when agents amount exceed the response maximum size"""
 
     def send_chunk_command(command):

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -60,8 +60,13 @@ def regex_match(regex, string):
 
 @pytest.fixture(scope="module")
 def clean_registered_agents():
-    control_service('restart')
     remove_all_agents()
+
+
+@pytest.fixture(scope="module")
+def retart_wazuh():
+    control_service('restart')
+
 
 
 @pytest.fixture(scope="function")
@@ -88,7 +93,7 @@ def pre_insert_agents():
                               for module_data, module_name in module_tests
                               for case in module_data]
                          )
-def test_wazuh_db_messages(clean_registered_agents, configure_sockets_environment, connect_to_sockets_module, test_case):
+def test_wazuh_db_messages(clean_registered_agents, retart_wazuh, configure_sockets_environment, connect_to_sockets_module, test_case):
     """Check that every input message in wazuh-db socket generates the adequate output to wazuh-db socket
 
     Parameters
@@ -112,7 +117,7 @@ def test_wazuh_db_messages(clean_registered_agents, configure_sockets_environmen
             .format(index + 1, stage['stage'], expected, response)
 
 
-def test_wazuh_db_create_agent(clean_registered_agents, configure_sockets_environment, connect_to_sockets_module):
+def test_wazuh_db_create_agent(clean_registered_agents, retart_wazuh, configure_sockets_environment, connect_to_sockets_module):
     """Check that Wazuh DB creates the agent database when a query with a new agent ID is sent"""
     test = {"name": "Create agent",
             "description": "Wazuh DB creates automatically the agent's database the first time a query with a new agent"
@@ -124,7 +129,7 @@ def test_wazuh_db_create_agent(clean_registered_agents, configure_sockets_enviro
     assert os.path.exists(os.path.join(WAZUH_PATH, 'queue', 'db', "999.db"))
 
 
-def test_wazuh_db_chunks(clean_agent_registered, configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
+def test_wazuh_db_chunks(clean_registered_agents, retart_wazuh, configure_sockets_environment, connect_to_sockets_module, pre_insert_agents):
     """Check that commands by chunks work properly when agents amount exceed the response maximum size"""
 
     def send_chunk_command(command):


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1535 |


## Description

After research #1493, we could see that WazuhDB tests fail in case Wazuh Manager does not start for the first time. Also, it was detected that in case of the manager has already registered some agents, independently of the state of them, these tests produce false positives. This is error is commented in the [original issue](https://github.com/wazuh/wazuh-qa/issues/1535#issuecomment-883309352). This PR has been created In order to make all wazuh-qa tests independent.


### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm

### Local internal options
No local internal options are required.

### Pytest args
No arguments are required.

## Testing process

In order, to properly test, this issue is necessary to ensure:
- There aren't false positives in a newly provisioned environment, in which the manager has not been started.
- There aren't false positives in an environment in which the manager has already registered agents.

## Tests results

### New provisioned environment

In progress.

### Already registered agents

In progress.

