### PR TITLE
Update user used by `Kibana` in the cluster performance tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
@@ -44,7 +44,7 @@ class CustomLogger:
 
 
 class APISimulator:
-    def __init__(self, host, port, protocol='https', frequency=60, user='wazuh', password='wazuh',
+    def __init__(self, host, port, protocol='https', frequency=60, user='wazuh-wui', password='wazuh-wui',
                  external_logger=None, request_percentage=0, request_template=None):
         self.host = host
         self.port = port


### PR DESCRIPTION
|Related issue|
|---|
| #1799 |

This PR closes #1799.

Right now, we are using the APISimulator to simulate 2 different sources in our cluster performance tests:

- Kibana requests
- Kibana extra load

The related issue aims to change the user used in the API simulated to `wazuh-wui` when we simulate the API using the Kibana APP. Therefore, logs from Kibana requests and Kibana requests with extra load will indicate the user `wazuh-wui` instead of `wazuh`.

The API logs generated by the API tests will still have the `wazuh` user.

To do this, I have changed the default user and password used in the `APISimulator` class to `wazuh-wui`, as this class is only used to simulate the API when it is used by Kibana.

Actual logs:

```
2021/08/31 08:54:21 INFO: wazuh 172.31.15.42 "GET /cluster/status" with parameters {} and body {} done in 0.012s: 200
2021/08/31 08:54:28 INFO: wazuh 172.31.6.109 "GET /" with parameters {} and body {} done in 0.006s: 200
2021/08/31 08:54:29 INFO: wazuh 172.31.6.109 "PUT /agents/group/new_test_group/restart" with parameters {} and body {} done in 0.405s: 200
2021/08/31 08:54:29 INFO: wazuh 172.31.15.42 "GET /agents" with parameters {"limit": "1", "q": "id!=000"} and body {} done in 0.021s: 200
2021/08/31 08:54:38 INFO: wazuh 172.31.15.42 "GET /manager/info" with parameters {} and body {} done in 0.009s: 200
2021/08/31 08:54:46 INFO: wazuh 172.31.15.42 "GET /security/users/me/policies" with parameters {} and body {} done in 0.007s: 200
2021/08/31 08:54:55 INFO: wazuh 172.31.15.42 "GET /agents/summary/status" with parameters {} and body {} done in 0.035s: 200
2021/08/31 08:54:59 INFO: wazuh 172.31.6.109 "GET /" with parameters {} and body {} done in 0.007s: 200
2021/08/31 08:54:59 INFO: wazuh 172.31.6.109 "PUT /agents/restart" with parameters {} and body {} done in 0.530s: 200
2021/08/31 08:55:03 INFO: wazuh 172.31.15.42 "GET /manager/stats/remoted" with parameters {"pretty": "True"} and body {} done in 0.009s: 200
2021/08/31 08:55:12 INFO: wazuh 172.31.15.42 "GET /manager/stats/analysisd" with parameters {"pretty": "True"} and body {} done in 0.010s: 200
```

After the changes:

```
2021/08/31 13:11:28 INFO: wazuh 172.31.45.100 "GET /" with parameters {} and body {} done in 0.006s: 200
2021/08/31 13:11:28 INFO: wazuh 172.31.45.100 "PUT /agents/group/new_test_group/restart" with parameters {} and body {} done in 0.022s: 200
2021/08/31 13:11:31 INFO: wazuh-wui 172.31.79.11 "GET /cluster/status" with parameters {} and body {} done in 0.013s: 200
2021/08/31 13:11:39 INFO: wazuh-wui 172.31.79.11 "GET /agents" with parameters {"limit": "1", "q": "id!=000"} and body {} done in 0.010s: 200
2021/08/31 13:11:48 INFO: wazuh-wui 172.31.79.11 "GET /manager/info" with parameters {} and body {} done in 0.009s: 200
2021/08/31 13:11:57 INFO: wazuh-wui 172.31.79.11 "GET /security/users/me/policies" with parameters {} and body {} done in 0.007s: 200
2021/08/31 13:11:58 INFO: wazuh 172.31.45.100 "GET /" with parameters {} and body {} done in 0.007s: 200
2021/08/31 13:11:58 INFO: wazuh 172.31.45.100 "PUT /agents/restart" with parameters {} and body {} done in 0.020s: 200
2021/08/31 13:12:05 INFO: wazuh-wui 172.31.79.11 "GET /agents/summary/status" with parameters {} and body {} done in 0.009s: 200
```