### PR TITLE
Migrate `test_active_response` documentation to QA Docs

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -3,6 +3,7 @@ Project path: "../../tests/integration"
 Output path: "../output"
 
 Include paths:
+  - "../../tests/integration/test_active_response"
   - "../../tests/integration/test_agentd"
 
 Include regex:
@@ -15,6 +16,8 @@ Function regex:
   - "^test_"
 
 Ignore paths:
+  - "../../tests/integration/test_active_response/test_analysisd/data"
+  - "../../tests/integration/test_active_response/test_execd/data"
   - "../../tests/integration/test_agentd/data"
 
 Output fields:

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -1,7 +1,52 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will check if the `analysisd` daemon processes `Active Response` messages correctly.
+
+tiers:
+    - 0
+
+component:
+    server
+
+path:
+    tests/integration/test_active_response/test_analysisd/
+
+daemons:
+    - analysisd
+    - execd
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+
+coverage:
+
+pytest_args:
+
+tags:
+    - active_response
+'''
 import json
 import os
 import pytest
@@ -350,7 +395,48 @@ def validate_ar_message(message, ids, log_monitor, agent, extra_args, timeout, a
 
 # TESTS
 def test_os_exec(set_debug_mode, get_configuration, configure_environment, restart_service, configure_agents):
-    """Check if Active Response message is sent in correct format depending on agent version"""
+    '''
+    description:
+        Check if `Active Response` message is sent in correct format depending on agent version.
+
+    wazuh_min_version:
+        4.2
+
+    parameters:
+        - set_debug_mode:
+            type: fixture
+            brief: Set execd daemon in debug mode.
+
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+
+        - restart_service:
+            type: fixture
+            brief: Restart Wazuh manager service and clean the ossec.log file.
+
+        - configure_agents:
+            type: fixture
+            brief: Create simulated agents for testing.
+
+    assertions:
+        - Validate Active Response messages in old string format.
+        - Validate Active Response messages in new `JSON` format.
+
+    test_input:
+        Different `Active Response` messages sent to Debian and Ubuntu simulated agents.
+
+    logging:
+        - ossec.log:
+            - r"Active response request received "
+
+    tags:
+        - simulator
+    '''
     metadata = get_configuration.get('metadata')
     protocol = metadata['protocol']
     extra_args = metadata['extra_args']

--- a/tests/integration/test_active_response/test_analysisd/test_os_exec.py
+++ b/tests/integration/test_active_response/test_analysisd/test_os_exec.py
@@ -16,7 +16,7 @@ tiers:
     - 0
 
 component:
-    server
+    manager
 
 path:
     tests/integration/test_active_response/test_analysisd/

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will check if the active responses, which are executed by
+    the `wazuh-execd` program via scripts, run correctly.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_active_response/test_execd/
+
+daemons:
+    - execd
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - active_response
+'''
 import json
 import os
 import platform
@@ -189,15 +240,62 @@ def build_message(metadata, expected):
 
 def test_execd_firewall_drop(set_debug_mode, get_configuration, test_version, configure_environment,
                              remove_ip_from_iptables, start_agent, set_ar_conf_mode):
