### PR TITLE
Disable test_wpk_agent tests only on Linux-Agent by core issue

### DIFF
--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -14,7 +14,7 @@ import json
 from wazuh_testing import tools
 from wazuh_testing.tools.monitoring import make_callback, FileMonitor
 from datetime import datetime
-from wazuh_testing.tools import WAZUH_PATH, get_version
+from wazuh_testing.tools import WAZUH_PATH, get_version, get_service
 from wazuh_testing.tools.authd_sim import AuthdSimulator
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.file import truncate_file, count_file_lines
@@ -42,6 +42,8 @@ UPGRADE_RESULT_PATH = os.path.join(WAZUH_PATH, upgrade_result_folder, 'upgrade_r
 CRYPTO = "aes"
 SERVER_ADDRESS = 'localhost'
 PROTOCOL = "tcp"
+mark_skip_agentLinux = pytest.mark.skipif(get_service() == 'wazuh-agent' and
+                                          sys_platform == 'Linux', reason="It will be blocked by wazuh/wazuh#9763")
 
 if not global_parameters.wpk_version:
     raise Exception("The WPK package version must be defined by parameter. See README.md")
@@ -342,10 +344,6 @@ def prepare_agent_version(get_configuration):
         if len(backups_files) > 0:
             subprocess.call(['tar', 'xzf', f'{WAZUH_PATH}/backup/{backups_files[-1]}',
                             '-C', '/'])
-
-
-mark_skip_agentLinux = pytest.mark.skipif(
-    pytest.mark.linux and pytest.mark.agent, reason="It will be blocked by wazuh/wazuh#9763")
 
 
 @mark_skip_agentLinux

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -344,6 +344,11 @@ def prepare_agent_version(get_configuration):
                             '-C', '/'])
 
 
+mark_skip_agentLinux = pytest.mark.skipif(
+    pytest.mark.linux and pytest.mark.agent, reason="It will be blocked by wazuh/wazuh#9763")
+
+
+@mark_skip_agentLinux
 def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                    configure_environment, start_agent):
     metadata = get_configuration['metadata']


### PR DESCRIPTION
|Related issue|
|---|
|#1705|

## Description
This PR only disable `test_wpk_agent` tests for all execuitons on Linux Agent.

The issue that affect this Test is https://github.com/wazuh/wazuh/issues/9763 

## Pipeline parameters

|  Jenkins branch  | QA branch   |  Version 	|   Revision |
|- |- |- |- |
|  4.2 |   1516-4.2.0-full-green | 4.2  |  1.1493 | 

## Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm
Agent | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.x86_64.rpm
Agent | Windows | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-agent-4.2.0-1.1493.msi

## local_internal_options.conf

#### Linux Manager
```
wazuh_modules.debug=2
```

#### Linux Agent
```
wazuh_modules.debug=2
```

#### Windows Agent
```
windows.debug=2
```

## pytest args
`--wpk_version=v4.2.0`

## Test Results - Research

| **Jenkins**  |  **Status** 
|:--:|:--: |
|  [Linux Manager- Results](https://ci.wazuh.info/view/Tests/job/Test_integration/9870/)   | 🟢 
|  [Linux Agent- Results](https://ci.wazuh.info/view/Tests/job/Test_integration/9871/)   |  🟢 
|  [Windows Agent- Results](https://ci.wazuh.info/view/Tests/job/Test_integration/9872/) | 🟢 
