### PR TITLE
Add a new method for obtaining S3 packages

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
+++ b/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
@@ -184,6 +184,21 @@
                     "installation_files_path": {
                       "type": "string"
                     },
+                    "version":{
+                      "type": "string"
+                    },
+                    "system":{
+                      "type": "string"
+                    },
+                    "revision":{
+                      "type": "string"
+                    },
+                    "repository":{
+                      "type": "string"
+                    },
+                    "architecture":{
+                      "type": "string"
+                    },
                     "wazuh_install_path": {
                       "type": "string",
                       "default": "/var/ossec"
@@ -204,7 +219,13 @@
                       "else": {
                         "oneOf": [
                           {"required": ["local_package_path"]},
-                          {"required": ["s3_package_url"]}
+                          {"required": ["s3_package_url"]},
+                          {"required": [
+                            "version", 
+                            "system", 
+                            "revision", 
+                            "repository",
+                            "architecture"]}
                         ]
                       }
                     },

--- a/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
+++ b/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
@@ -184,19 +184,16 @@
                     "installation_files_path": {
                       "type": "string"
                     },
-                    "version":{
-                      "type": "string"
-                    },
                     "system":{
+                      "type":"string"
+                    },
+                    "version":{
                       "type": "string"
                     },
                     "revision":{
                       "type": "string"
                     },
                     "repository":{
-                      "type": "string"
-                    },
-                    "architecture":{
                       "type": "string"
                     },
                     "wazuh_install_path": {
@@ -221,11 +218,10 @@
                           {"required": ["local_package_path"]},
                           {"required": ["s3_package_url"]},
                           {"required": [
+                            "system",
                             "version", 
-                            "system", 
                             "revision", 
-                            "repository",
-                            "architecture"]}
+                            "repository"]}
                         ]
                       }
                     },

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -146,7 +146,7 @@ class QAProvisioning():
                         installation_instance = WazuhS3Package(**installation_files_parameters)
                         remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,
                                                                                               hosts=current_host)
-                    if s3_package_url is None and version is None:
+                    elif s3_package_url is None and version is None:
                         installation_files_parameters['local_package_path'] = local_package_path
                         installation_instance = WazuhLocalPackage(**installation_files_parameters)
                         remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -105,6 +105,20 @@ class QAProvisioning():
             wazuh_branch = 'master' if 'wazuh_branch' not in deploy_info else deploy_info['wazuh_branch']
             s3_package_url = None if 's3_package_url' not in deploy_info \
                                         else deploy_info['s3_package_url']
+
+            version = None if 'version' not in deploy_info \
+                                else deploy_info['version']
+            repository = None if 'repository' not in deploy_info \
+                                else deploy_info['repository']
+
+            revision = None if 'revision' not in deploy_info \
+                                else deploy_info['revision']
+
+            system = None if 'system' not in deploy_info \
+                                else deploy_info['system']
+            architecture = None if 'architecture' not in deploy_info \
+                                else deploy_info['architecture']
+
             local_package_path = None if 'local_package_path' not in deploy_info \
                 else deploy_info['local_package_path']
             manager_ip = None if 'manager_ip' not in deploy_info else deploy_info['manager_ip']
@@ -122,16 +136,27 @@ class QAProvisioning():
                 installation_files_parameters['wazuh_branch'] = wazuh_branch
                 installation_instance = WazuhSources(**installation_files_parameters)
             if install_type == 'package':
-                    if s3_package_url is None:
+
+                    if s3_package_url is None and local_package_path is None:
+                        installation_files_parameters['version'] = version
+                        installation_files_parameters['system'] = system
+                        installation_files_parameters['revision'] = revision
+                        installation_files_parameters['repository'] = repository
+                        installation_files_parameters['architecture'] = architecture
+                        installation_instance = WazuhS3Package(**installation_files_parameters)
+                        remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,
+                                                                                              hosts=current_host)
+                    if s3_package_url is None and version is None:
                         installation_files_parameters['local_package_path'] = local_package_path
                         installation_instance = WazuhLocalPackage(**installation_files_parameters)
                         remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,
                                                                                               hosts=current_host)
+                    
                     else:
                         installation_files_parameters['s3_package_url'] = s3_package_url
                         installation_instance = WazuhS3Package(**installation_files_parameters)
