### PR TITLE
Fix `test_files/test_max_files_per_second/test_max_files_per_second.py`

### DIFF
--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -68,7 +68,9 @@ def test_max_files_per_second(inode_collision, get_configuration, configure_envi
     for i in range(n_files_to_create):
         fim.create_file(fim.REGULAR, test_directories[0], f'test_{i}', content='')
 
-    extra_timeout = (n_files_to_create / max_files_per_second) + global_parameters.default_timeout
+    extra_timeout = n_files_to_create / max_files_per_second
+    if inode_collision:
+        extra_timeout += global_parameters.default_timeout
 
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor,
                           timeout=global_parameters.default_timeout + extra_timeout)

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -68,7 +68,7 @@ def test_max_files_per_second(inode_collision, get_configuration, configure_envi
     for i in range(n_files_to_create):
         fim.create_file(fim.REGULAR, test_directories[0], f'test_{i}', content='')
 
-    extra_timeout = n_files_to_create / max_files_per_second
+    extra_timeout = (n_files_to_create / max_files_per_second) + global_parameters.default_timeout
 
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor,
                           timeout=global_parameters.default_timeout + extra_timeout)


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1655|

### Environment

|OS|
|:--:|
|CentOS 8|

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm


### local_internal_options.conf

#### Manager
```
syscheck.debug=2
analysisd.debug=2
monitord.rotate_log=0
```

#### Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

### pytest_args
`-v --tier 0 --tier 1 --tier 2`
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->


## Description

The test was failing because Wazuh was taking a few seconds more to generate the log
than the timeout of the test. We needed to increase that timeout.

||R1|R2|R3|R4|R5|R6|R7|R8|R9|R10| Reports|
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
|CentOS 8 Manager| 🟢 | 🟢  | 🟢  | 🟢 | 🟢  | 🟢  | 🟢  | 🟢  | 🟢  | 🟢  | [Tests results](https://github.com/wazuh/wazuh-qa/files/6898925/centos_manager_test_max_files_per_second.zip)|
|CentOS 8 Agent| :green_circle: | 🟢 | 🟢  | 🟢  | 🟢  |🟢  | 🟢  | 🟢  | 🟢  | 🟢  | [Tests results](https://github.com/wazuh/wazuh-qa/files/6898931/centos_agent_test_max_files_per_second.zip)|


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.