### PR TITLE
Fix `DeprecationWarning` in `test_providers_multiple_providers.py`

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py
@@ -62,7 +62,7 @@ def get_configuration(request):
 
 
 def test_multiple_providers(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """
+    r"""
 
     From now on, Redhat and Debian providers use two feeds to fetch vulnerabilities and CVEs' metadata.
     \<os path=...\> option indicates the local path where the OVAL feed is whereas \<path\> indicates the local path where


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1560|

This PR fixes the `DeprecationWarning` that appears when running the `test_providers_multiple_providers.py` test.
The message that no longer appears after running the test is as follows:
```
test_vulnerability_detector/test_providers/test_providers_multiple_providers.py:73
  /home/vagrant/wazuh-qa/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py:73: DeprecationWarning: invalid escape sequence \<
    """
```

### Test result:
| Test Executions | Date  | By  | Status | 
|--|--|--|--|
|[test_providers_multiple_providers_local_r1.log](https://github.com/wazuh/wazuh-qa/files/7006707/test_providers_multiple_providers_local_r1.log)| 2021-08-18 | Miguel| :yellow_circle: 