### PR TITLE
Improve validation of registry entries

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -95,6 +95,7 @@ REQUIRED_REG_VALUE_ATTRIBUTES = {
 
 _last_log_line = 0
 _os_excluded_from_rt_wd = ['darwin', 'sunos5']
+registry_ignore_path = None
 
 if sys.platform == 'win32':
     registry_parser = {
@@ -1291,20 +1292,28 @@ def callback_registry_count_entries(line):
         return match.group(1)
 
 
+def callback_key_event(line):
+    event = callback_detect_event(line)
+
+    if event is None:
+        return None
+
+    if event['data']['attributes']['type'] != 'registry_key' or event['data']['path'] == registry_ignore_path:
+        return None
+
+    return event
+
+
 def callback_value_event(line):
-    match = re.match(r'.*Sending FIM event: .*value_name.*', line)
+    event = callback_detect_event(line)
 
-    if match is not None:
-        msg = r'.*Sending FIM event: (.+)$'
-        match = re.match(msg, line)
+    if event is None:
+        return None
 
-        try:
-            if json.loads(match.group(1))['type'] == 'event':
-                return json.loads(match.group(1))
-        except (AttributeError, JSONDecodeError, KeyError):
-            pass
+    if event['data']['attributes']['type'] != 'registry_value':
+        return None
 
-    return None
+    return event
 
 
 def callback_detect_max_files_per_second(line):
@@ -1604,6 +1613,8 @@ if sys.platform == 'win32':
                      encoding=None, callback=callback_detect_event, is_value=False):
             self.log_monitor = log_monitor
             self.registry_key = registry_key
+            global registry_ignore_path
+            registry_ignore_path = registry_key
             self.registry_dict = registry_dict
             self.custom_validator = custom_validator
             self.options = options
@@ -1611,6 +1622,10 @@ if sys.platform == 'win32':
             self.events = None
             self.callback = callback
             self.is_value = is_value
+
+        def __del__(self):
+            global registry_ignore_path
+            registry_ignore_path = None
 
         def fetch_and_check(self, event_type, min_timeout=1, triggers_event=True, extra_timeout=0):
             """Call 'fetch_events', 'fetch_key_events' and 'check_events', depending on the type of event expected.
@@ -1623,8 +1638,7 @@ if sys.platform == 'win32':
             """
             assert event_type in ['added', 'modified', 'deleted'], f'Incorrect event type: {event_type}'
 
-            # Minus 1 because we don't need to count the registry parent key here
-            num_elems = len(self.registry_dict) - 1
+            num_elems = len(self.registry_dict)
 
             error_msg = "TimeoutError was raised because "
             error_msg += str(num_elems) if num_elems > 1 else "a single"
@@ -1642,52 +1656,32 @@ if sys.platform == 'win32':
             elif event_type == 'added':
                 self.events = self.fetch_events(min_timeout, triggers_event, extra_timeout, error_message=error_msg)
                 self.check_events(event_type)
-
-                # The callback for the registry parent key will be `None` when `check_mtime` is disabled
-                if self.registry_dict[self.registry_key][1] is not None:
-                    self.events = self.fetch_events(min_timeout, triggers_event, extra_timeout,
-                                                    error_message=key_error_msg, is_parent=True)
-                    self.check_events(event_type, check_parent_key=True)
             elif event_type == 'deleted':
-                if self.registry_dict[self.registry_key][1] is not None:
-                    self.events = self.fetch_events(min_timeout, triggers_event, extra_timeout,
-                                                    error_message=key_error_msg, is_parent=True)
-                    self.check_events(event_type, check_parent_key=True)
-
                 self.events = self.fetch_events(min_timeout, triggers_event, extra_timeout, error_message=error_msg)
                 self.check_events(event_type)
 
-        def fetch_events(self, min_timeout=1, triggers_event=True, extra_timeout=0, error_message='', is_parent=False):
+        def fetch_events(self, min_timeout=1, triggers_event=True, extra_timeout=0, error_message=''):
             try:
-                if is_parent:
-                    result = self.log_monitor.start(timeout=min_timeout,
-                                                    callback=self.registry_dict[self.registry_key][1],
-                                                    timeout_extra=extra_timeout,
-                                                    encoding=self.encoding,
-                                                    error_message=error_message).result()
-                else:
-                    # We substract 1 to the length of the dictionary because the parent key should not be detected here
-                    result = self.log_monitor.start(timeout=max((len(self.registry_dict) - 1) * 0.01, min_timeout),
-                                                    callback=self.callback,
-                                                    accum_results=len(self.registry_dict) - 1,
-                                                    timeout_extra=extra_timeout,
-                                                    encoding=self.encoding,
-                                                    error_message=error_message).result()
+                result = self.log_monitor.start(timeout=max((len(self.registry_dict)) * 0.01, min_timeout),
+                                                callback=self.callback,
+                                                accum_results=len(self.registry_dict),
+                                                timeout_extra=extra_timeout,
+                                                encoding=self.encoding,
+                                                error_message=error_message).result()
 
-                assert triggers_event, f'No events should be detected.'
+                assert triggers_event, 'No events should be detected.'
                 return result if isinstance(result, list) else [result]
             except TimeoutError:
                 if triggers_event:
                     raise
                 logger.info("TimeoutError was expected and correctly caught.")
 
-        def check_events(self, event_type, mode=None, check_parent_key=False):
+        def check_events(self, event_type, mode=None):
             """Check and validate all events in the 'events' list.
 
             Args:
                 event_type (str): Expected type of the raised event {'added', 'modified', 'deleted'}.
                 mode (str): expected mode of the raised event.
-                check_parent_key (bool, optional): check the event raised by the parent key. Defaults `False`
             """
 
             def validate_checkers_per_event(events, options, mode):
@@ -1707,21 +1701,15 @@ if sys.platform == 'win32':
             def check_events_type(events, ev_type, reg_list=['testkey0']):
                 event_types = Counter(filter_events(events, ".[].data.type"))
 
-                # We substract 1 to the length of the dictionary because the parent key should not be counted here
-                msg = f'Non expected number of events. {event_types[ev_type]} != {len(reg_list) - 1}'
+                msg = f'Non expected number of events. {event_types[ev_type]} != {len(reg_list)}'
 
-                assert (event_types[ev_type] == (len(reg_list)) - 1), msg
+                assert (event_types[ev_type] == len(reg_list)), msg
 
             def check_events_key_path(events, registry_key, reg_list=['testkey0'], mode=None):
                 mode = global_parameters.current_configuration['metadata']['fim_mode'] if mode is None else mode
                 key_path = filter_events(events, ".[].data.path")
-                skip_parent = True
 
                 for reg in reg_list:
-                    if skip_parent:
-                        skip_parent = False
-                        continue
-
                     expected_path = os.path.join(registry_key, reg)
 
                     if self.encoding is not None:
@@ -1731,30 +1719,12 @@ if sys.platform == 'win32':
                     error_msg = f"Expected key path was '{expected_path}' but event key path is '{key_path}'"
                     assert (expected_path in key_path), error_msg
 
-            def check_events_parent_registry_key(events, mode=None):
-                mode = global_parameters.current_configuration['metadata']['fim_mode'] if mode is None else mode
-                parent_key_path = filter_events(events, ".[].data.path")
-
-                if self.encoding is not None:
-                    for index, item in enumerate(parent_key_path):
-                        parent_key_path[index] = item.encode(encoding=self.encoding)
-
-                error_msg = f"Expected parent key path was '{self.registry_key}'"
-                error_msg += f"but event parent key path is '{parent_key_path}'"
-
-                assert (self.registry_key in parent_key_path), error_msg
-
             def check_events_registry_value(events, key, value_list=['testvalue0'], mode=None):
                 mode = global_parameters.current_configuration['metadata']['fim_mode'] if mode is None else mode
                 key_path = filter_events(events, ".[].data.path")
                 value_name = filter_events(events, ".[].data.value_name")
-                skip_parent = True
 
                 for value in value_list:
-                    if skip_parent:
-                        skip_parent = False
-                        continue
-
                     error_msg = f"Expected value name was '{value}' but event value name is '{value_name}'"
                     assert (value in value_name), error_msg
 
@@ -1773,9 +1743,7 @@ if sys.platform == 'win32':
             if self.events is not None:
                 validate_checkers_per_event(self.events, self.options, mode)
 
-                if check_parent_key:
-                    check_events_parent_registry_key(self.events, mode=mode)
-                elif self.is_value:
+                if self.is_value:
                     check_events_type(self.events, event_type, self.registry_dict)
                     check_events_registry_value(self.events, self.registry_key, value_list=self.registry_dict,
                                                 mode=mode)
@@ -1783,7 +1751,7 @@ if sys.platform == 'win32':
                     check_events_type(self.events, event_type, self.registry_dict)
                     check_events_key_path(self.events, self.registry_key, reg_list=self.registry_dict, mode=mode)
 
-                if self.custom_validator is not None and not check_parent_key:
+                if self.custom_validator is not None:
                     self.custom_validator.validate_after_cud(self.events)
 
                     if event_type == "added":
@@ -1804,7 +1772,6 @@ if sys.platform == 'win32':
                 result_list.append(expected_elem_path)
 
             return result_list
-
 
     def registry_value_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64KEY, value_list=['test_value'],
                            time_travel=False, min_timeout=1, options=None, triggers_event=True, triggers_event_add=True,
@@ -1861,29 +1828,23 @@ if sys.platform == 'win32':
             value_added_content = 0
             value_default_content = 1
 
-        if not isinstance(value_list, list) and not isinstance(value_list, dict):
-            raise ValueError('Value error. It can only be list or dict')
-        elif isinstance(value_list, list):
-            aux_dict = {registry_path: (value_default_content, callback_detect_event)}
-
+        aux_dict = {}
+        if isinstance(value_list, list):
             for elem in value_list:
                 aux_dict[elem] = (value_default_content, callback)
 
-            value_list = aux_dict
         elif isinstance(value_list, dict):
-            aux_dict = {registry_path: (value_default_content, callback_detect_event)}
-
             for key, elem in value_list.items():
                 aux_dict[key] = (elem, callback)
 
-            value_list = aux_dict
+        else:
+            raise ValueError('It can only be list or dict')
+
+        value_list = aux_dict
 
         options_set = REQUIRED_REG_VALUE_ATTRIBUTES[CHECK_ALL]
         if options is not None:
             options_set = options_set.intersection(options)
-
-        if options_set is not None and CHECK_MTIME not in options_set:
-            value_list[registry_path] = (value_default_content, None)
 
         triggers_event_add = triggers_event and triggers_event_add
         triggers_event_modified = triggers_event and triggers_event_modified
@@ -1944,7 +1905,7 @@ if sys.platform == 'win32':
     def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64KEY, key_list=['test_key'],
                          time_travel=False, min_timeout=1, options=None, triggers_event=True, triggers_event_add=True,
                          triggers_event_modified=True, triggers_event_delete=True, encoding=None,
-                         callback=callback_detect_event, validators_after_create=None, validators_after_update=None,
+                         callback=callback_key_event, validators_after_create=None, validators_after_update=None,
                          validators_after_delete=None, validators_after_cud=None):
         """Check if creation, update and delete registry key events are detected by syscheck.
 
@@ -1989,29 +1950,22 @@ if sys.platform == 'win32':
 
         registry_path = os.path.join(root_key, registry_sub_key)
 
-        if not isinstance(key_list, list) and not isinstance(key_list, dict):
-            raise ValueError('Value error. It can only be list or dict')
-        elif isinstance(key_list, list):
-            aux_dict = {registry_path: ('', callback_detect_event)}
-
+        aux_dict = {}
+        if isinstance(key_list, list):
             for elem in key_list:
                 aux_dict[elem] = ('', callback)
 
-            key_list = aux_dict
         elif isinstance(key_list, dict):
-            aux_dict = {registry_path: ('', callback_detect_event)}
-
             for key, elem in key_list.items():
                 aux_dict[key] = (elem, callback)
+        else:
+            raise ValueError('It can only be list or dict')
 
-            key_list = aux_dict
+        key_list = aux_dict
 
         options_set = REQUIRED_REG_KEY_ATTRIBUTES[CHECK_ALL]
         if options is not None:
             options_set = options_set.intersection(options)
-
-        if options_set is not None and CHECK_MTIME not in options_set:
-            key_list[registry_path] = ('', None)
 
         triggers_event_add = triggers_event and triggers_event_add
         triggers_event_modified = triggers_event and triggers_event_modified
@@ -2413,4 +2367,3 @@ def check_fim_start(file_monitor):
         detect_whodata_start(file_monitor)
     else:
         detect_initial_scan(file_monitor)
-        

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1870,6 +1870,13 @@ if sys.platform == 'win32':
         if triggers_event_add:
             logger.info("'added' {} detected as expected.\n".format("events" if len(value_list) > 1 else "event"))
 
+            # Update the position of the log to the end of the scan
+            if time_travel:
+                log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                                  update_position=True,
+                                  error_message=f'End of scheduled scan not detected after '
+                                  f'{global_parameters.default_timeout} seconds')
+
         # Modify previous registry values
         for name, content in value_list.items():
             if name in registry_path:
@@ -1884,6 +1891,13 @@ if sys.platform == 'win32':
         if triggers_event_modified:
             logger.info("'modified' {} detected as expected.\n".format("events" if len(value_list) > 1 else "event"))
 
+            # Update the position of the log to the end of the scan
+            if time_travel:
+                log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                                  update_position=True,
+                                  error_message=f'End of scheduled scan not detected after '
+                                  f'{global_parameters.default_timeout} seconds')
+
         # Delete previous registry values
         for name, _ in value_list.items():
             if name in registry_path:
@@ -1897,6 +1911,12 @@ if sys.platform == 'win32':
         if triggers_event_delete:
             logger.info("'deleted' {} detected as expected.\n".format("events" if len(value_list) > 1 else "event"))
 
+            # Update the position of the log to the end of the scan
+            if time_travel:
+                log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                                  update_position=True,
+                                  error_message=f'End of scheduled scan not detected after '
+                                  f'{global_parameters.default_timeout} seconds')
 
     def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64KEY, key_list=['test_key'],
                          time_travel=False, min_timeout=1, options=None, triggers_event=True, triggers_event_add=True,
@@ -1991,6 +2011,13 @@ if sys.platform == 'win32':
         if triggers_event_add:
             logger.info("'added' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
 
+            # Update the position of the log to the end of the scan
+            if time_travel:
+                log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                                  update_position=True,
+                                  error_message=f'End of scheduled scan not detected after '
+                                  f'{global_parameters.default_timeout} seconds')
+
         # Modify previous registry subkeys
         for name, _ in key_list.items():
             if name in registry_path:
@@ -2005,6 +2032,13 @@ if sys.platform == 'win32':
         if triggers_event_modified:
             logger.info("'modified' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
 
+            # Update the position of the log to the end of the scan
+            if time_travel:
+                log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                                  update_position=True,
+                                  error_message=f'End of scheduled scan not detected after '
+                                  f'{global_parameters.default_timeout} seconds')
+
         # Delete previous registry subkeys
         for name, _ in key_list.items():
             if name in registry_path:
@@ -2017,6 +2051,13 @@ if sys.platform == 'win32':
 
         if triggers_event_delete:
             logger.info("'deleted' {} detected as expected.\n".format("events" if len(key_list) > 1 else "event"))
+
+            # Update the position of the log to the end of the scan
+            if time_travel:
+                log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
+                                  update_position=True,
+                                  error_message=f'End of scheduled scan not detected after '
+                                  f'{global_parameters.default_timeout} seconds')
 
 
 class CustomValidator:

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1295,10 +1295,8 @@ def callback_registry_count_entries(line):
 def callback_key_event(line):
     event = callback_detect_event(line)
 
-    if event is None:
-        return None
-
-    if event['data']['attributes']['type'] != 'registry_key' or event['data']['path'] == registry_ignore_path:
+    if (event is None or event['data']['attributes']['type'] != 'registry_key' or
+            event['data']['path'] == registry_ignore_path):
         return None
 
     return event
@@ -1307,10 +1305,7 @@ def callback_key_event(line):
 def callback_value_event(line):
     event = callback_detect_event(line)
 
-    if event is None:
-        return None
-
-    if event['data']['attributes']['type'] != 'registry_value':
+    if event is None or event['data']['attributes']['type'] != 'registry_value':
         return None
 
     return event
@@ -1661,8 +1656,10 @@ if sys.platform == 'win32':
                 self.check_events(event_type)
 
         def fetch_events(self, min_timeout=1, triggers_event=True, extra_timeout=0, error_message=''):
+            timeout_per_registry_estimation = 0.01
             try:
-                result = self.log_monitor.start(timeout=max((len(self.registry_dict)) * 0.01, min_timeout),
+                result = self.log_monitor.start(timeout=max((len(self.registry_dict)) * timeout_per_registry_estimation,
+                                                            min_timeout),
                                                 callback=self.callback,
                                                 accum_results=len(self.registry_dict),
                                                 timeout_extra=extra_timeout,
@@ -1701,9 +1698,8 @@ if sys.platform == 'win32':
             def check_events_type(events, ev_type, reg_list=['testkey0']):
                 event_types = Counter(filter_events(events, ".[].data.type"))
 
-                msg = f'Non expected number of events. {event_types[ev_type]} != {len(reg_list)}'
-
-                assert (event_types[ev_type] == len(reg_list)), msg
+                assert (event_types[ev_type] == len(reg_list)
+                        ), f'Non expected number of events. {event_types[ev_type]} != {len(reg_list)}'
 
             def check_events_key_path(events, registry_key, reg_list=['testkey0'], mode=None):
                 mode = global_parameters.current_configuration['metadata']['fim_mode'] if mode is None else mode
@@ -1838,7 +1834,7 @@ if sys.platform == 'win32':
                 aux_dict[key] = (elem, callback)
 
         else:
-            raise ValueError('It can only be list or dict')
+            raise ValueError('It can only be a list or dictionary')
 
         value_list = aux_dict
 
@@ -1959,7 +1955,7 @@ if sys.platform == 'win32':
             for key, elem in key_list.items():
                 aux_dict[key] = (elem, callback)
         else:
-            raise ValueError('It can only be list or dict')
+            raise ValueError('It can only be a list or dictionary')
 
         key_list = aux_dict
 

--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -1551,7 +1551,7 @@ class EventChecker:
 
         def check_events_type(events, ev_type, file_list=['testfile0']):
             event_types = Counter(filter_events(events, ".[].data.type"))
-            msg = f'Non expected number of events. {event_types[ev_type]} != {len(file_list)}'
+            msg = f"Non expected number of events. {event_types[ev_type]} != {len(file_list)}"
             assert (event_types[ev_type] == len(file_list)), msg
 
         def check_events_path(events, folder, file_list=['testfile0'], mode=None):
@@ -1563,7 +1563,7 @@ class EventChecker:
                     for index, item in enumerate(data_path):
                         data_path[index] = item.encode(encoding=self.encoding)
                 if sys.platform == 'darwin' and self.encoding and self.encoding != 'utf-8':
-                    logger.info(f'Not asserting {expected_path} in event.data.path. '
+                    logger.info(f"Not asserting {expected_path} in event.data.path. "
                                 f'Reason: using non-utf-8 encoding in darwin.')
                 else:
                     error_msg = f"Expected data path was '{expected_path}' but event data path is '{data_path}'"
@@ -1643,7 +1643,7 @@ if sys.platform == 'win32':
             error_msg += " but were not detected." if num_elems > 1 else " but was not detected."
 
             key_error_msg = f"TimeoutError was raised because 1 event was expected for {self.registry_key} "
-            key_error_msg += "but was not detected."
+            key_error_msg += 'but was not detected.'
 
             if event_type == 'modified' or self.is_value:
                 self.events = self.fetch_events(min_timeout, triggers_event, extra_timeout, error_message=error_msg)
@@ -1875,7 +1875,7 @@ if sys.platform == 'win32':
                 log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
                                   update_position=True,
                                   error_message=f'End of scheduled scan not detected after '
-                                  f'{global_parameters.default_timeout} seconds')
+                                  f"{global_parameters.default_timeout} seconds")
 
         # Modify previous registry values
         for name, content in value_list.items():
@@ -1916,7 +1916,7 @@ if sys.platform == 'win32':
                 log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
                                   update_position=True,
                                   error_message=f'End of scheduled scan not detected after '
-                                  f'{global_parameters.default_timeout} seconds')
+                                  f"{global_parameters.default_timeout} seconds")
 
     def registry_key_cud(root_key, registry_sub_key, log_monitor, arch=KEY_WOW64_64KEY, key_list=['test_key'],
                          time_travel=False, min_timeout=1, options=None, triggers_event=True, triggers_event_add=True,
@@ -2016,7 +2016,7 @@ if sys.platform == 'win32':
                 log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
                                   update_position=True,
                                   error_message=f'End of scheduled scan not detected after '
-                                  f'{global_parameters.default_timeout} seconds')
+                                  f"{global_parameters.default_timeout} seconds")
 
         # Modify previous registry subkeys
         for name, _ in key_list.items():
@@ -2037,7 +2037,7 @@ if sys.platform == 'win32':
                 log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
                                   update_position=True,
                                   error_message=f'End of scheduled scan not detected after '
-                                  f'{global_parameters.default_timeout} seconds')
+                                  f"{global_parameters.default_timeout} seconds")
 
         # Delete previous registry subkeys
         for name, _ in key_list.items():
@@ -2057,7 +2057,7 @@ if sys.platform == 'win32':
                 log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_end_scan,
                                   update_position=True,
                                   error_message=f'End of scheduled scan not detected after '
-                                  f'{global_parameters.default_timeout} seconds')
+                                  f"{global_parameters.default_timeout} seconds")
 
 
 class CustomValidator:

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_delete_registry.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_delete_registry.py
@@ -107,8 +107,8 @@ def test_delete_registry(key, subkey, arch, value_list,
     for ev in events:
         validate_registry_value_event(ev, mode=mode)
 
-    assert counter_type['deleted'] == len(value_list), f'Number of "deleted" events should be {len(value_list) + 1}'
+    assert counter_type['deleted'] == len(value_list), f'Number of "deleted" events should be {len(value_list)}'
 
-    name_list = set([event['data']['value_name'] for event in event_list[1:]])
+    name_list = set([event['data']['value_name'] for event in event_list])
     for value in value_list:
         assert value in name_list, f'Value {value} not found within the events'

--- a/tests/integration/test_fim/test_registry/test_registry_ignore/test_ignore_registry.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ignore/test_ignore_registry.py
@@ -6,9 +6,6 @@ import os
 
 import pytest
 from wazuh_testing import global_parameters, fim
-from wazuh_testing.fim import LOG_FILE_PATH, create_registry, registry_parser, \
-    KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params, callback_key_event, check_time_travel, \
-    modify_registry_value, REG_SZ, callback_value_event, callback_detect_end_scan
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 
@@ -27,7 +24,7 @@ ignore_value = "value_ignored"
 ignore_value_regex = "ignored_value$"
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+wazuh_log_monitor = FileMonitor(fim.LOG_FILE_PATH)
 test_regs = [os.path.join(key, subkey_1), os.path.join(key, subkey_2)]
 
 reg1, reg2 = test_regs
@@ -44,7 +41,7 @@ conf_params = {'WINDOWS_REGISTRY_1': reg1,
                'VALUE_IGNORE_REGEX': ignore_value_regex
                }
 configurations_path = os.path.join(test_data_path, 'wazuh_registry_ignore_conf.yaml')
-p, m = generate_params(extra_params=conf_params, modes=['scheduled'])
+p, m = fim.generate_params(extra_params=conf_params, modes=['scheduled'])
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
 
@@ -62,15 +59,15 @@ def get_configuration(request):
 
 
 @pytest.mark.parametrize('root_key, registry, arch, subkey, triggers_event, tags_to_apply', [
-    (key, subkey_1, KEY_WOW64_32KEY, "some_key", True, {'ignore_registry_key'}),
-    (key, subkey_1, KEY_WOW64_64KEY, "some_key", True, {'ignore_registry_key'}),
-    (key, subkey_1, KEY_WOW64_64KEY, ignore_key, False, {'ignore_registry_key'}),
-    (key, subkey_1, KEY_WOW64_32KEY, ignore_key, False, {'ignore_registry_key'}),
-    (key, subkey_1, KEY_WOW64_64KEY, "regex_ignored_key", False, {'ignore_registry_key'}),
-    (key, subkey_1, KEY_WOW64_32KEY, "regex_ignored_key", False, {'ignore_registry_key'}),
-    (key, subkey_2, KEY_WOW64_64KEY, "some_key", True, {'ignore_registry_key'}),
-    (key, subkey_2, KEY_WOW64_64KEY, ignore_key, False, {'ignore_registry_key'}),
-    (key, subkey_2, KEY_WOW64_64KEY, "regex_ignored_key", False, {'ignore_registry_key'})
+    (key, subkey_1, fim.KEY_WOW64_32KEY, "some_key", True, {'ignore_registry_key'}),
+    (key, subkey_1, fim.KEY_WOW64_64KEY, "some_key", True, {'ignore_registry_key'}),
+    (key, subkey_1, fim.KEY_WOW64_64KEY, ignore_key, False, {'ignore_registry_key'}),
+    (key, subkey_1, fim.KEY_WOW64_32KEY, ignore_key, False, {'ignore_registry_key'}),
+    (key, subkey_1, fim.KEY_WOW64_64KEY, "regex_ignored_key", False, {'ignore_registry_key'}),
+    (key, subkey_1, fim.KEY_WOW64_32KEY, "regex_ignored_key", False, {'ignore_registry_key'}),
+    (key, subkey_2, fim.KEY_WOW64_64KEY, "some_key", True, {'ignore_registry_key'}),
+    (key, subkey_2, fim.KEY_WOW64_64KEY, ignore_key, False, {'ignore_registry_key'}),
+    (key, subkey_2, fim.KEY_WOW64_64KEY, "regex_ignored_key", False, {'ignore_registry_key'})
 ])
 def test_ignore_registry_key(root_key, registry, arch, subkey, triggers_event, tags_to_apply,
                              get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start,
@@ -99,37 +96,37 @@ def test_ignore_registry_key(root_key, registry, arch, subkey, triggers_event, t
     fim.registry_ignore_path = os.path.join(root_key, registry)
 
     # Create registry
-    create_registry(registry_parser[root_key], os.path.join(registry, subkey), arch)
+    fim.create_registry(fim.registry_parser[root_key], os.path.join(registry, subkey), arch)
     # Go ahead in time to let syscheck perform a new scan
-    check_time_travel(scheduled, monitor=wazuh_log_monitor)
+    fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                        callback=callback_key_event,
+                                        callback=fim.callback_key_event,
                                         error_message='Did not receive expected '
                                                       '"Sending FIM event: ..." event').result()
         assert event['data']['type'] == 'added', 'Wrong event type.'
         assert event['data']['path'] == os.path.join(root_key, registry, subkey), 'Wrong key path.'
-        assert event['data']['arch'] == '[x32]' if arch == KEY_WOW64_32KEY else '[x64]', 'Wrong key arch.'
+        assert event['data']['arch'] == '[x32]' if arch == fim.KEY_WOW64_32KEY else '[x64]', 'Wrong key arch.'
 
     else:
         with pytest.raises(TimeoutError):
             event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=callback_key_event,
+                                            callback=fim.callback_key_event,
                                             error_message='Did not receive expected '
                                                           '"Sending FIM event: ..." event').result()
 
 
 @pytest.mark.parametrize('root_key, registry, arch, value, triggers_event, tags_to_apply', [
-    (key, subkey_1, KEY_WOW64_32KEY, "some_value", True, {'ignore_registry_value'}),
-    (key, subkey_1, KEY_WOW64_64KEY, "some_value", True, {'ignore_registry_value'}),
-    (key, subkey_1, KEY_WOW64_64KEY, "regex_ignored_value", False, {'ignore_registry_value'}),
-    (key, subkey_1, KEY_WOW64_32KEY, "regex_ignored_value", False, {'ignore_registry_value'}),
-    (key, subkey_2, KEY_WOW64_64KEY, "regex_ignored_value", False, {'ignore_registry_value'}),
-    (key, subkey_2, KEY_WOW64_64KEY, "some_value", True, {'ignore_registry_value'}),
-    (key, subkey_1, KEY_WOW64_32KEY, ignore_value, False, {'ignore_registry_value'}),
-    (key, subkey_1, KEY_WOW64_64KEY, ignore_value, False, {'ignore_registry_value'}),
-    (key, subkey_2, KEY_WOW64_64KEY, ignore_value, False, {'ignore_registry_value'})
+    (key, subkey_1, fim.KEY_WOW64_32KEY, "some_value", True, {'ignore_registry_value'}),
+    (key, subkey_1, fim.KEY_WOW64_64KEY, "some_value", True, {'ignore_registry_value'}),
+    (key, subkey_1, fim.KEY_WOW64_64KEY, "regex_ignored_value", False, {'ignore_registry_value'}),
+    (key, subkey_1, fim.KEY_WOW64_32KEY, "regex_ignored_value", False, {'ignore_registry_value'}),
+    (key, subkey_2, fim.KEY_WOW64_64KEY, "regex_ignored_value", False, {'ignore_registry_value'}),
+    (key, subkey_2, fim.KEY_WOW64_64KEY, "some_value", True, {'ignore_registry_value'}),
+    (key, subkey_1, fim.KEY_WOW64_32KEY, ignore_value, False, {'ignore_registry_value'}),
+    (key, subkey_1, fim.KEY_WOW64_64KEY, ignore_value, False, {'ignore_registry_value'}),
+    (key, subkey_2, fim.KEY_WOW64_64KEY, ignore_value, False, {'ignore_registry_value'})
 ])
 def test_ignore_registry_value(root_key, registry, arch, value, triggers_event, tags_to_apply,
                                get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
@@ -154,26 +151,26 @@ def test_ignore_registry_value(root_key, registry, arch, value, triggers_event, 
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     # Open the key (this shouldn't create an alert)
-    key_h = create_registry(registry_parser[root_key], registry, arch)
+    key_h = fim.create_registry(fim.registry_parser[root_key], registry, arch)
     # Create values
-    modify_registry_value(key_h, value, REG_SZ, "test_value")
+    fim.modify_registry_value(key_h, value, fim.REG_SZ, "test_value")
     # Go ahead in time to let syscheck perform a new scan
-    check_time_travel(scheduled, monitor=wazuh_log_monitor)
+    fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                        callback=callback_value_event,
+                                        callback=fim.callback_value_event,
                                         error_message='Did not receive expected '
                                                       '"Sending FIM event: ..." event').result()
 
         assert event['data']['type'] == 'added', 'Wrong event type.'
         assert event['data']['path'] == os.path.join(root_key, registry), 'Wrong value path.'
-        assert event['data']['arch'] == '[x32]' if arch == KEY_WOW64_32KEY else '[x64]', 'wrong key arch.'
+        assert event['data']['arch'] == '[x32]' if arch == fim.KEY_WOW64_32KEY else '[x64]', 'wrong key arch.'
         assert event['data']['value_name'] == value, 'Wrong value name'
 
     else:
         with pytest.raises(TimeoutError):
             event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                            callback=callback_value_event,
+                                            callback=fim.callback_value_event,
                                             error_message='Did not receive expected '
                                                           '"Sending FIM event: ..." event').result()

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
@@ -8,7 +8,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params, \
     callback_disk_quota_default, create_registry, registry_parser, modify_registry_value, \
-    check_time_travel, validate_registry_value_event, callback_detect_event, REG_SZ
+    check_time_travel, validate_registry_value_event, callback_value_event, REG_SZ
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -101,8 +101,8 @@ def test_disk_quota_default(key, subkey, arch, value_name, tags_to_apply,
 
     modify_registry_value(key_h, "some_value", REG_SZ, "some content")
     check_time_travel(True, monitor=wazuh_log_monitor)
-    events = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
-                                     accum_results=2, error_message='Did not receive expected '
-                                                                    '"Sending FIM event: ..." event').result()
-    for ev in events:
-        validate_registry_value_event(ev, mode=mode)
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_value_event,
+                                    error_message='Did not receive expected '
+                                                  '"Sending FIM event: ..." event').result()
+
+    validate_registry_value_event(event, mode=mode)

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
@@ -8,7 +8,7 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, KEY_WOW64_32KEY, KEY_WOW64_64KEY, generate_params, \
     callback_diff_size_limit_value, create_registry, registry_parser, modify_registry_value, \
-    check_time_travel, validate_registry_value_event, callback_detect_event, REG_SZ
+    check_time_travel, validate_registry_value_event, callback_value_event, REG_SZ
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -104,8 +104,7 @@ def test_file_size_default(key, subkey, arch, value_name, tags_to_apply,
 
     modify_registry_value(key_h, "some_value", REG_SZ, "some content")
     check_time_travel(True, monitor=wazuh_log_monitor)
-    events = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_event,
-                                     accum_results=2, error_message='Did not receive expected '
+    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_value_event,
+                                    error_message='Did not receive expected '
                                                                     '"Sending FIM event: ..." event').result()
-    for ev in events:
-        validate_registry_value_event(ev, mode=mode)
+    validate_registry_value_event(event, mode=mode)

--- a/tests/integration/test_fim/test_registry/test_registry_restrict/test_registry_restrict.py
+++ b/tests/integration/test_fim/test_registry/test_registry_restrict/test_registry_restrict.py
@@ -173,7 +173,7 @@ def test_restrict_key(key, subkey, test_subkey, arch, triggers_event, tags_to_ap
 
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                        callback=callback_detect_event, accum_results=1).result()
+                                        callback=callback_detect_event).result()
         assert event['data']['type'] == 'added', 'Event type not equal'
         assert event['data']['path'] == os.path.join(key, test_key), 'Event path not equal'
         assert event['data']['arch'] == '[x32]' if arch == KEY_WOW64_32KEY else '[x64]', 'Arch not equal'
@@ -193,7 +193,7 @@ def test_restrict_key(key, subkey, test_subkey, arch, triggers_event, tags_to_ap
 
     if triggers_event:
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                        callback=callback_detect_event, accum_results=1).result()
+                                        callback=callback_detect_event).result()
 
         assert event['data']['type'] == 'deleted', 'key event not equal'
         assert event['data']['path'] == os.path.join(key, test_key), 'Key event wrong path'


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1660|

## Environment
|OS|
|--|
|Windows|

## local_internal_options.conf

### Agent
```
windows.debug=2
monitord.rotate_log=0
```

### pytest_args
```
--tier 0 --tier 1 --tier 2
```

## Description

In Windows, testing registry entries has been challenging due to random events being generated from the "parent" key that holds the element being modified (the parent key triggers events since its mtime is changed but only if more than 1 second has elapsed from the last event). This PR solves some random failures in the registry integration tests by ignoring events from the parent key and focusing solely on the element being modified.

## Tests results

||Windows Agent|
|--|--|
|R1|[🟢](https://github.com/wazuh/wazuh-qa/files/6901039/fix-registry-rerun-0.zip)|
|R2|[🟢](https://github.com/wazuh/wazuh-qa/files/6901040/fix-registry-rerun-1.zip)|
|R3|[🟢](https://github.com/wazuh/wazuh-qa/files/6901041/fix-registry-rerun-2.zip)|
