### PR TITLE
Disable only on Windows some Agentd tests by windows-core issues

### DIFF
--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -15,7 +15,7 @@ from wazuh_testing.tools.remoted_sim import RemotedSimulator
 from wazuh_testing.tools.services import control_service
 
 from conftest import *
-
+import sys
 # Marks
 
 pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0), pytest.mark.agent]
@@ -178,7 +178,7 @@ def check_log_error_conf(msg):
 
 
 @pytest.mark.parametrize('test_case', [case for case in tests])
-@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -178,6 +178,7 @@ def check_log_error_conf(msg):
 
 
 @pytest.mark.parametrize('test_case', [case for case in tests])
+@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,7 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,7 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-@pytest.mark.skip(reason="Test disabled by #1678 until #1593 and #8746 are fixed")
+@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')


### PR DESCRIPTION
|Related issue|
|---|
|#1678|

### Description

This PR only disable tests `

### Pipeline parameters

|  Jenkins branch  | QA branch   | 
|- |- |
|  4.2 |   1516-4.2.0-full-green |

### Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi

### local_internal_options.conf

#### Agent
```
agent.debug=2
execd.debug=2
monitord.rotate_log=0
```

### Test Results - Research

 | **Jenkins Results**  |  **Status** 
|:--:|:--:|
|    [Linux - Results](https://ci.wazuh.info/view/Tests/job/Test_integration/9842/)   |  🟢 
|  [Windows - Results ](https://ci.wazuh.info/view/Tests/job/Test_integration/9843/)   |  🟢 
