### PR TITLE
Replacing the MITM usage by the `archives.log` monitor in the `test_multi_agent_protocols_communication` tests

### DIFF
--- a/tests/integration/test_remoted/test_agent_communication/data/wazuh_multi_agent_protocols_communication.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/wazuh_multi_agent_protocols_communication.yaml
@@ -6,8 +6,12 @@
   - section: remote
     elements:
     - connection:
-        value: secure
+         value: secure
     - port:
          value: PORT
     - protocol:
          value: PROTOCOL
+  - section: global
+    elements:
+    - logall:
+         value: "yes"

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -100,7 +100,7 @@ def validate_agent_manager_protocol_communication(num_agents=2, manager_port=151
     # Create archives log monitor
     archives_monitor = rd.create_archives_log_monitor()
 
-    # Wait 10 seconds until socket monitor is fully initialized
+    # Wait 10 seconds until remoted is fully initialized
     sleep(10)
 
     # Start sender event threads


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1530|

## Description

This PR changes the mechanism used by the `test_multi_agent_protocols_communication.py` to verify if the messages sent by the agents to the manager are received properly. This basically removes the usage of the Man In The Middle to instead monitor the `archives.log` file.

|Test Execution |Status|
|--|--|
|[test_multi_agent_protocols_communication-r1.log](https://github.com/wazuh/wazuh-qa/files/6947626/test_multi_agent_protocols_communication-r1.log)| 🟢 |
|[test_multi_agent_protocols_communication-r2.log](https://github.com/wazuh/wazuh-qa/files/6947627/test_multi_agent_protocols_communication-r2.log)| 🟢 | 
|[test_multi_agent_protocols_communication-r3.log](https://github.com/wazuh/wazuh-qa/files/6947629/test_multi_agent_protocols_communication-r3.log)| 🟢 | 

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
