### PR TITLE
QACTL: Add parallelization of QACTL modules

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -27,7 +27,8 @@ setup(name='wazuh_testing',
                                       'tools/macos_log/log_generator.m',
                                       'qa_ctl/deployment/dockerfiles/*',
                                       'qa_ctl/deployment/vagrantfile_template.txt',
-                                      'qa_ctl/provisioning/wazuh_deployment/templates/preloaded_vars.conf.j2'
+                                      'qa_ctl/provisioning/wazuh_deployment/templates/preloaded_vars.conf.j2',
+                                      'data/qactl_conf_validator_schema.json'
                                       ]
                     },
       entry_points={

--- a/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
+++ b/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
@@ -25,7 +25,6 @@
                     "vm_cpu",
                     "vm_name",
                     "vm_system",
-                    "os",
                     "label",
                     "vm_ip"
                   ],
@@ -49,9 +48,6 @@
                       "type": "string"
                     },
                     "vm_system": {
-                      "type": "string"
-                    },
-                    "os": {
                       "type": "string"
                     },
                     "label": {
@@ -210,8 +206,8 @@
                       "if": {
                         "properties": {"target": {"const": "agent"}}
                       },
-                      "then": {"required": ["manager_ip"]}       
-                    }        
+                      "then": {"required": ["manager_ip"]}
+                    }
                   ]
                 },
                 "qa_framework": {

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/QAInfraestructure.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/QAInfraestructure.py
@@ -1,10 +1,12 @@
 # Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-from wazuh_testing.qa_ctl.deployment.DockerWrapper import DockerWrapper
-from wazuh_testing.qa_ctl.deployment.VagrantWrapper import VagrantWrapper
 import ipaddress
 import docker
+
+from wazuh_testing.qa_ctl.deployment.DockerWrapper import DockerWrapper
+from wazuh_testing.qa_ctl.deployment.VagrantWrapper import VagrantWrapper
+from wazuh_testing.tools.thread_executor import ThreadExecutor
 
 
 class QAInfraestructure:
@@ -87,23 +89,43 @@ class QAInfraestructure:
 
     def run(self):
         """Execute the run method on every configured instance."""
-        for instance in self.instances:
-            instance.run()
+        runner_threads = [ThreadExecutor(instance.run) for instance in self.instances]
+
+        for runner_thread in runner_threads:
+            runner_thread.start()
+
+        for runner_thread in runner_threads:
+            runner_thread.join()
 
     def halt(self):
         """Execute the 'halt' method on every configured instance."""
-        for instance in self.instances:
-            instance.halt()
+        runner_threads = [ThreadExecutor(instance.halt) for instance in self.instances]
+
+        for runner_thread in runner_threads:
+            runner_thread.start()
+
+        for runner_thread in runner_threads:
+            runner_thread.join()
 
     def restart(self):
         """Execute the 'restart' method on every configured instance."""
-        for instance in self.instances:
-            instance.restart()
+        runner_threads = [ThreadExecutor(instance.restart) for instance in self.instances]
+
+        for runner_thread in runner_threads:
+            runner_thread.start()
+
+        for runner_thread in runner_threads:
+            runner_thread.join()
 
     def destroy(self):
         """Execute the 'destroy' method on every configured instance."""
-        for instance in self.instances:
-            instance.destroy()
+        runner_threads = [ThreadExecutor(instance.destroy) for instance in self.instances]
+
+        for runner_thread in runner_threads:
+            runner_thread.start()
+
+        for runner_thread in runner_threads:
+            runner_thread.join()
 
         if self.docker_network:
             try:

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/QAInfraestructure.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/QAInfraestructure.py
@@ -87,45 +87,33 @@ class QAInfraestructure:
 
                     self.instances.append(docker_instance)
 
-    def run(self):
-        """Execute the run method on every configured instance."""
-        runner_threads = [ThreadExecutor(instance.run) for instance in self.instances]
+    def __threads_runner(self, threads):
+        """Auxiliary function to start and wait for threads
 
-        for runner_thread in runner_threads:
+        Args:
+            threads (list(ThreadExecutor)): Thread executors
+        """
+        for runner_thread in threads:
             runner_thread.start()
 
-        for runner_thread in runner_threads:
+        for runner_thread in threads:
             runner_thread.join()
+
+    def run(self):
+        """Execute the run method on every configured instance."""
+        self.__threads_runner([ThreadExecutor(instance.run) for instance in self.instances])
 
     def halt(self):
         """Execute the 'halt' method on every configured instance."""
-        runner_threads = [ThreadExecutor(instance.halt) for instance in self.instances]
-
-        for runner_thread in runner_threads:
-            runner_thread.start()
-
-        for runner_thread in runner_threads:
-            runner_thread.join()
+        self.__threads_runner([ThreadExecutor(instance.halt) for instance in self.instances])
 
     def restart(self):
         """Execute the 'restart' method on every configured instance."""
-        runner_threads = [ThreadExecutor(instance.restart) for instance in self.instances]
-
-        for runner_thread in runner_threads:
-            runner_thread.start()
-
-        for runner_thread in runner_threads:
-            runner_thread.join()
+        self.__threads_runner([ThreadExecutor(instance.restart) for instance in self.instances])
 
     def destroy(self):
         """Execute the 'destroy' method on every configured instance."""
-        runner_threads = [ThreadExecutor(instance.destroy) for instance in self.instances]
-
-        for runner_thread in runner_threads:
-            runner_thread.start()
-
-        for runner_thread in runner_threads:
-            runner_thread.join()
+        self.__threads_runner([ThreadExecutor(instance.destroy) for instance in self.instances])
 
         if self.docker_network:
             try:

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/QAProvisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/QAProvisioning.py
@@ -8,6 +8,7 @@ from wazuh_testing.qa_ctl.provisioning.wazuh_deployment.ManagerDeployment import
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleRunner import AnsibleRunner
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleTask import AnsibleTask
 from wazuh_testing.qa_ctl.provisioning.qa_framework.QAFramework import QAFramework
+from wazuh_testing.tools.thread_executor import ThreadExecutor
 
 
 class QAProvisioning():
@@ -57,6 +58,74 @@ class QAProvisioning():
                                    ansible_python_interpreter=host_info['ansible_python_interpreter'])
         return instance
 
