### PR TITLE
Add sleep before checking the status of the injector

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -635,7 +635,7 @@ def check_push_shared_config(agent, sender, injector=None):
 
     # Run injector with only receive messages module enabled
     stop_injector = False
-
+    time.sleep(1)
     if injector is None:
         injector = ag.Injector(sender, agent)
         injector.run()

--- a/tests/integration/test_remoted/test_agent_communication/test_agent_version_shared_configuration_startup_message.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_agent_version_shared_configuration_startup_message.py
@@ -74,7 +74,7 @@ def test_agent_remote_configuration(agent_name, get_configuration, configure_env
         agent = ag.Agent(**agent_info[agent_name])
 
         # Sleep to avoid ConnectionRefusedError
-        sleep(1)
+        sleep(2)
 
         sender = ag.Sender(agent_info[agent_name]['manager_address'], protocol=protocol)
 

--- a/tests/integration/test_remoted/test_agent_communication/test_agent_version_shared_configuration_startup_message.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_agent_version_shared_configuration_startup_message.py
@@ -74,7 +74,7 @@ def test_agent_remote_configuration(agent_name, get_configuration, configure_env
         agent = ag.Agent(**agent_info[agent_name])
 
         # Sleep to avoid ConnectionRefusedError
-        sleep(2)
+        sleep(1)
 
         sender = ag.Sender(agent_info[agent_name]['manager_address'], protocol=protocol)
 


### PR DESCRIPTION
|Related issue|
|---|
|#1514|

## Description
In my full remote test run, I had some failures related to `test_remoted / test_agent_communication / test_agent_version_shared_configuration_startup_message` tests.

I started to investigate why it failed.
- I verified that there is no need to extend the suspend to avoid connection refused error in `test_active_response_ar_sending` because after 3 executions it failed again.
- I tried to follow the path that the test should be doing and I could see that when we checked the status of the Injector, it was not empty as expected and for that reason, it was failing.
   I add a time.sleep(1) before checking the status of the injector in `check_push_shared_config` and it works!
I ran it many times.

## Logs example
Test Executions | Date | By | Status
-- | -- | -- | --
 [InjectorLastTime2.log](https://github.com/wazuh/wazuh-qa/files/6971642/InjectorLastTime2.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime3.log](https://github.com/wazuh/wazuh-qa/files/6971643/InjectorLastTime3.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime4.log](https://github.com/wazuh/wazuh-qa/files/6971644/InjectorLastTime4.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime5.log](https://github.com/wazuh/wazuh-qa/files/6971645/InjectorLastTime5.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime6.log](https://github.com/wazuh/wazuh-qa/files/6971646/InjectorLastTime6.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime7.log](https://github.com/wazuh/wazuh-qa/files/6971647/InjectorLastTime7.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime8.log](https://github.com/wazuh/wazuh-qa/files/6971648/InjectorLastTime8.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime9.log](https://github.com/wazuh/wazuh-qa/files/6971649/InjectorLastTime9.log)| 11-08-21 | Seyla| 🟡
[InjectorLastTime.log](https://github.com/wazuh/wazuh-qa/files/6971650/InjectorLastTime.log)| 11-08-21 | Seyla| 🟡

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
