### PR TITLE
Migrate `test_agentd` documentation to QA Docs

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -4,8 +4,6 @@ Output path: "../output"
 
 Include paths:
   - "../../tests/integration/test_agentd"
-  - "../../tests/integration/test_wazuh_db"
-  - "../../tests/integration/test_vulnerability_detector"
 
 Include regex:
   - "^test_.*py$"
@@ -18,7 +16,6 @@ Function regex:
 
 Ignore paths:
   - "../../tests/integration/test_agentd/data"
-  - "../../tests/integration/test_wazuh_db/data"
 
 Output fields:
   Module:

--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -3,6 +3,7 @@ Project path: "../../tests/integration"
 Output path: "../output"
 
 Include paths:
+  - "../../tests/integration/test_agentd"
   - "../../tests/integration/test_wazuh_db"
   - "../../tests/integration/test_vulnerability_detector"
 
@@ -16,26 +17,33 @@ Function regex:
   - "^test_"
 
 Ignore paths:
+  - "../../tests/integration/test_agentd/data"
   - "../../tests/integration/test_wazuh_db/data"
 
 Output fields:
   Module:
     Mandatory:
-      - brief
-      - metadata:
-        - modules
-        - daemons
-        - component
-        - operating_system
-        - tiers
+      - copyright
+      - type
+      - description
+      - tiers
+      - component
+      - path
+      - daemons
+      - os_support
     Optional:
+      - coverage
+      - pytest_args
       - tags
   Test:
     Mandatory:
-      - test_logic
-      - checks
+      - description
+      - wazuh_min_version
+      - assertions
+      - test_input
+      - logging
     Optional:
-      - expected_result
-      - test_cases
+      - parameters
+      - tags
 
 Test cases field: test_cases

--- a/tests/integration/test_agentd/test_agent_auth_enrollment.py
+++ b/tests/integration/test_agentd/test_agent_auth_enrollment.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will verify different situations that may occur at `agent-auth` during enrollment.
+    The objective is to check if the parameters sent by the `agent-auth` to the `wazuh-authd` daemon
+    are consistent with its responses.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_agentd/
+
+daemons:
+    - agentd
+    - authd
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - enrollment
+'''
 import os
 import platform
 import pytest
@@ -67,13 +120,40 @@ def configure_authd_server(request):
 
 @pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_auth_enrollment(configure_authd_server, configure_environment, test_case: list):
-    """Test different situations that can occur on the agent-auth program during agent enrollment.
+    '''
+    description:
+        Test different situations that can occur on the `agent-auth` program during agent enrollment.
 
