### PR TITLE
Change HTML report path

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/Pytest.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/Pytest.py
@@ -73,15 +73,17 @@ class Pytest(Test):
         """
         # Paths used below
         assets_folder = 'assets/'
+        reports_folder = 'reports/'
         assets_zip = "assets.zip"
         html_report_file_name = f"test_report-{datetime.now()}.html"
         plain_report_file_name = f"plain_report-{datetime.now()}.txt"
         playbook_file_path = os.path.join(tempfile.gettempdir(), 'playbook_file.yaml')
-        plain_report_file_path = os.path.join(self.tests_run_dir, plain_report_file_name)
-        html_report_file_path = os.path.join(self.tests_run_dir, html_report_file_name)
-        assets_dest_directory = os.path.join(self.tests_result_path, assets_folder)
-        assets_src_directory = os.path.join(self.tests_run_dir, assets_folder)
-        zip_src_path = os.path.join(self.tests_run_dir, assets_zip)
+        reports_directory = os.path.join(self.tests_run_dir, reports_folder)
+        plain_report_file_path = os.path.join(reports_directory, plain_report_file_name)
+        html_report_file_path = os.path.join(reports_directory, html_report_file_name)
+        assets_dest_directory = os.path.join(reports_directory, assets_folder)
+        assets_src_directory = os.path.join(reports_directory, assets_folder)
+        zip_src_path = os.path.join(reports_directory, assets_zip)
         zip_dest_path = os.path.join(self.tests_result_path, assets_zip)
 
         if self.tests_result_path is None:
@@ -113,7 +115,7 @@ class Pytest(Test):
         if self.markers:
             pytest_command += f"-m {' '.join(self.markers)} "
 
-        pytest_command += f"--html='{self.tests_run_dir}/{html_report_file_name}'"
+        pytest_command += f"--html='{reports_directory}/{html_report_file_name}'"
 
         execute_test_task = {'name': f"Launch pytest in {self.tests_run_dir}",
                              'shell': pytest_command, 'vars':

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/Pytest.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/Pytest.py
@@ -74,6 +74,7 @@ class Pytest(Test):
 
         assets_folder = 'assets/'
         assets_zip = "assets.zip"
+        html_report = "/home/vagrant/"
         playbook_file_path = os.path.join(tempfile.gettempdir(), 'playbook_file.yaml')
 
         if self.tests_result_path is None:
@@ -108,7 +109,7 @@ class Pytest(Test):
         if self.markers:
             pytest_command += f"-m {' '.join(self.markers)} "
 
-        pytest_command += f"--html='./{html_report_file_name}'"
+        pytest_command += f"--html='{html_report_file_name}'"
 
         execute_test_task = {'shell': pytest_command, 'vars':
                              {'chdir': self.tests_run_dir},
@@ -121,7 +122,7 @@ class Pytest(Test):
         fetch_plain_report = {'fetch': {'src': os.path.join(self.tests_run_dir, plain_report_file_name),
                                         'dest': self.tests_result_path, 'flat': 'yes'}}
 
-        fetch_html_report = {'fetch': {'src': os.path.join(self.tests_run_dir, html_report_file_name),
+        fetch_html_report = {'fetch': {'src': os.path.join(html_report, html_report_file_name),
                                        'dest': self.tests_result_path, 'flat': 'yes'}}
 
         create_assets_directory = {'local_action': {'module': 'ansible.builtin.file',
@@ -129,11 +130,11 @@ class Pytest(Test):
                                                     'state': 'directory'},
                                    'become': False}
 
-        compress_assets_folder = {'community.general.archive': {'path': os.path.join(self.tests_run_dir, assets_folder),
-                                                                'dest': os.path.join(self.tests_run_dir, assets_zip),
+        compress_assets_folder = {'community.general.archive': {'path': os.path.join(html_report, assets_folder),
+                                                                'dest': os.path.join(html_report, assets_zip),
                                                                 'format': 'zip'}}
 
-        fetch_compressed_assets = {'fetch': {'src': os.path.join(self.tests_run_dir, assets_zip),
+        fetch_compressed_assets = {'fetch': {'src': os.path.join(html_report, assets_zip),
                                              'dest': self.tests_result_path, 'flat': 'yes'}}
 
         uncompress_assets = {'local_action': {'module': 'unarchive',


### PR DESCRIPTION
|Related issue|
|---|
|close #1728|

## Description

This PR makes the followings changes:

- Fix HTML report file and assets path

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.

## Checks
HTML report correctly working now as showed here https://github.com/wazuh/wazuh-qa/issues/1728#issuecomment-901797765
