### PR TITLE
Avoid updating the position of FileMonitor when monitoring multiples logs in remoted tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -403,6 +403,7 @@ def check_syslog_event(wazuh_archives_log_monitor, message, port, protocol, time
     for msg in parsed_msg.split("\n"):
         detect_archives_log_event(archives_monitor=wazuh_archives_log_monitor,
                                   callback=callback_detect_syslog_event(msg),
+                                  update_position=False,
                                   timeout=timeout,
                                   error_message="Syslog message wasn't received or took too much time.")
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-qa/issues/1570 |

## Description

This PR modifies the `syslog` monitoring of `remoted` tests to avoid updating the position of the `FileMonitor` when the test looks for more than one log.

## Configuration options

All the tests are run with the default test configuration and the following options in `local_internal_options.conf`

```
remoted.debug=2
wazuh_database.interval=1
wazuh_db.commit_time=2
wazuh_db.commit_time_max=3
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.
