### PR TITLE
Fix and optimize: `test_cpe_indexing.py`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_windows/data/cpe_indexing.yaml
+++ b/tests/integration/test_vulnerability_detector/test_windows/data/cpe_indexing.yaml
@@ -32,7 +32,7 @@
           - path:
               value: NVD_JSON_PATH
           - update_interval:
-              value: '20s'
+              value: '5s'
     - section: sca
       elements:
       - enabled:
@@ -49,13 +49,13 @@
       attributes:
         - name: 'syscollector'
       elements:
-        - disabled:
-           value: 'yes'
-  - section: auth
-    elements:
       - disabled:
           value: 'yes'
-  - section: rule_test
-    elements:
+    - section: auth
+      elements:
+      - disabled:
+          value: 'yes'
+    - section: rule_test
+      elements:
       - enabled:
           value: 'no'

--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -146,6 +146,13 @@ def mock_system(request):
                             package='test', target=request.param['target'])
     vd.insert_package()
 
+    # Insert a vulnerability in the NVD_CVE table since this is needed
+    # for the vulnerability detector to generate the required log.
+    query_string = "INSERT INTO NVD_CVE \
+                    (NVD_METADATA_YEAR, CVE_ID, CWE_ID, ASSIGNER, DESCRIPTION, VERSION, PUBLISHED, LAST_MODIFIED) \
+                    VALUES (0, 'CVE-000', 'CWE-000', 'WAZUH', 'Wazuh integration test NVD vulnerability', '4.0', 0, 1)"
+    vd.make_query(vd.CVE_DB_PATH, [query_string])
+
     truncate_file(LOG_FILE_PATH)
 
     control_service('start', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -131,7 +131,6 @@ def get_configuration(request):
 
 @pytest.fixture(scope='module', params=system_data, ids=system_data_ids)
 def mock_system(request):
-    control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
 
     vd.clean_vd_tables(agent='000')
@@ -149,7 +148,6 @@ def mock_system(request):
 
     truncate_file(LOG_FILE_PATH)
 
-    control_service('start', daemon='wazuh-modulesd')
     control_service('start', daemon='wazuh-db')
 
     yield request.param
@@ -164,7 +162,7 @@ def mock_system(request):
 
 def test_window_version_indexing(get_configuration, configure_environment, restart_modulesd, check_cve_db, mock_system):
     wazuh_log_monitor.start(
-        timeout=50,
+        timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
         update_position=False,
         callback=vd.make_vuln_callback(
             rf"The CPE 'o:microsoft:{mock_system['index_name']}:(-|r2|{mock_system['os_release']}):" +


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #1565 |

## Description

This PR makes the following changes to `test_cpe_indexing`:
- Format properly the file cpe_indexing.yaml (this causes the test to fail at startup).
- Reduce the update interval of the `NVD` feed (it allows the test to be ready in less time).
- Remove unnecessary `modulesd` service restarting.
- Reduce `log-monitor` timeout.
- Insert a vulnerability in the `NVD_CVE` table (the reason is that for the log required by the test to be written,
this table must not be empty).

## Configuration options

All the tests are run with the default configuration and the following options in `local_internal_options.conf`

```
wazuh_modules.debug=2
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.