### PR TITLE
Disable inconsitent remoted tests

### DIFF
--- a/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
@@ -51,8 +51,9 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.skip(reason="It require review and rework of agent simulator, sometimes no work successfully when "
-                         "send keepalives and it cause that agent never change to active status.")
+@pytest.mark.skip(reason="It requires review and a rework for the agent simulator."
+                         "Sometimes it doesn't work properly when it sends keepalives "
+                         "messages causing the agent to never being in active status.")
 def test_active_response_ar_sending(get_configuration, configure_environment, restart_remoted):
     """Test if `wazuh-remoted` sends active response commands to the agent.
 

--- a/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send_ar.py
@@ -43,6 +43,7 @@ configuration_ids = [f"{x['PROTOCOL']}_{x['PORT']}" for x in parameters]
 
 manager_address = 'localhost'
 
+
 # fixtures
 @pytest.fixture(scope='module', params=configurations, ids=configuration_ids)
 def get_configuration(request):
@@ -50,6 +51,8 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It require review and rework of agent simulator, sometimes no work successfully when "
+                         "send keepalives and it cause that agent never change to active status.")
 def test_active_response_ar_sending(get_configuration, configure_environment, restart_remoted):
     """Test if `wazuh-remoted` sends active response commands to the agent.
 

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_status.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_status.py
@@ -115,6 +115,8 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It require review and rework of agent simulator, sometimes no work successfully when "
+                         "send keepalives and it cause that agent never change to active status.")
 def test_protocols_communication(get_configuration, configure_environment, restart_remoted):
     """Validate agent status after sending the start-up and keep-alive events"""
     manager_port = get_configuration['metadata']['port']

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_status.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_status.py
@@ -115,8 +115,9 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.skip(reason="It require review and rework of agent simulator, sometimes no work successfully when "
-                         "send keepalives and it cause that agent never change to active status.")
+@pytest.mark.skip(reason="It requires review and a rework for the agent simulator."
+                         "Sometimes it doesn't work properly when it sends keepalives "
+                         "messages causing the agent to never being in active status.")
 def test_protocols_communication(get_configuration, configure_environment, restart_remoted):
     """Validate agent status after sending the start-up and keep-alive events"""
     manager_port = get_configuration['metadata']['port']

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -9,7 +9,6 @@ from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing import remote as rd
 
-
 # Marks
 pytestmark = pytest.mark.tier(level=0)
 
@@ -99,6 +98,8 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It require review and rework of agent simulator, sometimes no work successfully when "
+                         "send keepalives and it cause that agent never change to active status.")
 def test_protocols_communication(get_configuration, configure_environment, restart_remoted):
     """Validate agent-manager communication using different protocols and ports"""
     protocol = get_configuration['metadata']['protocol']

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -98,8 +98,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.skip(reason="It require review and rework of agent simulator, sometimes no work successfully when "
-                         "send keepalives and it cause that agent never change to active status.")
 def test_protocols_communication(get_configuration, configure_environment, restart_remoted):
     """Validate agent-manager communication using different protocols and ports"""
     protocol = get_configuration['metadata']['protocol']


### PR DESCRIPTION
|Related issue|
|---|
|#1530|

## Description

This PR disables some test that fails by https://github.com/wazuh/wazuh-qa/issues/1698 

| Test Executions | Date  | By  | Status | 
|--|--|--|--|
|[Disabled.log](https://github.com/wazuh/wazuh-qa/files/6957010/Disabled.log)| 09-08-21| Seyla| 🟡 
|[Disabled2.log](https://github.com/wazuh/wazuh-qa/files/6957011/Disabled2.log)|09-08-21| Seyla| 🟡
|[Disabled3.log](https://github.com/wazuh/wazuh-qa/files/6957108/Disabled3.log)| 09-08-21| Seyla|  🟡


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
