### PR TITLE
Shutting down the agent socket before closing to avoid malformed messages errors

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -592,12 +592,12 @@ def check_queue_socket_event(raw_events=EXAMPLE_MESSAGE_PATTERN, timeout=30, upd
         control_service('start', daemon='wazuh-analysisd')
 
 
-def check_agent_received_message(message_queue, search_pattern, timeout=5, update_position=True, error_message='',
+def check_agent_received_message(agent, search_pattern, timeout=5, update_position=True, error_message='',
                                  escape=False):
     """Allow to monitor the agent received messages to search a pattern regex.
 
     Args:
-        message_queue (monitoring.Queue): Queue containing the messages received in the agent.
+        agent (Agent): Agent to monitor the received messages in its Queue.
         search_pattern (str): Regex to search in agent received messages.
         timeout (int): Maximum time in seconds to search the event.
         update_position (boolean): True to search in the entire queue, False to search in the current position of the
@@ -609,7 +609,7 @@ def check_agent_received_message(message_queue, search_pattern, timeout=5, updat
         TimeoutError: if search pattern is not found in agent received messages queue in the expected time.
 
     """
-    queue_monitor = monitoring.QueueMonitor(message_queue)
+    queue_monitor = monitoring.QueueMonitor(agent.rcv_msg_queue)
 
     queue_monitor.start(timeout=timeout, callback=monitoring.make_callback(search_pattern, '.*', escape),
                         update_position=update_position, error_message=error_message)
@@ -652,21 +652,21 @@ def check_push_shared_config(agent, sender, injector=None):
         sender.send_event(agent.keep_alive_event)
 
         # Check up file (push start) message
-        check_agent_received_message(agent.rcv_msg_queue, r'#!-up file \w+ merged.mg', timeout=10,
+        check_agent_received_message(agent, r'#!-up file \w+ merged.mg', timeout=10,
                                      error_message="initial up file message not received")
 
         # Check agent.conf message
-        check_agent_received_message(agent.rcv_msg_queue, '#default', timeout=10,
+        check_agent_received_message(agent, '#default', timeout=10,
                                      error_message="agent.conf message not received")
         # Check close file (push end) message
-        check_agent_received_message(agent.rcv_msg_queue, 'close', timeout=35,
+        check_agent_received_message(agent, 'close', timeout=35,
                                      error_message="initial close message not received")
 
         sender.send_event(agent.keep_alive_event)
 
         # Check that push message doesn't appear again
         with pytest.raises(TimeoutError):
-            check_agent_received_message(agent.rcv_msg_queue, r'#!-up file \w+ merged.mg', timeout=5)
+            check_agent_received_message(agent, r'#!-up file \w+ merged.mg', timeout=5)
             raise AssertionError("Same shared configuration pushed twice!")
 
         # Add agent to group and check if the configuration is pushed.
@@ -677,7 +677,7 @@ def check_push_shared_config(agent, sender, injector=None):
             sender.send_event(agent.keep_alive_event)
             time.sleep(1)
 
-        check_agent_received_message(agent.rcv_msg_queue, '#!-up file .* merged.mg', timeout=10,
+        check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=10,
                                      error_message="New group shared config not received")
 
     finally:

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1542,7 +1542,8 @@ class Injector:
         for thread in range(self.thread_number):
             self.threads[thread].stop_rec()
         sleep(2)
-        self.sender.socket.shutdown(socket.SHUT_RDWR)
+        if is_tcp(self.sender.protocol):
+            self.sender.socket.shutdown(socket.SHUT_RDWR)
         self.sender.socket.close()
 
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -1542,6 +1542,7 @@ class Injector:
         for thread in range(self.thread_number):
             self.threads[thread].stop_rec()
         sleep(2)
+        self.sender.socket.shutdown(socket.SHUT_RDWR)
         self.sender.socket.close()
 
 

--- a/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
@@ -53,8 +53,8 @@ def get_configuration(request):
 def test_active_response_ar_sending(get_configuration, configure_environment, restart_remoted):
     """Test if `wazuh-remoted` sends active response commands to the agent.
 
-    Check if execd sends active response command to the remoted module in the manager. Then, it ensures that the agent receives 
-    the active command message from the manager.
+    Check if execd sends active response command to the remoted module in the manager. Then, it
+    ensures that the agent receives the active command message from the manager.
 
     Raises:
         AssertionError: if `wazuh-remoted` does not send the active response command to the agent.
@@ -88,7 +88,6 @@ def test_active_response_ar_sending(get_configuration, configure_environment, re
             wazuh_log_monitor.start(timeout=10, callback=log_callback,
                                     error_message='The expected event has not been found in ossec.log')
 
-            remote.check_agent_received_message(agent.rcv_msg_queue, f"#!-execd {remote.ACTIVE_RESPONSE_EXAMPLE_COMMAND}",
-                                                                     escape=True)
+            remote.check_agent_received_message(agent, f"#!-execd {remote.ACTIVE_RESPONSE_EXAMPLE_COMMAND}", escape=True)
         finally:
             injector.stop_receive()

--- a/tests/integration/test_remoted/test_manager_messages/test_manager_ack.py
+++ b/tests/integration/test_remoted/test_manager_messages/test_manager_ack.py
@@ -81,7 +81,7 @@ def check_manager_ack(protocol):
         sender.send_event(agent.startup_msg)
 
         # Check ACK manager message
-        rd.check_agent_received_message(agent.rcv_msg_queue, '#!-agent ack')
+        rd.check_agent_received_message(agent, '#!-agent ack')
     finally:
         injector.stop_receive()
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-qa/issues/1571 |

## Description

This PR modifies the way in which the simulated agents are disconnected from the manager. This disconnection was done by calling the `close` function. But the python documentation states:

```
close() releases the resource associated with a connection but does not necessarily close the connection immediately. If you want to close the connection in a timely fashion, call shutdown() before close().
```

Considering that all the tests are executed under the same python process, it would probably use the same connection in the upcoming tests if the connection is not closed immediately. To avoid this scenario, this change adds the `shutdown` function before calling `close` only for the `TCP` sockets.

This change fixes the error reported in the next comment:
- For `test_active_response_send_ar`: https://github.com/wazuh/wazuh-qa/issues/1571#issuecomment-888261288 --- It is important to mention that the failure in this comment is not caused by the same issue that was causing the previous failures. The failure in this comment is a newly discovered issue that is fixed by this pull request.

## Configuration options

All the tests are run with the default test configuration and the following options in `local_internal_options.conf`

```
remoted.debug=2
wazuh_database.interval=1
wazuh_db.commit_time=2
wazuh_db.commit_time_max=3
monitord.rotate_log=0
```

## Tests

The comments will have the description for every test run

- [x] Proven that tests **pass** when they have to pass.