### PR TITLE
Timeout Extended to Vulnerability Detector Tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/vulnerability_detector.py
@@ -590,7 +590,7 @@ def set_custom_system(**kwargs):
 
 
 def check_vuln_detector_event(wazuh_log_monitor, callback, error_message='', update_position=True,
-                              timeout=VULN_DETECTOR_GLOBAL_TIMEOUT, prefix=VULNERABILITY_DETECTOR_PREFIX):
+                              timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, prefix=VULNERABILITY_DETECTOR_PREFIX):
     """Check if a vulnerability event occurs
 
     Args:
@@ -620,7 +620,7 @@ def check_vulnerabilities_number(expected_number):
                                                       f" Expected: {expected_number}, Got: {vulnerabilities_number}"
 
 
-def check_log_event(wazuh_log_monitor, log_event, update_position=False, timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+def check_log_event(wazuh_log_monitor, log_event, update_position=False, timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                     prefix=VULNERABILITY_DETECTOR_PREFIX):
     """Check if the vulnerable package has been reported
 
@@ -644,7 +644,7 @@ def check_log_event(wazuh_log_monitor, log_event, update_position=False, timeout
 
 
 def check_feed_imported_successfully(wazuh_log_monitor, log_system_name, expected_vulnerabilities_number,
-                                     update_position=False, timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+                                     update_position=False, timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                      check_vuln_number=True):
     """Check that redhat OVAL feeds have been imported successfully
 
@@ -667,7 +667,7 @@ def check_feed_imported_successfully(wazuh_log_monitor, log_system_name, expecte
 
 
 def check_failure_when_importing_feed(wazuh_log_monitor, expected_vulnerabilities_number=0, update_position=False,
-                                      timeout=VULN_DETECTOR_GLOBAL_TIMEOUT, parser_error=False):
+                                      timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, parser_error=False):
     """Check an error message when importing redhat OVAL feeds and checks that the vulnerabilities table is empty
 
     Args:
@@ -754,7 +754,7 @@ def check_if_modulesd_is_running():
 
 
 def check_feed_uncompressed_successfully(wazuh_log_monitor, feed, update_position=False,
-                                         timeout=VULN_DETECTOR_GLOBAL_TIMEOUT):
+                                         timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT):
     """Check that a feed from path or url have been uncompressed successfully
 
     Args:
@@ -798,7 +798,7 @@ def check_vulnerability_scan_event(wazuh_log_monitor, package, cve):
         cve (str): Package CVE. Example: 'CVE-2019-11764'
     """
     check_vuln_detector_event(
-        wazuh_log_monitor=wazuh_log_monitor, timeout=VULN_DETECTOR_SCAN_TIMEOUT, update_position=False,
+        wazuh_log_monitor=wazuh_log_monitor, timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, update_position=False,
         callback=f"The '{package}' package .* from agent .* is vulnerable to '{cve}'",
         error_message=f"Could not find the report which says that the package {package} is vulnerable with {cve}",
     )

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -10,7 +10,7 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations, check_a
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.vulnerability_detector import callback_detect_vulnerability_detector_disabled, \
     callback_detect_vulnerability_detector_enabled, \
-    VULN_DETECTOR_GLOBAL_TIMEOUT
+    VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -49,5 +49,5 @@ def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_confi
 
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    wazuh_log_monitor.start(timeout=VULN_DETECTOR_GLOBAL_TIMEOUT, callback=custom_callback,
+    wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, callback=custom_callback,
                             error_message=custom_error_message)

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -10,7 +10,7 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations, check_a
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.time import time_to_human_readable, unit_to_seconds
 from wazuh_testing.vulnerability_detector import callback_detect_vulnerability_scan_sleeping, \
-    VULN_DETECTOR_GLOBAL_TIMEOUT
+    VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -52,7 +52,7 @@ def test_interval(get_configuration, configure_environment, restart_modulesd):
 
     check_apply_test({'interval'}, get_configuration['tags'])
 