-    Args:
-        configure_authd_server (fixture): Initializes a simulated authd connection.
-        configure_environment (fixture): Configure a custom environment for testing.
-        test_case (list): List of tests to be performed.
-    """
+    wazuh_min_version:
+        4.1
+
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - test_case (list):
+            List of tests to be performed.
+
+    assertions:
+        - Check that the responses received are consistent with the parameters sent.
+
+    test_input:
+        The tests are based on using certain parameters to enroll the agent with the manager.
+        The enrollment is then started, and the response received is compared with
+        the expected one. Both parameters and responses are found in a YAML file.
+
+    logging:
+        - ossec.log:
+            - r"Multiple values located in the wazuh_enrollment_tests.yaml file."
+
+    tags:
+        - enrollment
+        - simulator
+        - ssl
+    '''
     print(f'Test: {test_case["name"]}')
     if 'agent-auth' in test_case.get("skips", []):
         pytest.skip("This test does not apply to agent-auth")

--- a/tests/integration/test_agentd/test_agent_auth_enrollment.py
+++ b/tests/integration/test_agentd/test_agent_auth_enrollment.py
@@ -128,14 +128,17 @@ def test_agent_auth_enrollment(configure_authd_server, configure_environment, te
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - test_case (list):
-            List of tests to be performed.
+        - test_case:
+            type: list
+            brief: List of tests to be performed.
 
     assertions:
         - Check that the responses received are consistent with the parameters sent.

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -272,14 +272,17 @@ def test_agent_agentd_enrollment(configure_authd_server, configure_environment, 
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - test_case (list):
-            List of tests to be performed.
+        - test_case:
+            type: list
+            brief: List of tests to be performed.
 
     assertions:
         - Check that the responses received are consistent with the parameters sent.

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will verify different situations that may occur at `wazuh-agentd` during enrollment.
+    The objective is to check the enrollment of the agent using certain settings
+    in the configuration file produces the expected responses from the server.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_agentd/
+
+daemons:
+    - agentd
+    - authd
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - enrollment
+'''
 import datetime
 import os
 import pytest
@@ -211,13 +264,39 @@ def check_log_error_conf(msg):
 
 @pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
-    """Test different situations that can occur on the wazuh-agentd daemon during agent enrollment.
+    '''
+    description:
+        Test different situations that can occur on the `wazuh-agentd` daemon during agent enrollment.
 
-    Args:
-        configure_authd_server (fixture): Initializes a simulated authd connection.
-        configure_environment (fixture): Configure a custom environment for testing.
-        test_case (list): List of tests to be performed.
-    """
+    wazuh_min_version:
+        4.1
+
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - test_case (list):
+            List of tests to be performed.
+
+    assertions:
+        - Check that the responses received are consistent with the parameters sent.
+
+    test_input:
+        The tests are based on using specific configurations for the agent, initiate the agent enrollment
+        with the manager, and finally, verify that the response received matches the expected one.
+        Both configurations and responses are found in a YAML file.
+
+    logging:
+        - ossec.log:
+            - r"Multiple values located in the wazuh_enrollment_tests.yaml file."
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     global remoted_server
     print(f'Test: {test_case["name"]}')
     if 'wazuh-agentd' in test_case.get("skips", []):

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -403,23 +403,29 @@ def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id
         4.1
 
     parameters:
-        - add_hostnames (fixture):
-            Adds to the OS hosts file the names and IP's of the test servers.
+        - add_hostnames:
+            type: fixture
+            brief: Adds to the OS hosts file the names and IP's of the test servers.
 
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - set_authd_id (fixture):
-            Sets the agent id to 101 in authd simulated connection.
+        - set_authd_id:
+            type: fixture
+            brief: Sets the agent id to 101 in authd simulated connection.
 
-        - clean_keys (fixture):
-            Clears the client.key file used by the simulated remote connections.
+        - clean_keys:
+            type: fixture
+            brief: Clears the client.key file used by the simulated remote connections.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Agent without keys. All servers will refuse the connection to remoted but will accept enrollment.
@@ -439,7 +445,7 @@ def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id
 
         - Agent with keys. The first server is available, but it disconnects, the second and third servers
           are not responding. The agent on disconnection, should try the second and
-          third servers and go back finally to the first server.**
+          third servers and go back finally to the first server.
 
     test_input:
         Several settings are used for the servers and the requests to be made along with the expected responses.
@@ -450,7 +456,7 @@ def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id
             - r"Valid key received"
             - r"Trying to connect to server"
             - r"Connected to the server"
-            - r"Received message: '#!-agent ack '"
+            - r"Received message"
             - r"Server responded. Releasing lock."
             - r"Unable to connect to"
 

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will check that the connection is finally made when
+    there are delays between connection attempts to the server.
+    The objective is to check how `wazuh-agentd` behaves when there are delays between connection attempts
+    to `wazuh-remoted` using `TCP` and `UDP` protocols.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_agentd/
+
+daemons:
+    - agentd
+    - remoted
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - enrollment
+'''
 from datetime import datetime, timedelta
 import os
 import platform
@@ -256,18 +310,51 @@ This test covers different options of delays between server connection attempts:
 
 def test_agentd_parametrized_reconnections(configure_authd_server, start_authd, stop_agent, set_keys,
                                            configure_environment, get_configuration):
