### PR TITLE
Disable 'test_agentd_state_config' by Windows-Core issues 

### DIFF
--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,6 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
+@pytest.mark.skip(reason="Test disabled by #1678 until #1593 and #8746 are fixed")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')


### PR DESCRIPTION
|Related issue|
|---|
|#1678  |

## Description

This test will be disabled until #1593 and wazuh/wazuh#8746 are fixed.

However, with this fix the test fails with a problem in `test_agentd_enrollment_params.py`.
But the focus here is disable this test and it works. After that I will retry executed again all  to research this fail, because it isn't affect by my changes.

### Pipeline parameters

|  Jenkins branch  | QA branch   | 
|- |- |
|  4.2 |   1516-4.2.0-full-green |

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi

### local_internal_options.conf

#### Agent
```
agent.debug=2
execd.debug=2
monitord.rotate_log=0
```

## Tests results

| **Jenkins**  |  **Status** |   **Date** |  **Comment**
|:--:|:--:|:--:|:--:|
| [Build](https://devel.ci.wazuh.info/view/Tests/job/Test_integration/1073/)   |  🔴 | 24-08-21 | Fails on Windows `test_agentd_enrollment_params.py`  -  CentOS work successfully.
