### PR TITLE
Apply correct formatting to `wazuh_providers_multiple_providers.yaml`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_multiple_providers.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/wazuh_providers_multiple_providers.yaml
@@ -36,13 +36,13 @@
       - disabled:
           value: 'yes'
   - section: auth
-      elements:
-          - disabled:
-            value: 'yes'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: rule_test
-      elements:
-          - enabled:
-            value: 'no'
+    elements:
+      - enabled:
+          value: 'no'
 #conf2
 - tags:
   - test_providers_path
@@ -82,13 +82,13 @@
       - disabled:
           value: 'yes'
   - section: auth
-      elements:
-          - disabled:
-            value: 'yes'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: rule_test
-      elements:
-          - enabled:
-            value: 'no'
+    elements:
+      - enabled:
+          value: 'no'
 #conf3
 - tags:
   - test_providers_multipath
@@ -128,13 +128,13 @@
       - disabled:
           value: 'yes'
   - section: auth
-      elements:
-          - disabled:
-            value: 'yes'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: rule_test
-      elements:
-          - enabled:
-            value: 'no'
+    elements:
+      - enabled:
+          value: 'no'
 #conf4
 - tags:
   - test_providers_path_multipath
@@ -176,13 +176,13 @@
       - disabled:
           value: 'yes'
   - section: auth
-      elements:
-          - disabled:
-            value: 'yes'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: rule_test
-      elements:
-          - enabled:
-            value: 'no'
+    elements:
+      - enabled:
+          value: 'no'
 #conf5
 - tags:
   - test_providers_url
@@ -222,13 +222,13 @@
       - disabled:
           value: 'yes'
   - section: auth
-      elements:
-          - disabled:
-            value: 'yes'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: rule_test
-      elements:
-          - enabled:
-            value: 'no'
+    elements:
+      - enabled:
+          value: 'no'
 #conf6
 - tags:
   - test_providers_multiurl
@@ -268,13 +268,13 @@
       - disabled:
           value: 'yes'
   - section: auth
-      elements:
-          - disabled:
-            value: 'yes'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: rule_test
-      elements:
-          - enabled:
-            value: 'no'
+    elements:
+      - enabled:
+          value: 'no'
 #conf7
 - tags:
   - test_providers_url_multiurl


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1637 |

## Description

This PR modifies the `wazuh_providers_multiple_providers.yaml` configuration file of `vulnerability detector` tests to apply the correct formatting. This causes the `test_providers_multiple_providers.py` test to fail at startup.

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
wazuh_modules.debug=2
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.