-    """Check how the agent behaves when there are delays between connection attempts to the server.
+    '''
+    description:
+        Check how the agent behaves when there are delays between connection attempts to the server.
+        For this purpose, different values for `max_retries` and `retry_interval` parameters are tested.
 
-    For this purpose, different values for max_retries and retry_interval parameters are tested.
+    wazuh_min_version:
+        4.1
 
-    Args:
-        configure_authd_server (fixture): Initialize a simulated authd connection.
-        start_authd (fixture): Enable authd to accept connections and perform enrollments.
-        stop_agent (fixture): Stop Wazuh's agent.
-        set_keys (fixture): Write to client.keys file the agent's enrollment details.
-        configure_environment (fixture): Configure a custom environment for testing.
-        get_configuration (fixture): Get configurations from the module.
-    """
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - start_authd (fixture):
+            Enable authd to accept connections and perform enrollments.
+
+        - stop_agent (fixture):
+            Stop Wazuh's agent.
+
+        - set_keys (fixture):
+            Write to client.keys file the agent's enrollment details.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - get_configuration (fixture):
+            Get configurations from the module.
+
+    assertions:
+        - Check for unsuccessful connection retries in agentd initialization.
+        - If auto enrollment is enabled, verify successfully enrollment.
+        - Check the server rollback feature.
+
+    test_input:
+        Different parameters are used for the server using the `TCP` and `UDP` protocols.
+
+    logging:
+        - ossec.log:
+            - r"Valid key received"
+            - r"Trying to connect to server"
+            - r"Unable to connect to any server"
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     DELTA = 1
     RECV_TIMEOUT = 5
     ENROLLMENT_SLEEP = 20

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -319,23 +319,29 @@ def test_agentd_parametrized_reconnections(configure_authd_server, start_authd, 
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - start_authd (fixture):
-            Enable authd to accept connections and perform enrollments.
+        - start_authd:
+            type: fixture
+            brief: Enable authd to accept connections and perform enrollments.
 
-        - stop_agent (fixture):
-            Stop Wazuh's agent.
+        - stop_agent:
+            type: fixture
+            brief: Stop Wazuh's agent.
 
-        - set_keys (fixture):
-            Write to client.keys file the agent's enrollment details.
+        - set_keys:
+            type: fixture
+            brief: Write to client.keys file the agent's enrollment details.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Check for unsuccessful connection retries in agentd initialization.

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will check if, during enrollment, the agent re-establishes communication with the manager
+    under different situations that interrupt it.
+    The objective is to check that, with different states in the `clients.key` file, the agent
+    successfully enrolls after losing connection with remoted.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_agentd/
+
+daemons:
+    - agentd
+    - remoted
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - enrollment
+'''
 import os
 import platform
 from time import sleep
@@ -181,18 +235,39 @@ when misses communication with Remoted and a new enrollment is sent to Authd.
 
 
 def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configure_environment, get_configuration):
-    """Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
+    '''
+    description:
+        Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
+        In this case, the agent starts with keys.
 
-    In this case, the agent starts with keys.
+    wazuh_min_version:
+        4.1
 
-    Args:
-        configure_authd_server (fixture): Initialize a simulated authd connection.
-        start_authd (fixture): Enable authd to accept connections and perform enrollments.
-        set_authd_id (fixture): Set agent id to 101 in the authd simulated connection.
-        set_keys (fixture): Write to client.keys file the agent's enrollment details.
-        configure_environment (fixture): Configure a custom environment for testing.
-        get_configuration (fixture): Get configurations from the module.
-    """
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - get_configuration (fixture):
+            Get configurations from the module.
+
+    assertions:
+        - Verify that the agent enrollment is successful.
+
+    test_input:
+        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+
+    logging:
+        - ossec.log:
+            - r"Valid key received"
+            - r"Sending keep alive"
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     global remoted_server
 
     remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], mode='CONTROLLED_ACK',
@@ -219,7 +294,6 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configu
     # Wait until Agent is notifying Manager
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
 
-
     # Start rejecting Agent
     remoted_server.set_mode('REJECT')
     # hearing on enrollment server
@@ -228,12 +302,12 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configu
     log_monitor.start(timeout=180, callback=wait_enrollment,
                       error_message="Agent never enrolled after rejecting connection!")
 
-
     # Start responding to Agent
     remoted_server.set_mode('CONTROLLED_ACK')
     # Wait until Agent is notifying Manager
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
     assert "aes" in remoted_server.last_message_ctx, "Incorrect Secure Message"
+
 
 """
 This test covers the scenario of Agent starting without client.keys file
@@ -242,18 +316,39 @@ and an enrollment is sent to Authd to start communicating with Remoted
 
 
 def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, configure_environment, get_configuration):
