### PR TITLE
Exploratory testing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,7 @@ deps/wazuh_testing/wazuh_testing.egg-info/
 
 # DocGenerator default output path
 docs/output/
+# DocGenerator logs path
+docs/DocGenerator/logs
 
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,7 @@ deps/wazuh_testing/build/
 deps/wazuh_testing/dist/
 deps/wazuh_testing/wazuh_testing.egg-info/
 
-.idea/
+# DocGenerator default output path
+docs/output/
 
+.idea/

--- a/docs/DocGenerator/CodeParser.py
+++ b/docs/DocGenerator/CodeParser.py
@@ -44,12 +44,9 @@ class CodeParser:
 
         except Exception as inst:
             if hasattr(function, 'name'):
-                warnings.warn(f"Error parsing comment of function '{function.name}'' from module {self.scan_file}")
+                warnings.warn(f"Error parsing comment of function '{function.name}'' from module {self.scan_file}", stacklevel=2)
             else:
-                warnings.warn(f"Error parsing comment of module {self.scan_file}")
-            print(type(inst))
-            print(inst.args)
-            print(inst)
+                warnings.warn(f"Error parsing comment of module {self.scan_file}", stacklevel=2)
             doc = None
 
         return doc
@@ -79,7 +76,7 @@ class CodeParser:
                         functions_doc.append(function_doc)
 
             if not functions_doc:
-                warnings.warn("Module doesn´t contain any test function")
+                warnings.warn("Module doesn´t contain any test function", stacklevel=2)
 
             module_doc['Tests'] = functions_doc
 

--- a/docs/DocGenerator/CodeParser.py
+++ b/docs/DocGenerator/CodeParser.py
@@ -20,8 +20,8 @@ from comment_parser import comment_parser
 import warnings
 import logging
 
-INTERNAL_FIELDS = ['Id', 'Group Id', 'Name']
-STOP_FIELDS = ['Tests','Test Cases']
+INTERNAL_FIELDS = ['id', 'group_id', 'name']
+STOP_FIELDS = ['tests','test_cases']
 
 
 class CodeParser:
@@ -53,9 +53,9 @@ class CodeParser:
         """
         allowed_fields = self.conf.module_fields.mandatory + self.conf.module_fields.optional + INTERNAL_FIELDS
         remove_inexistent(doc, allowed_fields, STOP_FIELDS)
-        if 'Tests' in doc:
+        if 'tests' in doc:
             allowed_fields = self.conf.test_fields.mandatory + self.conf.test_fields.optional + INTERNAL_FIELDS
-            for test in doc['Tests']:
+            for test in doc['tests']:
                 remove_inexistent(test, allowed_fields, STOP_FIELDS)
 
     def parse_comment(self, function):
@@ -67,7 +67,7 @@ class CodeParser:
         try:
             doc = yaml.safe_load(docstring)
             if hasattr(function, 'name'):
-                doc['Name'] = function.name
+                doc['name'] = function.name
 
         except Exception as inst:
             if hasattr(function, 'name'):
@@ -99,9 +99,9 @@ class CodeParser:
 
         module_doc = self.parse_comment(module)
         if module_doc:
-            module_doc['Name'] = os.path.basename(code_file)
-            module_doc['Id'] = id
-            module_doc['Group Id'] = group_id
+            module_doc['name'] = os.path.basename(code_file)
+            module_doc['id'] = id
+            module_doc['group_id'] = group_id
 
             test_cases = None
             if self.conf.test_cases_field:
@@ -118,10 +118,10 @@ class CodeParser:
                         functions_doc.append(function_doc)
 
             if not functions_doc:
-                warnings.warn(f"Module '{module_doc['Name']}' doesn´t contain any test function", stacklevel=2)
-                logging.warning(f"Module '{module_doc['Name']}' doesn´t contain any test function")
+                warnings.warn(f"Module '{module_doc['name']}' doesn´t contain any test function", stacklevel=2)
+                logging.warning(f"Module '{module_doc['name']}' doesn´t contain any test function")
             else:
-                module_doc['Tests'] = functions_doc
+                module_doc['tests'] = functions_doc
 
             self.remove_ignored_fields(module_doc)
 
@@ -139,9 +139,9 @@ class CodeParser:
         with open(group_file) as fd:
             file_content = fd.read()
         group_doc = {}
-        group_doc['Name'] = os.path.basename(os.path.dirname(group_file))
-        group_doc['Id'] = id
-        group_doc['Group id'] = group_id
-        group_doc['Description'] = file_content
+        group_doc['name'] = os.path.basename(os.path.dirname(group_file))
+        group_doc['id'] = id
+        group_doc['group_id'] = group_id
+        group_doc['description'] = file_content
 
         return group_doc

--- a/docs/DocGenerator/CodeParser.py
+++ b/docs/DocGenerator/CodeParser.py
@@ -38,7 +38,8 @@ class CodeParser:
     def is_documentable_function(self, function):
         """
         brief: Checks if a specific method match with the regexes to be documented.
-        args: -"function (_ast.FunctionDef): Function class with all the information of the method"
+        args:
+            -"function (_ast.FunctionDef): Function class with all the information of the method"
         returns: "boolean: True if the method should be documentd. False otherwise"
         """
         for regex in self.function_regexes:
@@ -49,7 +50,8 @@ class CodeParser:
     def remove_ignored_fields(self, doc):
         """
         brief: Removes the fields from a parsed test file to delete the fields that are not mandatories or optionals
-        args: -"doc (dict): The parsed documentation block"
+        args:
+            -"doc (dict): The parsed documentation block"
         """
         allowed_fields = self.conf.module_fields.mandatory + self.conf.module_fields.optional + INTERNAL_FIELDS
         remove_inexistent(doc, allowed_fields, STOP_FIELDS)
@@ -61,7 +63,8 @@ class CodeParser:
     def parse_comment(self, function):
         """
         brief: Parses one self-contained documentation block.
