### PR TITLE
Enable V.D. at startup to create the CVE database in `test_general_settings_ignore_time.py`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/wazuh_ignore_time.yaml
@@ -9,7 +9,7 @@
     - enabled:
         value: 'yes'
     - run_on_start:
-        value: 'no'
+        value: 'yes'
     - interval:
         value: INTERVAL
     - ignore_time: 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -6,6 +6,7 @@ import os
 from datetime import timedelta
 
 import pytest
+from wazuh_testing.tools.file import truncate_file
 import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.fim import check_time_travel
 from wazuh_testing.tools import LOG_FILE_PATH
@@ -67,6 +68,7 @@ def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
     vd.update_last_scan(agent=prepare_agent)
+    truncate_file(LOG_FILE_PATH)
     control_service('start', daemon='wazuh-db')
     control_service('start', daemon='wazuh-modulesd')
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1644 |

## Description

This PR modifies the `test_general_settings_ignore_time.py` of `Vulnerability Detector` tests to clear the log file before running each use case. The purpose is to prevent the test from detecting previously written messages in the log file and causing false positives. `Vulnerability Detector` is also enabled at startup to create the `CVEs` database to allow the insertion of the required testing vulnerability.

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
wazuh_modules.debug=2
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.