### PR TITLE
QACTL: Separate test execution and provisioning logic

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_framework/QAFramework.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_framework/QAFramework.py
@@ -30,8 +30,8 @@ class QAFramework():
             inventory_file_path (str): Path were save the ansible inventory.
         """
         dependencies_task = AnsibleTask({'name': 'Install python dependencies',
-                                         'shell': 'pip3 install -r requirements.txt --no-cache-dir --upgrade '
-                                                  '--only-binary=:cryptography,grpcio:',
+                                         'shell': 'python3 -m pip install -r requirements.txt --no-cache-dir --upgrade '
+                                                  '--only-binary=:cryptography,grpcio: --ignore-installed',
                                          'args': {'chdir': self.workdir}})
         ansible_tasks = [dependencies_task]
         playbook_parameters = {'hosts': hosts, 'tasks_list': ansible_tasks}

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/QARunTests.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/QARunTests.py
@@ -1,3 +1,5 @@
+from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleInstance import AnsibleInstance
+from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleInventory import AnsibleInventory
 from wazuh_testing.qa_ctl.run_tests.Pytest import Pytest
 
 
@@ -9,26 +11,65 @@ class RunQATests():
 
         Attributes:
             tests (list(Pytest)): list of Pytest instances to run at the specified remote machines
-
+            inventory_file_path (string): Path of the inventory file generated.
     """
 
     def __init__(self, tests_parameters):
         self.tests = []
-        for key, value in tests_parameters.items():
-            self.tests.append(self.__build_test(value))
+        self.inventory_file_path = None
 
-    def __build_test(self, test_params):
+        self.__process_inventory_data(tests_parameters)
+
+        for _, host_value in tests_parameters.items():
+            self.tests.append(self.__build_test(host_value['test'], host_value['host_info']['host']))
+
+    def __read_ansible_instance(self, host_info):
+        """Read every host info and generate the AnsibleInstance object.
+
+        Attributes:
+            host_info (dict): Dict with the host info needed coming from config file.
+
+        Returns:
+            instance (AnsibleInstance): Contains the AnsibleInstance for a given host.
+        """
+        extra_vars = None if 'host_vars' not in host_info else host_info['host_vars']
+        private_key_path = None if 'local_private_key_file_path' not in host_info \
+                                   else host_info['local_private_key_file_path']
+        instance = AnsibleInstance(host=host_info['host'], host_vars=extra_vars,
+                                   connection_method=host_info['connection_method'],
+                                   connection_port=host_info['connection_port'], connection_user=host_info['user'],
+                                   connection_user_password=host_info['password'],
+                                   ssh_private_key_file_path=private_key_path,
+                                   ansible_python_interpreter=host_info['ansible_python_interpreter'])
+        return instance
+
+    def __process_inventory_data(self, instances_info):
+        """Process config file info to generate the ansible inventory file."""
+        instances_list = []
+
+        for _, host_value in instances_info.items():
+            for module_key, module_value in host_value.items():
+                if module_key == 'host_info':
+                    current_host = module_value['host']
+                    if current_host:
+                        instances_list.append(self.__read_ansible_instance(module_value))
+
+        inventory_instance = AnsibleInventory(ansible_instances=instances_list)
+        self.inventory_file_path = inventory_instance.inventory_file_path
+
+    def __build_test(self, test_params, host=['all']):
         """Private method in charge of reading all the required fields to build one test of type Pytest
 
             Args:
                 test_params (dict): all the data regarding one specific test
+                host: Host IP where the test will be run
 
             Returns:
                 Pytest: one instance of Pytest built from the parameters in test_params
         """
         test_dict = {}
 
-        test_dict['hosts'] = ['all'] if 'hosts' not in test_params else test_params['hosts']
+        test_dict['hosts'] = [host]
 
         if 'path' in test_params:
             paths = test_params['path']

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/TestLauncher.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/TestLauncher.py
@@ -10,15 +10,11 @@ class TestLauncher:
 
     Attributes:
         tests (list(Test)): List containing all the tests to be executed in the remote machine
-        wazuh_dir_paths (dict): dictionary containing a list of key-value pairs referring to host alias and wazuh
-                                 installation path
         ansible_inventory_path (str): path to the ansible inventory file
         qa_framework_path (str, None): remote directory path where the qa repository will be download to
 
     Args:
         tests (list(Test)): List containing all the tests to be executed in the remote machine