-        args: -"function (_ast.FunctionDef): Function class with all the information of the method"
+        args:
+            -"function (_ast.FunctionDef): Function class with all the information of the method"
         """
         docstring = ast.get_docstring(function)
         try:

--- a/docs/DocGenerator/CodeParser.py
+++ b/docs/DocGenerator/CodeParser.py
@@ -68,14 +68,18 @@ class CodeParser:
             module_doc['Id'] = id
             module_doc['Group Id'] = group_id
 
-            test_cases = self.pytest.collect_test_cases(code_file)
+            test_cases = None
+            if self.conf.test_cases_field:
+                test_cases = self.pytest.collect_test_cases(code_file)
+
             functions_doc = []
             for function in functions:
                 if self.is_documentable_function(function):
                     function_doc = self.parse_comment(function)
                     if function_doc:
-                        if test_cases[function.name]:
-                            function_doc["Test Cases"] = test_cases[function.name]
+                        if test_cases and not self.conf.test_cases_field in function_doc \
+                           and test_cases[function.name]:
+                            function_doc[self.conf.test_cases_field] = test_cases[function.name]
                         functions_doc.append(function_doc)
 
             if not functions_doc:

--- a/docs/DocGenerator/Config.py
+++ b/docs/DocGenerator/Config.py
@@ -16,6 +16,7 @@ class Config():
         self.valid_tags = []
         self.module_fields = self.__fields()
         self.test_fields = self.__fields()
+        self.test_cases_field = None
 
         try:
             with open(CONFIG_PATH) as fd:
@@ -33,6 +34,7 @@ class Config():
         self.__read_ignore_paths()
         self.__read_valid_tags()
         self.__read_output_fields()
+        self.__read_test_cases_field()
 
     def __read_project_path(self):
         if 'Project path' in self.__config_data:
@@ -106,6 +108,10 @@ class Config():
             raise Exception("Config output fields is missing")
         self.__read_module_fields()
         self.__read_test_fields()
+
+    def __read_test_cases_field(self):
+        if 'Test cases field' in self.__config_data:
+            self.test_cases_field = self.__config_data['Test cases field']
     class __fields:
         def __init__(self):
             self.mandatory = []

--- a/docs/DocGenerator/Config.py
+++ b/docs/DocGenerator/Config.py
@@ -38,8 +38,8 @@ class Config():
             self.project_path = self.__config_data['Project path']
 
     def __read_documentation_path(self):
-        if 'Documentation path' in self.__config_data:
-            self.documentation_path = self.__config_data['Documentation path']
+        if 'Output path' in self.__config_data:
+            self.documentation_path = self.__config_data['Output path']
 
     def __read_include_paths(self):
         if not 'Include paths' in self.__config_data:
@@ -47,11 +47,7 @@ class Config():
         for include in self.__config_data['Include paths']:
             if not 'path' in include:
                 raise Exception("One include path is missing")
-            element = self.__paths()
-            element.path = include['path']
-            if 'recursive' in include:
-                element.recursive = include['recursive']
-            self.include_paths.append(element)
+            self.include_paths.append(include['path'] )
 
     def __read_include_regex(self):
         if not 'Include regex' in self.__config_data:
@@ -103,12 +99,6 @@ class Config():
             raise Exception("Output fields is missing")
         self.__read_module_fields()
         self.__read_test_fields()
-
-    class __paths:
-        def __init__(self):
-            self.path = []
-            self.recursive = True
-
     class __fields:
         def __init__(self):
             self.mandatory = []

--- a/docs/DocGenerator/Config.py
+++ b/docs/DocGenerator/Config.py
@@ -44,10 +44,7 @@ class Config():
     def __read_include_paths(self):
         if not 'Include paths' in self.__config_data:
             raise Exception("Include paths are empty")
-        for include in self.__config_data['Include paths']:
-            if not 'path' in include:
-                raise Exception("One include path is missing")
-            self.include_paths.append(include['path'] )
+        self.include_paths = self.__config_data['Include paths']
 
     def __read_include_regex(self):
         if not 'Include regex' in self.__config_data:

--- a/docs/DocGenerator/Config.py
+++ b/docs/DocGenerator/Config.py
@@ -1,3 +1,12 @@
+"""
+brief: Wazuh DocGenerator config parser.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+date: August 02, 2021
+license: This program is free software; you can redistribute it
+         and/or modify it under the terms of the GNU General Public
+         License (version 2) as published by the FSF - Free Software Foundation.
+"""
+
 import yaml
 import logging
 
@@ -5,6 +14,9 @@ CONFIG_PATH = "config.yaml"
 
 
 class Config():
+    """
+    brief: Class that parses the configuration file and exposes the available configurations.
+    """
     def __init__(self):
         self.project_path = "../.."
         self.documentation_path = ".."
@@ -14,73 +26,92 @@ class Config():
         self.function_regex = []
         self.ignore_paths = []
         self.valid_tags = []
-        self.module_fields = self.__fields()
-        self.test_fields = self.__fields()
+        self.module_fields = _fields()
+        self.test_fields = _fields()
         self.test_cases_field = None
 
         try:
             with open(CONFIG_PATH) as fd:
-                self.__config_data = yaml.safe_load(fd)
+                self._config_data = yaml.safe_load(fd)
         except:
             logging.error("Cannot load config file")
             raise Exception("Cannot load config file")
 
-        self.__read_project_path()
-        self.__read_documentation_path()
-        self.__read_include_paths()
-        self.__read_include_regex()
-        self.__read_group_files()
-        self.__read_function_regex()
-        self.__read_ignore_paths()
-        self.__read_valid_tags()
-        self.__read_output_fields()
-        self.__read_test_cases_field()
+        self._read_project_path()
+        self._read_documentation_path()
+        self._read_include_paths()
+        self._read_include_regex()
+        self._read_group_files()
+        self._read_function_regex()
+        self._read_ignore_paths()
+        self._read_output_fields()
+        self._read_test_cases_field()
 
-    def __read_project_path(self):
-        if 'Project path' in self.__config_data:
-            self.project_path = self.__config_data['Project path']
+    def _read_project_path(self):
+        """
+        brief: Reads from the config file the path of the project.
+        """
+        if 'Project path' in self._config_data:
+            self.project_path = self._config_data['Project path']
 
-    def __read_documentation_path(self):
-        if 'Output path' in self.__config_data:
-            self.documentation_path = self.__config_data['Output path']
+    def _read_documentation_path(self):
+        """
+        brief: Reads from the config file the path of the documentation output.
+        """
+        if 'Output path' in self._config_data:
+            self.documentation_path = self._config_data['Output path']
 
-    def __read_include_paths(self):
-        if not 'Include paths' in self.__config_data:
+    def _read_include_paths(self):
+        """
+        brief: Reads from the config file all the paths to be included in the parsing.
+        """
+        if not 'Include paths' in self._config_data:
             logging.error("Config include paths are empty")
             raise Exception("Config include paths are empty")
-        self.include_paths = self.__config_data['Include paths']
+        self.include_paths = self._config_data['Include paths']
 
-    def __read_include_regex(self):
-        if not 'Include regex' in self.__config_data:
+    def _read_include_regex(self):
+        """
+        brief: Reads from the config file the regexes used to identify test files.
+        """
+        if not 'Include regex' in self._config_data:
             logging.error("Config include regex is empty")
             raise Exception("Config include regex is empty")
-        self.include_regex = self.__config_data['Include regex']
+        self.include_regex = self._config_data['Include regex']
 
-    def __read_group_files(self):
-        if not 'Group files' in self.__config_data:
+    def _read_group_files(self):
+        """
+        brief: Reads from the config file the file name to be identified with a group.
+        """
+        if not 'Group files' in self._config_data:
             logging.error("Config group files is empty")
             raise Exception("Config group files is empty")
-        self.group_files = self.__config_data['Group files']
+        self.group_files = self._config_data['Group files']
 
-    def __read_function_regex(self):
-        if not 'Function regex' in self.__config_data:
+    def _read_function_regex(self):
+        """
+        brief: Reads from the config filefile the regexes used to identify a tes method.
+        """
+        if not 'Function regex' in self._config_data:
             logging.error("Config function regex is empty")
             raise Exception("Config function regex is empty")
-        self.function_regex = self.__config_data['Function regex']
+        self.function_regex = self._config_data['Function regex']
 
-    def __read_ignore_paths(self):
-        if 'Ignore paths' in self.__config_data:
-            self.ignore_paths = self.__config_data['Ignore paths']
+    def _read_ignore_paths(self):
+        """
+        brief: Reads from the config file all the paths to be excluded from the parsing.
+        """
+        if 'Ignore paths' in self._config_data:
+            self.ignore_paths = self._config_data['Ignore paths']
 
-    def __read_valid_tags(self):
-        if 'Valid tags' in self.__config_data:
-            self.valid_tags = self.__config_data['Valid tags']
-
-    def __read_module_fields(self):
-        if not 'Module' in self.__config_data['Output fields']:
+    def _read_module_fields(self):
+        """
+        brief: Reads from the config file the optional and mandatory fields for the test module.
+        """
+        if not 'Module' in self._config_data['Output fields']:
             logging.error("Config output module fields is missing")
             raise Exception("Config output module fields is missing")
-        module_fields = self.__config_data['Output fields']['Module']
+        module_fields = self._config_data['Output fields']['Module']
         if not 'Mandatory' in module_fields and not 'Optional' in module_fields:
             logging.error("Config output module fields are empty")
             raise Exception("Config output module fields are empty")
@@ -89,11 +120,14 @@ class Config():
         if 'Optional' in module_fields:
             self.module_fields.optional = module_fields['Optional']
 
-    def __read_test_fields(self):
-        if not 'Test' in self.__config_data['Output fields']:
+    def _read_test_fields(self):
+        """
+        brief: Reads from the config file the optional and mandatory fields for the test functions.
+        """
+        if not 'Test' in self._config_data['Output fields']:
             logging.error("Config output test fields is missing")
             raise Exception("Config output test fields is missing")
-        test_fields = self.__config_data['Output fields']['Test']
+        test_fields = self._config_data['Output fields']['Test']
         if not 'Mandatory' in test_fields and not 'Optional' in test_fields:
             logging.error("Config output test fields are empty")
             raise Exception("Config output test fields are empty")
@@ -102,17 +136,27 @@ class Config():
         if 'Optional' in test_fields:
             self.test_fields.optional = test_fields['Optional']
 
-    def __read_output_fields(self):
-        if not 'Output fields' in self.__config_data:
+    def _read_output_fields(self):
+        """
+        brief: Reads all the mandatory and optional fields.
+        """
+        if not 'Output fields' in self._config_data:
             logging.error("Config output fields is missing")
             raise Exception("Config output fields is missing")
-        self.__read_module_fields()
-        self.__read_test_fields()
+        self._read_module_fields()
+        self._read_test_fields()
 
-    def __read_test_cases_field(self):
-        if 'Test cases field' in self.__config_data:
-            self.test_cases_field = self.__config_data['Test cases field']
-    class __fields:
-        def __init__(self):
-            self.mandatory = []
-            self.optional = []
+    def _read_test_cases_field(self):
+        """
+        brief: Reads from the configuration file the key to identify a Test Case list.
+        """
+        if 'Test cases field' in self._config_data:
+            self.test_cases_field = self._config_data['Test cases field']
+
+class _fields:
+    """
+    brief: Struct for the documentation fields.
+    """
+    def __init__(self):
+        self.mandatory = []
+        self.optional = []

--- a/docs/DocGenerator/Config.py
+++ b/docs/DocGenerator/Config.py
@@ -1,5 +1,5 @@
-from collections import namedtuple
 import yaml
+import logging
 
 CONFIG_PATH = "config.yaml"
 
@@ -21,6 +21,7 @@ class Config():
             with open(CONFIG_PATH) as fd:
                 self.__config_data = yaml.safe_load(fd)
         except:
+            logging.error("Cannot load config file")
             raise Exception("Cannot load config file")
 
         self.__read_project_path()
@@ -43,22 +44,26 @@ class Config():
 
     def __read_include_paths(self):
         if not 'Include paths' in self.__config_data:
-            raise Exception("Include paths are empty")
+            logging.error("Config include paths are empty")
+            raise Exception("Config include paths are empty")
         self.include_paths = self.__config_data['Include paths']
 
     def __read_include_regex(self):
         if not 'Include regex' in self.__config_data:
-            raise Exception("Include regex is empty")
+            logging.error("Config include regex is empty")
+            raise Exception("Config include regex is empty")
         self.include_regex = self.__config_data['Include regex']
 
     def __read_group_files(self):
         if not 'Group files' in self.__config_data:
-            raise Exception("Group files is empty")
+            logging.error("Config group files is empty")
+            raise Exception("Config group files is empty")
         self.group_files = self.__config_data['Group files']
 
     def __read_function_regex(self):
         if not 'Function regex' in self.__config_data:
-            raise Exception("Function regex is empty")
+            logging.error("Config function regex is empty")
+            raise Exception("Config function regex is empty")
         self.function_regex = self.__config_data['Function regex']
 
     def __read_ignore_paths(self):
@@ -71,10 +76,12 @@ class Config():
 
     def __read_module_fields(self):
         if not 'Module' in self.__config_data['Output fields']:
-            raise Exception("Output module fields is missing")
+            logging.error("Config output module fields is missing")
+            raise Exception("Config output module fields is missing")
         module_fields = self.__config_data['Output fields']['Module']
         if not 'Mandatory' in module_fields and not 'Optional' in module_fields:
-            raise Exception("Output module fields are empty")
+            logging.error("Config output module fields are empty")
+            raise Exception("Config output module fields are empty")
         if 'Mandatory' in module_fields:
             self.module_fields.mandatory = module_fields['Mandatory']
         if 'Optional' in module_fields:
@@ -82,10 +89,12 @@ class Config():
 
     def __read_test_fields(self):
         if not 'Test' in self.__config_data['Output fields']:
-            raise Exception("Output test fields is missing")
+            logging.error("Config output test fields is missing")
+            raise Exception("Config output test fields is missing")
         test_fields = self.__config_data['Output fields']['Test']
         if not 'Mandatory' in test_fields and not 'Optional' in test_fields:
-            raise Exception("Output test fields are empty")
+            logging.error("Config output test fields are empty")
+            raise Exception("Config output test fields are empty")
         if 'Mandatory' in test_fields:
             self.test_fields.mandatory = test_fields['Mandatory']
         if 'Optional' in test_fields:
@@ -93,7 +102,8 @@ class Config():
 
     def __read_output_fields(self):
         if not 'Output fields' in self.__config_data:
-            raise Exception("Output fields is missing")
+            logging.error("Config output fields is missing")
+            raise Exception("Config output fields is missing")
         self.__read_module_fields()
         self.__read_test_fields()
     class __fields:

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -1,3 +1,12 @@
+"""
+brief: Wazuh DocGenerator tool.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+date: August 02, 2021
+license: This program is free software; you can redistribute it
+         and/or modify it under the terms of the GNU General Public
+         License (version 2) as published by the FSF - Free Software Foundation.
+"""
+
 import os
 import re
 import json
@@ -9,7 +18,12 @@ from Utils import clean_folder
 import warnings
 import logging
 
+
 class DocGenerator:
+    """
+    brief: Main class of DocGenerator tool.
+    It´s in charge of walk every test file, and every group file to dump the parsed documentation
+    """
     def __init__(self):
         self.conf = Config()
         self.parser = CodeParser()
@@ -22,12 +36,22 @@ class DocGenerator:
             self.include_regex.append(re.compile(include_regex))
 
     def is_valid_folder(self, path):
+        """
+        brief: Checks if a path should be ignored because its in the ignore list.
+        args: -"path (str): Folder location to be controlled"
+        returns: "boolean: False if the path should be ignored. True otherwise."
+        """
         for regex in self.ignore_regex:
             if regex.match(path):
                 return False
         return True
 
     def is_valid_file(self, path):
+        """
+        brief: Checks if a file path should be ignored because its in the ignore list or doesn´t match with the regexes.
+        args: -"path (str): File location to be controlled"
+        returns: "boolean: False if the path should be ignored. True otherwise."
+        """
         for regex in self.ignore_regex:
             if regex.match(path):
                 return False
@@ -41,26 +65,46 @@ class DocGenerator:
         return True
 
     def is_group_file(self, path):
+        """
+        brief: Checks if a file path should be considered as a file containing group information.
+        args: -"path (str): File location to be controlled"
+        returns: "boolean: True if the file is a group file. False otherwise."
+        """
         for group_file in self.conf.group_files:
             if path == group_file:
                 return True
         return False
 
     def get_group_doc_path(self, path):
+        """
+        brief: Returns the name of the group file in the documentation output based on the original file name.
+        args: -"path (str): The original file name"
+        returns: "string: The name of the documentation group file"
+        """
         base_path = os.path.join(self.conf.documentation_path, os.path.basename(self.scan_path))
-        relative_path = path.replace(self.scan_path, "")
-        group_dir = os.path.dirname(relative_path)
-        group_name = os.path.basename(group_dir)
-        doc_path = base_path+os.path.join(group_dir, group_name)+".group"
+        group_name = os.path.basename(self.scan_path)
+        doc_path = os.path.join(base_path,group_name+".group")
         return doc_path
 
     def get_test_doc_path(self, path):
+        """
+        brief: Returns the name of the test file in the documentation output based on the original file name.
+        args: -"path (str): The original file name"
+        returns: "string: The name of the documentation test file"
+        """
         base_path = os.path.join(self.conf.documentation_path, os.path.basename(self.scan_path))
         relative_path = path.replace(self.scan_path, "")
         doc_path = os.path.splitext(base_path + relative_path)[0]
         return doc_path
 
     def dump_output(self, content, doc_path):
+        """
+        brief: Creates a JSON and a YAML file with the parsed content of a test module.
+        It also creates the containing folder if it doesn´t exists.
+        args:
+            - "content (dict): The parsed content of a test file."
+            - "doc_path (string): The path where the information should be dumped."
+        """
         if not content:
             warnings.warn(f"Content for {doc_path} is empty, ignoring it", stacklevel=2)
             logging.warning(f"Content for {doc_path} is empty, ignoring it")
@@ -73,6 +117,13 @@ class DocGenerator:
             outfile.write(yaml.dump(content))
 
     def create_group(self, path, group_id):
+        """
+        brief: Parses the content of a group file and dumps the content into a file.
+        args:
+            - "path (string): The path of the group file to be parsed."
+            - "group_id (string): The id of the group where the new group belongs."
+        return "integer: The ID of the new generated group document.
+        """
         self.__id_counter = self.__id_counter + 1
         group = self.parser.parse_group(path, self.__id_counter, group_id)
         doc_path = self.get_group_doc_path(path)
@@ -81,6 +132,13 @@ class DocGenerator:
         return self.__id_counter
 
     def create_test(self, path, group_id):
+        """
+        brief: Parses the content of a test file and dumps the content into a file.
+        args:
+            - "path (string): The path of the test file to be parsed."
+            - "group_id (string): The id of the group where the new test belongs."
+        return "integer: The ID of the new generated test document.
+        """
         self.__id_counter = self.__id_counter + 1
         test = self.parser.parse_test(path, self.__id_counter, group_id)
         doc_path = self.get_test_doc_path(path)
@@ -89,6 +147,12 @@ class DocGenerator:
         return self.__id_counter
 
     def parse_folder(self, path, group_id):
+        """
+        brief: Search in a specific folder to parse possible group files and each test file
+        args:
+            - "path (string): The path of the folder to be parsed."
+            - "group_id (string): The id of the group where the new elements belong."
+        """
         if not os.path.exists(path):
             warnings.warn(f"Include path '{path}' doesn´t exist", stacklevel=2)
             logging.warning(f"Include path '{path}' doesn´t exist")
@@ -108,12 +172,16 @@ class DocGenerator:
             self.parse_folder(os.path.join(root,folder), group_id)
 
     def run(self):
+        """
+        brief: Run a complete scan of each include path to parse every test and group found.
+        """
         logging.info("\nStarting documentation parsing")
         clean_folder(self.conf.documentation_path)
         for path in self.conf.include_paths:
             self.scan_path = path
             logging.debug(f"Going to parse files on '{path}'")
             self.parse_folder(path, self.__id_counter)
+
 
 LOG_FOLDER = "logs"
 LOG_PATH = os.path.join(LOG_FOLDER, os.path.splitext(os.path.basename(__file__))[0]+".log" )

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -94,10 +94,9 @@ class DocGenerator:
             self.parse_folder(os.path.join(root,folder), group_id)
 
     def run(self):
-        for include in self.conf.include_paths:
-            self.scan_path = include.path
-            self.parse_folder(include.path, self.__id_counter)
-
+        for path in self.conf.include_paths:
+            self.scan_path = path
+            self.parse_folder(path, self.__id_counter)
 
 docs = DocGenerator()
 docs.run()

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -78,10 +78,9 @@ class DocGenerator:
                 return True
         return False
 
-    def get_group_doc_path(self, path):
+    def get_group_doc_path(self):
         """
         brief: Returns the name of the group file in the documentation output based on the original file name.