+    def __process_config_data(self, host_provision_info):
+        """Process config file info to generate all the tasks needed for deploy Wazuh
+
+        Args:
+            host_provision_info (dict): Dicionary with host provisioning info
+        """
+        current_host = host_provision_info['host_info']['host']
+
+        if 'wazuh_deployment' in host_provision_info:
+            deploy_info = host_provision_info['wazuh_deployment']
+            health_check = True if 'health_check' not in host_provision_info['wazuh_deployment'] \
+                else host_provision_info['wazuh_deployment']['health_check']
+            install_target = None if 'target' not in deploy_info else deploy_info['target']
+            install_type = None if 'type' not in deploy_info else deploy_info['type']
+            installation_files_path = None if 'installation_files_path' not in deploy_info \
+                else deploy_info['installation_files_path']
+            wazuh_install_path = None if 'wazuh_install_path' not in deploy_info \
+                else deploy_info['wazuh_install_path']
+            wazuh_branch = 'master' if 'wazuh_branch' not in deploy_info else deploy_info['wazuh_branch']
+            local_package_path = None if 'local_package_path' not in deploy_info \
+                else deploy_info['local_package_path']
+            manager_ip = None if 'manager_ip' not in deploy_info else deploy_info['manager_ip']
+
+            installation_files_parameters = {'wazuh_target': install_target}
+
+            if installation_files_path:
+                installation_files_parameters['installation_files_path'] = installation_files_path
+            if wazuh_install_path:
+                installation_files_parameters['wazuh_install_path'] = wazuh_install_path
+
+            if install_type == "sources":
+                installation_files_parameters['wazuh_branch'] = wazuh_branch
+                installation_instance = WazuhSources(**installation_files_parameters)
+            if install_type == "package":
+                installation_files_parameters['local_package_path'] = local_package_path
+                installation_instance = LocalPackage(**installation_files_parameters)
+
+            remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,
+                                                                                  hosts=current_host)
+
+            if install_target == "agent":
+                deployment_instance = AgentDeployment(remote_files_path,
+                                                      inventory_file_path=self.inventory_file_path,
+                                                      install_mode=install_type, hosts=current_host,
+                                                      server_ip=manager_ip)
+            if install_target == "manager":
+                deployment_instance = ManagerDeployment(remote_files_path,
+                                                        inventory_file_path=self.inventory_file_path,
+                                                        install_mode=install_type, hosts=current_host)
+            deployment_instance.install()
+
+            if health_check:
+                # Wait for Wazuh initialization before health_check
+                sleep(60)
+                deployment_instance.health_check()
+
+            self.wazuh_installation_paths[deployment_instance.hosts] = deployment_instance.install_dir_path
+
+        if 'qa_framework' in host_provision_info:
+            qa_framework_info = host_provision_info['qa_framework']
+            wazuh_qa_branch = None if 'wazuh_qa_branch' not in qa_framework_info \
+                else qa_framework_info['wazuh_qa_branch']
+
+            qa_instance = QAFramework(qa_branch=wazuh_qa_branch)
+            qa_instance.download_qa_repository(inventory_file_path=self.inventory_file_path, hosts=current_host)
+            qa_instance.install_dependencies(inventory_file_path=self.inventory_file_path, hosts=current_host)
+            qa_instance.install_framework(inventory_file_path=self.inventory_file_path, hosts=current_host)
+
     def check_hosts_connection(self, hosts='all'):
         """Check that all hosts are reachable via SSH connection
 
@@ -87,67 +156,13 @@ class QAProvisioning():
                                               ansible_groups=self.group_dict)
         self.inventory_file_path = inventory_instance.inventory_file_path
 
-    def process_deployment_data(self):
-        """Process config file info to generate all the tasks needed for deploy Wazuh"""
-        for _, host_value in self.provision_info['hosts'].items():
-            current_host = host_value['host_info']['host']
-            if 'wazuh_deployment' in host_value:
-                deploy_info = host_value['wazuh_deployment']
-                health_check = True if 'health_check' not in host_value['wazuh_deployment'] \
-                                       else host_value['wazuh_deployment']['health_check']
-                install_target = None if 'target' not in deploy_info else deploy_info['target']
-                install_type = None if 'type' not in deploy_info else deploy_info['type']
-                installation_files_path = None if 'installation_files_path' not in deploy_info \
-                                                  else deploy_info['installation_files_path']
-                wazuh_install_path = None if 'wazuh_install_path' not in deploy_info \
-                                             else deploy_info['wazuh_install_path']
-                wazuh_branch = 'master' if 'wazuh_branch' not in deploy_info else deploy_info['wazuh_branch']
-                local_package_path = None if 'local_package_path' not in deploy_info \
-                                             else deploy_info['local_package_path']
-                manager_ip = None if 'manager_ip' not in deploy_info else deploy_info['manager_ip']
+    def provision(self):
+        """Provision all hosts in a parallel way"""
+        provision_threads = [ThreadExecutor(self.__process_config_data, parameters={'host_provision_info': host_value})
+                                for _, host_value in self.provision_info['hosts'].items()]
 
-                installation_files_parameters = {'wazuh_target': install_target}
+        for runner_thread in provision_threads:
+            runner_thread.start()
 
-                if installation_files_path:
-                    installation_files_parameters['installation_files_path'] = installation_files_path
-                if wazuh_install_path:
-                    installation_files_parameters['wazuh_install_path'] = wazuh_install_path
-
-                if install_type == "sources":
-                    installation_files_parameters['wazuh_branch'] = wazuh_branch
-                    installation_instance = WazuhSources(**installation_files_parameters)
-                if install_type == "package":
-                    installation_files_parameters['local_package_path'] = local_package_path
-                    installation_instance = LocalPackage(**installation_files_parameters)
-
-                remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,
-                                                                                      hosts=current_host)
-
-                if install_target == "agent":
-                    deployment_instance = AgentDeployment(remote_files_path,
-                                                          inventory_file_path=self.inventory_file_path,
-                                                          install_mode=install_type, hosts=current_host,
-                                                          server_ip=manager_ip)
-                if install_target == "manager":
-                    deployment_instance = ManagerDeployment(remote_files_path,
-                                                            inventory_file_path=self.inventory_file_path,
-                                                            install_mode=install_type, hosts=current_host)
-
-                deployment_instance.install()
-
-                if health_check:
-                    # Wait for Wazuh initialization before health_check
-                    sleep(60)
-                    deployment_instance.health_check()
-
-                self.wazuh_installation_paths[deployment_instance.hosts] = deployment_instance.install_dir_path
-
-            if 'qa_framework' in host_value:
-                qa_framework_info = host_value['qa_framework']
-                wazuh_qa_branch = None if 'wazuh_qa_branch' not in qa_framework_info \
-                                          else qa_framework_info['wazuh_qa_branch']
-
-                qa_instance = QAFramework(qa_branch=wazuh_qa_branch)
-                qa_instance.download_qa_repository(inventory_file_path=self.inventory_file_path, hosts=current_host)
-                qa_instance.install_dependencies(inventory_file_path=self.inventory_file_path, hosts=current_host)
-                qa_instance.install_framework(inventory_file_path=self.inventory_file_path, hosts=current_host)
+        for runner_thread in provision_threads:
+            runner_thread.join()

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/WazuhDeployment.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/WazuhDeployment.py
@@ -75,7 +75,8 @@ class WazuhDeployment(ABC):
                                            'when': 'ansible_os_family|lower == "debian"'}))
 
             tasks_list.append(AnsibleTask({'name': 'Install Wazuh Agent from .rpm packages | yum',
-                                           'yum': {'name': f'{self.installation_files_path}'},
+                                           'yum': {'name': f'{self.installation_files_path}',
+                                                   'disable_gpg_check': 'yes'},
                                            'when': ['ansible_os_family|lower == "redhat"',
                                                     'not (ansible_distribution|lower == "centos" and ' +
                                                     'ansible_distribution_major_version >= "8")',
@@ -83,7 +84,8 @@ class WazuhDeployment(ABC):
                                                     'ansible_distribution_major_version >= "8")']}))
 
             tasks_list.append(AnsibleTask({'name': 'Install Wazuh Agent from .rpm packages | dnf',
-                                           'dnf': {'name': f'{self.installation_files_path}'},
+                                           'dnf': {'name': f'{self.installation_files_path}',
+                                                   'disable_gpg_check': 'yes'},
                                            'when': ['ansible_os_family|lower == "redhat"',
                                                     '(ansible_distribution|lower == "centos" and ' +
                                                     'ansible_distribution_major_version >= "8") or' +

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/Pytest.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/Pytest.py
@@ -1,16 +1,18 @@
-from datetime import datetime
-import tempfile
 import os
+
+from datetime import datetime
+from tempfile import gettempdir
 
 from wazuh_testing.qa_ctl.run_tests.TestResult import TestResult
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleRunner import AnsibleRunner
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleTask import AnsibleTask
 from wazuh_testing.qa_ctl.run_tests.Test import Test
+from wazuh_testing.tools.time import get_current_timestamp
 
 
 class Pytest(Test):
     """The class encapsulates the execution options of a specified set of tests and allows running them on the
