### PR TITLE
Adding integration tests for authd (cluster scenario) when the agent sends a key hash 

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -537,6 +537,60 @@ def configure_sockets_environment(request):
     control_service('start')
 
 
+@pytest.fixture(scope='function')
+def configure_sockets_environment_function(request):
+    """Configure environment for sockets and MITM"""
+    monitored_sockets_params = getattr(request.module, 'monitored_sockets_params')
+    log_monitor_paths = getattr(request.module, 'log_monitor_paths')
+
+    # Stop wazuh-service and ensure all daemons are stopped
+    control_service('stop')
+    check_daemon_status(running=False)
+
+    monitored_sockets = list()
+    mitm_list = list()
+    log_monitors = list()
+
+    # Truncate logs and create FileMonitors
+    for log in log_monitor_paths:
+        truncate_file(log)
+        log_monitors.append(FileMonitor(log))
+
+    # Start selected daemons and monitored sockets MITM
+    for daemon, mitm, daemon_first in monitored_sockets_params:
+        not daemon_first and mitm is not None and mitm.start()
+        control_service('start', daemon=daemon, debug_mode=True)
+        check_daemon_status(
+            running=True,
+            daemon=daemon,
+            extra_sockets=[mitm.listener_socket_address] if mitm is not None and mitm.family == 'AF_UNIX' else None
+        )
+        daemon_first and mitm is not None and mitm.start()
+        if mitm is not None:
+            monitored_sockets.append(QueueMonitor(queue_item=mitm.queue))
+            mitm_list.append(mitm)
+
+    setattr(request.module, 'monitored_sockets', monitored_sockets)
+    setattr(request.module, 'log_monitors', log_monitors)
+
+    yield
+
+    # Stop daemons and monitored sockets MITM
+    for daemon, mitm, _ in monitored_sockets_params:
+        mitm is not None and mitm.shutdown()
+        control_service('stop', daemon=daemon)
+        check_daemon_status(
+            running=False,
+            daemon=daemon,
+            extra_sockets=[mitm.listener_socket_address] if mitm is not None and mitm.family == 'AF_UNIX' else None
+        )
+
+    # Delete all db
+    delete_dbs()
+
+    control_service('start')
+
+
 @pytest.fixture(scope='module')
 def put_env_variables(get_configuration, request):
     """

--- a/tests/integration/test_authd/data/authd_key_hash.yaml
+++ b/tests/integration/test_authd/data/authd_key_hash.yaml
@@ -60,7 +60,7 @@
   test_case:
   -
     input: "OSSEC A:'user2' K:'13cdb438b53c1f46ec3edebb7c790c87a54b3c0d'"
-    output: "ERROR: Duplicated agent name:"
+    output: 'ERROR: Duplicated agent name:'
 -
   name: 'Testing general parsing options with key hash 7'
   description: 'Trying to enroll an existing IP with right key hash. Key denied'
@@ -69,4 +69,4 @@
   test_case:
   -
     input: "OSSEC A:'userx' IP:'192.168.0.100' K:'aa06c24575fe8c474cd0c5386577eb974928dce3'"
-    output: "ERROR: Duplicated IP:"
+    output: 'ERROR: Duplicated IP:'

--- a/tests/integration/test_authd/data/local_enroll_messages.yaml
+++ b/tests/integration/test_authd/data/local_enroll_messages.yaml
@@ -2,86 +2,102 @@
 - #ADD
   name: "AddAgent default"
   description: "Add an agent with name and IP"
+  pre_existent_keys:
   test_case:
-  -    
+  -
     input: '{"arguments":{"name":"user1","ip":"any"},"function":"add"}'
     output: '{"error":0,"data":{"id":"001","name":"user1","ip":"any","key":'
-  -    
+  -
     input: '{"arguments":{"name":"user2","ip":"any"},"function":"add"}'
     output: '{"error":0,"data":{"id":"002","name":"user2","ip":"any","key":'
-  -    
+  -
     input: '{"arguments":{"name":"user3","ip":"192.0.0.0"},"function":"add"}'
     output: '{"error":0,"data":{"id":"003","name":"user3","ip":"192.0.0.0","key":'
 -
   name: "AddAgent ID"
   description: "Add an agent with specific ID"
+  pre_existent_keys:
   test_case:
-  - 
+  -
     input: '{"arguments":{"id":"100","name":"user100","ip":"any"},"function":"add"}'
     output: '{"error":0,"data":{"id":"100","name":"user100","ip":"any","key":'
 -
   name: "AddAgent KEY"
-  description: "Add an agent with specific ID"
+  description: "Add an agent with specific Key"
+  pre_existent_keys:
+    - '100 user100 any SecretKey'
   test_case:
-  -  
+  -
     input: '{"arguments":{"name":"user4","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"},"function":"add"}'
     output: '{"error":0,"data":{"id":"101","name":"user4","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"'
 -
   name: "ERROR Duplicate Name"
   description: "Try to add an agent with an existent name"
+  pre_existent_keys:
+    - '001 user1 any SecretKey'
   test_case:
-  -    
+  -
     input: '{"arguments":{"name":"user1","ip":"any"},"function":"add"}'
     output: '{"error":9008,"message":"Duplicated name"}'
 -
   name: "ERROR Duplicate IP"
   description: "Try to add an agent with an existent IP"
+  pre_existent_keys:
+    - '001 user1 192.0.0.0 SecretKey'
   test_case:
-  -    
+  -
     input: '{"arguments":{"name":"user_","ip":"192.0.0.0"},"function":"add"}'
     output: '{"error":9007,"message":"Duplicated IP"}'
 -
   name: "ERROR Duplicate ID"
   description: "Try to add an agent with an existent ID"
+  pre_existent_keys:
+    - '001 user1 any SecretKey'
   test_case:
-  -    
+  -
     input: '{"arguments":{"id":"001","name":"user_","ip":"any"},"function":"add"}'
     output: '{"error":9012,"message":"Duplicated ID"}'
 -
   name: "Force"
   description: "Add duplicate agents with force option"
+  pre_existent_keys:
+    - '001 user1 any SecretKey'
+    - '002 user2 192.0.0.0 SecretKey'
+    - '003 user3 any SecretKey'
   test_case:
-  -    
+  -
     input: '{"arguments":{"force":1,"name":"user1","ip":"any"},"function":"add"}'
-    output: '{"error":0,"data":{"id":"102","name":"user1","ip":"any","key":'
-  -    
-    input: '{"arguments":{"force":1,"name":"user10","ip":"192.0.0.0"},"function":"add"}'
-    output: '{"error":0,"data":{"id":"103","name":"user10","ip":"192.0.0.0","key":'
-  -    
-    input: '{"arguments":{"force":1,"id":"001","name":"user11","ip":"any"},"function":"add"}'
-    output: '{"error":0,"data":{"id":"001","name":"user11","ip":"any","key":'
+    output: '{"error":0,"data":{"id":"004","name":"user1","ip":"any","key":'
+  -
+    input: '{"arguments":{"force":1,"name":"user_2","ip":"192.0.0.0"},"function":"add"}'
+    output: '{"error":0,"data":{"id":"005","name":"user_2","ip":"192.0.0.0","key":'
+  -
+    input: '{"arguments":{"force":1,"id":"003","name":"user_3","ip":"any"},"function":"add"}'
+    output: '{"error":0,"data":{"id":"003","name":"user_3","ip":"any","key":'
 -
   name: "Single Group"
   description: "Try to add an agent with group"
-  groups: 
+  pre_existent_keys:
+  groups:
     - 'Group1'
   test_case:
   -
     input: '{"arguments":{"name":"user21","ip":"any","groups":"Group1"},"function":"add"}'
-    output: '{"error":0,"data":{"id":"104","name":"user21","ip":"any","key":'
+    output: '{"error":0,"data":{"id":"001","name":"user21","ip":"any","key":'
   -
     input: '{"arguments":{"name":"user_","ip":"any","groups":"Group2"},"function":"add"}'
     output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
 -
   name: "Multi Group"
   description: "Try to add an agent with multiplegroup"
-  groups: 
+  pre_existent_keys:
+  groups:
     - 'Group1'
     - 'Group2'
   test_case:
   -
     input: '{"arguments":{"name":"user22","ip":"any","groups":"Group1,Group2"},"function":"add"}'
-    output: '{"error":0,"data":{"id":"105","name":"user22","ip":"any","key":'
+    output: '{"error":0,"data":{"id":"001","name":"user22","ip":"any","key":'
   -
     input: '{"arguments":{"name":"user_","ip":"any","groups":"Group1,Group2,Group3"},"function":"add"}'
     output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
@@ -89,13 +105,88 @@
 - #REMOVE
   name: "Remove agent"
   description: "Remove an agent default (no save_removed, no purge)"
+  pre_existent_keys:
+    - '001 user1 any SecretKey'
+    - '002 user1 any SecretKey'
+    - '003 user1 any SecretKey'
   test_case:
-  -    
+  -
     input: '{"arguments":{"id":"001"},"function":"remove"}'
     output: '{"error":0,"data":"Agent deleted successfully."}'
-  -    
+  -
     input: '{"arguments":{"id":"002", "purge":true},"function":"remove"}'
     output: '{"error":0,"data":"Agent deleted successfully."}'
-  -    
+  -
     input: '{"arguments":{"id":"200"},"function":"remove"}'
     output: '{"error":9011,"message":"Agent ID not found"}'
+
+- # Add agent with key_hash
+  name: "Agent with key hash 1"
+  description: "Simple request with key hash for new user"
+  pre_existent_keys:
+  test_case:
+  -
+    input: '{"arguments":{"name":"new_user1","ip":"any","key_hash":"123ABC"},"function":"add"}'
+    output: '{"error":0,"data":{"id":"001","name":"new_user1","ip":"any","key":'
+-
+  name: "Agent with key hash 2"
+  description: "Simple request with wrong key hash for existing user"
+  pre_existent_keys:
+    - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
+  test_case:
+  -
+    input: '{"arguments":{"force":1,"name":"user1","ip":"any","key_hash":"123ABC"},"function":"add"}'
+    output: '{"error":0,"data":{"id":"002","name":"user1","ip":"any","key":'
+-
+  name: "Agent with key hash 3"
+  description: "Simple request with right key hash for existing user"
+  pre_existent_keys:
+    - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
+  test_case:
+  # The output message isn't giving details about the same key, it still uses the 'Duplicated name' message
+  -
+    input: '{"arguments":{"force":1,"name":"user1","ip":"any","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307"},"function":"add"}'
+    output: '{"error":9008,"message":"Duplicated name"}'
+-
+  name: "Agent with key hash 4"
+  description: "Complete request with key hash for new user"
+  pre_existent_keys:
+  groups:
+    - 'Group1'
+  test_case:
+  -
+    input: '{"arguments":{"force":1,"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC"},"function":"add"}'
+    output: '{"error":0,"data":{"id":"001","name":"user1","ip":"10.10.10.10","key":'
+-
+  name: "Agent with key hash 5"
+  description: "Complete request with wrong key hash for existing user"
+  pre_existent_keys:
+    - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
+  groups:
+    - 'Group1'
+  test_case:
+  -
+    input: '{"arguments":{"force":1,"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC"},"function":"add"}'
+    output: '{"error":0,"data":{"id":"002","name":"user1","ip":"10.10.10.10","key":'
+-
+  name: "Agent with key hash 6"
+  description: "Complete request with right key hash for existing user"
+  pre_existent_keys:
+    - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
+  groups:
+    - 'Group1'
+  test_case:
+  -
+    input: '{"arguments":{"force":1,"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307"},"function":"add"}'
+    output: '{"error":9008,"message":"Duplicated name"}'
+-
+  name: "Agent with key hash 7"
+  description: "Complete request with right key hash for existing IP"
+  pre_existent_keys:
+    - '001 user1 10.10.10.10 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
+  groups:
+    - 'Group1'
+  test_case:
+  -
+    input: '{"arguments":{"force":1,"name":"user_","ip":"10.10.10.10","groups":"Group1","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307"},"function":"add"}'
+    output: '{"error":9007,"message":"Duplicated IP"}'

--- a/tests/integration/test_authd/data/local_enroll_messages.yaml
+++ b/tests/integration/test_authd/data/local_enroll_messages.yaml
@@ -1,7 +1,7 @@
 ---
 - #ADD
-  name: "AddAgent default"
-  description: "Add an agent with name and IP"
+  name: 'AddAgent default'
+  description: 'Add an agent with name and IP'
   pre_existent_keys:
   test_case:
   -
@@ -14,16 +14,16 @@
     input: '{"arguments":{"name":"user3","ip":"192.0.0.0"},"function":"add"}'
     output: '{"error":0,"data":{"id":"003","name":"user3","ip":"192.0.0.0","key":'
 -
-  name: "AddAgent ID"
-  description: "Add an agent with specific ID"
+  name: 'AddAgent ID'
+  description: 'Add an agent with specific ID'
   pre_existent_keys:
   test_case:
   -
     input: '{"arguments":{"id":"100","name":"user100","ip":"any"},"function":"add"}'
     output: '{"error":0,"data":{"id":"100","name":"user100","ip":"any","key":'
 -
-  name: "AddAgent KEY"
-  description: "Add an agent with specific Key"
+  name: 'AddAgent KEY'
+  description: 'Add an agent with specific Key'
   pre_existent_keys:
     - '100 user100 any SecretKey'
   test_case:
@@ -31,8 +31,8 @@
     input: '{"arguments":{"name":"user4","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"},"function":"add"}'
     output: '{"error":0,"data":{"id":"101","name":"user4","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"'
 -
-  name: "ERROR Duplicate Name"
-  description: "Try to add an agent with an existent name"
+  name: 'ERROR Duplicate Name'
+  description: 'Try to add an agent with an existent name'
   pre_existent_keys:
     - '001 user1 any SecretKey'
   test_case:
@@ -40,8 +40,8 @@
     input: '{"arguments":{"name":"user1","ip":"any"},"function":"add"}'
     output: '{"error":9008,"message":"Duplicated name"}'
 -
-  name: "ERROR Duplicate IP"
-  description: "Try to add an agent with an existent IP"
+  name: 'ERROR Duplicate IP'
+  description: 'Try to add an agent with an existent IP'
   pre_existent_keys:
     - '001 user1 192.0.0.0 SecretKey'
   test_case:
@@ -49,8 +49,8 @@
     input: '{"arguments":{"name":"user_","ip":"192.0.0.0"},"function":"add"}'
     output: '{"error":9007,"message":"Duplicated IP"}'
 -
-  name: "ERROR Duplicate ID"
-  description: "Try to add an agent with an existent ID"
+  name: 'ERROR Duplicate ID'
+  description: 'Try to add an agent with an existent ID'
   pre_existent_keys:
     - '001 user1 any SecretKey'
   test_case:
@@ -58,8 +58,8 @@
     input: '{"arguments":{"id":"001","name":"user_","ip":"any"},"function":"add"}'
     output: '{"error":9012,"message":"Duplicated ID"}'
 -
-  name: "Force"
-  description: "Add duplicate agents with force option"
+  name: 'Force'
+  description: 'Add duplicate agents with force option'
   pre_existent_keys:
     - '001 user1 any SecretKey'
     - '002 user2 192.0.0.0 SecretKey'
@@ -75,8 +75,8 @@
     input: '{"arguments":{"force":1,"id":"003","name":"user_3","ip":"any"},"function":"add"}'
     output: '{"error":0,"data":{"id":"003","name":"user_3","ip":"any","key":'
 -
-  name: "Single Group"
-  description: "Try to add an agent with group"
+  name: 'Single Group'
+  description: 'Try to add an agent with group'
   pre_existent_keys:
   groups:
     - 'Group1'
@@ -88,8 +88,8 @@
     input: '{"arguments":{"name":"user_","ip":"any","groups":"Group2"},"function":"add"}'
     output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
 -
-  name: "Multi Group"
-  description: "Try to add an agent with multiplegroup"
+  name: 'Multi Group'
+  description: 'Try to add an agent with multiple group'
   pre_existent_keys:
   groups:
     - 'Group1'
@@ -103,8 +103,8 @@
     output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
 
 - #REMOVE
-  name: "Remove agent"
-  description: "Remove an agent default (no save_removed, no purge)"
+  name: 'Remove agent'
+  description: 'Remove an agent default (no save_removed, no purge)'
   pre_existent_keys:
     - '001 user1 any SecretKey'
     - '002 user1 any SecretKey'
@@ -121,16 +121,16 @@
     output: '{"error":9011,"message":"Agent ID not found"}'
 
 - # Add agent with key_hash
-  name: "Agent with key hash 1"
-  description: "Simple request with key hash for new user"
+  name: 'Agent with key hash 1'
+  description: 'Simple request with key hash for new user'
   pre_existent_keys:
   test_case:
   -
     input: '{"arguments":{"name":"new_user1","ip":"any","key_hash":"123ABC"},"function":"add"}'
     output: '{"error":0,"data":{"id":"001","name":"new_user1","ip":"any","key":'
 -
-  name: "Agent with key hash 2"
-  description: "Simple request with wrong key hash for existing user"
+  name: 'Agent with key hash 2'
+  description: 'Simple request with wrong key hash for existing user'
   pre_existent_keys:
     - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
   test_case:
@@ -138,8 +138,8 @@
     input: '{"arguments":{"force":1,"name":"user1","ip":"any","key_hash":"123ABC"},"function":"add"}'
     output: '{"error":0,"data":{"id":"002","name":"user1","ip":"any","key":'
 -
-  name: "Agent with key hash 3"
-  description: "Simple request with right key hash for existing user"
+  name: 'Agent with key hash 3'
+  description: 'Simple request with right key hash for existing user'
   pre_existent_keys:
     - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
   test_case:
@@ -148,8 +148,8 @@
     input: '{"arguments":{"force":1,"name":"user1","ip":"any","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307"},"function":"add"}'
     output: '{"error":9008,"message":"Duplicated name"}'
 -
-  name: "Agent with key hash 4"
-  description: "Complete request with key hash for new user"
+  name: 'Agent with key hash 4'
+  description: 'Complete request with key hash for new user'
   pre_existent_keys:
   groups:
     - 'Group1'
@@ -158,8 +158,8 @@
     input: '{"arguments":{"force":1,"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC"},"function":"add"}'
     output: '{"error":0,"data":{"id":"001","name":"user1","ip":"10.10.10.10","key":'
 -
-  name: "Agent with key hash 5"
-  description: "Complete request with wrong key hash for existing user"
+  name: 'Agent with key hash 5'
+  description: 'Complete request with wrong key hash for existing user'
   pre_existent_keys:
     - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
   groups:
@@ -169,8 +169,8 @@
     input: '{"arguments":{"force":1,"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC"},"function":"add"}'
     output: '{"error":0,"data":{"id":"002","name":"user1","ip":"10.10.10.10","key":'
 -
-  name: "Agent with key hash 6"
-  description: "Complete request with right key hash for existing user"
+  name: 'Agent with key hash 6'
+  description: 'Complete request with right key hash for existing user'
   pre_existent_keys:
     - '001 user1 any 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
   groups:
@@ -180,8 +180,8 @@
     input: '{"arguments":{"force":1,"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307"},"function":"add"}'
     output: '{"error":9008,"message":"Duplicated name"}'
 -
-  name: "Agent with key hash 7"
-  description: "Complete request with right key hash for existing IP"
+  name: 'Agent with key hash 7'
+  description: 'Complete request with right key hash for existing IP'
   pre_existent_keys:
     - '001 user1 10.10.10.10 998bb619f50225fa0a4ec3b2a4888ae0a9b1d249189827462a5689d1d5586deb'
   groups:

--- a/tests/integration/test_authd/data/password_tests.yaml
+++ b/tests/integration/test_authd/data/password_tests.yaml
@@ -1,78 +1,78 @@
 ---
   -
-    name: "Default USE_PASSWORD request with password use_password enabled"
-    description: "Try register an agent with password and use_password enabled: register"
+    name: 'Default USE_PASSWORD request with password use_password enabled'
+    description: 'Try register an agent with password and use_password enabled: register'
     test_case:
     -
       input: "OSSEC PASS: TopSecret OSSEC A:'user1'"
       output: "OSSEC K:'001 user1 any "
-      insert_prev_agent: "no"
-    USE_PASSWORD: "yes"
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'yes'
   -
-    name: "Manager without password"
-    description: "Try register an agent without password and use_password disabled: register"
+    name: 'Manager without password'
+    description: 'Try register an agent without password and use_password disabled: register'
     test_case:
     -
       input: "OSSEC A:'user1'"
       output: "OSSEC K:'001 user1 any "
-      insert_prev_agent: "no"
-    USE_PASSWORD: "no"
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'no'
   -
-    name: "Manager without password, request with password"
-    description: "Try register an agent with password and use_password disabled: rejected"
+    name: 'Manager without password, request with password'
+    description: 'Try register an agent with password and use_password disabled: rejected'
     test_case:
     -
       input: "OSSEC PASS: TopSecret OSSEC A:'user1'"
-      output: "ERROR: Invalid request for new agent"
-      insert_prev_agent: "no"
-    USE_PASSWORD: "no"
+      output: 'ERROR: Invalid request for new agent'
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'no'
   -
-    name: "Manager with password, request with correct password"
-    description: "Try register an agent with correct password and use_password enabled: register"
+    name: 'Manager with password, request with correct password'
+    description: 'Try register an agent with correct password and use_password enabled: register'
     test_case:
     -
       input: "OSSEC PASS: TopSecret OSSEC A:'user1'"
       output: "OSSEC K:'001 user1 any "
-      insert_prev_agent: "no"
-    USE_PASSWORD: "yes"
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'yes'
   -
-    name: "Manager with password, request with wrong password"
-    description: "Try register an agent with password and use_password enabled: rejected"
+    name: 'Manager with password, request with wrong password'
+    description: 'Try register an agent with password and use_password enabled: rejected'
     test_case:
     -
       input: "OSSEC PASS: wrongPass OSSEC A:'user1'"
-      output: "ERROR: Invalid password"
-      insert_prev_agent: "no"
-    USE_PASSWORD: "yes"
+      output: 'ERROR: Invalid password'
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'yes'
   -
-    name: "Random password, request with correct password"
-    description: "Try register an agent with correct password and use_password enabled, random password created: register"
+    name: 'Random password, request with correct password'
+    description: 'Try register an agent with correct password and use_password enabled, random password created: register'
     test_case:
     -
       input: "OSSEC PASS: {} OSSEC A:'user1'"
       output: "OSSEC K:'001 user1 any "
-      insert_prev_agent: "no"
-      insert_random_pass_in_query: "yes"
+      insert_prev_agent: 'no'
+      insert_random_pass_in_query: 'yes'
 
-    USE_PASSWORD: "yes"
-    random_pass: "yes"
+    USE_PASSWORD: 'yes'
+    random_pass: 'yes'
   -
-    name: "Random password, request with wrong password"
-    description: "Try register an agent with wrong password and use_password enabled, random password created: rejected"
+    name: 'Random password, request with wrong password'
+    description: 'Try register an agent with wrong password and use_password enabled, random password created: rejected'
     test_case:
     -
       input: "OSSEC PASS: wrongPass OSSEC A:'user1'"
-      output: "ERROR: Invalid password"
-      insert_prev_agent: "no"
-    USE_PASSWORD: "yes"
-    random_pass: "yes"
+      output: 'ERROR: Invalid password'
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'yes'
+    random_pass: 'yes'
   -
-    name: "Random password, request without password"
-    description: "Try register an agent without password and use_password enabled, random password created: rejected"
+    name: 'Random password, request without password'
+    description: 'Try register an agent without password and use_password enabled, random password created: rejected'
     test_case:
     -
       input: "OSSEC A:'user1'"
-      output: "ERROR: Invalid password"
-      insert_prev_agent: "no"
-    USE_PASSWORD: "yes"
-    random_pass: "yes"
+      output: 'ERROR: Invalid password'
+      insert_prev_agent: 'no'
+    USE_PASSWORD: 'yes'
+    random_pass: 'yes'

--- a/tests/integration/test_authd/data/test_authd_force_options.yaml
+++ b/tests/integration/test_authd/data/test_authd_force_options.yaml
@@ -1,82 +1,82 @@
 ---
   -
-    name: "Agent name same as Manager"
-    description: "Check for register an agent with name same as manager: rejected"
+    name: 'Agent name same as Manager'
+    description: 'Check for register an agent with name same as manager: rejected'
     test_case:
     -
       input: "OSSEC A:'{}'"
-      output: "ERROR: Invalid agent name: {}"
-      insert_hostname_in_query: "yes"
-    FORCE_INSERT: "no"
+      output: 'ERROR: Invalid agent name: {}'
+      insert_hostname_in_query: 'yes'
+    FORCE_INSERT: 'no'
   -
-    name: "Register with Default config"
-    description: "Default manager configuration: registered"
+    name: 'Register with Default config'
+    description: 'Default manager configuration: registered'
     test_case:
     -
       input: "OSSEC A:'user1'"
       output: "OSSEC K:'001 user1 any "
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
 
   -
-    name: "Try register duplicate agent name"
-    description: "Check for register an agent with repeated name and force_insert disabled: rejected"
+    name: 'Try register duplicate agent name'
+    description: 'Check for register an agent with repeated name and force_insert disabled: rejected'
     test_case:
     -
       input: "OSSEC A:'user1'"
-      output: "ERROR: Duplicated agent name: "
-      insert_prev_agent: "yes"
+      output: 'ERROR: Duplicated agent name: '
+      insert_prev_agent: 'yes'
 
-    FORCE_INSERT: "no"
+    FORCE_INSERT: 'no'
   -
-    name: "Overwrite agent name"
-    description: "Check for register an agent with repeated name and force_insert enabled: registered"
+    name: 'Overwrite agent name'
+    description: 'Check for register an agent with repeated name and force_insert enabled: registered'
     test_case:
     -
       input: "OSSEC A:'user1'"
       output: "OSSEC K:'002 user1 any "
-      insert_prev_agent: "yes"
-    FORCE_INSERT: "yes"
+      insert_prev_agent: 'yes'
+    FORCE_INSERT: 'yes'
   -
-    name: "Too short agent name"
-    description: "Agent name too short < 2: rejected"
+    name: 'Too short agent name'
+    description: 'Agent name too short < 2: rejected'
     test_case:
     -
       input: "OSSEC A:'n'"
-      output: "ERROR: Invalid agent name: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid agent name: '
+      insert_prev_agent: 'no'
   -
-    name: "Min len agent name"
-    description: "Agent name length = 2: registered"
+    name: 'Min len agent name'
+    description: 'Agent name length = 2: registered'
     test_case:
     -
       input: "OSSEC A:'nn'"
       output: "OSSEC K:'001 nn any "
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
 
   -
-    name: "Max len agent name"
-    description: "Agent name length = 128: registered"
+    name: 'Max len agent name'
+    description: 'Agent name length = 128: registered'
     test_case:
     -
       input: "OSSEC A:'userxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
       output: "OSSEC K:'001 userxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx any"
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
   -
-    name: "Too long agent name"
-    description: "Agent name length = 129: rejected"
+    name: 'Too long agent name'
+    description: 'Agent name length = 129: rejected'
     test_case:
     -
       input: "OSSEC A:'userxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
-      output: "ERROR: Invalid agent name: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid agent name: '
+      insert_prev_agent: 'no'
   -
     name: "Check non-alphanumeric '*'"
     description: "Agent name with '*': rejected"
     test_case:
     -
       input: "OSSEC A:'user*1'"
-      output: "ERROR: Invalid agent name: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid agent name: '
+      insert_prev_agent: 'no'
   -
     name: "Check non-alphanumeric '-'"
     description: "Agent name with '-': registered"
@@ -84,7 +84,7 @@
     -
       input: "OSSEC A:'user-1'"
       output: "OSSEC K:'001 user-1 any "
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
   -
     name: "Check non-alphanumeric '_'"
     description: "Agent name with '_': registered"
@@ -92,7 +92,7 @@
     -
       input: "OSSEC A:'user_1'"
       output: "OSSEC K:'001 user_1 any "
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
   -
     name: "Check non-alphanumeric '.'"
     description: "Agent name with '.': registered"
@@ -100,212 +100,212 @@
     -
       input: "OSSEC A:'user.1'"
       output: "OSSEC K:'001 user.1 any "
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
   #IP tests
   -
-    name: "Valid IP"
-    description: "Try register an agent with valid IP: register"
+    name: 'Valid IP'
+    description: 'Try register an agent with valid IP: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.10'"
       output: "OSSEC K:'001 user1 10.10.10.10 "
-      insert_prev_agent: "no"
+      insert_prev_agent: 'no'
   -
-    name: "Valid and duplicate IP - force_insert disabled"
-    description: "Try register an agent with existing IP in client.keys and force_insert disabled: rejected"
+    name: 'Valid and duplicate IP - force_insert disabled'
+    description: 'Try register an agent with existing IP in client.keys and force_insert disabled: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.10'"
-      output: "ERROR: Duplicated IP: "
-      insert_prev_agent: "yes"
+      output: 'ERROR: Duplicated IP: '
+      insert_prev_agent: 'yes'
       insert_prev_agent_custom: "OSSEC A:'user0' IP:'10.10.10.10'"
-    FORCE_INSERT: "no"
+    FORCE_INSERT: 'no'
   -
-    name: "Valid and duplicate IP - force_insert enabled"
-    description: "Try register an agent with existing IP in client.keys and force_insert disabled: register"
+    name: 'Valid and duplicate IP - force_insert enabled'
+    description: 'Try register an agent with existing IP in client.keys and force_insert disabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.10'"
       output: "OSSEC K:'002 user1 10.10.10.10 "
-      insert_prev_agent: "yes"
+      insert_prev_agent: 'yes'
       insert_prev_agent_custom: "OSSEC A:'user0' IP:'10.10.10.10'"
-    FORCE_INSERT: "yes"
+    FORCE_INSERT: 'yes'
   -
-    name: "Invalid IP: incomplete"
-    description: "Try register an agent with invalid IP: rejected"
+    name: 'Invalid IP: incomplete'
+    description: 'Try register an agent with invalid IP: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10'"
-      output: "ERROR: Invalid IP: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid IP: '
+      insert_prev_agent: 'no'
   -
-    name: "Invalid IP: alphabetic character"
-    description: "Try register an agent with invalid IP: rejected"
+    name: 'Invalid IP: alphabetic character'
+    description: 'Try register an agent with invalid IP: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.nn'"
-      output: "ERROR: Invalid IP: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid IP: '
+      insert_prev_agent: 'no'
   -
-    name: "Invalid IP: greater than 255"
-    description: "Try register an agent with invalid IP: rejected"
+    name: 'Invalid IP: greater than 255'
+    description: 'Try register an agent with invalid IP: rejected'
     # The manager should validate the IP https://github.com/wazuh/wazuh/issues/4965
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.257'"
-      output: "ERROR: Invalid IP: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid IP: '
+      insert_prev_agent: 'no'
       expected_fail: 'yes'
   -
-    name: "Invalid IP: greater than 255"
-    description: "Try register an agent with invalid IP: rejected"
+    name: 'Invalid IP: greater than 255'
+    description: 'Try register an agent with invalid IP: rejected'
     # The manager should validate the IP https://github.com/wazuh/wazuh/issues/4965
     test_case:
     -
       input: "OSSEC A:'user1' IP:'257.257.257.257'"
-      output: "ERROR: Invalid IP: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid IP: '
+      insert_prev_agent: 'no'
       expected_fail: 'yes'
   -
-    name: "Invalid IP: 4 digits"
-    description: "Try register an agent with invalid IP: rejected"
+    name: 'Invalid IP: 4 digits'
+    description: 'Try register an agent with invalid IP: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'999.9999.999.999'"
-      output: "ERROR: Invalid IP: "
-      insert_prev_agent: "no"
+      output: 'ERROR: Invalid IP: '
+      insert_prev_agent: 'no'
   -
-    name: "Not specific IP, USE_SOURCE yes"
-    description: "Not specific IP, USE_SOURCE yes: register"
+    name: 'Not specific IP, USE_SOURCE yes'
+    description: 'Not specific IP, USE_SOURCE yes: register'
     test_case:
     -
       input: "OSSEC A:'user1' "
       output: "OSSEC K:'001 user1 127.0.0.1 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Not specific IP, USE_SOURCE no"
-    description: "Not specific IP, USE_SOURCE no: register"
+    name: 'Not specific IP, USE_SOURCE no'
+    description: 'Not specific IP, USE_SOURCE no: register'
     test_case:
     -
       input: "OSSEC A:'user1' "
       output: "OSSEC K:'001 user1 any "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Let manager decide, USE_SOURCE no"
-    description: "Let manager decide, USE_SOURCE no: register"
+    name: 'Let manager decide, USE_SOURCE no'
+    description: 'Let manager decide, USE_SOURCE no: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'src'"
       output: "OSSEC K:'001 user1 127.0.0.1 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Let manager decide, use_source_ip enabled"
-    description: "Let manager decide, use_source_ip enabled: register"
+    name: 'Let manager decide, use_source_ip enabled'
+    description: 'Let manager decide, use_source_ip enabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'src'"
       output: "OSSEC K:'001 user1 127.0.0.1 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Ip with mask/24, use_source_ip enabled"
-    description: "Ip with mask, use_source_ip enabled: register"
+    name: 'Ip with mask/24, use_source_ip enabled'
+    description: 'Ip with mask, use_source_ip enabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/24'"
       output: "OSSEC K:'001 user1 10.10.10.1/24 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Ip with mask/32, use_source_ip enabled"
-    description: "Ip with mask, use_source_ip enabled: register"
+    name: 'Ip with mask/32, use_source_ip enabled'
+    description: 'Ip with mask, use_source_ip enabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/32'"
       output: "OSSEC K:'001 user1 10.10.10.1/32"
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Ip with mask/0, use_source_ip enabled"
-    description: "Ip with mask, use_source_ip disabled: register"
+    name: 'Ip with mask/0, use_source_ip enabled'
+    description: 'Ip with mask, use_source_ip disabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/0'"
       output: "OSSEC K:'001 user1 10.10.10.1/0 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Ip with mask/0, use_source_ip disabled"
-    description: "Ip with mask, use_source_ip disabled: register"
+    name: 'Ip with mask/0, use_source_ip disabled'
+    description: 'Ip with mask, use_source_ip disabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.10/0'"
       output: "OSSEC K:'001 user1 10.10.10.10/0 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Ip with mask/0, use_source_ip disabled"
-    description: "Ip with mask, use_source_ip disabled: register"
+    name: 'Ip with mask/0, use_source_ip disabled'
+    description: 'Ip with mask, use_source_ip disabled: register'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'0.0.0.0/0'"
       output: "OSSEC K:'001 user1 0.0.0.0/0 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Ip with mask /24 force_insert disabled"
-    description: "Ip with mask /24 force_insert disabled"
+    name: 'Ip with mask /24 force_insert disabled'
+    description: 'Ip with mask /24 force_insert disabled'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/24'"
       output: "OSSEC K:'001 user1 10.10.10.1/24 "
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Ip with mask /32 force_insert disabled"
-    description: "Ip with mask /32 force_insert disabled"
+    name: 'Ip with mask /32 force_insert disabled'
+    description: 'Ip with mask /32 force_insert disabled'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/32'"
       output: "OSSEC K:'001 user1 10.10.10.1/32"
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Invalid mask, use_source_ip disabled"
-    description: "Invalid mask, use_source_ip disabled: rejected"
+    name: 'Invalid mask, use_source_ip disabled'
+    description: 'Invalid mask, use_source_ip disabled: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/55'"
-      output: "ERROR: Invalid IP: 10.10.10.1"
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "no"
+      output: 'ERROR: Invalid IP: 10.10.10.1'
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'no'
   -
-    name: "Invalid mask, use_source_ip enabled"
-    description: "Invalid mask, use_source_ip enabled: rejected"
+    name: 'Invalid mask, use_source_ip enabled'
+    description: 'Invalid mask, use_source_ip enabled: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/55'"
-      output: "ERROR: Invalid IP: 10.10.10.1"
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      output: 'ERROR: Invalid IP: 10.10.10.1'
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Invalid mask, wrong character"
-    description: "Invalid mask, wrong character, use_source_ip enabled: rejected"
+    name: 'Invalid mask, wrong character'
+    description: 'Invalid mask, wrong character, use_source_ip enabled: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/2{'"
-      output: "ERROR: Invalid IP: 10.10.10.1"
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      output: 'ERROR: Invalid IP: 10.10.10.1'
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'
   -
-    name: "Invalid mask, wrong charact"
-    description: "Invalid mask, wrong charact, use_source_ip enabled: rejected"
+    name: 'Invalid mask, wrong character'
+    description: 'Invalid mask, wrong character, use_source_ip enabled: rejected'
     test_case:
     -
       input: "OSSEC A:'user1' IP:'10.10.10.1/<'"
-      output: "ERROR: Invalid IP: 10.10.10.1"
-      insert_prev_agent: "no"
-    USE_SOURCE_IP: "yes"
+      output: 'ERROR: Invalid IP: 10.10.10.1'
+      insert_prev_agent: 'no'
+    USE_SOURCE_IP: 'yes'

--- a/tests/integration/test_authd/data/worker_messages.yaml
+++ b/tests/integration/test_authd/data/worker_messages.yaml
@@ -1,6 +1,6 @@
 -
-  name: "AgentName"
-  description: "Check default enrollment"
+  name: 'AgentName'
+  description: 'Check default enrollment'
   test_case:
   -
     port_input: "OSSEC A:'user1'"
@@ -8,8 +8,8 @@
     cluster_output: '{"error":0,"data":{"id":"001","name":"user1","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
-  name: "Single Group - Valid group"
-  description: "Check single group enrollment"
+  name: 'Single Group - Valid group'
+  description: 'Check single group enrollment'
   test_case:
   -
     port_input: "OSSEC A:'user2' G:'Group1'"
@@ -17,8 +17,8 @@
     cluster_output: '{"error":0,"data":{"id":"002","name":"user2","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
-  name: "Multi Group - Valid groups"
-  description: "Check multi group enrollment"
+  name: 'Multi Group - Valid groups'
+  description: 'Check multi group enrollment'
   test_case:
   -
     port_input: "OSSEC A:'user3' G:'Group1,Group2'"
@@ -26,8 +26,8 @@
     cluster_output: '{"error":0,"data":{"id":"003","name":"user3","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
-  name: "Specific IP"
-  description: "Check enrollment with specific IP"
+  name: 'Specific IP'
+  description: 'Check enrollment with specific IP'
   test_case:
   -
     port_input: "OSSEC A:'user4' IP:'192.0.0.0'"
@@ -35,36 +35,36 @@
     cluster_output: '{"error":0,"data":{"id":"003","name":"user4","ip":"192.0.0.0","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
-  name: "Error Agent Name - Duplicate name"
-  description: "Try to add an agent with duplicate name"
+  name: 'Error Agent Name - Duplicate name'
+  description: 'Try to add an agent with duplicate name'
   test_case:
   -
     port_input: "OSSEC A:'user1'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user1","ip":"any","force":0},"function":"add"}}'
     cluster_output: '{"error":9008,"message":"Duplicated name"}'
-    port_output: "ERROR: Duplicated name"
+    port_output: 'ERROR: Duplicated name'
 -
-  name: "Error Group - Invalid group"
-  description: "Try to add an agent with unexistent group"
+  name: 'Error Group - Invalid group'
+  description: 'Try to add an agent with inexistent group'
   test_case:
   -
     port_input: "OSSEC A:'user_' G:'GroupA'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user_","ip":"any","groups":"GroupA","force":0},"function":"add"}}'
     cluster_output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
-    port_output: "ERROR: Invalid Group(s) Name(s)"
+    port_output: 'ERROR: Invalid Group(s) Name(s)'
 -
-  name: "Error IP - Duplicate IP"
-  description: "Try to add an agent with duplicate IP"
+  name: 'Error IP - Duplicate IP'
+  description: 'Try to add an agent with duplicate IP'
   test_case:
   -
     port_input: "OSSEC A:'user_' IP:'192.0.0.0'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user_","ip":"192.0.0.0","force":0},"function":"add"}}'
     cluster_output: '{"error":9007,"message":"Duplicated IP"}'
-    port_output: "ERROR: Duplicated IP"
+    port_output: 'ERROR: Duplicated IP'
 
 - # Testing messages with agent's key hash
-  name: "Agent's key hash 1"
-  description: "Simple request with key hash"
+  name: 'Agent message with key hash 1'
+  description: 'Simple request with key hash'
   test_case:
   -
     port_input: "OSSEC A:'user1' K:'123ABC'"
@@ -72,8 +72,8 @@
     cluster_output: '{"error":0,"data":{"id":"001","name":"user1","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
-  name: "Agent's key hash 2"
-  description: "Complete request with key hash"
+  name: 'Agent message with key hash 2'
+  description: 'Complete request with key hash'
   test_case:
   -
     port_input: "OSSEC A:'user1' G:'Group1' IP:'10.10.10.10' K:'123ABC'"

--- a/tests/integration/test_authd/data/worker_messages.yaml
+++ b/tests/integration/test_authd/data/worker_messages.yaml
@@ -9,27 +9,27 @@
     port_output: "OSSEC K:'"
 -
   name: "Single Group - Valid group"
-  description: "Check single group enrollment"  
+  description: "Check single group enrollment"
   test_case:
-  -   
+  -
     port_input: "OSSEC A:'user2' G:'Group1'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user2","ip":"any","groups":"Group1","force":0},"function":"add"}}'
     cluster_output: '{"error":0,"data":{"id":"002","name":"user2","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
   name: "Multi Group - Valid groups"
-  description: "Check multi group enrollment"  
+  description: "Check multi group enrollment"
   test_case:
-  -   
+  -
     port_input: "OSSEC A:'user3' G:'Group1,Group2'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user3","ip":"any","groups":"Group1,Group2","force":0},"function":"add"}}'
     cluster_output: '{"error":0,"data":{"id":"003","name":"user3","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
     port_output: "OSSEC K:'"
 -
   name: "Specific IP"
-  description: "Check enrollment with specific IP"  
+  description: "Check enrollment with specific IP"
   test_case:
-  -   
+  -
     port_input: "OSSEC A:'user4' IP:'192.0.0.0'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user4","ip":"192.0.0.0","force":0},"function":"add"}}'
     cluster_output: '{"error":0,"data":{"id":"003","name":"user4","ip":"192.0.0.0","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
@@ -42,7 +42,7 @@
     port_input: "OSSEC A:'user1'"
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user1","ip":"any","force":0},"function":"add"}}'
     cluster_output: '{"error":9008,"message":"Duplicated name"}'
-    port_output: "ERROR: Duplicated name"    
+    port_output: "ERROR: Duplicated name"
 -
   name: "Error Group - Invalid group"
   description: "Try to add an agent with unexistent group"
@@ -61,3 +61,22 @@
     cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user_","ip":"192.0.0.0","force":0},"function":"add"}}'
     cluster_output: '{"error":9007,"message":"Duplicated IP"}'
     port_output: "ERROR: Duplicated IP"
+
+- # Testing messages with agent's key hash
+  name: "Agent's key hash 1"
+  description: "Simple request with key hash"
+  test_case:
+  -
+    port_input: "OSSEC A:'user1' K:'123ABC'"
+    cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user1","ip":"any","key_hash":"123ABC","force":0},"function":"add"}}'
+    cluster_output: '{"error":0,"data":{"id":"001","name":"user1","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
+    port_output: "OSSEC K:'"
+-
+  name: "Agent's key hash 2"
+  description: "Complete request with key hash"
+  test_case:
+  -
+    port_input: "OSSEC A:'user1' G:'Group1' IP:'10.10.10.10' K:'123ABC'"
+    cluster_input: '{"daemon_name":"authd","message":{"arguments":{"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC","force":0},"function":"add"}}'
+    cluster_output: '{"error":0,"data":{"id":"001","name":"user1","ip":"10.10.10.10","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}}'
+    port_output: "OSSEC K:'"

--- a/tests/integration/test_authd/test_authd_force_options.py
+++ b/tests/integration/test_authd/test_authd_force_options.py
@@ -39,9 +39,9 @@ for case in force_options_tests:
     conf_params['USE_SOURCE_IP'].append(case.get('USE_SOURCE_IP', DEFAULT_USE_USER_IP))
     conf_params['FORCE_INSERT'].append(case.get('FORCE_INSERT', DEFAULT_FORCE_INSERT))
 
-p, m = generate_params(extra_params=conf_params, modes=['scheduled'] * len(force_options_tests))
+parameters, metadata = generate_params(extra_params=conf_params, modes=['scheduled'] * len(force_options_tests))
 
-configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 # Variables
 log_monitor_paths = []

--- a/tests/integration/test_authd/test_authd_force_options.py
+++ b/tests/integration/test_authd/test_authd_force_options.py
@@ -44,6 +44,7 @@ parameters, metadata = generate_params(extra_params=conf_params, modes=['schedul
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 # Variables
+
 log_monitor_paths = []
 receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
 monitored_sockets_params = [('wazuh-modulesd', None, True), ('wazuh-db', None, True), ('wazuh-authd', None, True)]
@@ -54,6 +55,7 @@ hostname = socket.gethostname()
 
 test_index = 0
 
+# Functions
 
 def get_current_test():
     global test_index
@@ -122,6 +124,14 @@ def send_message(message):
     return response
 
 
+# Fixtures
+
+@pytest.fixture(scope="module", params=configurations)
+def get_configuration(request):
+    """Get configurations from the module"""
+    return request.param
+
+
 # Initial clean client_keys file
 # Stop Wazuh
 control_service('stop')
@@ -132,7 +142,7 @@ truncate_file(client_keys_path)
 # Start Wazuh
 control_service('start')
 
-"""Wait until authd has begun"""
+# Wait until authd has begun
 
 log_monitor = FileMonitor(LOG_FILE_PATH)
 log_monitor.start(timeout=30, callback=callback_authd_startup)

--- a/tests/integration/test_authd/test_authd_force_options.py
+++ b/tests/integration/test_authd/test_authd_force_options.py
@@ -62,7 +62,7 @@ def get_current_test():
     return current
 
 
-@pytest.fixture(scope="module", params=configurations)
+@pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module"""
     return request.param