-        args: -"path (str): The original file name"
         returns: "string: The name of the documentation group file"
         """
         base_path = os.path.join(self.conf.documentation_path, os.path.basename(self.scan_path))
@@ -129,7 +128,7 @@ class DocGenerator:
         """
         self.__id_counter = self.__id_counter + 1
         group = self.parser.parse_group(path, self.__id_counter, group_id)
-        doc_path = self.get_group_doc_path(path)
+        doc_path = self.get_group_doc_path()
         self.dump_output(group, doc_path)
         logging.debug(f"New group file '{doc_path}' was created with ID:{self.__id_counter}")
         return self.__id_counter
@@ -197,8 +196,7 @@ if __name__ == '__main__':
     parser.add_argument('-s', help="Run a sanity check", action='store_true', dest='sanity')
     parser.add_argument('-v', help="Print version", action='store_true', dest="version")
     parser.add_argument('-t', help="Test configuration", action='store_true', dest='test_config')
-    parser.add_argument('-d', help="Enable debug messages. Use twice to increase verbosity.", action='count',
-                        dest='debug_level')
+    parser.add_argument('-d', help="Enable debug messages.", action='count', dest='debug_level')
     args = parser.parse_args()
 
     if args.debug_level:

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -14,10 +14,13 @@ import yaml
 import ast
 from Config import Config
 from CodeParser import CodeParser
