### PR TITLE
Fix test `test_fim/test_files/test_skip/test_skip.py`

### DIFF
--- a/tests/integration/test_fim/test_files/test_skip/data/configure_nfs_rpm.sh
+++ b/tests/integration/test_fim/test_files/test_skip/data/configure_nfs_rpm.sh
@@ -4,10 +4,20 @@ rpm -qa | grep -E "iproute.*" || yum -y install iproute
 ip=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
 # Check if nfs-utils is installed
 rpm -qa | grep -E "nfs-utils.*" || yum -y install nfs-utils
+
 service nfs restart
+if [ $? -ne 0 ]; then
+    service nfs-server restart
+fi
+
 mkdir /media/nfs-folder
 mkdir /nfs-mount-point
 echo "/media/nfs-folder     $ip*(rw,sync,no_root_squash)" > /etc/exports
 exportfs -a
+
 service nfs restart
+if [ $? -ne 0 ]; then
+    service nfs-server restart
+fi
+
 mount -o hard,nolock "$ip":/media/nfs-folder /nfs-mount-point/


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1654|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Environment
|OS|
|--|
|CentOS 8|

## local_internal_options.conf

### Agent
```
syscheck.debug=2
monitord.rotate_log=0
```

### pytest_args
```
--tier 0 --tier 1 --tier 2 --fim_mode=scheduled
```

## Description

In CentOS 8 systems, the command `service nfs restart` was failing because the the service is actually called `nfs-server`. This PR changes the bash script in charge of setting up the nfs server so that in case `service nfs restart` fails, `service nfs-server restart` is executed.

## Tests results

||CentOS 8 Agent|
|--|--|
|R1|[🟢](https://github.com/wazuh/wazuh-qa/files/6886286/test-skip-0.zip)|
|R2|[🟢](https://github.com/wazuh/wazuh-qa/files/6886287/test-skip-1.zip)|
|R3|[🟢](https://github.com/wazuh/wazuh-qa/files/6886288/test-skip-2.zip)|