-        remote host
+       remote host
 
     Args:
         tests_result_path(str): Path to the directory where the reports will be stored in the local machine
@@ -30,6 +32,7 @@ class Pytest(Test):
         hosts(list(), ['all']): List of hosts aliases where the tests will be runned
 
     Attributes:
+        tests_result_path(str): Path to the directory where the reports will be stored in the local machine
         tests_path (str): Path to the set of tests to be executed
         tests_run_dir (str): Path to the directory from where the tests are going to be executed
         tier (srt, None): List of tiers to be executed
@@ -44,7 +47,6 @@ class Pytest(Test):
         log_level(str, None): Log level to be set
         markers(list(str), None): Set of markers to be added to the test execution command
         hosts(list(), ['all']): List of hosts aliases where the tests will be runned
-
     """
 
     RUN_PYTEST = 'python3 -m pytest '
@@ -62,6 +64,11 @@ class Pytest(Test):
         self.log_level = log_level
         self.markers = markers
         self.hosts = hosts
+        self.tests_result_path = gettempdir() if tests_result_path is None else tests_result_path
+
+        if not os.path.exists(self.tests_result_path):
+            os.makedirs(self.tests_result_path)
+
         super().__init__(tests_path, tests_run_dir, tests_result_path)
 
     def run(self, ansible_inventory_path):
@@ -71,13 +78,13 @@ class Pytest(Test):
         Args:
             ansible_inventory_path (str): Path to ansible inventory file
         """