+from Sanity import Sanity
 from Utils import clean_folder
 import warnings
 import logging
+import argparse
 
+VERSION = "0.1"
 
 class DocGenerator:
     """
@@ -182,12 +185,34 @@ class DocGenerator:
             logging.debug(f"Going to parse files on '{path}'")
             self.parse_folder(path, self.__id_counter)
 
+def start_logging(folder, debug_level=logging.INFO):
+    LOG_PATH = os.path.join(folder, os.path.splitext(os.path.basename(__file__))[0]+".log" )
+    if not os.path.exists(folder):
+        os.makedirs(folder)
+    logging.basicConfig(filename=LOG_PATH, level=debug_level)
 
-LOG_FOLDER = "logs"
-LOG_PATH = os.path.join(LOG_FOLDER, os.path.splitext(os.path.basename(__file__))[0]+".log" )
-if not os.path.exists(LOG_FOLDER):
-    os.makedirs(LOG_FOLDER)
-logging.basicConfig(filename=LOG_PATH, level=logging.DEBUG)
 
-docs = DocGenerator()
-docs.run()
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', help="Run a sanity check", action='store_true', dest='sanity')
+    parser.add_argument('-v', help="Print version", action='store_true', dest="version")
+    parser.add_argument('-t', help="Test configuration", action='store_true', dest='test_config')
+    parser.add_argument('-d', help="Enable debug messages. Use twice to increase verbosity.", action='count',
+                        dest='debug_level')
+    args = parser.parse_args()
+
+    if args.debug_level:
+        start_logging("logs", logging.DEBUG)
+    else:
+        start_logging("logs")
+
+    if args.version:
+        print(f"DocGenerator v{VERSION}")
+    elif args.test_config:
+        conf = Config()
+    elif args.sanity:
+        sanity = Sanity()
+        sanity.run()
+    else:
+        docs = DocGenerator()
+        docs.run()

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -41,7 +41,8 @@ class DocGenerator:
     def is_valid_folder(self, path):
         """
         brief: Checks if a path should be ignored because its in the ignore list.
-        args: -"path (str): Folder location to be controlled"
+        args:
+            - "path (str): Folder location to be controlled"
         returns: "boolean: False if the path should be ignored. True otherwise."
         """
         for regex in self.ignore_regex:
@@ -52,7 +53,8 @@ class DocGenerator:
     def is_valid_file(self, path):
         """
         brief: Checks if a file path should be ignored because its in the ignore list or doesn´t match with the regexes.
