### PR TITLE
Add TestCaseParser module to DocGenerator

### DIFF
--- a/docs/DocGenerator/CodeParser.py
+++ b/docs/DocGenerator/CodeParser.py
@@ -4,6 +4,7 @@ import re
 import json
 import yaml
 from Config import Config
+from TestCaseParser import TestCaseParser
 from docstring_parser import parse
 from comment_parser import comment_parser
 import warnings
@@ -11,6 +12,7 @@ import warnings
 class CodeParser:
     def __init__(self):
         self.conf = Config()
+        self.test_case_parser = TestCaseParser()
         self.function_regexes = []
         for regex in self.conf.function_regex:
             self.function_regexes.append(re.compile(regex))
@@ -58,18 +60,23 @@ class CodeParser:
             module_doc['Id'] = id
             module_doc['Group Id'] = group_id
 
+            test_cases = self.test_case_parser.collect(code_file)
+
             functions_doc = []
             for function in functions:
                 if self.is_documentable_function(function):
                     function_doc = self.parse_comment(function)
                     if function_doc:
+                        if test_cases[function.name]:
+                            function_doc["Test Cases"] = test_cases[function.name]
                         functions_doc.append(function_doc)
+
             if not functions_doc:
                 warnings.warn("Module doesn´t contain any test function")
 
             module_doc['Tests'] = functions_doc
 
-            self.remove_ignored_fields(module_doc)
+            #self.remove_ignored_fields(module_doc)
 
         return module_doc
 

--- a/docs/DocGenerator/TestCaseParser.py
+++ b/docs/DocGenerator/TestCaseParser.py
@@ -1,0 +1,33 @@
+import pytest
+
+class PytestPlugin:
+    def __init__(self):
+        self.collected = []
+
+    def pytest_collection_modifyitems(self, items):
+        for item in items:
+            self.collected.append(item.nodeid)
+
+class TestCaseParser:
+    def __init__(self):
+        self.plugin = PytestPlugin()
+
+    def collect(self, path):
+        pytest.main(['--collect-only', path], plugins=[self.plugin])
+        output = {}
+        for item in self.plugin.collected:
+            tmp = item.split("::")
+            file = tmp[0]
+            tmp = tmp[1].split("[")
+            test = tmp[0]
+            if not test in output:
+                output[test] = []
+            if len(tmp) >= 2:
+                tmp = tmp[1].split("]")
+                test_case = tmp[0]
+                output[test].append(test_case)
+        return output
+
+
+test = TestCaseParser()
+test.collect("../../tests/integration/test_wazuh_db/test_wazuh_db.py")


### PR DESCRIPTION
|Related issue|
|---|
|#1639|

## Description
This PR implements a TastCase parser module for DocGenerator.
The implementation is done by calling programmatically pytest as a dry-run using the **--collect-only** option.
The result is parsed and the obtained different test cases are added as a list to the test documentation.