### PR TITLE
Disable `test_extra_tags_canonical_feed.py`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
@@ -73,6 +73,7 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
                                         expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solve we can enable again this test")
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
 def test_extra_tags_canonical_feed(test_values, clean_vuln_tables, get_configuration, configure_environment,
                                    modify_feed):


### PR DESCRIPTION
|Related issue|
|---|
|#1545|

## Description

This PR disables the `test_extra_tags_canonical_feed` test (blocked by the issue https://github.com/wazuh/wazuh/issues/9309).