-        args: -"path (str): File location to be controlled"
+        args:
+            - "path (str): File location to be controlled"
         returns: "boolean: False if the path should be ignored. True otherwise."
         """
         for regex in self.ignore_regex:
@@ -70,7 +72,8 @@ class DocGenerator:
     def is_group_file(self, path):
         """
         brief: Checks if a file path should be considered as a file containing group information.
-        args: -"path (str): File location to be controlled"
+        args:
+            - "path (str): File location to be controlled"
         returns: "boolean: True if the file is a group file. False otherwise."
         """
         for group_file in self.conf.group_files:
@@ -91,7 +94,8 @@ class DocGenerator:
     def get_test_doc_path(self, path):
         """
         brief: Returns the name of the test file in the documentation output based on the original file name.
-        args: -"path (str): The original file name"
+        args:
+            - "path (str): The original file name"
         returns: "string: The name of the documentation test file"
         """
         base_path = os.path.join(self.conf.documentation_path, os.path.basename(self.scan_path))

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -6,6 +6,7 @@ import ast
 from Config import Config
 from CodeParser import CodeParser
 from Utils import clean_folder
+import warnings
 
 class DocGenerator:
     def __init__(self):
@@ -59,6 +60,9 @@ class DocGenerator:
         return doc_path
 
     def dump_output(self, content, doc_path):
+        if not content:
+            warnings.warn(f"Content for {doc_path} is empty, ignoring it")
+            return
         if not os.path.exists(os.path.dirname(doc_path)):
             os.makedirs(os.path.dirname(doc_path))
         with open(doc_path + ".json", "w+") as outfile:
@@ -81,6 +85,9 @@ class DocGenerator:
         return self.__id_counter
 
     def parse_folder(self, path, group_id):
+        if not os.path.exists(path):
+            warnings.warn(f"Include path '{path}' doesn´t exist")
+            return
         if not self.is_valid_folder(path):
             return
         (root, folders, files) = next(os.walk(path))

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -61,7 +61,7 @@ class DocGenerator:
 
     def dump_output(self, content, doc_path):
         if not content:
-            warnings.warn(f"Content for {doc_path} is empty, ignoring it")
+            warnings.warn(f"Content for {doc_path} is empty, ignoring it", stacklevel=2)
             return
         if not os.path.exists(os.path.dirname(doc_path)):
             os.makedirs(os.path.dirname(doc_path))
@@ -86,7 +86,7 @@ class DocGenerator:
 
     def parse_folder(self, path, group_id):
         if not os.path.exists(path):
-            warnings.warn(f"Include path '{path}' doesn´t exist")
+            warnings.warn(f"Include path '{path}' doesn´t exist", stacklevel=2)
             return
         if not self.is_valid_folder(path):
             return

--- a/docs/DocGenerator/DocGenerator.py
+++ b/docs/DocGenerator/DocGenerator.py
@@ -5,6 +5,7 @@ import yaml
 import ast
 from Config import Config
 from CodeParser import CodeParser
+from Utils import clean_folder
 
 class DocGenerator:
     def __init__(self):
@@ -94,6 +95,7 @@ class DocGenerator:
             self.parse_folder(os.path.join(root,folder), group_id)
 
     def run(self):
+        clean_folder(self.conf.documentation_path)
         for path in self.conf.include_paths:
             self.scan_path = path
             self.parse_folder(path, self.__id_counter)

--- a/docs/DocGenerator/PytestWrap.py
+++ b/docs/DocGenerator/PytestWrap.py
@@ -34,7 +34,8 @@ class PytestWrap:
     def collect_test_cases(self, path):
         """
         brief: "Executes pytest in 'collect-only' mode to extract all the test cases found for a test file.
-        args: - "path (string): Path of the test file to extract the test cases.
+        args:
+            - "path (string): Path of the test file to extract the test cases.
         returns: "dictionary: The output of pytest parsed into a dictionary"
         """
         logging.debug(f"Running pytest to collect testcases for '{path}'")

--- a/docs/DocGenerator/PytestWrap.py
+++ b/docs/DocGenerator/PytestWrap.py
@@ -1,19 +1,42 @@
+"""
+brief: Wazuh pytest wrapper.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+date: August 02, 2021
+license: This program is free software; you can redistribute it
+         and/or modify it under the terms of the GNU General Public
+         License (version 2) as published by the FSF - Free Software Foundation.
+"""
+
 import pytest
 import logging
 
 class PytestPlugin:
+    """
+    brief: Plugin to extract information from a pytest eecution
+    """
     def __init__(self):
         self.collected = []
 
     def pytest_collection_modifyitems(self, items):
+        """
+        brief: Callback to receive the output of a pytest execution
+        """
         for item in items:
             self.collected.append(item.nodeid)
 
 class PytestWrap:
+    """
+    brief: Class that wraps the execution of pytest
+    """
     def __init__(self):
         self.plugin = PytestPlugin()
 
     def collect_test_cases(self, path):
+        """
+        brief: "Executes pytest in 'collect-only' mode to extract all the test cases found for a test file.
+        args: - "path (string): Path of the test file to extract the test cases.
+        returns: "dictionary: The output of pytest parsed into a dictionary"
+        """
         logging.debug(f"Running pytest to collect testcases for '{path}'")
         pytest.main(['--collect-only', "-qq", path], plugins=[self.plugin])
         output = {}

--- a/docs/DocGenerator/PytestWrap.py
+++ b/docs/DocGenerator/PytestWrap.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 class PytestPlugin:
     def __init__(self):
@@ -8,11 +9,12 @@ class PytestPlugin:
         for item in items:
             self.collected.append(item.nodeid)
 
-class TestCaseParser:
+class PytestWrap:
     def __init__(self):
         self.plugin = PytestPlugin()
 
-    def collect(self, path):
+    def collect_test_cases(self, path):
+        logging.debug(f"Running pytest to collect testcases for '{path}'")
         pytest.main(['--collect-only', "-qq", path], plugins=[self.plugin])
         output = {}
         for item in self.plugin.collected:

--- a/docs/DocGenerator/Sanity.py
+++ b/docs/DocGenerator/Sanity.py
@@ -22,9 +22,20 @@ class Sanity():
             raise Exception(f"Cannot load {full_path} file")
 
     def validate_fields(self, required_fields, available_fields):
-        for field in required_fields:
-            if not check_existance(available_fields, field):
-                self.add_report(f"Mandatory field '{field}' is missing in file {self.scan_file}")
+        if isinstance(required_fields, dict):
+            for field in required_fields:
+                if not check_existance(available_fields, field):
+                    self.add_report(f"Mandatory field '{field}' is missing in file {self.scan_file}")
+                elif isinstance(required_fields[field], dict) or  isinstance(required_fields[field], list):
+                    self.validate_fields(required_fields[field], available_fields)
+        elif isinstance(required_fields, list):
+            for field in required_fields:
+                if isinstance(field, dict) or isinstance(field, list):
+                    self.validate_fields(field, available_fields)
+                else:
+                    if not check_existance(available_fields, field):
+                        self.add_report(f"Mandatory field '{field}' is missing in file {self.scan_file}")
+
 
     def validate_module_fields(self, fields):
         self.validate_fields(self.conf.module_fields.mandatory, fields)

--- a/docs/DocGenerator/Sanity.py
+++ b/docs/DocGenerator/Sanity.py
@@ -6,6 +6,7 @@ license: This program is free software; you can redistribute it
          and/or modify it under the terms of the GNU General Public
          License (version 2) as published by the FSF - Free Software Foundation.
 """
+
 from Config import Config
 import os
 import re
@@ -13,6 +14,8 @@ import json
 import ast
 import logging
 from Utils import check_existance
+
+
 class Sanity():
     """
     brief: Class in charge of performing a general sanity check on the already parsed documentation.
@@ -30,7 +33,8 @@ class Sanity():
     def get_content(self, full_path):
         """
         brief: Loads a documentation file into a JSON dictionary.
