### PR TITLE
Disable `test_cpe_indexing.py` (change of reason)

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -167,7 +167,7 @@ def mock_system(request):
     control_service('start', daemon='wazuh-db')
 
 
-@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
+@pytest.mark.skip(reason="It will be blocked by wazuh/wazuh#9309, when it was solve we can enable again this test")
 def test_window_version_indexing(get_configuration, configure_environment, restart_modulesd, check_cve_db, mock_system):
     wazuh_log_monitor.start(
         timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,


### PR DESCRIPTION
|Related issue|
|---|
|#1565|

## Description

This PR changes the reason why `test_cpe_indexing` is disabled (due to the issue https://github.com/wazuh/wazuh/issues/9309).

