### PR TITLE
DeprecationWarnings that affect vuln-det tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -269,7 +269,7 @@ def set_section_wazuh_conf(sections, template=None):
         return ET.tostringlist(elementTree.getroot(), encoding="unicode")
 
     def find_module_config(wazuh_conf: ET.ElementTree, section: str, attributes: List[dict]) -> ET.ElementTree:
-        """
+        r"""
         Check if a certain configuration section exists in ossec.conf and returns the corresponding block if exists.
         (This extra function has been necessary to implement it to configure the wodle blocks, since they have the same
         section but different attributes).
@@ -360,7 +360,7 @@ def expand_placeholders(mutable_obj, placeholders=None):
 
 def add_metadata(dikt, metadata=None):
     """
-    Create a new key 'metadata' in dikt if not already exists and updates it with metadata content.
+    Create a new key 'metadata' in dict if not already exists and updates it with metadata content.
 
     Args:
         dikt (dict):  Target dict to update metadata in.
@@ -393,7 +393,7 @@ def process_configuration(config, placeholders=None, metadata=None):
 
 
 def load_wazuh_configurations(yaml_file_path: str, test_name: str, params: list = None, metadata: list = None) -> Any:
-    """
+    r"""
     Load different configurations of Wazuh from a YAML file.
 
     Args:
@@ -510,7 +510,7 @@ def check_apply_test(apply_to_tags: Set, tags: List):
 
 
 def generate_syscheck_config():
-    """Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags'.
+    r"""Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags'.
 
     Every configuration is ready to be applied in the tag \<directories\>.
     """
@@ -527,7 +527,7 @@ def generate_syscheck_config():
 
 
 def generate_syscheck_registry_config():
-    """Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags' for Windowsregistries.
+    r"""Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags' for Windowsregistries.
 
     Every configuration is ready to be applied in the tag \<directories\>.
     """

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -59,7 +59,7 @@ class HostManager:
             check (bool, optional): Ansible check mode("Dry Run")(https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html), by default it is enabled so no changes will be applied. Default `False`
         """
         replace = f'{after}{replace}{before}'
-        self.get_host(host).ansible("replace", f"path={path} regexp='{after}[\s\S]+{before}' replace='{replace}'",
+        self.get_host(host).ansible("replace", fr"path={path} regexp='{after}[\s\S]+{before}' replace='{replace}'",
                                     check=check)
 
     def modify_file_content(self, host: str, path: str = None, content: str = ''):

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -66,7 +66,7 @@ def replace_regex(pattern, new_value, data, replace_group=False):
 
 
 def insert_xml_tag(pattern, tag, value, data):
-    """
+    r"""
     Function to insert a xml tag in a string data.
 
     Args:


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #1731|


## Description

This PR fixes the `DeprecationWarnings` that appears when running the **Vulnerability Detector** tests.
The messages that no longer appears after running the test is as follows:

<details><summary>Details</summary>
<p>

```python
../../../../../usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:283
  /usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:283: DeprecationWarning: invalid escape sequence \<
    """

../../../../../usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:409
  /usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:409: DeprecationWarning: invalid escape sequence \>
    """

../../../../../usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:516
  /usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:516: DeprecationWarning: invalid escape sequence \<
    """

../../../../../usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:533
  /usr/local/lib/python3.6/site-packages/wazuh_testing/tools/configuration.py:533: DeprecationWarning: invalid escape sequence \<
    """

../../../../../usr/local/lib/python3.6/site-packages/wazuh_testing/tools/system.py:62
  /usr/local/lib/python3.6/site-packages/wazuh_testing/tools/system.py:62: DeprecationWarning: invalid escape sequence \s
    self.get_host(host).ansible("replace", f"path={path} regexp='{after}[\s\S]+{before}' replace='{replace}'",

../../../../../usr/local/lib/python3.6/site-packages/wazuh_testing/tools/utils.py:86
  /usr/local/lib/python3.6/site-packages/wazuh_testing/tools/utils.py:86: DeprecationWarning: invalid escape sequence \<
    """
```
</p>
</details>

### Test results:
| Test Executions | Date  | By  | Status | 
|--|--|--|--|
|[test_vulnerability_detector_local_r1.log](https://github.com/wazuh/wazuh-qa/files/7019505/test_vulnerability_detector_local_r1.log)| 2021-08-19 | Miguel | :green_circle: 
|[test_vulnerability_detector_local_r2.log](https://github.com/wazuh/wazuh-qa/files/7019508/test_vulnerability_detector_local_r2.log)| 2021-08-19 | Miguel | :green_circle: 
|[test_vulnerability_detector_local_r3.log](https://github.com/wazuh/wazuh-qa/files/7019510/test_vulnerability_detector_local_r3.log)| 2021-08-19 | Miguel | :green_circle: 