-        args: -"full_path (str): The documentation file."
+        args:
+            - "full_path (str): The documentation file."
         """
         try:
             with open(full_path) as file:
@@ -64,18 +68,19 @@ class Sanity():
                         self.add_report(f"Mandatory field '{field}' is missing in file {self.scan_file}")
                         logging.error(f"Mandatory field '{field}' is missing in file {self.scan_file}")
 
-
     def validate_module_fields(self, fields):
         """
         brief: Checks if all the mandatory module fields are present.
-        args: - "fields(dict): The module fields found in the documentation file."
+        args:
+            - "fields(dict): The module fields found in the documentation file."
         """
         self.validate_fields(self.conf.module_fields.mandatory, fields)
 
     def validate_test_fields(self, fields):
         """
         brief: Checks if all the mandatory test fields are present.
-        args: - "fields(dict): The test fields found in the documentation file."
+        args:
+            - "fields(dict): The test fields found in the documentation file."
         """
         if 'tests' in fields:
             for test_fields in fields['tests']:
@@ -84,7 +89,8 @@ class Sanity():
     def identify_tags(self, content):
         """
         brief: Identifies every new tag found in the documentation files and saves it for future reporting.
-        args: - "content(dict): The dictionary content of a documentation file."
+        args:
+            - "content(dict): The dictionary content of a documentation file."
         """
         if 'metadata' in content and 'tags' in content['metadata']:
             for tag in content['metadata']['tags']:
@@ -93,7 +99,8 @@ class Sanity():
     def identify_tests(self, content):
         """
         brief: Identifies every new test found in the documentation files and saves it for future reporting.
-        args: - "content(dict): The dictionary content of a documentation file."
+        args:
+            - "content(dict): The dictionary content of a documentation file."
         """
         if 'tests' in content:
             for test in content['tests']:
@@ -127,7 +134,8 @@ class Sanity():
     def add_report(self, message):
         """
         brief: Adds a new entry to the report.
-        args: - "message (string): Message to be included in the report."
+        args:
+            - "message (string): Message to be included in the report."
         """
         self.error_reports.append(message)
 

--- a/docs/DocGenerator/Sanity.py
+++ b/docs/DocGenerator/Sanity.py
@@ -3,7 +3,7 @@ import os
 import re
 import json
 import ast
-
+from Utils import check_existance
 class Sanity():
     def __init__(self,):
         self.conf = Config()
@@ -23,13 +23,7 @@ class Sanity():
 
     def validate_fields(self, required_fields, available_fields):
         for field in required_fields:
-            if isinstance(field, dict):
-                for key in field:
-                    if key in available_fields:
-                        self.validate_fields(field[key], available_fields[key])
-                    else:
-                        self.add_report(f"Mandatory field '{key}' is missing in file {self.scan_file}")
-            elif not field in available_fields:
+            if not check_existance(available_fields, field):
                 self.add_report(f"Mandatory field '{field}' is missing in file {self.scan_file}")
 
     def validate_module_fields(self, fields):
@@ -40,7 +34,7 @@ class Sanity():
             self.validate_fields(self.conf.test_fields.mandatory, test_fields)
 
     def identify_tags(self, content):
-        if 'Tags' in content['Metadata']:
+        if 'Metadata' in content and 'Tags' in content['Metadata']:
             for tag in content['Metadata']['Tags']:
                 self.found_tags.add(tag)
 

--- a/docs/DocGenerator/Sanity.py
+++ b/docs/DocGenerator/Sanity.py
@@ -77,8 +77,8 @@ class Sanity():
         brief: Checks if all the mandatory test fields are present.
         args: - "fields(dict): The test fields found in the documentation file."
         """
-        if 'Tests' in fields:
-            for test_fields in fields['Tests']:
+        if 'tests' in fields:
+            for test_fields in fields['tests']:
                 self.validate_fields(self.conf.test_fields.mandatory, test_fields)
 
     def identify_tags(self, content):
@@ -86,8 +86,8 @@ class Sanity():
         brief: Identifies every new tag found in the documentation files and saves it for future reporting.
         args: - "content(dict): The dictionary content of a documentation file."
         """
-        if 'Metadata' in content and 'Tags' in content['Metadata']:
-            for tag in content['Metadata']['Tags']:
+        if 'metadata' in content and 'tags' in content['metadata']:
+            for tag in content['metadata']['tags']:
                 self.found_tags.add(tag)
 
     def identify_tests(self, content):
@@ -95,9 +95,9 @@ class Sanity():
         brief: Identifies every new test found in the documentation files and saves it for future reporting.
         args: - "content(dict): The dictionary content of a documentation file."
         """
