### PR TITLE
Bump pyyaml dependency version to 5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pycryptodome==3.9.8
 pyOpenSSL==19.1.0
 pytest-html==2.0.1
 pytest==6.2.2
-pyyaml==5.3
+pyyaml==5.4
 requests==2.23.0
 scipy>=1.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 seaborn>=0.11.1; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'


### PR DESCRIPTION
This PR updates the Pyyaml dependency version to `5.4` due to when using `5.3` the following error is obtained

```
ImportError while loading conftest '/tmp/wazuh-qa/tests/integration/conftest.py'.
conftest.py:19: in <module>
    from wazuh_testing.tools.configuration import get_wazuh_conf, set_section_wazuh_conf, write_wazuh_conf
/home/vagrant/.local/lib/python3.8/site-packages/wazuh_testing/tools/configuration.py:13: in <module>
    import yaml
/home/vagrant/.local/lib/python3.8/site-packages/yaml/__init__.py:13: in <module>
    from .cyaml import *
/home/vagrant/.local/lib/python3.8/site-packages/yaml/cyaml.py:7: in <module>
    from _yaml import CParser, CEmitter
/usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:8: in <module>
    if not yaml.__with_libyaml__:
E   AttributeError: partially initialized module 'yaml' has no attribute '__with_libyaml__' (most likely due to a circular import)
```