--- a/tests/integration/test_authd/test_authd_local.py
+++ b/tests/integration/test_authd/test_authd_local.py
@@ -1,5 +1,5 @@
 '''
-brief: This module verifies the correct behavior of the enrollment daemon authd under different messages in a Cluster scenario (for Master)
+brief: This module verifies the correct behavior of authd under different messages in a Cluster scenario (for Master)
 copyright:
     Copyright (C) 2015-2021, Wazuh Inc.
     Created by Wazuh, Inc. <info@wazuh.com>.
@@ -79,7 +79,7 @@ def set_up_groups_keys(request):
         # The client.keys file is cleaned always
         # but the keys are added only if pre_existent_keys has values
         with open(client_keys_path, "w") as keys_file:
-            if(keys != None):
+            if(keys is not None):
                 for key in keys:
                     keys_file.write(key + '\n')
             keys_file.close()
@@ -100,7 +100,8 @@ def set_up_groups_keys(request):
 
 
 def test_ossec_auth_messages(set_up_groups_keys, get_configuration, configure_environment,
-                             configure_sockets_environment_function, connect_to_sockets_function, wait_for_agentd_startup):
+                             configure_sockets_environment_function, connect_to_sockets_function,
+                             wait_for_agentd_startup):
     """
         test_logic:
             "Check that every input message in trough local authd port generates the adequate response to worker"
@@ -119,5 +120,5 @@ def test_ossec_auth_messages(set_up_groups_keys, get_configuration, configure_en
         receiver_sockets[0].send(stage['input'], size=True)
         response = receiver_sockets[0].receive(size=True).decode()
         assert response[:len(expected)] == expected, \
-            'Failed test case "{}". Response was: {} instead of: {}'.format \
-            (set_up_groups_keys['name'], response, expected)
+            'Failed test case "{}". Response was: {} instead of: {}' \
+            .format(set_up_groups_keys['name'], response, expected)

--- a/tests/integration/test_authd/test_authd_local.py
+++ b/tests/integration/test_authd/test_authd_local.py
@@ -10,6 +10,7 @@ metadata:
         - Manager
     modules:
         - Authd
+        - Cluster
     daemons:
         - authd
     operating_system:
@@ -20,7 +21,6 @@ metadata:
     tags:
         - Enrollment
         - Authd
-        - Cluster
         - Master
 '''
 