-        # Paths used below
+
         assets_folder = 'assets/'
         reports_folder = 'reports/'
         assets_zip = "assets.zip"
         html_report_file_name = f"test_report-{datetime.now()}.html"
         plain_report_file_name = f"plain_report-{datetime.now()}.txt"
-        playbook_file_path = os.path.join(tempfile.gettempdir(), 'playbook_file.yaml')
+        playbook_file_path = os.path.join(gettempdir(), f"{get_current_timestamp()}.yaml")
         reports_directory = os.path.join(self.tests_run_dir, reports_folder)
         plain_report_file_path = os.path.join(reports_directory, plain_report_file_name)
         html_report_file_path = os.path.join(reports_directory, html_report_file_name)
@@ -85,11 +92,6 @@ class Pytest(Test):
         assets_src_directory = os.path.join(reports_directory, assets_folder)
         zip_src_path = os.path.join(reports_directory, assets_zip)
         zip_dest_path = os.path.join(self.tests_result_path, assets_zip)
-
-        if self.tests_result_path is None:
-            self.tests_result_path = os.path.join(tempfile.gettempdir(), '')
-        else:
-            self.tests_result_path = os.path.join(self.tests_result_path, '')
 
         pytest_command = self.RUN_PYTEST
 
@@ -130,12 +132,12 @@ class Pytest(Test):
         fetch_plain_report = {'name': f"Move {plain_report_file_name} from "
                               f"{plain_report_file_path} to {self.tests_result_path}",
                               'fetch': {'src': plain_report_file_path,
-                                        'dest': self.tests_result_path, 'flat': 'yes'}}
+                                        'dest': f"{self.tests_result_path}/", 'flat': 'yes'}}
 
         fetch_html_report = {'name': f"Move {html_report_file_name} from {html_report_file_path}"
                              f" to {self.tests_result_path}",
                              'fetch': {'src': html_report_file_path,
-                                       'dest': self.tests_result_path, 'flat': 'yes'}}
+                                       'dest': f"{self.tests_result_path}/", 'flat': 'yes'}}
 
         create_assets_directory = {'name': f"Create {assets_dest_directory} directory",
                                    'local_action': {'module': 'ansible.builtin.file',
@@ -150,7 +152,7 @@ class Pytest(Test):
 
         fetch_compressed_assets = {'name': f"Copy compressed assets from {zip_src_path} to {self.tests_result_path}",
                                    'fetch': {'src': zip_src_path,
-                                             'dest': self.tests_result_path, 'flat': 'yes'}}
+                                             'dest': f"{self.tests_result_path}/", 'flat': 'yes'}}
 
         uncompress_assets = {'name': f"Uncompress {assets_zip} in {assets_dest_directory}",
                              'local_action': {'module': 'unarchive',

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/QARunTests.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/QARunTests.py
@@ -1,6 +1,8 @@
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleInstance import AnsibleInstance
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleInventory import AnsibleInventory
+from wazuh_testing.qa_ctl.run_tests.TestLauncher import TestLauncher
 from wazuh_testing.qa_ctl.run_tests.Pytest import Pytest
+from wazuh_testing.tools.thread_executor import ThreadExecutor
 
 
 class RunQATests():
@@ -10,18 +12,16 @@ class RunQATests():
             test_parameters (dict): a dictionary containing all the required data to build the tests
 
         Attributes:
-            tests (list(Pytest)): list of Pytest instances to run at the specified remote machines
             inventory_file_path (string): Path of the inventory file generated.
+            test_launchers (list(TestLauncher)): Test launchers objects (one for each host).
     """
 
     def __init__(self, tests_parameters):
-        self.tests = []
         self.inventory_file_path = None
-
+        self.test_launchers = []
         self.__process_inventory_data(tests_parameters)
+        self.__process_test_data(tests_parameters)
 
-        for _, host_value in tests_parameters.items():
-            self.tests.append(self.__build_test(host_value['test'], host_value['host_info']['host']))
 
     def __read_ansible_instance(self, host_info):
         """Read every host info and generate the AnsibleInstance object.
@@ -44,7 +44,11 @@ class RunQATests():
         return instance
 
     def __process_inventory_data(self, instances_info):
-        """Process config file info to generate the ansible inventory file."""
+        """Process config file info to generate the ansible inventory file.
+
+         Args:
+            instances_info (dict): Dictionary with hosts configuration.
+        """
         instances_list = []
 
         for _, host_value in instances_info.items():
@@ -57,6 +61,22 @@ class RunQATests():
         inventory_instance = AnsibleInventory(ansible_instances=instances_list)
         self.inventory_file_path = inventory_instance.inventory_file_path
 
+
+    def __process_test_data(self, instances_info):
+        """Process test data configuration and build the test launchers, setting the related class attribute.
+
+        Args:
+            instances_info (dict): Dictionary with hosts configuration.
+        """
+        for _, host_value in instances_info.items():
+            test_launcher = TestLauncher([], self.inventory_file_path)
+            for module_key, module_value in host_value.items():
+                hosts = host_value['host_info']['host']
+                if module_key == 'test':
+                    test_launcher.add(self.__build_test(module_value, hosts))
+            self.test_launchers.append(test_launcher)
+
+
     def __build_test(self, test_params, host=['all']):
         """Private method in charge of reading all the required fields to build one test of type Pytest
 
@@ -67,29 +87,41 @@ class RunQATests():
             Returns:
                 Pytest: one instance of Pytest built from the parameters in test_params
         """
-        test_dict = {}
+        if test_params['type'] == 'pytest':
+            test_dict = {}
+            test_dict['hosts'] = [host]
 
-        test_dict['hosts'] = [host]
+            if 'path' in test_params:
+                paths = test_params['path']
+                test_dict['tests_path'] = paths['test_files_path']
+                test_dict['tests_result_path'] = paths['test_results_path']
+                test_dict['tests_run_dir'] = paths['run_tests_dir_path']
 
-        if 'path' in test_params:
-            paths = test_params['path']
-            test_dict['tests_path'] = paths['test_files_path']
-            test_dict['tests_result_path'] = paths['test_results_path']
-            test_dict['tests_run_dir'] = paths['run_tests_dir_path']
+            if 'parameters' in test_params:
+                parameters = test_params['parameters']
+                if parameters is not None:
+                    test_dict['tiers'] = [] if 'tiers' not in parameters else parameters['tiers']
+                    test_dict['stop_after_first_failure'] = False if 'stop_after_first_failure' not in parameters \
+                                                                    else parameters['stop_after_first_failure']
+                    test_dict['keyword_expression'] = None if 'keyword_expression' not in parameters else \
+                                                            parameters['keyword_expression']
+                    test_dict['traceback'] = 'auto' if 'traceback' not in parameters else parameters['traceback']
+                    test_dict['dry_run'] = False if 'dry_run' not in parameters else parameters['dry_run']
+                    test_dict['custom_args'] = [] if 'custom_args' not in parameters else parameters['custom_args']
+                    test_dict['verbose_level'] = False if 'verbose_level' not in parameters else parameters['verbose_level']
+                    test_dict['log_level'] = None if 'log_level' not in parameters else parameters['log_level']
+                    test_dict['markers'] = [] if 'markers' not in parameters else parameters['markers']
 
-        if 'parameters' in test_params:
-            parameters = test_params['parameters']
-            if parameters is not None:
-                test_dict['tiers'] = [] if 'tiers' not in parameters else parameters['tiers']
-                test_dict['stop_after_first_failure'] = False if 'stop_after_first_failure' not in parameters \
-                                                                 else parameters['stop_after_first_failure']
-                test_dict['keyword_expression'] = None if 'keyword_expression' not in parameters else \
-                                                          parameters['keyword_expression']
-                test_dict['traceback'] = 'auto' if 'traceback' not in parameters else parameters['traceback']
-                test_dict['dry_run'] = False if 'dry_run' not in parameters else parameters['dry_run']
-                test_dict['custom_args'] = [] if 'custom_args' not in parameters else parameters['custom_args']
-                test_dict['verbose_level'] = False if 'verbose_level' not in parameters else parameters['verbose_level']
-                test_dict['log_level'] = None if 'log_level' not in parameters else parameters['log_level']
-                test_dict['markers'] = [] if 'markers' not in parameters else parameters['markers']
+            return Pytest(**test_dict)
+        else:
+            raise ValueError(f"Test \'{test_params['type']}\' is not allowed. Allowed value: pytest")
 
-        return Pytest(**test_dict)
+    def run(self):
+        """Run testing threads. One thread per TestLauncher object"""
+        runner_threads = [ThreadExecutor(test_launcher.run) for test_launcher in self.test_launchers]
+
+        for runner_thread in runner_threads:
+            runner_thread.start()
+
+        for runner_thread in runner_threads:
+            runner_thread.join()

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/TestLauncher.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/TestLauncher.py
@@ -1,8 +1,10 @@
 import os
-import tempfile
+
+from tempfile import gettempdir
 
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleRunner import AnsibleRunner
 from wazuh_testing.qa_ctl.provisioning.ansible.AnsibleTask import AnsibleTask
+from wazuh_testing.tools.time import get_current_timestamp
 
 
 class TestLauncher:
@@ -26,7 +28,7 @@ class TestLauncher:
 
     def __init__(self, tests, ansible_inventory_path, qa_framework_path=None):
         self.qa_framework_path = qa_framework_path if qa_framework_path is not None else \
-                                                     os.path.join(tempfile.gettempdir(), 'wazuh-qa/')
+                                                     os.path.join(gettempdir(), 'wazuh-qa/')
         self.ansible_inventory_path = ansible_inventory_path
         self.tests = tests
 
@@ -39,7 +41,7 @@ class TestLauncher:
                                   wazuh installation path
         """
         local_internal_options = '\n'.join(self.DEBUG_OPTIONS)
-        playbook_file_path = os.path.join(tempfile.gettempdir(), 'playbook_file.yaml')
+        playbook_file_path = os.path.join(gettempdir(), f"{get_current_timestamp()}.yaml")
 
         local_internal_path = '/var/ossec/etc/local_internal_options.conf'
 
@@ -53,8 +55,17 @@ class TestLauncher:
 
         AnsibleRunner.run_ephemeral_tasks(self.ansible_inventory_path, playbook_parameters, raise_on_error=False)
 
+    def add(self, test):
+        """Add new test to the TestLauncher instance.
+
+        Args:
+            test (Test): Test object.
+        """
+        if test:
+            self.tests.append(test)
+
     def run(self):
-        """ Function to iterate over a list of a set of ests and execute them one by one. """
+        """Function to iterate over a list of tests and run them one by one."""
         for test in self.tests:
             self.__set_local_internal_options(test.hosts)
             test.run(self.ansible_inventory_path)

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -44,7 +44,7 @@ def main():
                 qa_provisioning = QAProvisioning(provision_dict)
                 qa_provisioning.process_inventory_data()
                 qa_provisioning.check_hosts_connection()
-                qa_provisioning.process_deployment_data()
+                qa_provisioning.provision()
 
             if TEST_KEY in yaml_config:
                 test_dict = yaml_config[TEST_KEY]

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -8,7 +8,6 @@ import yaml
 from wazuh_testing.qa_ctl.deployment.QAInfraestructure import QAInfraestructure
 from wazuh_testing.qa_ctl.provisioning.QAProvisioning import QAProvisioning
 from wazuh_testing.qa_ctl.run_tests.QARunTests import RunQATests
-from wazuh_testing.qa_ctl.run_tests.TestLauncher import TestLauncher
 
 
 DEPLOY_KEY = 'deployment'
@@ -42,15 +41,12 @@ def main():
             if PROVISION_KEY in yaml_config:
                 provision_dict = yaml_config[PROVISION_KEY]
                 qa_provisioning = QAProvisioning(provision_dict)
-                qa_provisioning.process_inventory_data()
-                qa_provisioning.check_hosts_connection()
-                qa_provisioning.provision()
+                qa_provisioning.run()
 
             if TEST_KEY in yaml_config:
                 test_dict = yaml_config[TEST_KEY]
                 tests_runner = RunQATests(test_dict)
-                test_launcher = TestLauncher(tests_runner.tests, tests_runner.inventory_file_path)
-                test_launcher.run()
+                tests_runner.run()
 
         finally:
             if arguments.destroy:

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -20,7 +20,8 @@ _data_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__fil
 
 
 def validate_conf(configuration):
-    schema_file = 'qactl_conf_validator_schema.json'
+    data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data')
+    schema_file = os.path.join(data_path, 'qactl_conf_validator_schema.json')
 
     with open(os.path.join(_data_path, schema_file), 'r') as f:
         schema = json.load(f)


### PR DESCRIPTION
|Related issue|
|---|
|close #1754|

## Description

This PR contains the necessary changes to parallelize the use of deployment, provisioning and test execution. For this purpose, threads have been used, one for each host.

Specifically, the changes made are the following:

- Parallelization of deployment module: Run, halt, start, pause, destroy
- Parallelization of provisioning module
- Rework of QARunTest module to be modular and capable of parallelization
- Parallelization of 
- Fixes of config schema validation
- Fixes when obtaining pytest results
- Fix to install yum packages without gpg key check
- Automatic generation of the results directories in the local environment
- Simplified and modularized use of modules in qactl script


For example, a comparison for a deployment and provisioning of 3 hosts is as follows:

|     -      | Deployment | Provisioning | Destroy |
|------------|------------|--------------|---------|
| Secuential |     118s   |     533s     |   12s   |
| Parallel   |     55s    |     211s     |   4.6s  |