-        if 'Tests' in content:
-            for test in content['Tests']:
-                self.found_tests.add(test['Name'])
+        if 'tests' in content:
+            for test in content['tests']:
+                self.found_tests.add(test['name'])
 
     def count_project_tests(self):
         """
@@ -175,7 +175,7 @@ class Sanity():
                     self.validate_test_fields(content)
                     self.identify_tags(content)
                     self.identify_tests(content)
-                    self.found_modules.add(content['Name'])
+                    self.found_modules.add(content['name'])
 
         self.count_project_tests()
         self.print_report()

--- a/docs/DocGenerator/TestCaseParser.py
+++ b/docs/DocGenerator/TestCaseParser.py
@@ -27,7 +27,3 @@ class TestCaseParser:
                 test_case = tmp[0]
                 output[test].append(test_case)
         return output
-
-
-test = TestCaseParser()
-test.collect("../../tests/integration/test_wazuh_db/test_wazuh_db.py")

--- a/docs/DocGenerator/TestCaseParser.py
+++ b/docs/DocGenerator/TestCaseParser.py
@@ -13,7 +13,7 @@ class TestCaseParser:
         self.plugin = PytestPlugin()
 
     def collect(self, path):
-        pytest.main(['--collect-only', path], plugins=[self.plugin])
+        pytest.main(['--collect-only', "-qq", path], plugins=[self.plugin])
         output = {}
         for item in self.plugin.collected:
             tmp = item.split("::")

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -1,0 +1,100 @@
+def check_existance(source, key):
+    if not isinstance(source, dict) and not isinstance(source, list):
+        return False
+
+    if key in source:
+        return True
+    elif isinstance(source, dict):
+
+        for item in source:
+            if check_existance(source[item], key):
+                return True
+        return False
+    elif isinstance(source, list):
+        for item in source:
+            if check_existance(item, key):
+                return True
+        return False
+    else:
+        return False
+
+def remove_inexistent(source, keys):
+    for element in list(source):
+        if element not in keys:
+            del source[element]
+        else:
+            if isinstance(source[element], dict):
+                remove_inexistent(source[element], keys)
+
+def get_keys_dict(dic):
+    keys = []
+    for item in dic:
+        value = dic[item]
+        if isinstance(value, dict):
+            result = get_keys_dict(value)
+            keys.append({item : result})
+        elif isinstance(value, list):
+            result = get_keys_list(value)
+            keys.append({item : result})
+        else:
+            keys.append(item)
+
+    if len(keys) == 1:
+        return keys[0]
+    else:
+        return keys
+
+def get_keys_list(dic):
+    keys = []
+    for item in dic:
+        if isinstance(item, dict):
+            result = get_keys_dict(item)
+            keys.append(result)
+        elif isinstance(item, list):
+            result = get_keys_list(item)
+            keys.append(result)
+        else:
+            keys.append(item)
+
+    if len(keys) == 1:
+        return keys[0]
+    else:
+        return keys
+
+def find_item(search_item, check):
+    for item in check:
+        if isinstance(item, dict):
+            list_element = list(item.keys())
+            if search_item == list_element[0]:
+                return list(item.values())[0]
+        else:
+            if search_item == item:
+                return item
+    return None
+
+def check_missing_field(source, check):
+    missing_filed = None
+    for source_field in source:
+        if isinstance(source_field, dict):
+            key = list(source_field.keys())[0]
+            found_item = find_item(key, check)
+            if not found_item:
+                print(f"Missing key {source_field}")
+                return key
+            missing_filed = check_missing_field(source_field[key], found_item)
+            if missing_filed:
+                return missing_filed
+        elif isinstance(source_field, list):
+            missing_filed = None
+            for check_element in check:
+                missing_filed = check_missing_field(source_field, check_element)
+                if not missing_filed:
+                    break
+            if missing_filed:
+                return source_field
+        else:
+            found_item = find_item(source_field, check)
+            if not found_item:
+                print(f"Missing key {source_field}")
+                return source_field
+    return missing_filed

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -1,4 +1,6 @@
 import os, shutil
+import logging
+import warnings
 
 def check_existance(source, key):
     if not isinstance(source, dict) and not isinstance(source, list):
@@ -104,6 +106,7 @@ def check_missing_field(source, check):
 def clean_folder(folder):
     if not os.path.exists(folder):
         return
+    logging.debug(f"Going to clean '{folder}' folder")
     for filename in os.listdir(folder):
         file_path = os.path.join(folder, filename)
         try:
@@ -112,4 +115,5 @@ def clean_folder(folder):
             elif os.path.isdir(file_path):
                 shutil.rmtree(file_path)
         except Exception as e:
-            print('Failed to delete %s. Reason: %s' % (file_path, e))
+            warnings.warn(f"Failed to delete {file_path}. Reason: {e}")
+            logging.error(f"Failed to delete {file_path}. Reason: {e}")

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -1,3 +1,5 @@
+import os, shutil
+
 def check_existance(source, key):
     if not isinstance(source, dict) and not isinstance(source, list):
         return False
@@ -98,3 +100,14 @@ def check_missing_field(source, check):
                 print(f"Missing key {source_field}")
                 return source_field
     return missing_filed
+
+def clean_folder(folder):
+    for filename in os.listdir(folder):
+        file_path = os.path.join(folder, filename)
+        try:
+            if os.path.isfile(file_path) or os.path.islink(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            print('Failed to delete %s. Reason: %s' % (file_path, e))

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -1,8 +1,23 @@
+"""
+brief: Wazuh DocGeneratot utils module
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+date: August 02, 2021
+license: This program is free software; you can redistribute it
+         and/or modify it under the terms of the GNU General Public
+         License (version 2) as published by the FSF - Free Software Foundation.
+"""
+
 import os, shutil
 import logging
 import warnings
 
 def check_existance(source, key):
+    """
+        brief: Checks recursively if a key exists into a dictionary.
+        args:
+            - "source (dict): The source dictionary where the key should be found."
+            - "key (string): The name of the key to look into the source dictionary."
+    """
     if not isinstance(source, dict) and not isinstance(source, list):
         return False
 
@@ -22,6 +37,13 @@ def check_existance(source, key):
         return False
 
 def remove_inexistent(source, check_list, stop_list=None):
+    """
+        brief: Checks recursively if a source dictionary contains invalid keys that must be deleted.
+        args:
+            - "source (dict): The source dictionary where the key should be found."
+            - "check_list (dict): Dictionary with all the valid keys."
+            - "check_list (list): Keys where the recursive must finish"
+    """
     for element in list(source):
         if stop_list and element in stop_list:
             break
@@ -30,10 +52,14 @@ def remove_inexistent(source, check_list, stop_list=None):
         elif isinstance(source[element], dict):
             remove_inexistent(source[element], check_list, stop_list)
 
-def get_keys_dict(dic):
+def get_keys_dict(_dic):
+    """
+        brief: Flat a dictionary into a list of its keys
+        args: - "_dic (dict): The source dictionary to be flattened."
+    """
     keys = []
-    for item in dic:
-        value = dic[item]
+    for item in _dic:
+        value = _dic[item]
         if isinstance(value, dict):
             result = get_keys_dict(value)
             keys.append({item : result})
@@ -48,9 +74,13 @@ def get_keys_dict(dic):
     else:
         return keys
 
-def get_keys_list(dic):
+def get_keys_list(_list):
+    """
+        brief: Flat a list of dictionaries into a list of its keys
+        args: - "_list (list): The source list to be flattened."
+    """
     keys = []
-    for item in dic:
+    for item in _list:
         if isinstance(item, dict):
             result = get_keys_dict(item)
             keys.append(result)
@@ -66,6 +96,13 @@ def get_keys_list(dic):
         return keys
 
 def find_item(search_item, check):
+    """
+        brief: Search for a specific key into a list of dictionaries or values
+        args:
+              - "search_item (string): The key to be found."
+              - "check (list): A list of dictionaries or values where the key should be found."
+        returns: None if the key couldn´t be found. The value of the finding.
+    """
     for item in check:
         if isinstance(item, dict):
             list_element = list(item.keys())
@@ -77,6 +114,12 @@ def find_item(search_item, check):
     return None
 
 def check_missing_field(source, check):
+    """
+        brief: Checks recursively if a source dictionary contains all the expected keys.
+        args:
+            - "source (dict): The source dictionary where the key should be found."
+            - "check (list): The expected keys."
+    """
     missing_filed = None
     for source_field in source:
         if isinstance(source_field, dict):
@@ -104,6 +147,11 @@ def check_missing_field(source, check):
     return missing_filed
 
 def clean_folder(folder):
+    """
+        brief: Completely cleans the content into a folder.
+        args:
+            - "folder (string): The path of the folder to be cleaned."
+    """
     if not os.path.exists(folder):
         return
     logging.debug(f"Going to clean '{folder}' folder")

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -55,7 +55,8 @@ def remove_inexistent(source, check_list, stop_list=None):
 def get_keys_dict(_dic):
     """
         brief: Flat a dictionary into a list of its keys
-        args: - "_dic (dict): The source dictionary to be flattened."
+        args:
+            - "_dic (dict): The source dictionary to be flattened."
     """
     keys = []
     for item in _dic:
@@ -77,7 +78,8 @@ def get_keys_dict(_dic):
 def get_keys_list(_list):
     """
         brief: Flat a list of dictionaries into a list of its keys
