### PR TITLE
Full Yellow Local - Fix Agentd tests in 4.2

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -11,12 +11,11 @@ import pytest
 import wazuh_testing.api as api
 import wazuh_testing.tools.agent_simulator as ag
 import wazuh_testing.tools as tools
-from wazuh_testing import UDP, TCP, TCP_UDP
+from wazuh_testing import UDP, TCP
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools import file
 from wazuh_testing.tools import monitoring
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.tools.utils import retry
 
 
 REMOTED_GLOBAL_TIMEOUT = 10

--- a/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_ping_pong_message.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 import wazuh_testing.remote as rm
+from wazuh_testing import TCP_UDP
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 
 
@@ -92,7 +93,7 @@ def test_ping_pong_message(get_configuration, configure_environment, restart_rem
     test_multiple_pings = False
 
     if config['protocol'] in ['TCP,UDP', 'UDP,TCP', 'tcp,udp', 'udp,tcp']:
-        protocol, test_multiple_pings = rm.TCP_UDP, True
+        protocol, test_multiple_pings = TCP_UDP, True
     elif config['protocol'] in ['TCP,TCP', 'UDP,UDP', 'tcp,tcp', 'udp,udp']:
         protocol = config['protocol'].split(',')[0]
     else:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1521|

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi


#### Agentd

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh_agent_v4.2.0_linux_x86_64.wpk
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh_agent_v4.2.0_windows.wpk

### pytest_args
` python3 -m pytest -ssv --html=report.html --self-contained-html test_agentd/`

## Description

After research #1493, we saw that Agentd tests were inconsistent.
Issue #1521 was created In order to fix these tests cases.

**Linux** 

Linux tests are working properly with no errors ahead. 

**Windows**
A couple of tests were failing because Windows errors correctly were not properly handled. Moreover, Wazuh internal settings were not being set.

PR: https://github.com/wazuh/wazuh-qa/pull/1592

We are accepting the tests as valid even with the known product issues regarding Windows service and Wazuh logging:

- https://github.com/wazuh/wazuh/issues/9298 
- https://github.com/wazuh/wazuh/issues/8746 

## Tests results

@juliamagan 

<details>
<summary>Test Execution 1 </summary>

### Windows Agent

```
==================================================== test session starts ====================================================
platform win32 -- Python 3.7.4, pytest-6.2.2, py-1.10.0, pluggy-0.13.0 -- C:\Python37\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.7.4', 'Platform': 'Windows-10-10.0.14393-SP0', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy
': '0.13.0'}, 'Plugins': {'html': '2.0.1', 'metadata': '1.8.0', 'testinfra': '5.0.0'}}
rootdir: C:\Windows\system32\wazuh-qa\tests\integration, configfile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0, testinfra-5.0.0
collected 6 items

tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED    [ 16%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASSED [33%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] PASSED [50%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED        [ 66%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED     [ 83%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED     [100%]

==================================================== 6 passed in 19.09s =====================================================
```

### CentOS 8 Agent

```
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-193.19.1.el8_2.x86_64-x86_64-with-centos-8.2.2004-Core', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'testinfra': '5.0.0', 'html': '2.0.1'}}
rootdir: /home/centos/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-2.0.1
collected 6 items                                                                                                                                            

tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED                                    [ 16%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASSED                             [ 33%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] PASSED                           [ 50%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED                                        [ 66%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED                                     [ 83%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED                                     [100%]

===================================================================== 6 passed in 14.34s =====================================================================
```

</details>

<details>
<summary>Test Execution 2 </summary>

### Windows Agent

```
========================================================= test session starts =========================================================
platform win32 -- Python 3.7.4, pytest-6.2.2, py-1.10.0, pluggy-0.13.0 -- C:\Python37\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.7.4', 'Platform': 'Windows-10-10.0.14393-SP0', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.0
'}, 'Plugins': {'html': '2.0.1', 'metadata': '1.8.0', 'testinfra': '5.0.0'}}
rootdir: C:\Windows\system32\wazuh-qa\tests\integration, configfile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0, testinfra-5.0.0
collected 6 items

tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED              [ 16%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASSED       [ 33%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] PASSED     [ 50%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED                  [ 66%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED               [ 83%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED               [100%]

========================================================= 6 passed in 21.59s ==========================================================
```

### CentOS 8 Agent
```
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-193.19.1.el8_2.x86_64-x86_64-with-centos-8.2.2004-Core', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'testinfra': '5.0.0', 'html': '2.0.1'}}
rootdir: /home/centos/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-2.0.1
collected 6 items                                                                                                                                            

tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED                                    [ 16%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASSED                             [ 33%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] PASSED                           [ 50%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED                                        [ 66%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED                                     [ 83%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED                                     [100%]

===================================================================== 6 passed in 14.34s =====================================================================
```

</details>

<details>
<summary>Test Execution 3 </summary>

### Windows Agent

We knew that this failure could happen since issue #1588 is blocked by issue https://github.com/wazuh/wazuh/issues/8746

```
============================================================= test session starts ==============================================================
platform win32 -- Python 3.7.4, pytest-6.2.2, py-1.10.0, pluggy-0.13.0 -- C:\Python37\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.7.4', 'Platform': 'Windows-10-10.0.14393-SP0', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.0'}, 'Plug
ins': {'html': '2.0.1', 'metadata': '1.8.0', 'testinfra': '5.0.0'}}
rootdir: C:\Windows\system32\wazuh-qa\tests\integration, configfile: pytest.ini
plugins: html-2.0.1, metadata-1.8.0, testinfra-5.0.0
collected 6 items

tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED                       [ 16%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASSED                [ 33%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] FAILED              [ 50%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED                           [ 66%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED                        [ 83%]
tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED                        [100%]

=================================================================== FAILURES ===================================================================
__________________________________________ test_agentd_state_config[State interval option dont exist] __________________________________________

test_case = {'agentd_ends': True, 'interval': None, 'log_expect': 'interval_not_found', 'state_file_exist': False}
set_local_internal_options = None

    @pytest.mark.parametrize('test_case',
                             [test_case['test_case'] for test_case in test_cases],
                             ids=[test_case['name'] for test_case in test_cases])
    def test_agentd_state_config(test_case, set_local_internal_options):

        control_service('stop', 'wazuh-agentd')

        # Truncate ossec.log in order to watch it correctly
        truncate_file(LOG_FILE_PATH)

        # Remove state file to check if agent behavior is as expected
        os.remove(state_file_path) if os.path.exists(state_file_path) else None

        # Set state interval value according to test case specs
        set_state_interval(test_case['interval'], internal_options)

        if sys.platform == 'win32':
            if test_case['agentd_ends']:
                with pytest.raises(ValueError):
                    control_service('start')
                assert (test_case['agentd_ends']
                        is not check_if_process_is_running('wazuh-agentd'))
            else:
                control_service('start')
        else:
            control_service('start', 'wazuh-agentd')
            assert (test_case['agentd_ends']
                        is not check_if_process_is_running('wazuh-agentd'))

        # Check if test require checking state file existance
        if 'state_file_exist' in test_case:
            if test_case['state_file_exist']:
                # Wait until state file was dumped
                time.sleep(test_case['interval'])
            assert test_case['state_file_exist'] == os.path.exists(state_file_path)

        # Follow ossec.log to find desired messages by a callback
        wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
        wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                callback=callbacks.get(test_case['log_expect']),
>                               error_message='Event not found')

tests\integration\test_agentd\test_agentd_state_config.py:119:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\Python37\lib\site-packages\wazuh_testing-4.2.0-py3.7.egg\wazuh_testing\tools\monitoring.py:196: in start
    error_message=error_message).result()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <wazuh_testing.tools.monitoring.QueueMonitor object at 0x000001E0C476EA48>, timeout = 10
callback = <function callback_state_interval_not_found at 0x000001E0C474C1F8>, accum_results = 1, update_position = True, timeout_extra = 0
error_message = 'Event not found'

    def start(self, timeout=-1, callback=_callback_default, accum_results=1, update_position=True, timeout_extra=0,
              error_message=''):
        """Start the queue monitoring until the stop method is called."""
        if not self._continue:
            self._continue = True
            self._abort = False
            result = None

            while self._continue:
                if self._abort:
                    self.stop()
                    if error_message:
                        logger.error(error_message)
                        logger.error(f"Results accumulated: "
                                     f"{len(result) if isinstance(result, list) else 0}")
                        logger.error(f"Results expected: {accum_results}")
>                   raise TimeoutError(error_message)
E                   TimeoutError: Event not found

C:\Python37\lib\site-packages\wazuh_testing-4.2.0-py3.7.egg\wazuh_testing\tools\monitoring.py:456: TimeoutError
------------------------------------------------------------- Captured stdout call -------------------------------------------------------------

The Wazuh service was stopped successfully.

The Wazuh service is starting.
The Wazuh service could not be started.

The service did not report an error.

More help is available by typing NET HELPMSG 3534.


------------------------------------------------------------- Captured stderr call -------------------------------------------------------------
2021-07-16 14:26:12,802 - wazuh_testing - ERROR - Event not found
2021-07-16 14:26:12,802 - wazuh_testing - ERROR - Results accumulated: 0
2021-07-16 14:26:12,802 - wazuh_testing - ERROR - Results expected: 1
-------------------------------------------------------------- Captured log call ---------------------------------------------------------------
ERROR    wazuh_testing:monitoring.py:452 Event not found
ERROR    wazuh_testing:monitoring.py:453 Results accumulated: 0
ERROR    wazuh_testing:monitoring.py:455 Results expected: 1
=========================================================== short test summary info ============================================================
FAILED tests\integration\test_agentd\test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] - TimeoutError: E...
========================================================= 1 failed, 5 passed in 29.36s =========================================================
```

### CentOS 8 Agent
```
==================================================================== test session starts =====================================================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-193.19.1.el8_2.x86_64-x86_64-with-centos-8.2.2004-Core', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'testinfra': '5.0.0', 'html': '2.0.1'}}
rootdir: /home/centos/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-2.0.1
collected 6 items                                                                                                                                            

tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Negative state interval] PASSED                                    [ 16%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Undefined state interval value] PASSED                             [ 33%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[State interval option dont exist] PASSED                           [ 50%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Zero state interval] PASSED                                        [ 66%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Too big state interval] PASSED                                     [ 83%]
tests/integration/test_agentd/test_agentd_state_config.py::test_agentd_state_config[Default state interval] PASSED                                     [100%]

===================================================================== 6 passed in 14.33s =====================================================================
```
</details>

@Rebits 

#### R1
- :green_circle:  [Linux Agent](https://github.com/wazuh/wazuh-qa/files/6839141/r1_agentd_state_config_agent_linux.log)
- :red_circle:  [Windows Agent](https://github.com/wazuh/wazuh-qa/files/6839207/r1_agentd_state_config_agent_windows.log)

#### R2
- :green_circle:  [Linux Agent](https://github.com/wazuh/wazuh-qa/files/6839142/r2_agentd_state_config_agent_linux.log)
- :red_circle: [Windows Agent](https://github.com/wazuh/wazuh-qa/files/6839209/r2_agentd_state_config_agent_windows.log)


#### R3
- :green_circle:  [Linux Agent](https://github.com/wazuh/wazuh-qa/files/6839143/r3_agentd_state_config_agent_linux.log)
- :red_circle:   [Windows Agent](https://github.com/wazuh/wazuh-qa/files/6839210/r3_agentd_state_config_agent_windows.log)

@snaow 

||Status|Reports|
|:--:|:--:|:--:|
|agent/linux| 🟠 |[fullyellow-agentd-linux-r1.zip](https://github.com/wazuh/wazuh-qa/files/6963887/fullyellow-agentd-linux-r1.zip)|
|agent/windows| 🔴|[fullyellow-local-agentd-r1.zip](https://github.com/wazuh/wazuh-qa/files/6963776/fullyellow-local-agentd-r1.zip)|