-    """Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
+    '''
+    description:
+        Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
+        In this case, the agent doesn't have client.keys file.
 
-    In this case, the agent doesn't have client.keys file.
+    wazuh_min_version:
+        4.1
 
-    Args:
-        configure_authd_server (fixture): Initialize a simulated authd connection.
-        start_authd (fixture): Enable authd to accept connections and perform enrollments.
-        set_authd_id (fixture): Set agent id to 101 in the authd simulated connection.
-        delete_keys (fixture): Remove the agent's client.keys file.
-        configure_environment (fixture): Configure a custom environment for testing.
-        get_configuration (fixture): Get configurations from the module.
-    """
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - get_configuration (fixture):
+            Get configurations from the module.
+
+    assertions:
+        - Verify that the agent enrollment is successful.
+
+    test_input:
+        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+
+    logging:
+        - ossec.log:
+            - r"Valid key received"
+            - r"Sending keep alive"
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     global remoted_server
 
     remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], mode='CONTROLLED_ACK',
@@ -305,18 +400,39 @@ and an enrollment is sent to Authd to start communicating with Remoted
 
 
 def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure_environment, get_configuration):
-    """Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
+    '''
+    description:
+        Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
+        In this case, the agent has its client.keys file empty.
 
-    In this case, the agent has its client.keys file empty.
+    wazuh_min_version:
+        4.1
 
-    Args:
-        configure_authd_server (fixture): Initialize a simulated authd connection.
-        start_authd (fixture): Enable authd to accept connections and perform enrollments.
-        set_authd_id (fixture): Set agent id to 101 in the authd simulated connection.
-        clean_keys (fixture): Clear the agent's client.keys file.
-        configure_environment (fixture): Configure a custom environment for testing.
-        get_configuration (fixture): Get configurations from the module.
-    """
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - get_configuration (fixture):
+            Get configurations from the module.
+
+    assertions:
+        - Verify that the agent enrollment is successful.
+
+    test_input:
+        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+
+    logging:
+        - ossec.log:
+            - r"Valid key received"
+            - r"Sending keep alive"
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     global remoted_server
 
     remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], mode='CONTROLLED_ACK',
@@ -341,7 +457,7 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure
 
     # Wait until Agent asks keys for the first time
     log_monitor.start(timeout=120, callback=wait_enrollment,
-                          error_message="Agent never enrolled for the first time rejecting connection!")
+                      error_message="Agent never enrolled for the first time rejecting connection!")
 
     # Wait until Agent is notifying Manager
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")
@@ -369,19 +485,41 @@ and multiple retries are required until the new key is obtained to start communi
 
 
 def test_agentd_initial_enrollment_retries(configure_authd_server, configure_environment, get_configuration):
-    """Check how the agent behaves when it makes multiple enrollment attempts before getting its key.
+    '''
+    description:
+        Check how the agent behaves when it makes multiple enrollment attempts before getting its key.
+        For this, the agent starts without keys and perform multiple enrollment requests
+        to authd before getting the new key to communicate with remoted.
 
-    For this, the agent starts without keys and perform multiple enrollment requests
-    to authd before getting the new key to communicate with remoted.
+    wazuh_min_version:
+        4.1
 
-    Args:
-        configure_authd_server (fixture): Initialize a simulated authd connection.
-        stop_authd (fixture): Disable authd to accept connections and perform enrollments.
-        set_authd_id (fixture): Set agent id to 101 in the authd simulated connection.
-        clean_keys (fixture): Clear the agent's client.keys file.
-        configure_environment (fixture): Configure a custom environment for testing.
-        get_configuration (fixture): Get configurations from the module.
-    """
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - get_configuration (fixture):
+            Get configurations from the module.
+
+    assertions:
+        - Verify that the agent enrollment is successful.
+
+    test_input:
+        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+
+    logging:
+        - ossec.log:
+            - r"Requesting a key"
+            - r"Valid key received"
+            - r"Sending keep alive"
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     global remoted_server
 
     remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], mode='CONTROLLED_ACK',
