### PR TITLE
Delete deprecation warnings on Remoted

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -269,7 +269,7 @@ def set_section_wazuh_conf(sections, template=None):
         return ET.tostringlist(elementTree.getroot(), encoding="unicode")
 
     def find_module_config(wazuh_conf: ET.ElementTree, section: str, attributes: List[dict]) -> ET.ElementTree:
-        """
+        r"""
         Check if a certain configuration section exists in ossec.conf and returns the corresponding block if exists.
         (This extra function has been necessary to implement it to configure the wodle blocks, since they have the same
         section but different attributes).
@@ -393,7 +393,7 @@ def process_configuration(config, placeholders=None, metadata=None):
 
 
 def load_wazuh_configurations(yaml_file_path: str, test_name: str, params: list = None, metadata: list = None) -> Any:
-    """
+    r"""
     Load different configurations of Wazuh from a YAML file.
 
     Args:
@@ -510,7 +510,7 @@ def check_apply_test(apply_to_tags: Set, tags: List):
 
 
 def generate_syscheck_config():
-    """Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags'.
+    r"""Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags'.
 
     Every configuration is ready to be applied in the tag \<directories\>.
     """
@@ -527,7 +527,7 @@ def generate_syscheck_config():
 
 
 def generate_syscheck_registry_config():
-    """Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags' for Windowsregistries.
+    r"""Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags' for Windowsregistries.
 
     Every configuration is ready to be applied in the tag \<directories\>.
     """

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -59,7 +59,7 @@ class HostManager:
             check (bool, optional): Ansible check mode("Dry Run")(https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html), by default it is enabled so no changes will be applied. Default `False`
         """
         replace = f'{after}{replace}{before}'
-        self.get_host(host).ansible("replace", f"path={path} regexp='{after}[\s\S]+{before}' replace='{replace}'",
+        self.get_host(host).ansible("replace", fr"path={path} regexp='{after}[\s\S]+{before}' replace='{replace}'",
                                     check=check)
 
     def modify_file_content(self, host: str, path: str = None, content: str = ''):

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -66,7 +66,7 @@ def replace_regex(pattern, new_value, data, replace_group=False):
 
 
 def insert_xml_tag(pattern, tag, value, data):
-    """
+    r"""
     Function to insert a xml tag in a string data.
 
     Args:


### PR DESCRIPTION
|Related issue|
|---|
|#1740|


## Description

This issue has the same changes of this [PR ](https://github.com/wazuh/wazuh-qa/pull/1735). Only remove general warnings.

## Configuration options

```
remoted.debug=2
wazuh_database.interval=1
wazuh_db.commit_time=2
wazuh_db.commit_time_max=3
monitord.rotate_log=0
```

## Logs example

| Test Executions | Date  | By  | Status
|--|--|--|--|
|[Results 1](https://github.com/wazuh/wazuh-qa/files/7016384/GreenRemoted.log)| 2021-08-19 | Seyla|   :green_circle: 
|[Results 2](https://github.com/wazuh/wazuh-qa/files/7016626/GreenRemoted2.log)| 2021-08-19 | Seyla|  :green_circle: 



## Tests

- [x] Proven that tests **pass** when they have to pass.