-        args: - "_list (list): The source list to be flattened."
+        args:
+            - "_list (list): The source list to be flattened."
     """
     keys = []
     for item in _list:

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -5,7 +5,6 @@ def check_existance(source, key):
     if key in source:
         return True
     elif isinstance(source, dict):
-
         for item in source:
             if check_existance(source[item], key):
                 return True
@@ -18,13 +17,14 @@ def check_existance(source, key):
     else:
         return False
 
-def remove_inexistent(source, keys):
+def remove_inexistent(source, check_list, stop_list=None):
     for element in list(source):
-        if element not in keys:
+        if stop_list and element in stop_list:
+            break
+        if not check_existance(check_list, element):
             del source[element]
-        else:
-            if isinstance(source[element], dict):
-                remove_inexistent(source[element], keys)
+        elif isinstance(source[element], dict):
+            remove_inexistent(source[element], check_list, stop_list)
 
 def get_keys_dict(dic):
     keys = []

--- a/docs/DocGenerator/Utils.py
+++ b/docs/DocGenerator/Utils.py
@@ -102,6 +102,8 @@ def check_missing_field(source, check):
     return missing_filed
 
 def clean_folder(folder):
+    if not os.path.exists(folder):
+        return
     for filename in os.listdir(folder):
         file_path = os.path.join(folder, filename)
         try:

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -1,6 +1,6 @@
 Project path: "../../tests/integration"
 
-Documentation path: "../output"
+Output path: "../output"
 
 Include paths:
   - wazuh_db:
@@ -18,7 +18,6 @@ Function regex:
 
 Ignore paths:
   - "../../tests/integration/test_wazuh_db/data"
-  - "/data/*"
 
 Output fields:
   Module:

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -21,19 +21,19 @@ Ignore paths:
 Output fields:
   Module:
     Mandatory:
-      - Brief
-      - Metadata:
-        - Modules
-        - Daemons
-        - Operating System
-        - Tiers
+      - brief
+      - metadata:
+        - modules
+        - daemons
+        - operating_system
+        - tiers
     Optional:
-      - Tags
+      - tags
   Test:
     Mandatory:
-      - Test Logic
-      - Checks
+      - test_logic
+      - checks
     Optional:
-      - Expected result
+      - expected_result
 
-Test cases field: "Test Cases"
+Test cases field: "test_cases"

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -35,3 +35,5 @@ Output fields:
       - Checks
     Optional:
       - Expected result
+
+Test cases field: "Test Cases"

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -3,11 +3,8 @@ Project path: "../../tests/integration"
 Output path: "../output"
 
 Include paths:
-  - wazuh_db:
-    path: "../../tests/integration/test_wazuh_db"
-
-  - vulnerability_detector:
-    path: "../../tests/integration/test_vulnerability_detector"
+  - "../../tests/integration/test_wazuh_db"
+  - "../../tests/integration/test_vulnerability_detector"
 
 Include regex:
   - "^test_.*py$"

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -6,8 +6,6 @@ Include paths:
   - wazuh_db:
     path: "../../tests/integration/test_wazuh_db"
     recursive: false
-  - vulnerability_detector:
-    path: "../../tests/integration/test_vulnerability_detector"
 
 Include regex:
   - "^test_.*py$"
@@ -22,24 +20,15 @@ Ignore paths:
   - "../../tests/integration/test_wazuh_db/data"
   - "/data/*"
 
-Valid tags:
-  - DB
-  - Feeds
-  - VulDet
-  - Vulnerability Detector
-
 Output fields:
   Module:
     Mandatory:
       - Brief
-      - Metadata:
-        - Modules
-        - Daemons
-        - Operating System
-        - Tiers
-        - Demo:
-          - One
-          - Two
+      - Metadata
+      - Modules
+      - Daemons
+      - Operating System
+      - Tiers
     Optional:
       - Tags
   Test:

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -5,7 +5,9 @@ Output path: "../output"
 Include paths:
   - wazuh_db:
     path: "../../tests/integration/test_wazuh_db"
-    recursive: false
+
+  - vulnerability_detector:
+    path: "../../tests/integration/test_vulnerability_detector"
 
 Include regex:
   - "^test_.*py$"

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -24,11 +24,11 @@ Output fields:
   Module:
     Mandatory:
       - Brief
-      - Metadata
-      - Modules
-      - Daemons
-      - Operating System
-      - Tiers
+      - Metadata:
+        - Modules
+        - Daemons
+        - Operating System
+        - Tiers
     Optional:
       - Tags
   Test:

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -1,6 +1,29 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+Brief: Module description
+
+COPYRIGHT:
+    Copyright (C) 2015-2021, Wazuh Inc.
+
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+Metadata:
+    Modules:
+        - Wazuh DB
+    Daemons:
+        - wazuh_db
+    Operating System:
+        - Windows
+        - Ubuntu
+    Wazuh Max Version: 4.0.0
+    Wazuh Min Version: 4.1.5
+    Tiers:
+        - 0
+        - 1
+    Tags:
+        - Enrollment
+'''
 
 import os
 import re
@@ -83,13 +106,15 @@ def pre_insert_agents():
                               for case in module_data]
                          )
 def test_wazuh_db_messages(configure_sockets_environment, connect_to_sockets_module, test_case: list):
-    """Check that every input message in wazuh-db socket generates the adequate output to wazuh-db socket
-
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys).
     """
+    Test Logic:
+        "Check that every input message in wazuh-db socket generates the adequate output to wazuh-db socket"
+    Parameters:
+        - test_case:
+            type: list
+            brief: List of test_case stages (dicts with input, output and stage keys).
+    """
+
     for index, stage in enumerate(test_case):
         if 'ignore' in stage and stage['ignore'] == "yes":
             continue
@@ -106,8 +131,22 @@ def test_wazuh_db_messages(configure_sockets_environment, connect_to_sockets_mod
             .format(index + 1, stage['stage'], expected, response)
 
 
-def test_wazuh_db_create_agent(configure_sockets_environment, connect_to_sockets_module):
-    """Check that Wazuh DB creates the agent database when a query with a new agent ID is sent"""
+def test_wazuh_db_create_agent(test_case, connect_to_sockets_module):
+    """
+    Test Logic:
+        "Check that Wazuh DB creates the agent database when a query with a new agent ID is sent.
+        Also...
+
+        But also..."
+    Checks:
+        - The received output must match with...
+        - The received output with regex must match with...
+    Parameters:
+        - test_case:
+            type: list
+            brief: List of test_case stages (dicts with input, output and stage keys).
+    """
+
     test = {"name": "Create agent",
             "description": "Wazuh DB creates automatically the agent's database the first time a query with a new agent"
                            " ID reaches it. Once the database is created, the query is processed as expected.",

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -1,27 +1,27 @@
 '''
-Brief: Module description
+brief: Module description
 
-COPYRIGHT:
+copyright:
     Copyright (C) 2015-2021, Wazuh Inc.
 
     Created by Wazuh, Inc. <info@wazuh.com>.
 
     This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-Metadata:
-    Modules:
+metadata:
+    modules:
         - Wazuh DB
-    Daemons:
+    daemons:
         - wazuh_db
-    Operating System:
+    operating_system:
         - Windows
         - Ubuntu
-    Wazuh Max Version: 4.0.0
-    Wazuh Min Version: 4.1.5
-    Tiers:
+    wazuh_max_version: 4.0.0
+    wazuh_min_version: 4.1.5
+    tiers:
         - 0
         - 1
-    Tags:
+    tags:
         - Enrollment
 '''
 
@@ -107,9 +107,9 @@ def pre_insert_agents():
                          )
 def test_wazuh_db_messages(configure_sockets_environment, connect_to_sockets_module, test_case: list):
     """
-    Test Logic:
+    test_logic:
         "Check that every input message in wazuh-db socket generates the adequate output to wazuh-db socket"
-    Parameters:
+    parameters:
         - test_case:
             type: list
             brief: List of test_case stages (dicts with input, output and stage keys).
@@ -133,15 +133,15 @@ def test_wazuh_db_messages(configure_sockets_environment, connect_to_sockets_mod
 
 def test_wazuh_db_create_agent(test_case, connect_to_sockets_module):
     """
-    Test Logic:
+    test_logic:
         "Check that Wazuh DB creates the agent database when a query with a new agent ID is sent.
         Also...
 
         But also..."
-    Checks:
+    checks:
         - The received output must match with...
         - The received output with regex must match with...
-    Parameters:
+    parameters:
         - test_case:
             type: list
             brief: List of test_case stages (dicts with input, output and stage keys).


### PR DESCRIPTION
|Related issue|
|---|
|#1641|

## Description
This PR include the fixes for the minor problems found during the exploratory testing:
 - The default output folder isn´t under the git ignore list
 - The configuration file refers to a deprecate option "recursive" for include and ignore paths
 - The output folder isn´t cleaned on each parser run.
 - Empty results after parsing are generating an empty file.
 - Terminal output of the script is too verbose, which makes the warning messages to get lost
 - A log module is required
 - Include path list is not clear enough as it requires a name to identify each element
 - Test Case functionality should be optional.
 - The tool must be documented with the same yaml format of the tests
 - The tool should support arguments to be called. i.e.: -s for a Sanity check or -d to enable the debug log level
 - Change documentation key names to snake_case.
