### PR TITLE
Fix `test_registry/test_registry_basic_usage/test_long_registry_path.py`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, \
-    create_registry, registry_parser, registry_value_cud, KEY_WOW64_64KEY, delete_registry
+    registry_value_cud, KEY_WOW64_64KEY
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -26,13 +26,13 @@ for i in range(30):
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-reg1 = os.path.join(key, sub_key_1)
+test_regs = [os.path.join(key, sub_key_1)]
 
 monitoring_modes = ['scheduled']
 
 # Configurations
 
-conf_params = {'WINDOWS_REGISTRY_1': reg1}
+conf_params = {'WINDOWS_REGISTRY_1': test_regs}
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_reg_attr.yaml')
 p, m = generate_params(extra_params=conf_params, modes=monitoring_modes)
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
@@ -44,15 +44,6 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
-
-
-# tests
-
-def extra_configuration_before_yield():
-    create_registry(registry_parser[key], sub_key_1, arch)
-
-def extra_configuration_after_yield():
-    delete_registry(registry_parser[key], sub_key_1, arch)
 
 
 def test_long_registry_path(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, \
-    create_registry, registry_parser, registry_value_cud, KEY_WOW64_64KEY
+    create_registry, registry_parser, registry_value_cud, KEY_WOW64_64KEY, delete_registry
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -50,6 +50,9 @@ def get_configuration(request):
 
 def extra_configuration_before_yield():
     create_registry(registry_parser[key], sub_key_1, arch)
+
+def extra_configuration_after_yield():
+    delete_registry(registry_parser[key], sub_key_1, arch)
 
 
 def test_long_registry_path(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1658|
### Environment

|OS|
|:--:|
|Windows|

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | msi (Windows) | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi 


### local_internal_options.conf

#### Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

### pytest_args
`-v --tier 0 --tier 1 --tier 2`

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The test was failing because if the test failed once, the registry wasn't deleted and in the next execution, the `added` event wasn't appearing. We have added that when the test finishes, it deletes the registry even if the test failed.

## Tests results

||Windows Agent|Reports|
|:--:|:--:|:--:|
|R1|  🟢 |[Test results](https://github.com/wazuh/wazuh-qa/files/6900160/windows_agent_test_long_registry_path_r1.zip)|
|R2|  🟢 |[Test results](https://github.com/wazuh/wazuh-qa/files/6900162/windows_agent_test_long_registry_path_r2.zip)|
|R3|  🟢 |[Test results](https://github.com/wazuh/wazuh-qa/files/6900163/windows_agent_test_long_registry_path_r3.zip)|

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.