-                        remote_files_path = installation_instance.download_installation_files(s3_package_url,
-                                                                                              self.inventory_file_path,
+                        remote_files_path = installation_instance.download_installation_files(self.inventory_file_path,
+                                                                                              s3_package_url,
                                                                                               hosts=current_host)
 
             if install_target == 'agent':

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_s3_package.py
@@ -1,4 +1,3 @@
-from logging import setLoggerClass
 import os
 
 from pathlib import Path
@@ -38,15 +37,35 @@ class WazuhS3Package(WazuhPackage):
 
     LOGGER = Logging.get_logger(QACTL_LOGGER)
 
-    def __init__(self, wazuh_target, installation_files_path, qa_ctl_configuration, s3_package_url=None, version=None,
-                 system=None, revision=None, repository=None, architecture=None):
+    def __init__(self, wazuh_target, installation_files_path, qa_ctl_configuration,
+                 s3_package_url=None, system=None, version=None, revision=None, repository=None):
+        self.system = system
         self.revision = revision
         self.repository = repository
-        self.architecture = architecture
         self.s3_package_url = s3_package_url
-        super().__init__(wazuh_target=wazuh_target, installation_files_path=installation_files_path, version=version,
-                         system=system, qa_ctl_configuration=qa_ctl_configuration)
-        
+        super().__init__(wazuh_target=wazuh_target, installation_files_path=installation_files_path,
+                         system=system, version=version, qa_ctl_configuration=qa_ctl_configuration)
+
+    def get_architecture(self, system):
+        """Get the needed architecture for the wazuh package
+
+        Args:
+            system (string): String with the system value given
+
+        Returns:
+            str: String with the default architecture for the system
+        """
+        default_architectures = {
+            'deb': 'x86_64',
+            'rpm': 'x86_64',
+            'windows': 'amd64',
+            'macos': 'amd64',
+            'solaris10': 'i386',
+            'solaris11': 'i386',
+            'wpk-linux': 'x86_64',
+            'wpk-windows': 'amd64',
+        }
+        return default_architectures[system]
 
     def download_installation_files(self, inventory_file_path, s3_package_url=None, hosts='all'):
         """Download the installation files of Wazuh in the given inventory file path
@@ -59,15 +78,18 @@ class WazuhS3Package(WazuhPackage):
             wazuh_target (string): Type of the Wazuh instance desired (agent or manager).
             version (string): The version of Wazuh.
             revision (string): Revision of the wazuh package.
-            system (string): System of the Wazuh installation files.
-            architecture (string): Architecture of the Wazuh package.
-        
+            system (string): System for the wazuh package.
+
         Returns:
             str: String with the complete path of the downloaded installation package
-        """   
+        """
         WazuhS3Package.LOGGER.debug(f"Downloading Wazuh S3 package from <url> in {hosts} hosts")
-        if s3_package_url is None:
-            s3_package_url = get_s3_package_url(self.repository, self.wazuh_target, self.version, self.revision, self.system, self.architecture)
+
+        if s3_package_url is None and self.version is not None and self.repository is not None and self.version is not None and self.revision is not None:
+            architecture = self.get_architecture(self.system)
+            s3_package_url = get_s3_package_url(self.repository, self.wazuh_target, self.version,
+                                                self.revision, self.system, architecture)
+
         package_name = Path(s3_package_url).name
         download_s3_package = AnsibleTask({'name': 'Download S3 package',
                                            'get_url': {'url': s3_package_url,
@@ -79,4 +101,3 @@ class WazuhS3Package(WazuhPackage):
         super().download_installation_files(inventory_file_path, [download_s3_package], hosts)
 
         return os.path.join(self.installation_files_path, package_name)
-

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_s3_package.py
@@ -1,11 +1,12 @@
+from logging import setLoggerClass
 import os
 
 from pathlib import Path
-
 from wazuh_testing.qa_ctl.provisioning.wazuh_deployment.wazuh_package import WazuhPackage
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_task import AnsibleTask
 from wazuh_testing.qa_ctl import QACTL_LOGGER
 from wazuh_testing.tools.logging import Logging
+from wazuh_testing.tools.s3_package import get_s3_package_url
 
 
 class WazuhS3Package(WazuhPackage):
@@ -37,36 +38,37 @@ class WazuhS3Package(WazuhPackage):
 
     LOGGER = Logging.get_logger(QACTL_LOGGER)
 
-    def __init__(self, wazuh_target, s3_package_url, installation_files_path, qa_ctl_configuration, version=None,
+    def __init__(self, wazuh_target, installation_files_path, qa_ctl_configuration, s3_package_url=None, version=None,
                  system=None, revision=None, repository=None, architecture=None):
         self.revision = revision
         self.repository = repository
         self.architecture = architecture
         self.s3_package_url = s3_package_url
-        self.package_name = Path(self.s3_package_url).name
         super().__init__(wazuh_target=wazuh_target, installation_files_path=installation_files_path, version=version,
                          system=system, qa_ctl_configuration=qa_ctl_configuration)
+        
 
-    def get_package_name(self):
-        pass
-
-
-    def get_s3_package_url(self):
-        pass
-
-    def download_installation_files(self, s3_package_url, inventory_file_path, hosts='all'):
+    def download_installation_files(self, inventory_file_path, s3_package_url=None, hosts='all'):
         """Download the installation files of Wazuh in the given inventory file path
 
         Args:
             s3_package_url (string): URL of the S3 Wazuh package.
             inventory_file_path (string): path where the instalation files are going to be stored.
             hosts (string): Parameter set to `all` by default.
+            repository (string): Repository of the wazuh package.
+            wazuh_target (string): Type of the Wazuh instance desired (agent or manager).
+            version (string): The version of Wazuh.
+            revision (string): Revision of the wazuh package.
+            system (string): System of the Wazuh installation files.
+            architecture (string): Architecture of the Wazuh package.
         
         Returns:
             str: String with the complete path of the downloaded installation package
         """   
         WazuhS3Package.LOGGER.debug(f"Downloading Wazuh S3 package from <url> in {hosts} hosts")
-
+        if s3_package_url is None:
+            s3_package_url = get_s3_package_url(self.repository, self.wazuh_target, self.version, self.revision, self.system, self.architecture)
+        package_name = Path(s3_package_url).name
         download_s3_package = AnsibleTask({'name': 'Download S3 package',
                                            'get_url': {'url': s3_package_url,
                                                        'dest': self.installation_files_path},
@@ -76,5 +78,5 @@ class WazuhS3Package(WazuhPackage):
 
         super().download_installation_files(inventory_file_path, [download_s3_package], hosts)
 
-        return os.path.join(self.installation_files_path, self.package_name)
+        return os.path.join(self.installation_files_path, package_name)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
@@ -2,8 +2,15 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+from wazuh_testing.tools.exceptions import QAValueError
 
-systems = {
+
+PROD_BUCKET = 'packages.wazuh.com'
+DEV_BUCKET = 'packages-dev.wazuh.com'
+S3_SERVER = 's3-us-west-1'
+INSTALL_DIR = 'var'
+
+SYSTEMS = {
     'rpm': 'rpm',
     'deb': 'deb',
     'windows': 'windows',
@@ -15,7 +22,7 @@ systems = {
     'wpk-windows': 'wpk-windows'
 }
 
-architectures = {
+ARCHITECTURES = {
     'i386': 'i386',
     'sparc': 'sparc',
     'x86_64': 'x86_64',
@@ -23,195 +30,6 @@ architectures = {
     'arm64v8': 'arm64v8',
     'arm32v7': 'arm32v7'
 }
-
-def get_version(version):
-    """Format the version
-
-    Args:
-        version (string) : String containing the version
-
-    Returns:
-        str: String with the version in a usable format for the tool
-    """
-    tokens = version.split('.')
-    def_version = f"{tokens[0]}.{tokens[1]}"
-    return def_version
-
-
-
-def is_repository(repo):
-    """Check if the directory is a repo type in the S3 server
-
-    Args:
-        repo (string): String with the directory name  
-
-    Returns:
-        boolean: True if the directory is a repo, false otherwise.
-    """
-    repository_list = ['pre-release', 'futures', 'debug', 'trash', 'staging', 'live']
-    non_repository_list = ['warehouse-branches', 'warehouse-pullrequests', 'warehouse-test']
-    is_repo = False
-
-    if repo in repository_list:
-        is_repo = True
-    elif repo in non_repository_list:
-        is_repo = False
-
-    return is_repo
-
-def generate_repository_url(s3_path, package_name, s3_bucket, short_url=True):
-    """Generate the url for a package of a repository type directory
-    
-    Args:
-        s3_path (string): Path with the s3_path where the package is locate
-        package_name (string): String with the name of the package
-        s3_bucket (string): String with the s3 bucket type
-        short_url (boolean): Defines wether if the url is going to be a short type or not.
-                            This parameter is set to False by default. 
-    
-    Returns:
-        str: The url of the given package
-    """
-    if short_url == True:
-        url = f"https://{s3_bucket}/{s3_path}/{package_name}"
-    else:
-        url = f"https://s3.us-west-1.amazonaws.com/{s3_bucket}/{s3_path}/{package_name}"
-    
-    return url
-
-def generate_non_repository_url( target, version, system, revision, repository, architecture, s3_bucket, short_url=True):
-    """Generate the url for a package of a non-repository type directory
-    
-    Args:
-        target (string): Type of the wazuh installation package.
-        version (string): Version of the installation package
-        system (string): System desired for the installation version
-        revision (string): Revisision of the package version
-        repository (string): non-repository directory where the package is located
-        architecture (string): Architecture of the package
-        s3_bucket (string): String with the s3 bucket type
-        short_url (boolean): Defines wether if the url is going to be a short type or not.
-                            This parameter is set to False by default.
-    
-    Returns:
-        str: The url of the given package
-    """
-    if short_url == True:
-        non_repository_url = f"https://{s3_bucket}/"
-    else:
-        non_repository_url = f"https://s3.us-west-1.amazonaws.com/{s3_bucket}/"
-
-    fixed_version = get_version(version)
-
-    if repository == 'warehouse-branches':
-        non_repository_url += f"warehouse/branches/{fixed_version}/"
-    elif repository == 'warehouse-pullrequests':
-        non_repository_url += f"warehouse/pullrequests/{fixed_version}/"
-    elif repository == 'warehouse-test':
-        non_repository_url += f"warehouse/test/{fixed_version}/"
-    else:
-        print("generate_non_repository_url error")          
-    
-    
-    if system == systems['rpm'] or system == systems['rpm5'] or system == systems['deb']:
-        if repository == 'warehouse-test' and fixed_version == '4.1':
-            non_repository_url += f"{system}/opt/"
-        else:
-            non_repository_url += f"{system}/var/"
-        
-    elif system == systems['solaris10']:
-        non_repository_url += "solaris/i386/10/"
-    elif system == systems['solaris11']:
-        non_repository_url += "solaris/i386/11/"
-    elif system ==systems['windows'] or system == systems['macos']:
-        non_repository_url += f"{system}/"
-    elif system == systems['wpk-windows']:
-        non_repository_url += "wpk/windows/"
-    elif system == systems['wpk-linux']:
-        non_repository_url += "wpk/linux/"
-
-    
-    package_name = get_package_name(target, version, system, revision, repository, architecture)
-    non_repository_url += package_name
-    return non_repository_url
-
-    
-def get_package_name( target, version, system, revision, repository, architecture):
-    """Generate the name of the package
-
-    Args:
-        target (string): Type of the wazuh installation package.
-        version (string): Version of the installation package
-        system (string): System desired for the installation version
-        revision (string): Revisision of the package version
-        repository (string): non-repository directory where the package is located
-        architecture (string): Architecture of the package
-    
-    Returns:
-        str: The full name of the package
-    """
-    package_name = 'wazuh-'
-
-    if architecture == architectures['i386']:
-        deb_architecture = architecture
-        rpm_architecture = architecture
-    if architecture == architectures['sparc']:
-        deb_architecture = architecture
-        rpm_architecture = architecture
-    elif architecture == architectures['x86_64']:
-        deb_architecture = 'amd64'
-        rpm_architecture = architecture
-    elif architecture == architectures['amd64']:
-        deb_architecture = architecture
-        rpm_architecture = 'x86_64'
-    elif architecture == architectures['arm64v8']:
-        deb_architecture = 'arm64'
-        rpm_architecture = 'aarch64'
-    elif architecture == architectures['arm32v7']:
-        deb_architecture = 'armhf'
-        rpm_architecture = 'armv7hl'
-    else:
-        print ("get_package_name  architecture section error ") 
-
-
-    package_name += target
-
-    if system == systems['rpm']:
-        package_name += f"-{version}-{revision}.{rpm_architecture}.rpm"
-    elif system == systems['deb']:
-        package_name += f"_{version}-{revision}_{deb_architecture}.deb"
-    elif system == systems['windows']:
-        package_name += f"-{version}-{revision}.msi"
-    elif system == systems['macos']:
-        package_name += f"-{version}-{revision}.pkg"
-    elif system == systems['solaris10']:
-        package_name += f"_v{version}"
-        if repository != 'live':
-            if repository  != 'pre-release':
-                package_name += f"-{revision}"
-        package_name += f"-sol10-{architecture}.pkg"
-    elif system == systems['solaris11']:
-        package_name += f"_v{version}"
-        if repository != 'live':
-            if repository  != 'pre-release':
-                package_name += f"-{revision}"
-        package_name += f"-sol11-{architecture}.p5p"
-    elif system == systems['rpm5']:
-        package_name += f"-{version}-{revision}.el5.{rpm_architecture}.rpm"
-    elif system == systems['wpk-linux']:
-        revision_part = ''
-        if revision  != '1':
-            revision_part = f"-{revision}"
-        package_name = f"wazuh_agent_v{version}{revision_part}_linux_x86_64.wpk"
-    elif system == systems['wpk-windows']:
-        revision_part = ''
-        if revision  != '1':
-            revision_part = f"-{revision}"
-        package_name = f"wazuh_agent_v{version}{revision_part}_windows.wpk"
-    else:
-        print("get_package_name system section error ")   
-    
-    return package_name
 
 
 def get_s3_package_url(repository, target, version, revision, system, architecture, short_url=True):
@@ -225,51 +43,218 @@ def get_s3_package_url(repository, target, version, revision, system, architectu
         architecture (string): Architecture of the package
         s3_bucket (string): String with the s3 bucket type
         short_url (boolean): Defines wether if the url is going to be a short type or not.
-                            This parameter is set to False by default.
-    
+        This parameter is set to False by default.
+
     Returns:
         str: The url of the desired package
     """
+    s3_bucket = DEV_BUCKET
+    system_path = {
+       SYSTEMS['rpm']: 'yum',
+       SYSTEMS['deb']: f"/apt/pool/main/w/wazuh-{target}",
+       SYSTEMS['windows']: '/windows',
+       SYSTEMS['macos']: '/macos',
+       SYSTEMS['solaris10']: f"/solaris/{architecture}/10",
+       SYSTEMS['solaris11']: f"/solaris/{architecture}/11",
+       SYSTEMS['rpm5']: f"/yum5/{architecture}",
+       SYSTEMS['wpk-linux']: f"/wpk/linux/{architecture}",
+       SYSTEMS['wpk-windows']: f"/wpk/windows"
+    }
+
     if is_repository(repository):
-        s3_bucket = 'packages-dev.wazuh.com'
 
         if repository == 'live':
-            s3_bucket = 'packages.wazuh.com'
+            s3_bucket = PROD_BUCKET
             tokens = version.split('.')
-            def_version = f"{tokens[0]}.x"
-            s3_path = f"{def_version}/"            
+            s3_path = f"{tokens[0]}.x"
         else:
-            s3_path = f"{repository}/"
-        
+            s3_path = f"{repository}"
 
-        if system == systems['rpm']:
-            s3_path += 'yum'
-        elif system == systems['deb']:
-            s3_path += f"apt/pool/main/w/wazuh-{target}"
-        elif system == systems['windows']:
-            s3_path += 'windows'
-        elif system == systems['macos']:
-            s3_path += 'macos'
-        elif system == systems['solaris10']:
-            s3_path += f"solaris/{architecture}/10"
-        elif system == systems['solaris11']:
-            s3_path += f"solaris/{architecture}/11"
-        elif system == systems['rpm5']:
-            s3_path += f"yum5/{architecture}"
-        elif system == systems['wpk-linux']:
-            s3_path += f"wpk/linux/{architecture}"
-        elif system == systems['wpk-windows']:
-            s3_path += f"wpk/windows/{architecture}"
-        else:
-            print("get_s3_package_url error")              
-        
+        try:
+            s3_path += system_path[system]
+        except KeyError:
+            raise f"System {system} is not a valid system"
+
         package_name = get_package_name(target, version, system, revision, repository, architecture)
-        result_tmp = generate_repository_url(s3_path, package_name, s3_bucket)
-        print(result_tmp)
-        return result_tmp
+        return get_repository_url(s3_path, package_name, s3_bucket)
     else:
-        s3_bucket = 'packages-dev.wazuh.com'
-        result_tmp =  generate_non_repository_url( target, version, system, revision, repository, architecture, s3_bucket, short_url)
-        print(result_tmp)
-        return result_tmp
-        
+        return get_non_repository_url(target, version, system, revision, repository,
+                                      architecture, s3_bucket)
+
+
+def get_short_version(version):
+    """Format the package version to a usable format type for generating the url
+
+    Args:
+        version (string) : String containing the version
+
+    Returns:
+        str: String with the version in a usable format for the tool
+    """
+    tokens = version.split('.')
+    def_version = f"{tokens[0]}.{tokens[1]}"
+    return def_version
+
+
+def is_repository(folder_path):
+    """Check if the directory is a S3 repository
+
+    Args:
+        folder_path (string): String with the directory name
+
+    Returns:
+        boolean: True if the directory is a repo, false otherwise.
+    """
+    repository_list = ['pre-release', 'futures', 'debug', 'trash', 'staging', 'live']
+    non_repository_list = ['warehouse-branches', 'warehouse-pullrequests', 'warehouse-test']
+    is_repo = False
+
+    if folder_path in repository_list:
+        return True
+    elif folder_path in non_repository_list:
+        return False
+    else:
+        raise QAValueError(f"{folder_path} is unknown. It was not found in {repository_list} or {non_repository_list}")
+
+
+def get_repository_url(s3_path, package_name, s3_bucket, short_url=True):
+    """Generate the url for a package of a repository type directory
+
+    Args:
+        s3_path (string): Path with the s3_path where the package is locate
+        package_name (string): String with the name of the package
+        s3_bucket (string): String with the s3 bucket type
+        short_url (boolean): Defines wether if the url is going to be a short type or not.
+                            This parameter is set to False by default.
+
+    Returns:
+        str: The url of the given package
+    """
+    if short_url:
+        url = f"https://{s3_bucket}/{s3_path}/{package_name}"
+    else:
+        url = f"https://{S3_SERVER}/{s3_bucket}/{s3_path}/{package_name}"
+
+    return url
+
+
+def get_non_repository_url(target, version, system, revision, repository, architecture, s3_bucket, short_url=True):
+    """Generate the url for a package of a non-repository type directory
+
+    Args:
+        target (string): Type of the wazuh installation package.
+        version (string): Version of the installation package
+        system (string): System desired for the installation version
+        revision (string): Revisision of the package version
+        repository (string): non-repository directory where the package is located
+        architecture (string): Architecture of the package
+        s3_bucket (string): String with the s3 bucket type
+        short_url (boolean): Defines wether if the url is going to be a short type or not.
+                            This parameter is set to False by default.
+
+    Returns:
+        str: The url of the given package
+    """
+    if short_url:
+        non_repository_url = f"https://{s3_bucket}"
+    else:
+        non_repository_url = f"https://{S3_SERVER}/{s3_bucket}"
+
+    short_version = get_short_version(version)
+
+    if repository == 'warehouse-branches':
+        non_repository_url += f"/warehouse/branches/{short_version}"
+    elif repository == 'warehouse-pullrequests':
+        non_repository_url += f"/warehouse/pullrequests/{short_version}"
+    elif repository == 'warehouse-test':
+        non_repository_url += f"/warehouse/test/{short_version}"
+    else:
+        raise QAValueError(f"The repository named {repository} is unknown.")
+
+    if system == SYSTEMS['rpm'] or system == SYSTEMS['rpm5'] or system == SYSTEMS['deb']:
+        non_repository_url += f"/{system}"
+        if repository == 'warehouse-test' and short_version == '4.1':
+            non_repository_url += f"/opt"
+        else:
+            non_repository_url += f"/{INSTALL_DIR}"
+    elif system == SYSTEMS['solaris10']:
+        non_repository_url += f"/solaris/{architecture}/10"
+    elif system == SYSTEMS['solaris11']:
+        non_repository_url += f"/solaris/{architecture}/11"
+    elif system == SYSTEMS['windows'] or system == SYSTEMS['macos']:
+        non_repository_url += f"/{system}"
+    elif system == SYSTEMS['wpk-windows']:
+        non_repository_url += "/wpk/windows"
+    elif system == SYSTEMS['wpk-linux']:
+        non_repository_url += "/wpk/linux"
+
+    package_name = get_package_name(target, version, system, revision, repository, architecture)
+    non_repository_url += f"/{package_name}"
+    return non_repository_url
+
+
+def get_package_name(target, version, system, revision, repository, architecture):
+    """Generate the name of the package
+
+    Args:
+        target (string): Type of the wazuh installation package.
+        version (string): Version of the installation package
+        system (string): System desired for the installation version
+        revision (string): Revisision of the package version
+        repository (string): non-repository directory where the package is located
+        architecture (string): Architecture of the package
+
+    Returns:
+        str: The full name of the package
+    """
+    package_name = 'wazuh-'
+
+    if architecture == ARCHITECTURES['i386']:
+        deb_architecture = architecture
+        rpm_architecture = architecture
+    elif architecture == ARCHITECTURES['sparc']:
+        deb_architecture = architecture
+        rpm_architecture = architecture
+    elif architecture == ARCHITECTURES['x86_64']:
+        deb_architecture = 'amd64'
+        rpm_architecture = architecture
+    elif architecture == ARCHITECTURES['amd64']:
+        deb_architecture = architecture
+        rpm_architecture = 'x86_64'
+    elif architecture == ARCHITECTURES['arm64v8']:
+        deb_architecture = 'arm64'
+        rpm_architecture = 'aarch64'
+    elif architecture == ARCHITECTURES['arm32v7']:
+        deb_architecture = 'armhf'
+        rpm_architecture = 'armv7hl'
+    else:
+        raise QAValueError(f"{architecture} is an invalid architecture")
+
+    package_name += target
+
+    if system == SYSTEMS['rpm']:
+        package_name += f"-{version}-{revision}.{rpm_architecture}.rpm"
+    elif system == SYSTEMS['deb']:
+        package_name += f"_{version}-{revision}_{deb_architecture}.deb"
+    elif system == SYSTEMS['windows']:
+        package_name += f"-{version}-{revision}.msi"
+    elif system == SYSTEMS['macos']:
+        package_name += f"-{version}-{revision}.pkg"
+    elif system == SYSTEMS['solaris10'] or system == SYSTEMS['solaris11']:
+        package_name += f"_v{version}"
+        if repository != 'live' and repository != 'pre-release':
+            package_name += f"-{revision}"
+        architecture_section = f"-sol10-{architecture}.pkg" if system == SYSTEMS['solaris10'] else f"-sol11-{architecture}.p5p"
+        package_name += architecture_section
+    elif system == SYSTEMS['rpm5']:
+        package_name += f"-{version}-{revision}.el5.{rpm_architecture}.rpm"
+    elif system == SYSTEMS['wpk-linux']:
+        revision_section = f"-{revision}" if revision != 1 else ''
+        package_name = f"wazuh_agent_v{version}{revision_section}_linux_x86_64.wpk"
+    elif system == SYSTEMS['wpk-windows']:
+        revision_section = f"-{revision}" if revision != 1 else ''
+        package_name = f"wazuh_agent_v{version}{revision_section}_windows.wpk"
+    else:
+        raise QAValueError(f"{system} is not a valid system")
+
+    return package_name

--- a/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
@@ -1,12 +1,53 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 
-def get_version(self, version):
+systems = {
+    'rpm': 'rpm',
+    'deb': 'deb',
+    'windows': 'windows',
+    'macos': 'macos',
+    'solaris10': 'solaris10',
+    'solaris11': 'solaris11',
+    'rpm5': 'rpm5',
+    'wpk-linux': 'wpk-linux',
+    'wpk-windows': 'wpk-windows'
+}
+
+architectures = {
+    'i386': 'i386',
+    'sparc': 'sparc',
+    'x86_64': 'x86_64',
+    'amd64': 'amd64',
+    'arm64v8': 'arm64v8',
+    'arm32v7': 'arm32v7'
+}
+
+def get_version(version):
+    """Format the version
+
+    Args:
+        version (string) : String containing the version
+
+    Returns:
+        str: String with the version in a usable format for the tool
+    """
     tokens = version.split('.')
-    def_version = f"{tokens[0]}+{tokens[1]}"
+    def_version = f"{tokens[0]}.{tokens[1]}"
     return def_version
 
 
-def is_repository(self, repo):
+
+def is_repository(repo):
+    """Check if the directory is a repo type in the S3 server
+
+    Args:
+        repo (string): String with the directory name  
+
+    Returns:
+        boolean: True if the directory is a repo, false otherwise.
+    """
     repository_list = ['pre-release', 'futures', 'debug', 'trash', 'staging', 'live']
     non_repository_list = ['warehouse-branches', 'warehouse-pullrequests', 'warehouse-test']
     is_repo = False
@@ -18,16 +59,48 @@ def is_repository(self, repo):
 
     return is_repo
 
-def generate_repository_url(self, s3_path, package_name, s3_bucket, short_url=False):
+def generate_repository_url(s3_path, package_name, s3_bucket, short_url=True):
+    """Generate the url for a package of a repository type directory
+    
+    Args:
+        s3_path (string): Path with the s3_path where the package is locate
+        package_name (string): String with the name of the package
+        s3_bucket (string): String with the s3 bucket type
+        short_url (boolean): Defines wether if the url is going to be a short type or not.
+                            This parameter is set to False by default. 
+    
+    Returns:
+        str: The url of the given package
+    """
     if short_url == True:
         url = f"https://{s3_bucket}/{s3_path}/{package_name}"
     else:
-        url = f"https://s3-us-west-1.amazonaws.com/{s3_bucket}/{s3_path}/{package_name}"
+        url = f"https://s3.us-west-1.amazonaws.com/{s3_bucket}/{s3_path}/{package_name}"
     
     return url
 
-def generate_non_repository_url(self, target, version, system, revision, repository, architecture):
-    non_repository_url = 'https://packages-dev.wazuh.com/'
+def generate_non_repository_url( target, version, system, revision, repository, architecture, s3_bucket, short_url=True):
+    """Generate the url for a package of a non-repository type directory
+    
+    Args:
+        target (string): Type of the wazuh installation package.
+        version (string): Version of the installation package
+        system (string): System desired for the installation version
+        revision (string): Revisision of the package version
+        repository (string): non-repository directory where the package is located
+        architecture (string): Architecture of the package
+        s3_bucket (string): String with the s3 bucket type
+        short_url (boolean): Defines wether if the url is going to be a short type or not.
+                            This parameter is set to False by default.
+    
+    Returns:
+        str: The url of the given package
+    """
+    if short_url == True:
+        non_repository_url = f"https://{s3_bucket}/"
+    else:
+        non_repository_url = f"https://s3.us-west-1.amazonaws.com/{s3_bucket}/"
+
     fixed_version = get_version(version)
 
     if repository == 'warehouse-branches':
@@ -37,105 +110,166 @@ def generate_non_repository_url(self, target, version, system, revision, reposit
     elif repository == 'warehouse-test':
         non_repository_url += f"warehouse/test/{fixed_version}/"
     else:
-        print("error")          #Error messages?!
+        print("generate_non_repository_url error")          
     
     
-    if system == 'rpm' or system == 'rpm5' or system == 'deb':
-        non_repository_url += 'var/'
+    if system == systems['rpm'] or system == systems['rpm5'] or system == systems['deb']:
+        if repository == 'warehouse-test' and fixed_version == '4.1':
+            non_repository_url += f"{system}/opt/"
+        else:
+            non_repository_url += f"{system}/var/"
+        
+    elif system == systems['solaris10']:
+        non_repository_url += "solaris/i386/10/"
+    elif system == systems['solaris11']:
+        non_repository_url += "solaris/i386/11/"
+    elif system ==systems['windows'] or system == systems['macos']:
+        non_repository_url += f"{system}/"
+    elif system == systems['wpk-windows']:
+        non_repository_url += "wpk/windows/"
+    elif system == systems['wpk-linux']:
+        non_repository_url += "wpk/linux/"
+
     
     package_name = get_package_name(target, version, system, revision, repository, architecture)
     non_repository_url += package_name
-
     return non_repository_url
 
     
-def get_package_name(self, target, version, system, revision, repository, architecture):
+def get_package_name( target, version, system, revision, repository, architecture):
+    """Generate the name of the package
+
+    Args:
+        target (string): Type of the wazuh installation package.
+        version (string): Version of the installation package
+        system (string): System desired for the installation version
+        revision (string): Revisision of the package version
+        repository (string): non-repository directory where the package is located
+        architecture (string): Architecture of the package
+    
+    Returns:
+        str: The full name of the package
+    """
     package_name = 'wazuh-'
-    if architecture == 'i386':
-        deb_architecture = 'i386'
-        rpm_architecture = 'i386'
-    elif architecture == 'x86_64':
+
+    if architecture == architectures['i386']:
+        deb_architecture = architecture
+        rpm_architecture = architecture
+    if architecture == architectures['sparc']:
+        deb_architecture = architecture
+        rpm_architecture = architecture
+    elif architecture == architectures['x86_64']:
         deb_architecture = 'amd64'
         rpm_architecture = architecture
-    elif architecture == 'arm64v8':
+    elif architecture == architectures['amd64']:
+        deb_architecture = architecture
+        rpm_architecture = 'x86_64'
+    elif architecture == architectures['arm64v8']:
         deb_architecture = 'arm64'
         rpm_architecture = 'aarch64'
-    elif architecture == 'arm32v7':
+    elif architecture == architectures['arm32v7']:
         deb_architecture = 'armhf'
         rpm_architecture = 'armv7hl'
     else:
-        print ("Error")     #Error messages?!
+        print ("get_package_name  architecture section error ") 
+
 
     package_name += target
 
-    if system == 'rpm':
+    if system == systems['rpm']:
         package_name += f"-{version}-{revision}.{rpm_architecture}.rpm"
-    elif system == 'deb':
+    elif system == systems['deb']:
         package_name += f"_{version}-{revision}_{deb_architecture}.deb"
-    elif system == 'windows':
+    elif system == systems['windows']:
         package_name += f"-{version}-{revision}.msi"
-    elif system == ' macos':
+    elif system == systems['macos']:
         package_name += f"-{version}-{revision}.pkg"
-    elif system == 'solaris10':
+    elif system == systems['solaris10']:
         package_name += f"_v{version}"
         if repository != 'live':
             if repository  != 'pre-release':
                 package_name += f"-{revision}"
         package_name += f"-sol10-{architecture}.pkg"
-    elif system == 'solaris11':
+    elif system == systems['solaris11']:
         package_name += f"_v{version}"
         if repository != 'live':
             if repository  != 'pre-release':
                 package_name += f"-{revision}"
         package_name += f"-sol11-{architecture}.p5p"
-    elif system == 'rpm5':
+    elif system == systems['rpm5']:
         package_name += f"-{version}-{revision}.el5.{rpm_architecture}.rpm"
-    elif system == 'wpk-linux':
+    elif system == systems['wpk-linux']:
+        revision_part = ''
         if revision  != '1':
             revision_part = f"-{revision}"
         package_name = f"wazuh_agent_v{version}{revision_part}_linux_x86_64.wpk"
-    elif system == 'wpk-windows':
+    elif system == systems['wpk-windows']:
+        revision_part = ''
         if revision  != '1':
             revision_part = f"-{revision}"
         package_name = f"wazuh_agent_v{version}{revision_part}_windows.wpk"
     else:
-        print("Error")   #Error messages?!
+        print("get_package_name system section error ")   
     
     return package_name
 
 
-def get_s3_package_url(self, repository, target, version, revision, system, architecture):
+def get_s3_package_url(repository, target, version, revision, system, architecture, short_url=True):
+    """Generate the url for a package of the s3 servers
+    Args:
+        target (string): Type of the wazuh installation package.
+        version (string): Version of the installation package
+        system (string): System desired for the installation version
+        revision (string): Revisision of the package version
+        repository (string): non-repository directory where the package is located
+        architecture (string): Architecture of the package
+        s3_bucket (string): String with the s3 bucket type
+        short_url (boolean): Defines wether if the url is going to be a short type or not.
+                            This parameter is set to False by default.
+    
+    Returns:
+        str: The url of the desired package
+    """
     if is_repository(repository):
         s3_bucket = 'packages-dev.wazuh.com'
 
         if repository == 'live':
             s3_bucket = 'packages.wazuh.com'
-            s3_path = get_version(version)             #solve 
+            tokens = version.split('.')
+            def_version = f"{tokens[0]}.x"
+            s3_path = f"{def_version}/"            
         else:
-            s3_path = repository
+            s3_path = f"{repository}/"
         
-        if system == 'rmp':
+
+        if system == systems['rpm']:
             s3_path += 'yum'
-        elif system == 'deb':
+        elif system == systems['deb']:
             s3_path += f"apt/pool/main/w/wazuh-{target}"
-        elif system == 'windows':
+        elif system == systems['windows']:
             s3_path += 'windows'
-        elif system == 'macos':
-            if repository == 'live':
-                s3_path += 'osx'
-            else:
-                s3_path += 'macos'
-        elif system == 'solaris10':
+        elif system == systems['macos']:
+            s3_path += 'macos'
+        elif system == systems['solaris10']:
             s3_path += f"solaris/{architecture}/10"
-        elif system == 'solaris11':
+        elif system == systems['solaris11']:
             s3_path += f"solaris/{architecture}/11"
-        elif system == 'rpm5':
+        elif system == systems['rpm5']:
             s3_path += f"yum5/{architecture}"
+        elif system == systems['wpk-linux']:
+            s3_path += f"wpk/linux/{architecture}"
+        elif system == systems['wpk-windows']:
+            s3_path += f"wpk/windows/{architecture}"
         else:
-            print("error")              #error messages?!
+            print("get_s3_package_url error")              
         
-        package_name = get_package_name(target, version, system, revision, repository, architecture)
-        return generate_repository_url(s3_path, package_name, s3_bucket, True)
+        package_name = get_package_name(target, version, system, revision, repository, architecture, short_url)
+        result_tmp = generate_repository_url(s3_path, package_name, s3_bucket)
+        print(result_tmp)
+        return result_tmp
     else:
-        return generate_non_repository_url(self, target, version, system, revision, repository, architecture)
+        s3_bucket = 'packages-dev.wazuh.com'
+        result_tmp =  generate_non_repository_url( target, version, system, revision, repository, architecture, s3_bucket, short_url)
+        print(result_tmp)
+        return result_tmp
         

--- a/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
@@ -104,7 +104,7 @@ def get_repository_url(target, version, system, revision, repository, architectu
     s3_bucket = DEV_BUCKET
 
     system_path = {
-       SYSTEMS['rpm']: 'yum',
+       SYSTEMS['rpm']: '/yum',
        SYSTEMS['deb']: f"/apt/pool/main/w/wazuh-{target}",
        SYSTEMS['windows']: '/windows',
        SYSTEMS['macos']: '/macos',
@@ -248,10 +248,10 @@ def get_package_name(target, version, system, revision, repository, architecture
     elif system == SYSTEMS['rpm5']:
         package_name += f"-{version}-{revision}.el5.{rpm_architecture}.rpm"
     elif system == SYSTEMS['wpk-linux']:
-        revision_section = f"-{revision}" if revision != 1 else ''
+        revision_section = f"-{revision}" if revision != '1' else ''
         package_name = f"wazuh_agent_v{version}{revision_section}_linux_x86_64.wpk"
     elif system == SYSTEMS['wpk-windows']:
-        revision_section = f"-{revision}" if revision != 1 else ''
+        revision_section = f"-{revision}" if revision != '1' else ''
         package_name = f"wazuh_agent_v{version}{revision_section}_windows.wpk"
     else:
         raise QAValueError(f"{system} is not a valid system")

--- a/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
@@ -1,0 +1,141 @@
+
+
+def get_version(self, version):
+    tokens = version.split('.')
+    def_version = f"{tokens[0]}+{tokens[1]}"
+    return def_version
+
+
+def is_repository(self, repo):
+    repository_list = ['pre-release', 'futures', 'debug', 'trash', 'staging', 'live']
+    non_repository_list = ['warehouse-branches', 'warehouse-pullrequests', 'warehouse-test']
+    is_repo = False
+
+    if repo in repository_list:
+        is_repo = True
+    elif repo in non_repository_list:
+        is_repo = False
+
+    return is_repo
+
+def generate_repository_url(self, s3_path, package_name, s3_bucket, short_url=False):
+    if short_url == True:
+        url = f"https://{s3_bucket}/{s3_path}/{package_name}"
+    else:
+        url = f"https://s3-us-west-1.amazonaws.com/{s3_bucket}/{s3_path}/{package_name}"
+    
+    return url
+
+def generate_non_repository_url(self, target, version, system, revision, repository, architecture):
+    non_repository_url = 'https://packages-dev.wazuh.com/'
+    fixed_version = get_version(version)
+
+    if repository == 'warehouse-branches':
+        non_repository_url += f"warehouse/branches/{fixed_version}/"
+    elif repository == 'warehouse-pullrequests':
+        non_repository_url += f"warehouse/pullrequests/{fixed_version}/"
+    elif repository == 'warehouse-test':
+        non_repository_url += f"warehouse/test/{fixed_version}/"
+    else:
+        print("error")          #Error messages?!
+    
+    
+    if system == 'rpm' or system == 'rpm5' or system == 'deb':
+        non_repository_url += 'var/'
+    
+    package_name = get_package_name(target, version, system, revision, repository, architecture)
+    non_repository_url += package_name
+
+    return non_repository_url
+
+    
+def get_package_name(self, target, version, system, revision, repository, architecture):
+    package_name = 'wazuh-'
+    if architecture == 'i386':
+        deb_architecture = 'i386'
+        rpm_architecture = 'i386'
+    elif architecture == 'x86_64':
+        deb_architecture = 'amd64'
+        rpm_architecture = architecture
+    elif architecture == 'arm64v8':
+        deb_architecture = 'arm64'
+        rpm_architecture = 'aarch64'
+    elif architecture == 'arm32v7':
+        deb_architecture = 'armhf'
+        rpm_architecture = 'armv7hl'
+    else:
+        print ("Error")     #Error messages?!
+
+    package_name += target
+
+    if system == 'rpm':
+        package_name += f"-{version}-{revision}.{rpm_architecture}.rpm"
+    elif system == 'deb':
+        package_name += f"_{version}-{revision}_{deb_architecture}.deb"
+    elif system == 'windows':
+        package_name += f"-{version}-{revision}.msi"
+    elif system == ' macos':
+        package_name += f"-{version}-{revision}.pkg"
+    elif system == 'solaris10':
+        package_name += f"_v{version}"
+        if repository != 'live':
+            if repository  != 'pre-release':
+                package_name += f"-{revision}"
+        package_name += f"-sol10-{architecture}.pkg"
+    elif system == 'solaris11':
+        package_name += f"_v{version}"
+        if repository != 'live':
+            if repository  != 'pre-release':
+                package_name += f"-{revision}"
+        package_name += f"-sol11-{architecture}.p5p"
+    elif system == 'rpm5':
+        package_name += f"-{version}-{revision}.el5.{rpm_architecture}.rpm"
+    elif system == 'wpk-linux':
+        if revision  != '1':
+            revision_part = f"-{revision}"
+        package_name = f"wazuh_agent_v{version}{revision_part}_linux_x86_64.wpk"
+    elif system == 'wpk-windows':
+        if revision  != '1':
+            revision_part = f"-{revision}"
+        package_name = f"wazuh_agent_v{version}{revision_part}_windows.wpk"
+    else:
+        print("Error")   #Error messages?!
+    
+    return package_name
+
+
+def get_s3_package_url(self, repository, target, version, revision, system, architecture):
+    if is_repository(repository):
+        s3_bucket = 'packages-dev.wazuh.com'
+
+        if repository == 'live':
+            s3_bucket = 'packages.wazuh.com'
+            s3_path = get_version(version)             #solve 
+        else:
+            s3_path = repository
+        
+        if system == 'rmp':
+            s3_path += 'yum'
+        elif system == 'deb':
+            s3_path += f"apt/pool/main/w/wazuh-{target}"
+        elif system == 'windows':
+            s3_path += 'windows'
+        elif system == 'macos':
+            if repository == 'live':
+                s3_path += 'osx'
+            else:
+                s3_path += 'macos'
+        elif system == 'solaris10':
+            s3_path += f"solaris/{architecture}/10"
+        elif system == 'solaris11':
+            s3_path += f"solaris/{architecture}/11"
+        elif system == 'rpm5':
+            s3_path += f"yum5/{architecture}"
+        else:
+            print("error")              #error messages?!
+        
+        package_name = get_package_name(target, version, system, revision, repository, architecture)
+        return generate_repository_url(s3_path, package_name, s3_bucket, True)
+    else:
+        return generate_non_repository_url(self, target, version, system, revision, repository, architecture)
+        

--- a/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/s3_package.py
@@ -263,7 +263,7 @@ def get_s3_package_url(repository, target, version, revision, system, architectu
         else:
             print("get_s3_package_url error")              
         
-        package_name = get_package_name(target, version, system, revision, repository, architecture, short_url)
+        package_name = get_package_name(target, version, system, revision, repository, architecture)
         result_tmp = generate_repository_url(s3_path, package_name, s3_bucket)
         print(result_tmp)
         return result_tmp


### PR DESCRIPTION
|Related issue|
|---|
| #1809  |

## Description
It is necessary to implement new functionalities in order to get a new alternative method for getting the packages from the S3 server. 

This PR makes the following changes:
- Add new fields  and conditional requirements in the schema validator for accepting the needed parameters of the new functionality.
- Add a new tool for generating s3 package URLs called  `s3_package.py`
- Modify the `QAProvisioning` implementation in order to add a new alternative method for getting the s3 package if needed.

- [x] There is a new tool now called `s3_package.py`
- [x] There is a new way to get the s3 packages if needed
- [x] The schema validator now validates new fields  


## Tasks
The tasks made for achieving this new implementation are listed in the [issue itself](https://github.com/wazuh/wazuh-qa/issues/1809#issue-982728735).
However, the last changes are commented in this [comment](https://github.com/wazuh/wazuh-qa/issues/1809#issuecomment-910228487).

