### PR TITLE
Disable blocked Vuln Detect tests 

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -101,6 +101,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_download_feeds(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd downloads successfully the feeds from different providers and os.

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -166,6 +166,7 @@ def manage_files(request):
     file.remove_file(zip_dest_path)
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configuration, configure_environment,
                                    restart_modulesd):
     """

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -138,6 +138,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solve we can enable again this test")
 def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
     """
     Check that when importing bad feed files, vulnerability report a log parse error otherwise they are imported

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_enabled.py
@@ -59,6 +59,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_enabled(get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd downloads the feeds from different providers when enabled is set to yes.

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_no_os.py
@@ -50,6 +50,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_providers_no_os(clean_vuln_tables, get_configuration, configure_environment):
     """
     Check if modulesd downloads the feeds without specifing the os version.

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_os.py
@@ -61,6 +61,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solve we can enable again this test")
 def test_providers(get_configuration, configure_environment, restart_modulesd):
     """
     Check if modulesd downloads the feeds for each os

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
@@ -51,6 +51,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_update_from_year(clean_vuln_tables, get_configuration, configure_environment,
                           restart_modulesd_catching_ossec_conf_error):
     """ Check if vulnerability detector download feeds from the correct year based on `update_from_year` option """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_debian_inventory_debian_feed.py
@@ -60,6 +60,7 @@ def mock_vulnerability_scan(request, mock_agent):
                                 target=request.param['target'])
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solve we can enable again this test")
 def test_debian_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                        mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_macos_inventory.py
@@ -62,7 +62,7 @@ def mock_vulnerability_scan(request, mock_agent):
     for vulnerability in request.param['vulnerabilities']:
         vd.insert_package(**vulnerability['package'], agent=mock_agent, source=vulnerability['package']['name'])
 
-
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_macos_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                       mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_msu_inventory_msu_feed.py
@@ -105,6 +105,7 @@ def is_hotfix_installed(cve_patch, dependencies, hotfixes):
         return False, cve_patch
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db, mock_agent,
                                 mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_duplicate_vulns.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_duplicate_vulns.py
@@ -45,6 +45,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_redhat_duplicate_vulns(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
     """
     RedHat provider was duplicating vulnerabilities when it downloaded a feed to update the database.

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_inventory_redhat_feed.py
@@ -60,6 +60,7 @@ def mock_vulnerability_scan(request, mock_agent):
                                 target=request.param['target'])
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solve we can enable again this test")
 def test_redhat_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                        mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_different_cves.py
@@ -101,6 +101,7 @@ def mock_vulnerability_scan(request, mock_agent):
                           format=request.param['format'], agent=mock_agent)
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_feed.py
@@ -115,6 +115,7 @@ def mock_vulnerability_scan(request, mock_agent):
                           format=request.param['format'], agent=mock_agent)
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_providers_and_nvd_feed.py
@@ -96,6 +96,7 @@ def mock_vulnerability_scan(request, mock_agent):
                           format=request.param['format'], agent=mock_agent)
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                 mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_ubuntu_inventory_canonical_feed.py
@@ -62,6 +62,7 @@ def mock_vulnerability_scan(request, mock_agent):
                                 target=request.param['target'])
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solve we can enable again this test")
 def test_ubuntu_vulnerabilities_report(get_configuration, configure_environment, restart_modulesd, check_cve_db,
                                        mock_vulnerability_scan):
     """

--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -167,6 +167,7 @@ def mock_system(request):
     control_service('start', daemon='wazuh-db')
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_window_version_indexing(get_configuration, configure_environment, restart_modulesd, check_cve_db, mock_system):
     wazuh_log_monitor.start(
         timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,


### PR DESCRIPTION
|Related issue|
|---|
|#1531|

## Description

This PR disables some test that fails by #1602 and https://github.com/wazuh/wazuh/issues/9309

## Logs example

| Test Executions | Date  | By  | Status | 
|--|--|--|--|
|[FullVulnDet.log](https://github.com/wazuh/wazuh-qa/files/6967916/FullVulnDet.log)| 11-08-21| Seyla| 🟡 
|[FullVulnDet2.log](https://github.com/wazuh/wazuh-qa/files/6967919/FullVulnDet2.log)|11-08-21| Seyla| 🟡
|[FullVulnDet3.log](https://github.com/wazuh/wazuh-qa/files/6967920/FullVulnDet3.log)| 11-08-21| Seyla|  🟡

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