-    """Check if firewall-drop Active Response is executed correctly.
+    '''
+    description:
+        Check if firewall-drop command of Active Response is executed correctly.
 
-    Args:
-        set_debug_mode (fixture): Set execd daemon in debug mode.
-        test_version (fixture): Validate Wazuh version.
-        set_ar_conf_mode (fixture): Configure Active Responses used in tests.
-        start_agent (fixture): Create Remoted and Authd simulators, register agent and start it.
-        remove_ip_from_iptables (fixture): Remove the test IP from iptables if it exist
-    """
+    wazuh_min_version:
+        4.2
+
+    parameters:
+        - set_debug_mode:
+            type: fixture
+            brief: Set execd daemon in debug mode.
+
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+
+        - test_version:
+            type: fixture
+            brief: Validate Wazuh version.
+
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+
+        - remove_ip_from_iptables:
+            type: fixture
+            brief: Remove the test IP from iptables if it exist.
+
+        - start_agent:
+            type: fixture
+            brief: Create Remoted and Authd simulators, register agent and start it.
+
+        - set_ar_conf_mode:
+            type: fixture
+            brief: Configure Active Responses used in tests.
+
+    assertions:
+        - Check that the sent IP is added to iptables.
+        - Check that the sent IP is removed from iptables.
+
+    test_input:
+        Several `firewall-drop` commands with different parameters and the expected result after running them.
+
+    logging:
+        - ossec.log:
+            - r"DEBUG: Received message "
+
+        - active-responses.log:
+            - r"Starting"
+            - r"active-response/bin/firewall-drop "
+            - r"Ended"
+            - r"Cannot read 'srcip' from data"
+
+    tags:
+        - active_response
+    '''
     metadata = get_configuration['metadata']
     expected = metadata['results']
     ossec_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
 
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+description:
+    These tests will check if the active responses, which are executed by
+    the `wazuh-execd` program via scripts, run correctly.
+
+tiers:
+    - 0
+
+component:
+    agent
+
+path:
+    tests/integration/test_active_response/test_execd/
+
+daemons:
+    - execd
+
+os_support:
+    - linux, rhel5
+    - linux, rhel6
+    - linux, rhel7
+    - linux, rhel8
+    - linux, amazon linux 1
+    - linux, amazon linux 2
+    - linux, debian buster
+    - linux, debian stretch
+    - linux, debian wheezy
+    - linux, ubuntu bionic
+    - linux, ubuntu xenial
+    - linux, ubuntu trusty
+    - linux, arch linux
+    - windows, 7
+    - windows, 8
+    - windows, 10
+    - windows, server 2003
+    - windows, server 2012
+    - windows, server 2016
+
+coverage:
+
+pytest_args:
+
+tags:
+    - active_response
+'''
 import os
 import platform
 import pytest
@@ -144,16 +195,59 @@ def build_message(metadata, expected):
 
 def test_execd_restart(set_debug_mode, get_configuration, test_version,
                        configure_environment, start_agent, set_ar_conf_mode):