-        install_dir_paths (dict): dictionary containing a list of key-value pairs referring to host alias and wazuh
-                                 installation path
         ansible_inventory_path (str): path to the ansible inventory file
         qa_framework_path (str, None): remote directory path where the qa repository will be download to
 
@@ -28,14 +24,12 @@ class TestLauncher:
                      "wazuh_modules.debug=2", "wazuh_database.interval=1", "wazuh_db.commit_time=2",
                      "wazuh_db.commit_time_max=3", "remoted.debug=2"]
 
-    def __init__(self, tests, install_dir_paths, ansible_inventory_path,
-                 qa_framework_path=None):
+    def __init__(self, tests, ansible_inventory_path, qa_framework_path=None):
         self.qa_framework_path = qa_framework_path if qa_framework_path is not None else \
                                                      os.path.join(tempfile.gettempdir(), 'wazuh-qa/')
         self.ansible_inventory_path = ansible_inventory_path
         self.tests = tests
-        self.wazuh_dir_paths = install_dir_paths
-        self.wazuh_dir_paths.update({'all': '/var/ossec/'})
+
 
     def __set_local_internal_options(self, hosts):
         """Private method that set the local internal options in the hosts passed by parameter
@@ -44,16 +38,10 @@ class TestLauncher:
                 hosts (list(str)): list of hosts aliases to index the dict attribute wazuh_dir_paths and extract the
                                   wazuh installation path
         """
-        local_internal_path = ""
-        local_internal_options = "\n".join(self.DEBUG_OPTIONS)
+        local_internal_options = '\n'.join(self.DEBUG_OPTIONS)
         playbook_file_path = os.path.join(tempfile.gettempdir(), 'playbook_file.yaml')
 
-        if hosts in self.wazuh_dir_paths:
-            local_internal_path += os.path.join(self.wazuh_dir_paths[hosts], '')
-        else:
-            local_internal_path += self.wazuh_dir_paths['all']
-
-        local_internal_path += 'etc/local_internal_options.conf'
+        local_internal_path = '/var/ossec/etc/local_internal_options.conf'
 
         set_local_internal_opts = {'lineinfile': {'path': local_internal_path,
                                    'line': local_internal_options}}

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -3,11 +3,14 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import argparse
 import os
+import yaml
+
+from time import sleep
 from wazuh_testing.qa_ctl.deployment.QAInfraestructure import QAInfraestructure
 from wazuh_testing.qa_ctl.provisioning.QAProvisioning import QAProvisioning
 from wazuh_testing.qa_ctl.run_tests.QARunTests import RunQATests
 from wazuh_testing.qa_ctl.run_tests.TestLauncher import TestLauncher
-import yaml
+
 
 DEPLOY_KEY = 'deployment'
 PROVISION_KEY = 'provision'
@@ -38,6 +41,8 @@ def main():
                 instance_handler.run()
 
             if PROVISION_KEY in yaml_config:
+                if DEPLOY_KEY in yaml_config:
+                    sleep(5)  # If machines are deployed, wait 5 seconds before connecting
                 provision_dict = yaml_config[PROVISION_KEY]
                 qa_provisioning = QAProvisioning(provision_dict)
                 qa_provisioning.process_inventory_data()

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -45,10 +45,8 @@ def main():
 
             if TEST_KEY in yaml_config:
                 test_dict = yaml_config[TEST_KEY]
-                qa_test = RunQATests(test_dict)
-                test_launcher = TestLauncher(tests=qa_test.tests,
-                                             ansible_inventory_path=qa_provisioning.inventory_file_path,
-                                             install_dir_paths=qa_provisioning.wazuh_installation_paths)
+                tests_runner = RunQATests(test_dict)
+                test_launcher = TestLauncher(tests_runner.tests, tests_runner.inventory_file_path)
                 test_launcher.run()
 
         finally:


### PR DESCRIPTION
|Related issue|
|---|
|close #1734 |

## Description

The objective of this PR is to separate the test module from the provisioning module so that there are no dependencies between the two. Until now, to execute the test module it was always necessary to execute the provisioning module. This PR makes the necessary changes to make it independent.

The following changes have been made:

- Update an error when installing python dependencies on centOS
- Update QARunTests module to add and process host information
- Delete custom wazuh installation paths because it was causing some errors and it is not necessary currently.
- Add waiting time between deployment and provision stage due to connection refused errors.