@@ -109,7 +109,6 @@ def test_ossec_auth_messages(set_up_groups_keys, get_configuration, configure_en
             - The received output must match with expected
             - The enrollment messages are parsed as expected
             - The agent keys are denied if the hash is the same than the manager's
-
     """
     test_case = set_up_groups_keys['test_case']
     for stage in test_case:

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -1,6 +1,28 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+brief: This module verifies the correct behavior of the enrollment daemon authd under different messages in a Cluster scenario (for Cluster)
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
+    Created by Wazuh, Inc. <info@wazuh.com>.
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+metadata:
+    component:
+        - Manager
+    modules:
+        - Authd
+        - Cluster
+    daemons:
+        - authd
+    operating_system:
+        - Ubuntu
+        - CentOS
+    tiers:
+        - 0
+    tags:
+        - Enrollment
+        - Authd
+        - Worker
+'''
 
 import os
 import subprocess
@@ -91,18 +113,20 @@ def get_configuration(request):
 
 def test_ossec_auth_messages(get_configuration, set_up_groups, configure_environment, configure_sockets_environment,
                              connect_to_sockets_module, wait_for_agentd_startup):
-    """Check that every input message in authd port generates the adequate output
+    """
+        test_logic:
+            "Check that every message from the agent is correctly formatted for master, and every master
+            response is correctly parsed for agent"
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys).
+        checks:
+            - The 'port_input' from agent is formatted to 'cluster_input' for master
+            - The 'cluster_output' response from master is correctly parsed to 'port_output' for agent
     """
     test_case = set_up_groups['test_case']
     for stage in test_case:
         # Push expected info to mitm queue
         mitm_master.set_cluster_messages(stage['cluster_input'], stage['cluster_output'])
-        # Reopen socket (socket is closed by maanger after sending message with client key)
+        # Reopen socket (socket is closed by manager after sending message with client key)
         mitm_master.restart()
         receiver_sockets[0].open()
         expected = stage['port_output']

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -1,5 +1,5 @@
 '''
-brief: This module verifies the correct behavior of the enrollment daemon authd under different messages in a Cluster scenario (for Cluster)
+brief: This module verifies the correct behavior of authd under different messages in a Cluster scenario (for Worker)
 copyright:
     Copyright (C) 2015-2021, Wazuh Inc.
     Created by Wazuh, Inc. <info@wazuh.com>.


### PR DESCRIPTION
|Related issue|
|---|
|#1772|

## Description

This PR adds the corresponding IT for **authd** in `tests/integration/test_authd/test_authd_local.py` and `tests/integration/test_authd/test_authd_worker.py` (cluster scenario) now that the agent sends its key hash in the enrollment message . The test is documented according to the new DocGenerator framework.
Both master and worker cases are covered.

Also, the tests cases for master are isolated with an individual environment, because the previous implementation created a list of interdependent tests. This situation has slightly increased the test time because now Wazuh needs to be restarted every time but this approach seems more clean and correct.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The test is documented following the Documentation schema V0.1 (#1536).
- [x] DocGenerator sanity check is executed without errors.