-    """Check if restart-wazuh Active Response is executed correctly.
+    '''
+    description:
+        Check if `restart-wazuh` command of Active Response is executed correctly.
 
-    Args:
-        set_debug_mode (fixture): Set execd daemon in debug mode.
-        get_configuration (fixture): Get configurations from the module.
-        test_version (fixture): Validate Wazuh version.
-        configure_environment (fixture): Configure a custom environment for testing.
-        start_agent (fixture): Create Remoted and Authd simulators, register agent and start it.
-        set_ar_conf_mode (fixture): Configure Active Responses used in tests.
-    """
+    wazuh_min_version:
+        4.2
+
+    parameters:
+        - set_debug_mode:
+            type: fixture
+            brief: Set execd daemon in debug mode.
+
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+
+        - test_version:
+            type: fixture
+            brief: Validate Wazuh version.
+
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+
+        - start_agent:
+            type: fixture
+            brief: Create Remoted and Authd simulators, register agent and start it.
+
+        - set_ar_conf_mode:
+            type: fixture
+            brief: Configure Active Responses used in tests.
+
+    assertions:
+        - Check that the active response restart-wazuh is received.
+        - Check that the agent is ready to restart.
+
+    test_input:
+        Several `restart-wazuh` commands with different parameters and the expected result after running them.
+
+    logging:
+        - ossec.log:
+            - r"DEBUG: Received message "
+            - r"Shutdown received. Deleting responses."
+
+        - active-responses.log:
+            - r"Starting"
+            - r"active-response/bin/restart-wazuh "
+            - r"Ended"
+            - r"Invalid input format"
+
+    tags:
+        - active_response
+    '''
     metadata = get_configuration['metadata']
     expected = metadata['results']
     ossec_log_monitor = FileMonitor(LOG_FILE_PATH)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1599|

## Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **QA Docs**. 
The used schema is provisional (third proposal of issue #1694) until we have the definitive one.

## Docs example 
<details><summary>test_os_exec.yaml</summary>
<p>

```yaml
component: server
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- analysisd
- execd
description: These tests will check if the `analysisd` daemon processes `Active Response`
  messages correctly.
group_id: 0
id: 1
name: test_os_exec.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
path: tests/integration/test_active_response/test_analysisd/
pytest_args: null
tags:
- active_response
tests:
- assertions:
  - Validate Active Response messages in old string format.
  - Validate Active Response messages in new `JSON` format.
  description: Check if `Active Response` message is sent in correct format depending
    on agent version.
  logging:
  - ossec.log:
    - r"Active response request received "
  name: test_os_exec
  parameters:
  - set_debug_mode:
      brief: Set execd daemon in debug mode.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_service:
      brief: Restart Wazuh manager service and clean the ossec.log file.
      type: fixture
  - configure_agents:
      brief: Create simulated agents for testing.
      type: fixture
  tags:
  - simulator
  test_input: Different `Active Response` messages sent to Debian and Ubuntu simulated
    agents.
  wazuh_min_version: 4.2
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_execd_firewall_drop.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- execd
description: These tests will check if the active responses, which are executed by
  the `wazuh-execd` program via scripts, run correctly.
group_id: 0
id: 2
name: test_execd_firewall_drop.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_active_response/test_execd/
pytest_args: null
tags:
- active_response
tests:
- assertions:
  - Check that the sent IP is added to iptables.
  - Check that the sent IP is removed from iptables.
  description: Check if firewall-drop command of Active Response is executed correctly.
  logging:
  - ossec.log:
    - r"DEBUG: Received message "
  - active-responses.log:
    - r"Starting"
    - r"active-response/bin/firewall-drop "
    - r"Ended"
    - r"Cannot read 'srcip' from data"
  name: test_execd_firewall_drop
  parameters:
  - set_debug_mode:
      brief: Set execd daemon in debug mode.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - test_version:
      brief: Validate Wazuh version.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - remove_ip_from_iptables:
      brief: Remove the test IP from iptables if it exist.
      type: fixture
  - start_agent:
      brief: Create Remoted and Authd simulators, register agent and start it.
      type: fixture
  - set_ar_conf_mode:
      brief: Configure Active Responses used in tests.
      type: fixture
  tags:
  - active_response
  test_input: Several `firewall-drop` commands with different parameters and the expected
    result after running them.
  wazuh_min_version: 4.2
tiers:
- 0
type: integration
```
</p>
</details>



<details><summary>test_execd_restart.yaml</summary>
<p>

```yaml
component: agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
coverage: null
daemons:
- execd
description: These tests will check if the active responses, which are executed by
  the `wazuh-execd` program via scripts, run correctly.
group_id: 0
id: 3
name: test_execd_restart.py
os_support:
- linux, rhel5
- linux, rhel6
- linux, rhel7
- linux, rhel8
- linux, amazon linux 1
- linux, amazon linux 2
- linux, debian buster
- linux, debian stretch
- linux, debian wheezy
- linux, ubuntu bionic
- linux, ubuntu xenial
- linux, ubuntu trusty
- linux, arch linux
- windows, 7
- windows, 8
- windows, 10
- windows, server 2003
- windows, server 2012
- windows, server 2016
path: tests/integration/test_active_response/test_execd/
pytest_args: null
tags:
- active_response
tests:
- assertions:
  - Check that the active response restart-wazuh is received.
  - Check that the agent is ready to restart.
  description: Check if `restart-wazuh` command of Active Response is executed correctly.
  logging:
  - ossec.log:
    - r"DEBUG: Received message "
    - r"Shutdown received. Deleting responses."
  - active-responses.log:
    - r"Starting"
    - r"active-response/bin/restart-wazuh "
    - r"Ended"
    - r"Invalid input format"
  name: test_execd_restart
  parameters:
  - set_debug_mode:
      brief: Set execd daemon in debug mode.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - test_version:
      brief: Validate Wazuh version.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - start_agent:
      brief: Create Remoted and Authd simulators, register agent and start it.
      type: fixture
  - set_ar_conf_mode:
      brief: Configure Active Responses used in tests.
      type: fixture
  tags:
  - active_response
  test_input: Several `restart-wazuh` commands with different parameters and the expected
    result after running them.
  wazuh_min_version: 4.2
tiers:
- 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`