-    sleeping_interval = wazuh_log_monitor.start(timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+    sleeping_interval = wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                                 callback=callback_detect_vulnerability_scan_sleeping,
                                                 error_message='Missing sleep between scans').result()
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -9,7 +9,7 @@ import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_GLOBAL_TIMEOUT
+from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -57,7 +57,7 @@ def test_run_on_start(get_configuration, configure_environment, restart_modulesd
 
     if get_configuration['metadata']['run_on_start'] == 'yes':
         # If enable, check that vuln scan has started when the service starts
-        wazuh_log_monitor.start(timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+        wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                 callback=callback_detect_vulnerability_scan_started,
                                 error_message='Could not find vulnerability starting scan log')
 
@@ -68,6 +68,6 @@ def test_run_on_start(get_configuration, configure_environment, restart_modulesd
     else:
         # If disabled, check that vuln scan has not started
         with pytest.raises(TimeoutError):
-            wazuh_log_monitor.start(timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+            wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                     callback=callback_detect_vulnerability_scan_started)
             raise AttributeError(f'Found starting scan log when run on start is disabled')

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py
@@ -8,7 +8,7 @@ import pytest
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_GLOBAL_TIMEOUT
+from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -66,12 +66,12 @@ def test_enabled(get_configuration, configure_environment, restart_modulesd):
     provider_name = get_configuration['metadata']['provider_name']
     if get_configuration['metadata']['enabled'] == 'no':
         with pytest.raises(TimeoutError):
-            wazuh_log_monitor.start(timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+            wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                     callback=make_vuln_callback("Starting.+database update"))
             raise AttributeError(f"Unexpected event {provider_name} database updating")
     else:
         wazuh_log_monitor.start(
-            timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+            timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
             callback=make_vuln_callback(f"Starting '{provider_name}' database update"),
             error_message=f"Could not find {provider_name} update starting log",
         )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.py
@@ -10,7 +10,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_GLOBAL_TIMEOUT
+from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -64,7 +64,7 @@ def test_providers_no_os(clean_vuln_tables, get_configuration, configure_environ
         assert 'error' in get_configuration['metadata']
 
     if 'error' in get_configuration['metadata']:
-        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                 callback=vd.make_vuln_callback(r".* \(\d+\): Configuration error at.*",
                                                                prefix='.*wazuh-modulesd.*'),
                                 error_message=f"Error log 'Configuration error at '/var/ossec/etc/ossec.conf'.' "
@@ -77,7 +77,7 @@ def test_providers_no_os(clean_vuln_tables, get_configuration, configure_environ
                 os_name = f"JSON {provider_name}" if 'Red Hat' in provider_name else f"{provider_name}"
 
             wazuh_log_monitor.start(
-                timeout=80 if 'Red Hat' in os_name else VULN_DETECTOR_GLOBAL_TIMEOUT,
+                timeout=80 if 'Red Hat' in os_name else VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                 callback=make_vuln_callback(f"Starting '{os_name}' database update"),
                 error_message=f"Could not find {os_name} update starting log",
             )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py
@@ -9,7 +9,7 @@ import wazuh_testing.vulnerability_detector as vd
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_GLOBAL_TIMEOUT
+from wazuh_testing.vulnerability_detector import make_vuln_callback, VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
 
 # Marks
 pytestmark = pytest.mark.tier(level=1)
@@ -69,13 +69,13 @@ def test_providers(get_configuration, configure_environment, restart_modulesd):
 
     provider_name = get_configuration['metadata']['provider_name']
     if 'os_warning' in get_configuration['metadata']:
-        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+        wazuh_log_monitor.start(timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                                 callback=vd.make_vuln_callback(rf".*Invalid option 'os' for .* provider.*",
                                                                prefix='.*wazuh-modulesd.*'),
                                 error_message=f"Warning log 'Invalid option 'os' for '{provider_name}' "
                                               f"provider not found")
     wazuh_log_monitor.start(
-        timeout=VULN_DETECTOR_GLOBAL_TIMEOUT,
+        timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
         callback=make_vuln_callback(f"Starting '{provider_name}' database update"),
         error_message=f"Could not find {provider_name} update starting log",
     )

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
@@ -75,10 +75,10 @@ def test_update_from_year(clean_vuln_tables, get_configuration, configure_enviro
 
         # Check update from year log event
         vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=correct_year_log_event, update_position=False,
-                           timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT, prefix=MODULESD_PREFIX)
+                           timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, prefix=MODULESD_PREFIX)
     else:
         log_event = "ERROR: Invalid content for 'update_from_year' option at module 'vulnerability-detector'"
         vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event, update_position=False,
-                           timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT, prefix=MODULESD_PREFIX)
+                           timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, prefix=MODULESD_PREFIX)
 
     vd.clean_vd_tables()

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -117,7 +117,7 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
         installed, hotfix = is_hotfix_installed(item[0]['patch'], dep, hotfixes)
         if installed:
             wazuh_log_monitor.start(
-                timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                 update_position=False,
                 callback=vd.make_vuln_callback(
                     f"Agent '{mock_agent}' has installed '{hotfix}' that corrects the vulnerability '{cve}'"
@@ -126,7 +126,7 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
             )
         else:
             wazuh_log_monitor.start(
-                timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT,
+                timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
                 update_position=False,
                 callback=vd.make_vuln_callback(
                     f"Agent '{mock_agent}' is vulnerable to '{cve}'. Condition: 'KB{hotfix} patch is not installed'"

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -70,7 +70,7 @@ def test_redhat_vulnerabilities_report(get_configuration, configure_environment,
     # Check that the number of OVAL vulnerabilities is the expected
     vd.check_detected_vulnerabilities_number(wazuh_log_monitor=wazuh_log_monitor,
                                              expected_vulnerabilities_number=vulnerabilities_number,
-                                             feed_source='OVAL', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
+                                             feed_source='OVAL', timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT)
 
     # Check the vulnerabilities of packages inserted
     for item in mock_vulnerability_scan['vulnerabilities']:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -146,6 +146,6 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
     if mock_vulnerability_scan["format"] != "win":
         vd.check_detected_vulnerabilities_number(wazuh_log_monitor=wazuh_log_monitor,
                                                  expected_vulnerabilities_number=vulnerabilities_number,
-                                                 feed_source='NVD', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
+                                                 feed_source='NVD', timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT)
 
     vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
@@ -124,7 +124,7 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
 
     # Check that the number of provider vulnerabilities is the expected
     wazuh_log_monitor.start(
-        timeout=SCAN_TIMEOUT,
+        timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
         update_position=False,
         callback=vd.make_vuln_callback(
             f"A total of '{provider_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' " +
@@ -135,7 +135,7 @@ def test_vulnerabilities_report(get_configuration, configure_environment, restar
 
     # Check that the number of NVD vulnerabilities is the expected
     wazuh_log_monitor.start(
-        timeout=SCAN_TIMEOUT,
+        timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
         update_position=False,
         callback=vd.make_vuln_callback(
             f"A total of '{nvd_vulnerabilities_number}' vulnerabilities have been reported for agent '.*' " +

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -72,7 +72,7 @@ def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment,
     # Check that the number of OVAL vulnerabilities is the expected
     vd.check_detected_vulnerabilities_number(wazuh_log_monitor=wazuh_log_monitor,
                                              expected_vulnerabilities_number=vulnerabilities_number,
-                                             feed_source='OVAL', timeout=vd.VULN_DETECTOR_SCAN_TIMEOUT)
+                                             feed_source='OVAL', timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT)
 
     # Check the vulnerabilities of packages inserted
     for item in mock_vulnerability_scan['vulnerabilities']:

--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -169,7 +169,7 @@ def mock_system(request):
 
 def test_window_version_indexing(get_configuration, configure_environment, restart_modulesd, check_cve_db, mock_system):
     wazuh_log_monitor.start(
-        timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+        timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
         update_position=False,
         callback=vd.make_vuln_callback(
             rf"The CPE 'o:microsoft:{mock_system['index_name']}:(-|r2|{mock_system['os_release']}):" +


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1531|

## Description

This PR only change the timeout on some test to help find some logs. There are an issue FileMonitor that cause the fails.
In the future is require work on reduce the time.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