@@ -430,6 +568,7 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, configure_env
             if "Unable to access queue:" in line:
                 raise AssertionError("A Wazuh module stopped because of Agentd initialization!")
 
+
 """
 This test covers and check the scenario of Agent starting with keys but Remoted is not reachable during some seconds
 and multiple connection retries are required prior to requesting a new enrollment
@@ -437,18 +576,39 @@ and multiple connection retries are required prior to requesting a new enrollmen
 
 
 def test_agentd_connection_retries_pre_enrollment(configure_authd_server, configure_environment, get_configuration):
-    """Check how the agent behaves when Remoted is not available and performs multiple connection attempts to it.
+    '''
+    description:
+        Check how the agent behaves when Remoted is not available and performs multiple connection attempts to it.
+        For this, the agent starts with keys but `remoted` is not available for several seconds,
+        then the agent performs multiple connection retries before requesting a new enrollment.
 
-    For this, the agent starts with keys but Remoted is not available for several seconds,
-    then the agent performs multiple connection retries before requesting a new enrollment.
+    wazuh_min_version:
+        4.1
 
-    Args:
-        configure_authd_server (fixture): Initialize a simulated authd connection.
-        stop_authd (fixture): Disable authd to accept connections and perform enrollments.
-        set_keys (fixture): Write to client.keys file the agent's enrollment details.
-        configure_environment (fixture): Configure a custom environment for testing.
-        get_configuration (fixture): Get configurations from the module.
-    """
+    parameters:
+        - configure_authd_server (fixture):
+            Initializes a simulated authd connection.
+
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - get_configuration (fixture):
+            Get configurations from the module.
+
+    assertions:
+        - Verify that the agent enrollment is successful.
+
+    test_input:
+        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+
+    logging:
+        - ossec.log:
+            - r"Sending keep alive"
+
+    tags:
+        - enrollment
+        - simulator
+    '''
     global remoted_server
     REMOTED_KEYS_SYNC_TIME = 10
 

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -244,14 +244,17 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configu
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Verify that the agent enrollment is successful.
@@ -325,14 +328,17 @@ def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, conf
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Verify that the agent enrollment is successful.
@@ -409,14 +415,17 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Verify that the agent enrollment is successful.
@@ -495,14 +504,17 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, configure_env
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Verify that the agent enrollment is successful.
@@ -586,14 +598,17 @@ def test_agentd_connection_retries_pre_enrollment(configure_authd_server, config
         4.1
 
     parameters:
-        - configure_authd_server (fixture):
-            Initializes a simulated authd connection.
+        - configure_authd_server:
+            type: fixture
+            brief: Initializes a simulated authd connection.
 
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - get_configuration (fixture):
-            Get configurations from the module.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
 
     assertions:
         - Verify that the agent enrollment is successful.

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    The statistics files are documents that show real-time information about the Wazuh environment.
+    These tests will check if the content of the `wazuh-agentd` statistics file is valid.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_agentd/
+
+daemons:
+    - agentd
+    - remoted
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - stats_file
+'''
 import json
 import os
 import sys
@@ -79,6 +131,37 @@ def add_custom_key():
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
 def test_agentd_state(configure_environment, test_case: list):
+    '''
+    description:
+        Check that the statistics file `wazuh-agentd.state` is created automatically
+        and verify that the content of its fields is correct.
+
+    wazuh_min_version:
+        4.2
+
+    parameters:
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - test_case (list):
+            List of tests to be performed.
+
+    assertions:
+        - Verify the creation of the statistics file.
+        - Check that the fields in the statistics file are consistent with the connection to remoted.
+
+    test_input:
+        Different use cases that are contained in an external `YAML` file
+        that includes the parameters and expected responses.
+
+    logging:
+        - ossec.log:
+            - r"pending"
+            - r"connected"
+
+    tags:
+        - simulator
+    '''
     global remoted_server
     if remoted_server is not None:
         remoted_server.stop()

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -140,11 +140,13 @@ def test_agentd_state(configure_environment, test_case: list):
         4.2
 
     parameters:
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - test_case (list):
-            List of tests to be performed.
+        - test_case:
+            type: list
+            brief: List of tests to be performed.
 
     assertions:
         - Verify the creation of the statistics file.

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    The statistics files are documents that show real-time information about the Wazuh environment.
+    These tests will check if the configuration options related to the `wazuh-agentd`
+    statistics file are working properly.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_agentd/
+
+daemons:
+    - agentd
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - stats_file
+'''
 import os
 import sys
 import time
@@ -73,7 +125,39 @@ def get_configuration(request):
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
 def test_agentd_state_config(configure_environment, test_case: list):
+    '''
+    description:
+        Check that the statistics file `wazuh-agentd.state` is created automatically
+        and verify that the update intervals work properly.
 
+    wazuh_min_version:
+        4.2
+
+    parameters:
+        - configure_environment (fixture):
+            Configure a custom environment for testing.
+
+        - test_case (list):
+            List of tests to be performed.
+
+    assertions:
+        - Verify the creation of the statistics file.
+        - Check update intervals of the statistics file.
+
+    test_input:
+        Different use cases that are contained in an external `YAML` file
+        that includes the parameters and expected responses.
+
+    logging:
+        - ossec.log:
+            - r"interval_not_found"
+            - r"interval_not_valid"
+            - r"file_enabled"
+            - r"file_not_enabled"
+
+    tags:
+
+    '''
     control_service('stop', 'wazuh-agentd')
 
     # Truncate ossec.log in order to watch it correctly

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -134,11 +134,13 @@ def test_agentd_state_config(configure_environment, test_case: list):
         4.2
 
     parameters:
-        - configure_environment (fixture):
-            Configure a custom environment for testing.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
 
-        - test_case (list):
-            List of tests to be performed.
+        - test_case:
+            type: list
+            brief: List of tests to be performed.
 
     assertions:
         - Verify the creation of the statistics file.


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1801|

## Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **QA Docs**. 
The used schema is provisional (third proposal of issue #1694) until we have the definitive one.

## Docs example 
<details><summary>test_agent_auth_enrollment.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
- authd
description: These tests will verify different situations that may occur at `agent-auth`
  during enrollment. The objective is to check if the parameters sent by the `agent-auth`
  to the `wazuh-authd` daemon are consistent with its responses.
group_id: 0
id: 2
name: test_agent_auth_enrollment.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- enrollment
tests:
- assertions:
  - Check that the responses received are consistent with the parameters sent.
  description: Test different situations that can occur on the `agent-auth` program
    during agent enrollment.
  logging:
  - ossec.log:
    - r"Multiple values located in the wazuh_enrollment_tests.yaml file."
  name: test_agent_auth_enrollment
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  tags:
  - enrollment
  - simulator
  - ssl
  test_input: The tests are based on using certain parameters to enroll the agent
    with the manager. The enrollment is then started, and the response received is
    compared with the expected one. Both parameters and responses are found in a YAML
    file.
  wazuh_min_version: 4.1
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_agentd_enrollment_params.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
- authd
description: These tests will verify different situations that may occur at `wazuh-agentd`
  during enrollment. The objective is to check the enrollment of the agent using certain
  settings in the configuration file produces the expected responses from the server.
group_id: 0
id: 3
name: test_agentd_enrollment_params.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- enrollment
tests:
- assertions:
  - Check that the responses received are consistent with the parameters sent.
  description: Test different situations that can occur on the `wazuh-agentd` daemon
    during agent enrollment.
  logging:
  - ossec.log:
    - r"Multiple values located in the wazuh_enrollment_tests.yaml file."
  name: test_agent_agentd_enrollment
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  tags:
  - enrollment
  - simulator
  test_input: The tests are based on using specific configurations for the agent,
    initiate the agent enrollment with the manager, and finally, verify that the response
    received matches the expected one. Both configurations and responses are found
    in a YAML file.
  wazuh_min_version: 4.1
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_agentd_multi_server.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
- authd
description: These tests will check the agent's enrollment and connection to a manager
  in a multi-server environment. The objective is to check how the agent manages the
  connections to the servers depending on their status.
group_id: 0
id: 4
name: test_agentd_multi_server.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- enrollment
tests:
- assertions:
  - Agent without keys. All servers will refuse the connection to remoted but will
    accept enrollment. The agent should try to connect and enroll to each of them.
  - Agent without keys. The first server only has enrollment available, and the third
    server only has remoted available. The agent should enroll in the first server
    and connect to the third one.
  - Agent without keys. The agent should enroll and connect to the first server, and
    then the first server will disconnect, agent should connect to the second server
    with the same key.
  - Agent without keys. The agent should enroll and connect to the first server, and
    then the first server will disconnect, agent should try to enroll to the first
    server again, and then after failure, move to the second server and connect.
  - Agent with keys. The agent should enroll and connect to the last server.
  - Agent with keys. The first server is available, but it disconnects, the second
    and third servers are not responding. The agent on disconnection, should try the
    second and third servers and go back finally to the first server.
  description: Check the agent's enrollment and connection to a manager in a multi-server
    environment. Initialize an environment with multiple simulated servers in which
    the agent is forced to enroll under different test conditions, verifying the agent's
    behavior through its log files.
  logging:
  - ossec.log:
    - r"Requesting a key from server"
    - r"Valid key received"
    - r"Trying to connect to server"
    - r"Connected to the server"
    - r"Received message"
    - r"Server responded. Releasing lock."
    - r"Unable to connect to"
  name: test_agentd_multi_server
  parameters:
  - add_hostnames:
      brief: Adds to the OS hosts file the names and IP's of the test servers.
      type: fixture
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - set_authd_id:
      brief: Sets the agent id to 101 in authd simulated connection.
      type: fixture
  - clean_keys:
      brief: Clears the client.key file used by the simulated remote connections.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: Several settings are used for the servers and the requests to be made
    along with the expected responses.
  wazuh_min_version: 4.1
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_agentd_parametrized_reconnections.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
- remoted
description: These tests will check that the connection is finally made when there
  are delays between connection attempts to the server. The objective is to check
  how `wazuh-agentd` behaves when there are delays between connection attempts to
  `wazuh-remoted` using `TCP` and `UDP` protocols.
group_id: 0
id: 6
name: test_agentd_parametrized_reconnections.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- enrollment
tests:
- assertions:
  - Check for unsuccessful connection retries in agentd initialization.
  - If auto enrollment is enabled, verify successfully enrollment.
  - Check the server rollback feature.
  description: Check how the agent behaves when there are delays between connection
    attempts to the server. For this purpose, different values for `max_retries` and
    `retry_interval` parameters are tested.
  logging:
  - ossec.log:
    - r"Valid key received"
    - r"Trying to connect to server"
    - r"Unable to connect to any server"
  name: test_agentd_parametrized_reconnections
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - start_authd:
      brief: Enable authd to accept connections and perform enrollments.
      type: fixture
  - stop_agent:
      brief: Stop Wazuh's agent.
      type: fixture
  - set_keys:
      brief: Write to client.keys file the agent's enrollment details.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: Different parameters are used for the server using the `TCP` and `UDP`
    protocols.
  wazuh_min_version: 4.1
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_agentd_reconnection.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
- remoted
description: These tests will check if, during enrollment, the agent re-establishes
  communication with the manager under different situations that interrupt it. The
  objective is to check that, with different states in the `clients.key` file, the
  agent successfully enrolls after losing connection with remoted.
group_id: 0
id: 7
name: test_agentd_reconnection.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- enrollment
tests:
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when losing communication with remoted
    and a new enrollment is sent to authd. In this case, the agent starts with keys.
  logging:
  - ossec.log:
    - r"Valid key received"
    - r"Sending keep alive"
  name: test_agentd_reconection_enrollment_with_keys
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: An IP address and port are used for the server using the `TCP` and `UDP`
    protocols.
  wazuh_min_version: 4.1
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when losing communication with remoted
    and a new enrollment is sent to authd. In this case, the agent doesn't have client.keys
    file.
  logging:
  - ossec.log:
    - r"Valid key received"
    - r"Sending keep alive"
  name: test_agentd_reconection_enrollment_no_keys_file
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: An IP address and port are used for the server using the `TCP` and `UDP`
    protocols.
  wazuh_min_version: 4.1
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when losing communication with remoted
    and a new enrollment is sent to authd. In this case, the agent has its client.keys
    file empty.
  logging:
  - ossec.log:
    - r"Valid key received"
    - r"Sending keep alive"
  name: test_agentd_reconection_enrollment_no_keys
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: An IP address and port are used for the server using the `TCP` and `UDP`
    protocols.
  wazuh_min_version: 4.1
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when it makes multiple enrollment attempts
    before getting its key. For this, the agent starts without keys and perform multiple
    enrollment requests to authd before getting the new key to communicate with remoted.
  logging:
  - ossec.log:
    - r"Requesting a key"
    - r"Valid key received"
    - r"Sending keep alive"
  name: test_agentd_initial_enrollment_retries
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: An IP address and port are used for the server using the `TCP` and `UDP`
    protocols.
  wazuh_min_version: 4.1
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when Remoted is not available and performs
    multiple connection attempts to it. For this, the agent starts with keys but `remoted`
    is not available for several seconds, then the agent performs multiple connection
    retries before requesting a new enrollment.
  logging:
  - ossec.log:
    - r"Sending keep alive"
  name: test_agentd_connection_retries_pre_enrollment
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated authd connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - enrollment
  - simulator
  test_input: An IP address and port are used for the server using the `TCP` and `UDP`
    protocols.
  wazuh_min_version: 4.1
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_agentd_state_config.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
description: The statistics files are documents that show real-time information about
  the Wazuh environment. These tests will check if the configuration options related
  to the `wazuh-agentd` statistics file are working properly.
group_id: 0
id: 1
name: test_agentd_state_config.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- stats_file
tests:
- assertions:
  - Verify the creation of the statistics file.
  - Check update intervals of the statistics file.
  description: Check that the statistics file `wazuh-agentd.state` is created automatically
    and verify that the update intervals work properly.
  logging:
  - ossec.log:
    - r"interval_not_found"
    - r"interval_not_valid"
    - r"file_enabled"
    - r"file_not_enabled"
  name: test_agentd_state_config
  parameters:
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  tags: null
  test_input: Different use cases that are contained in an external `YAML` file that
    includes the parameters and expected responses.
  wazuh_min_version: 4.2
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_agentd_state.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- agentd
- remoted
description: The statistics files are documents that show real-time information about
  the Wazuh environment. These tests will check if the content of the `wazuh-agentd`
  statistics file is valid.
group_id: 0
id: 5
name: test_agentd_state.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_agentd/
pytest_args: null
tags:
- stats_file
tests:
- assertions:
  - Verify the creation of the statistics file.
  - Check that the fields in the statistics file are consistent with the connection
    to remoted.
  description: Check that the statistics file `wazuh-agentd.state` is created automatically
    and verify that the content of its fields is correct.
  logging:
  - ossec.log:
    - r"pending"
    - r"connected"
  name: test_agentd_state
  parameters:
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  tags:
  - simulator
  test_input: Different use cases that are contained in an external `YAML` file that
    includes the parameters and expected responses.
  wazuh_min_version: 4.2
tiers:
- 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`