### PR TITLE
Fix QACTL docker deployment and provisioning

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/amazon/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/amazon/Dockerfile
@@ -1,0 +1,36 @@
+FROM amazonlinux:2.0.20200602.0
+
+RUN yum update -y && \
+    yum install -y \
+        openssh-server \
+        nano \
+        openssl \
+        sudo \
+        gcc \
+        git \
+        python3 \
+        python3-devel
+
+ADD entrypoint.sh /usr/bin/entrypoint.sh
+ADD https://raw.githubusercontent.com/wazuh/wazuh-qa/master/requirements.txt /tmp/requirements.txt
+
+RUN pip3 install --upgrade pip && \
+    pip install -r /tmp/requirements.txt
+
+RUN useradd wazuh && \
+    echo 'wazuh:wazuh' | chpasswd && \
+    echo "wazuh ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN echo 'root:root' | chpasswd
+
+RUN sed -i 's/#SyslogFacility AUTHPRIV/SyslogFacility DAEMON/g' /etc/ssh/sshd_config && \
+    sed -ri 's/.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config && \
+    sed -i 's/#Port 22/Port 22/g' /etc/ssh/sshd_config && \
+    mkdir /var/run/sshd && \
+    mkdir -p /home/wazuh && \
+    chmod +x /usr/bin/entrypoint.sh && \
+    echo 'Defaults:root !requiretty' >> /etc/sudoers
+
+EXPOSE 22/tcp 1514/udp 1514/tcp 1515/tcp 1516/tcp 514/udp 514/tcp 55000/tcp
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/amazon/entrypoint.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/amazon/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/ssh-keygen -A  # Generate the ssh keys
+/usr/sbin/sshd
+
+tail -f /dev/null

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/ubuntu/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/ubuntu/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:focal
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+      software-properties-common \
+      openssl \
+      curl \
+      apt-transport-https \
+      lsb-release \
+      gnupg2 \
+      make \
+      libc6-dev \
+      gcc \
+      g++ \
+      python \
+      python3-pip \
+      policycoreutils \
+      automake \
+      autoconf \
+      libtool \
+      libssl-dev \
+      git \
+      wget \
+      openssh-server
+ADD entrypoint.sh /usr/bin/entrypoint.sh
+ADD https://raw.githubusercontent.com/wazuh/wazuh-qa/master/requirements.txt /tmp/requirements.txt
+
+RUN pip3 install --upgrade pip && \
+    pip install -r /tmp/requirements.txt
+
+RUN useradd wazuh && \
+    echo 'wazuh:wazuh' | chpasswd && \
+    echo "wazuh ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN echo 'root:root' | chpasswd
+
+RUN sed -i 's/#SyslogFacility AUTHPRIV/SyslogFacility DAEMON/g' /etc/ssh/sshd_config && \
+    sed -ri 's/.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config && \
+    sed -i 's/#Port 22/Port 22/g' /etc/ssh/sshd_config && \
+    mkdir /var/run/sshd && \
+    mkdir -p /home/wazuh && \
+    chmod +x /usr/bin/entrypoint.sh && \
+    echo 'Defaults:root !requiretty' >> /etc/sudoers
+
+
+EXPOSE 22/tcp 1514/udp 1514/tcp 1515/tcp 1516/tcp 514/udp 514/tcp 55000/tcp
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/ubuntu/entrypoint.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/ubuntu/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+/usr/sbin/sshd
+
+tail -f /dev/null

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/AnsibleInventory.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/AnsibleInventory.py
@@ -47,7 +47,7 @@ class AnsibleInventory():
                         'ansible_python_interpreter': instance.ansible_python_interpreter,
                         'ansible_ssh_private_key_file': instance.ssh_private_key_file_path,
                         'vars': instance.host_vars,
-                        'ansible_ssh_common_args': "-o StrictHostKeyChecking=no"
+                        'ansible_ssh_common_args': "-o UserKnownHostsFile=/dev/null"
                         }
 
             # Remove ansible vars with None value


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1743|

This PR fixes deployment issues for `Amazon Linux` and `Ubuntu 20.04` containers.

#### Connection problems on `Amazon Linux`

The problem was due to not using `systemd` to start the `sshd` service in Docker containers. This service (`systemd` unit `sshd.service`) is responsible for generating the necessary keys for the `sshd` daemon when it is run for the first time. As a workaround I have added to the `entrypoint.sh` file of Amazon Linux the command that generates these keys before the start of the sshd service.

Once the fix is applied, Ansible connects correctly and deployment of the environment proceeds smoothly:

<details><summary>QACTL deployment and provisioning output</summary>
<p>

```python
PLAY [172.11.0.1] **************************************************************

TASK [Create /tmp path] ********************************************************
ok: [172.11.0.1]

TASK [Copy (hiden_path)/wazuh-manager-4.2.0-1.1493.x86_64.rpm package to                                                    /tmp] ***
changed: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAY [172.11.0.1] **************************************************************

TASK [Gathering Facts] *********************************************************
ok: [172.11.0.1]

TASK [Install Wazuh Agent from .deb packages] **********************************
skipping: [172.11.0.1]

TASK [Install Wazuh Agent from .rpm packages | yum] ****************************
changed: [172.11.0.1]

TASK [Install Wazuh Agent from .rpm packages | dnf] ****************************
skipping: [172.11.0.1]

TASK [Install Wazuh Agent from Windows packages] *******************************
skipping: [172.11.0.1]

TASK [Install macOS wazuh package] *********************************************
skipping: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=2    changed=1    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   


PLAY [172.11.0.1] **************************************************************

TASK [Gathering Facts] *********************************************************
ok: [172.11.0.1]

TASK [Wazuh manager start service from systemd] ********************************
fatal: [172.11.0.1]: FAILED! => {"changed": false, "msg": "Service is in unknown state", "status": {}}
...ignoring

TASK [Wazuh agent start service from wazuh-control] ****************************
changed: [172.11.0.1]

TASK [Wazuh agent start service from Windows] **********************************
skipping: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=3    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=1   


PLAY [172.11.0.1] **************************************************************

TASK [Gathering Facts] *********************************************************
ok: [172.11.0.1]

TASK [Read ossec.log searching errors] *****************************************
changed: [172.11.0.1]

TASK [Read ossec.log searching errors] *****************************************
skipping: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=2    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   


PLAY [172.11.0.1] **************************************************************

TASK [Gathering Facts] *********************************************************
ok: [172.11.0.1]

TASK [Extract service status] **************************************************
changed: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAY [172.11.0.1] **************************************************************

TASK [Create /tmp/wazuh-qa path] ***********************************************
changed: [172.11.0.1]

TASK [Download https://github.com/wazuh/wazuh-qa.git QA repository] ************
changed: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAY [172.11.0.1] **************************************************************

TASK [Install python dependencies] *********************************************
changed: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAY [172.11.0.1] **************************************************************

TASK [Install wazuh-qa framework] **********************************************
changed: [172.11.0.1]

PLAY RECAP *********************************************************************
172.11.0.1                 : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
</p>
</details>

<details><summary>Manager status</summary>
<p>

```python
bash-4.2# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
bash-4.2# 
```
</p>
</details>

<details><summary>Wazuh-QA local repository</summary>
<p>

```python
bash-4.2# cd /tmp/wazuh-qa/
bash-4.2# git branch
* master
bash-4.2# 
```
</p>
</details>


#### Error when a different SSH key exists in the `known_hosts` file.

The solution is to replace in the Ansible inventory the SSH option `StrictHostKeyChecking=no` by `UserKnownHostsFile=/dev/null`