### PR TITLE
Fix cached dependencies, typos and debian repos

### DIFF
--- a/tests/system/provisioning/agentless_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -12,8 +16,10 @@
       - automake
       - autoconf
       - libtool
-    force_apt_get: True
+    force_apt_get: yes
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -13,8 +17,10 @@
       - autoconf
       - libtool
       - python3-pytest
-    force_apt_get: True
+    force_apt_get: yes
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/basic_cluster/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/agent-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -13,8 +17,10 @@
       - autoconf
       - libtool
       - python3-pytest
-    force_apt_get: True
+    force_apt_get: yes
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -13,9 +17,9 @@
       - autoconf
       - libtool
       - sqlite3
-    force_apt_get: True
+    force_apt_get: yes
     state: present
-    update-cache: true
+    update_cache: yes
     cache_valid_time: 3600
 
 - name: "Clone wazuh repository"

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -14,9 +18,9 @@
       - libtool
       - python3-pytest
       - sqlite3
-    force_apt_get: True
+    force_apt_get: yes
     state: present
-    update-cache: true
+    update_cache: yes
     cache_valid_time: 3600
 
 - name: "Clone wazuh repository"

--- a/tests/system/provisioning/enrollment_cluster/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/agent-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -13,8 +17,10 @@
       - autoconf
       - libtool
       - python3-pytest
-    force_apt_get: True
+    force_apt_get: yes
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -12,8 +16,10 @@
       - automake
       - autoconf
       - libtool
-    force_apt_get: True
+    force_apt_get: yes
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
 - name: "Installing dependencies using apt"
   apt:
     pkg:
@@ -13,8 +17,10 @@
       - autoconf
       - libtool
       - python3-pytest
-    force_apt_get: True
+    force_apt_get: yes
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: "Clone wazuh repository"
   git:


### PR DESCRIPTION
|Related issue|
|---|
| #1719  | 

# Description
This PR closes #1719.
Few APT errors appear when trying to build test environments for system tests, using Ansible.
This problem seemed to be related with cached dependencies.
Adding these lines to each `.yml` provisioning file fixed it but one new error was raised.
```
    update_cache: yes
    cache_valid_time: 3600
```

```shell
fatal: [wazuh-master]: FAILED! => changed=false 
  msg: 'Failed to update apt cache: W:This must be accepted explicitly before updates for this repository can be applied. 
See apt-secure(8) manpage for details., E:Repository ''http://security.debian.org/debian-security buster/updates InRelease'' changed its ''Suite'' value from ''stable'' to ''oldstable'', 
W:This must be accepted explicitly before updates for this repository can be applied. 
See apt-secure(8) manpage for details., W:Repository ''http://deb.debian.org/debian buster InRelease'' changed its ''Version'' value from ''10.4'' to ''10.10'', E:Repository ''http://deb.debian.org/debian buster InRelease'' changed its ''Suite'' value from ''stable'' to ''oldstable'', 
W:This must be accepted explicitly before updates for this repository can be applied. 
See apt-secure(8) manpage for details., E:Repository ''http://deb.debian.org/debian buster-updates InRelease'' changed its ''Suite'' value from ''stable-updates'' to ''oldstable-updates'''
```
Fixed it with a new block inside each `.yml` file.
```
- name: "Check and update debian repositories"
  shell:
    cmd: apt-get update --allow-releaseinfo-change
```
From man pages:
```
--allow-releaseinfo-change
Allow the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release. APT will fail at the update command for such repositories until the change is confirmed to ensure the user is prepared for the change. See also apt-secure(8) for details on the concept and configuration. 
```

I ran a test after making these changes to be sure everything is working fine (packages and dependencies, etc).
```shell script
⬦⬦⬦ ~/git/wazuh-qa/tests/system/test_cluster/test_integrity_sync ⊶ fix/1719-cached-dependencies ⨘ pytest -vv test_integrity_sync.py  --disable-warnings 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /home/kondent/pythonEnv/qa-env/bin/python3.9
cachedir: .pytest_cache
metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.11.0-27-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.2.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0', 'testinfra': '5.0.0'}}
rootdir: /home/kondent/git/wazuh-qa/tests/system/test_cluster/test_integrity_sync
plugins: html-3.1.1, metadata-1.11.0, testinfra-5.0.0
collected 4 items                                                                                                                                                                            

test_integrity_sync.py::test_missing_file PASSED                                                                                                                                       [ 25%]
test_integrity_sync.py::test_shared_files PASSED                                                                                                                                       [ 50%]
test_integrity_sync.py::test_extra_files PASSED                                                                                                                                        [ 75%]
test_integrity_sync.py::test_extra_valid_files PASSED                                                                                                                                  [100%]

=============================================================================== 4 passed in 367.45s (0:06:07) ================================================================================
```

Regards,
Alexis