### PR TITLE
Remove warnings with unverified HTTPs requests

### DIFF
--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -60,6 +62,7 @@ def test_invalid_protocol(get_configuration, configure_environment, restart_remo
         AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected warning messages or does not
         set properly protocol values.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
     protocol_field = cfg['protocol'].split(',')
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_valid.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -56,6 +58,7 @@ def test_connection_valid(get_configuration, configure_environment, restart_remo
 
     Raises:
         AssertionError: if API answer is different of expected configuration."""
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     used_protocol = cfg['protocol']

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -45,6 +47,7 @@ def test_ipv6_secure(get_configuration, configure_environment, restart_remoted):
     Raises:
         AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected warning message or
         if API answer is different of expected configuration."""
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     if cfg['connection'] == 'secure':

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
@@ -6,9 +6,10 @@ import os
 import pytest
 import netifaces
 
-
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -55,6 +56,7 @@ def test_local_ip_valid(get_configuration, configure_environment, restart_remote
     Raises:
         AssertionError: if API answer is different of expected configuration.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     # Check that API query return the selected configuration

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -47,6 +49,7 @@ def test_big_queue_size(get_configuration, configure_environment, restart_remote
         AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected warning messages or if API answer is
         different of expected configuration.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     log_callback = remote.callback_queue_size_too_big()

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -50,6 +52,7 @@ def test_queue_size_valid(get_configuration, configure_environment, restart_remo
     Raises:
         AssertionError: if API answer is different of expected configuration.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     remote.compare_config_api_response(cfg)

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -58,6 +60,7 @@ def test_rids_closing_time_valid(get_configuration, configure_environment, resta
     Raises:
         AssertionError: if API answer is different of expected configuration.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     # Check that API query return the selected configuration

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -49,6 +51,7 @@ def test_allowed_denied_ips_syslog(get_configuration, configure_environment, res
     Raises:
         AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     log_callback = remote.callback_detect_syslog_allowed_ips(cfg['allowed-ips'])

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
@@ -7,6 +7,8 @@ import pytest
 
 import wazuh_testing.remote as remote
 from wazuh_testing.tools.configuration import load_wazuh_configurations
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
@@ -43,6 +45,7 @@ def test_denied_ips_syslog(get_configuration, configure_environment, restart_rem
         AssertionError: if `wazuh-remoted` does not show in `ossec.log` expected error message or API answer different
         of expected configuration.
     """
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     log_callback = remote.callback_detect_syslog_allowed_ips(cfg['allowed-ips'])


### PR DESCRIPTION
|Related issue|
|---|
|#1530|

## Description

After each Full Execution there are a lot of Warnings. I create this PR only to remove warnings related to Remoted Tests.  It means that you can see some warnings but this will be related to scripts general that after merge all PRs we will if require fix or if it was fixes in another PR.

In this PR, I only focus on: 

```
test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py: 8 warnings
test_remoted/test_configuration/test_basic_configuration_connection_valid.py: 8 warnings
test_remoted/test_configuration/test_basic_configuration_ipv6.py: 2 warnings
test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py: 3 warnings
test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py: 1 warning
test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py: 3 warnings
test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py: 8 warnings
test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py: 5 warnings
test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py: 1 warning
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning,
```

This warning happen because we don't check certificate validation. (In our case we are the other remote server).
The warning doesn't really prevent whatever's happening. It's not disabling validation, it's disabling the warning about the lack of validation. 

After apply this changes you see warnings but none of the above list. .
 
## Logs example

| Test Executions | Date  | By  | Status | 
|--|--|--|--|
|[WithoutWarnings.log](https://github.com/wazuh/wazuh-qa/files/6964154/WithoutWarnings.log)|10-08-21| Seyla| 🟡
|[WithoutWarnings2.log](https://github.com/wazuh/wazuh-qa/files/6964156/WithoutWarnings2.log)|10-08-21| Seyla|  🟡


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
