### PR TITLE
Create local_internal_options configuration handler fixture

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -146,3 +146,23 @@ WAZUH_OPTIONAL_SOCKETS = [
     MODULESD_KREQUEST_SOCKET_PATH,
     AUTHD_SOCKET_PATH
 ]
+
+DISABLE_MONITORD_ROTATE_LOG_OPTION = {'monitord.rotate_log': '0'}
+REMOTED_LOCAL_INTERNAL_OPTIONS = {'remoted.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+ANALYSISD_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+AGENTD_LOCAL_INTERNAL_OPTIONS = {'agent.debug': '2', 'execd': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+
+FIM_LOCAL_INTERNAL_OPTIONS_MANAGER = {'syscheck.debug': '2',
+                                        'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+FIM_LOCAL_INTERNAL_OPTIONS_AGENT_UNIX = {'syscheck.debug': '2',
+                                        'agent.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+FIM_LOCAL_INTERNAL_OPTIONS_AGENT_WINDOWS = {'syscheck.debug': '2',
+                                            'windows.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+
+GCLOUD_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2',
+                                'wazuh_modules.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+LOGTEST_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2'}
+REMOTED_LOCAL_INTERNAL_OPTIONS = {'remoted.debug': '2', 'wazuh_database.interval': '2', 'wazuh_db.commit_time': '2',
+                                    'wazuh_db.commit_time_max': '3' }.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+VD_LOCAL_INTERNAL_OPTIONS = {'wazuh_modules.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+WPK_LOCAL_INTERNAL_OPTIONS = {'wazuh_modules.debug': '2'}

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -103,8 +103,8 @@ QUEUE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
 CLUSTER_SOCKET_PATH = os.path.join(WAZUH_PATH, 'queue', 'cluster')
 
 
-ANALYSISD_ANALISIS_SOCKET_PATH= os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
-ANALYSISD_QUEUE_SOCKET_PATH= os.path.join(QUEUE_SOCKETS_PATH, 'queue')
+ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
+ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
 AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
@@ -117,7 +117,7 @@ MODULESD_DOWNLOAD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'download')
 MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
 MODULESD_KREQUEST_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'krequest')
 MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(CLUSTER_SOCKET_PATH, 'c-internal.sock')
-ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_ALERTS_PATH,'ar')
+ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_ALERTS_PATH, 'ar')
 
 WAZUH_SOCKETS = {
     'wazuh-agentd': [],
@@ -152,15 +152,15 @@ REMOTED_LOCAL_INTERNAL_OPTIONS = {'remoted.debug': '2'}.update(DISABLE_MONITORD_
 ANALYSISD_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 AGENTD_LOCAL_INTERNAL_OPTIONS = {'agent.debug': '2', 'execd': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 FIM_LOCAL_INTERNAL_OPTIONS_MANAGER = {'syscheck.debug': '2',
-                                        'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+                                      'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 FIM_LOCAL_INTERNAL_OPTIONS_AGENT_UNIX = {'syscheck.debug': '2',
-                                        'agent.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+                                         'agent.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 FIM_LOCAL_INTERNAL_OPTIONS_AGENT_WINDOWS = {'syscheck.debug': '2',
                                             'windows.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 GCLOUD_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2',
-                                'wazuh_modules.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+                                 'wazuh_modules.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 LOGTEST_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2'}
 REMOTED_LOCAL_INTERNAL_OPTIONS = {'remoted.debug': '2', 'wazuh_database.interval': '2', 'wazuh_db.commit_time': '2',
-                                    'wazuh_db.commit_time_max': '3' }.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
+                                  'wazuh_db.commit_time_max': '3'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 VD_LOCAL_INTERNAL_OPTIONS = {'wazuh_modules.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 WPK_LOCAL_INTERNAL_OPTIONS = {'wazuh_modules.debug': '2'}

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -151,14 +151,12 @@ DISABLE_MONITORD_ROTATE_LOG_OPTION = {'monitord.rotate_log': '0'}
 REMOTED_LOCAL_INTERNAL_OPTIONS = {'remoted.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 ANALYSISD_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 AGENTD_LOCAL_INTERNAL_OPTIONS = {'agent.debug': '2', 'execd': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
-
 FIM_LOCAL_INTERNAL_OPTIONS_MANAGER = {'syscheck.debug': '2',
                                         'analysisd.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 FIM_LOCAL_INTERNAL_OPTIONS_AGENT_UNIX = {'syscheck.debug': '2',
                                         'agent.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 FIM_LOCAL_INTERNAL_OPTIONS_AGENT_WINDOWS = {'syscheck.debug': '2',
                                             'windows.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
-
 GCLOUD_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2',
                                 'wazuh_modules.debug': '2'}.update(DISABLE_MONITORD_ROTATE_LOG_OPTION)
 LOGTEST_LOCAL_INTERNAL_OPTIONS = {'analysisd.debug': '2'}

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -227,10 +227,12 @@ def set_section_wazuh_conf(sections, template=None):
 
         Args:
             str_list (list or str): The content of the ossec.conf file in a list of str.
-            root_delimeter (str, optional: The expected string to identify when the first root element ends, by default "</ossec_config>"
+            root_delimeter (str, optional: The expected string to identify when the first root element ends,
+            by default "</ossec_config>"
 
         Returns:
-            list of str : The first N lines of the specified str_list until the root_delimeter is found. The rest of the list will be ignored.
+            list of str : The first N lines of the specified str_list until the root_delimeter is found. The rest of
+            the list will be ignored.
         """
         line_counter = 0
         for line in str_list:
@@ -277,7 +279,8 @@ def set_section_wazuh_conf(sections, template=None):
         Args:
             wazuh_conf (ElementTree): An ElementTree object with all the data of the ossec.conf
             section (str): Name of the tag or configuration section to search for. For example: vulnerability_detector
-            attributes (list\<dict\> ): List with section attributes. Needed to check if the section exists with all the searched attributes and values. For example (wodle section) [{'name': 'syscollector'}]
+            attributes (list of dict): List with section attributes. Needed to check if the section exists with all the
+            searched attributes and values. For example (wodle section) [{'name': 'syscollector'}]
         Returns:
             ElementTree: An ElementTree object with the section data found in ossec.conf. None if nothing was found.
         """
@@ -399,7 +402,8 @@ def load_wazuh_configurations(yaml_file_path: str, test_name: str, params: list 
     Args:
         yaml_file_path (str): Full path of the YAML file to be loaded.
         test_name (str): Name of the file which contains the test that will be executed.
-        params (list, optional) : List of dicts where each dict represents a replacement MATCH -\> REPLACEMENT. Default `None`
+        params (list, optional) : List of dicts where each dict represents a replacement
+        MATCH/REPLACEMENT. Default `None`
         metadata (list, optional): Custom metadata to be inserted in the configuration. Default `None`
 
     Returns:
@@ -439,7 +443,8 @@ def set_correct_prefix(configurations, new_prefix):
         new_prefix (str): Prefix to be inserted before every path.
 
     Returns:
-        configurations (list): List of configurations with the correct prefix added in the directories and ignore sections.
+        configurations (list): List of configurations with the correct prefix added in the directories and
+        ignore sections.
     """
 
     def inserter(path):
@@ -512,7 +517,7 @@ def check_apply_test(apply_to_tags: Set, tags: List):
 def generate_syscheck_config():
     """Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags'.
 
-    Every configuration is ready to be applied in the tag \<directories\>.
+    Every configuration is ready to be applied in the tag directories.
     """
     check_platform = 'check_attrs' if sys.platform == 'win32' else 'check_inode'
     check_names = ['check_all', 'check_sha1sum', 'check_md5sum', 'check_sha256sum', 'check_size', 'check_owner',
@@ -529,7 +534,7 @@ def generate_syscheck_config():
 def generate_syscheck_registry_config():
     """Generate all possible syscheck configurations with 'check_*', 'report_changes' and 'tags' for Windowsregistries.
 
-    Every configuration is ready to be applied in the tag \<directories\>.
+    Every configuration is ready to be applied in the tag directories.
     """
     check_names = ['check_all', 'check_sha1sum', 'check_md5sum', 'check_sha256sum', 'check_size', 'check_owner',
                    'check_group', 'check_perm', 'check_mtime', 'check_type', 'report_changes']
@@ -592,7 +597,7 @@ def local_internal_options_to_dict(local_internal_options):
     Args:
         local_internal_options (List of str): A list containing local internal options.
     """
-    dict_local_internal_options= {}
+    dict_local_internal_options = {}
     no_comments_options = [line.strip() for line in local_internal_options
                            if not (line.startswith('#') or line == '\n')]
     for line in no_comments_options:

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -603,7 +603,7 @@ def local_internal_options_to_dict(local_internal_options):
 
 
 def get_local_internal_options_dict():
-    """Return the local internal options in a dictionary
+    """Return the local internal options in a dictionary.
 
     Returns:
         dict: Local internal options.
@@ -620,7 +620,7 @@ def get_local_internal_options_dict():
 
 
 def set_local_internal_options_dict(dict_local_internal_options):
-    """Set the local internal options using a dictionary
+    """Set the local internal options using a dictionary.
 
     Args:
         local_internal_options_dict (dict): A dictionary containing local internal options.

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -600,3 +600,32 @@ def local_internal_options_to_dict(local_internal_options):
         dict_local_internal_options[key.rstrip("\n")] = value
 
     return dict_local_internal_options
+
+
+def get_local_internal_options_dict():
+    """Return the local internal options in a dictionary
+
+    Returns:
+        dict: Local internal options.
+    """
+    local_internal_option_dict = {}
+    with open(WAZUH_LOCAL_INTERNAL_OPTIONS, 'r') as local_internal_option_file:
+        configuration_options = local_internal_option_file.readlines()
+        for configuration_option in configuration_options:
+            if not configuration_option.startswith('#'):
+                option_name, option_value = configuration_option.split('=')
+                local_internal_option_dict[option_name] = option_value
+
+    return local_internal_option_dict
+
+
+def set_local_internal_options_dict(dict_local_internal_options):
+    """Set the local internal options using a dictionary
+
+    Args:
+        local_internal_options_dict (dict): A dictionary containing local internal options.
+    """
+    with open(WAZUH_LOCAL_INTERNAL_OPTIONS, 'w') as local_internal_option_file:
+        for option_name, option_value in dict_local_internal_options.items():
+            local_internal_configuration_string = f"{str(option_name)}={str(option_value)}\n"
+            local_internal_option_file.write(local_internal_configuration_string)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -620,12 +620,10 @@ def configure_local_internal_options_module(request):
 
     backup_local_internal_options = conf.get_local_internal_options_dict()
 
-    logger.debug('Set local_internal_option to ' +
-                 f"{str(local_internal_options)}")
+    logger.debug(f"Set local_internal_option to {str(local_internal_options)}")
     conf.set_local_internal_options_dict(local_internal_options)
 
     yield
 
-    logger.debug('Restore local_internal_option to ' +
-                 f"{str(backup_local_internal_options)}")
+    logger.debug(f"Restore local_internal_option to {str(backup_local_internal_options)}")
     conf.set_local_internal_options_dict(backup_local_internal_options)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -620,12 +620,12 @@ def configure_local_internal_options_module(request):
 
     backup_local_internal_options = conf.get_local_internal_options_dict()
 
-    logger.error('Configure Local Internal Options: DEBUG - Set local_internal_option to '  +
-                    f"{str(local_internal_options)}")
+    logger.error('Configure Local Internal Options: DEBUG - Set local_internal_option to ' +
+                 f"{str(local_internal_options)}")
     conf.set_local_internal_options_dict(local_internal_options)
 
     yield
 
-    logger.error('Configure Local Internal Options: DEBUG - Restore local_internal_option to '  +
-                    f"{str(backup_local_internal_options)}")
+    logger.error('Configure Local Internal Options: DEBUG - Restore local_internal_option to ' +
+                 f"{str(backup_local_internal_options)}")
     conf.set_local_internal_options_dict(backup_local_internal_options)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -615,17 +615,17 @@ def configure_local_internal_options_module(request):
     try:
         local_internal_options = getattr(request.module, 'local_internal_options')
     except AttributeError as local_internal_configuration_not_set:
-        logger.debug('Configure Local Internal Options: Error - local_internal_options is not set')
+        logger.debug('local_internal_options is not set')
         raise local_internal_configuration_not_set
 
     backup_local_internal_options = conf.get_local_internal_options_dict()
 
-    logger.debug('Configure Local Internal Options: DEBUG - Set local_internal_option to ' +
+    logger.debug('Set local_internal_option to ' +
                  f"{str(local_internal_options)}")
     conf.set_local_internal_options_dict(local_internal_options)
 
     yield
 
-    logger.debug('Configure Local Internal Options: DEBUG - Restore local_internal_option to ' +
+    logger.debug('Restore local_internal_option to ' +
                  f"{str(backup_local_internal_options)}")
     conf.set_local_internal_options_dict(backup_local_internal_options)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ from numpydoc.docscrape import FunctionDoc
 from py.xml import html
 
 import wazuh_testing.tools.configuration as conf
-from wazuh_testing import global_parameters
+from wazuh_testing import global_parameters, logger
 from wazuh_testing.logcollector import create_file_structure, delete_file_structure
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_CONF, get_service, ALERT_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
@@ -602,3 +602,32 @@ def create_file_structure_function(get_files_list):
     yield
 
     delete_file_structure(get_files_list)
+
+
+@pytest.fixture(scope="module")
+def configure_local_internal_options_module(request):
+    """Fixture to configure the local internal options file.
+
+    It uses the test variable local_internal_options. This should be
+    a dictionary wich keys and values corresponds to the internal option configuration, For example:
+    local_internal_options = ['monitord.rotate_log': '0', 'syscheck.debug': '0' ]
+    """
+    try:
+        local_internal_options = getattr(request.module, 'local_internal_options', [])
+    except AttributeError as local_internal_configuration_not_set:
+        logger.error('Configure Local Internal Options: Error - local_internal_options is not set')
+        raise local_internal_configuration_not_set
+
+
+    backup_local_internal_options = conf.get_local_internal_options_dict()
+
+    logger.error('Configure Local Internal Options: DEBUG - Set local_internal_option to '  +
+                    f"{str(local_internal_options)}")
+    conf.set_local_internal_options_dict(local_internal_options)
+
+    yield
+
+
+    logger.error('Configure Local Internal Options: DEBUG - Restore local_internal_option to '  +
+                    f"{str(backup_local_internal_options)}")
+    conf.set_local_internal_options_dict(backup_local_internal_options)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -604,7 +604,7 @@ def create_file_structure_function(get_files_list):
     delete_file_structure(get_files_list)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def configure_local_internal_options_module(request):
     """Fixture to configure the local internal options file.
 
@@ -615,17 +615,17 @@ def configure_local_internal_options_module(request):
     try:
         local_internal_options = getattr(request.module, 'local_internal_options')
     except AttributeError as local_internal_configuration_not_set:
-        logger.error('Configure Local Internal Options: Error - local_internal_options is not set')
+        logger.debug('Configure Local Internal Options: Error - local_internal_options is not set')
         raise local_internal_configuration_not_set
 
     backup_local_internal_options = conf.get_local_internal_options_dict()
 
-    logger.error('Configure Local Internal Options: DEBUG - Set local_internal_option to ' +
+    logger.debug('Configure Local Internal Options: DEBUG - Set local_internal_option to ' +
                  f"{str(local_internal_options)}")
     conf.set_local_internal_options_dict(local_internal_options)
 
     yield
 
-    logger.error('Configure Local Internal Options: DEBUG - Restore local_internal_option to ' +
+    logger.debug('Configure Local Internal Options: DEBUG - Restore local_internal_option to ' +
                  f"{str(backup_local_internal_options)}")
     conf.set_local_internal_options_dict(backup_local_internal_options)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -613,11 +613,10 @@ def configure_local_internal_options_module(request):
     local_internal_options = ['monitord.rotate_log': '0', 'syscheck.debug': '0' ]
     """
     try:
-        local_internal_options = getattr(request.module, 'local_internal_options', [])
+        local_internal_options = getattr(request.module, 'local_internal_options')
     except AttributeError as local_internal_configuration_not_set:
         logger.error('Configure Local Internal Options: Error - local_internal_options is not set')
         raise local_internal_configuration_not_set
-
 
     backup_local_internal_options = conf.get_local_internal_options_dict()
 
@@ -626,7 +625,6 @@ def configure_local_internal_options_module(request):
     conf.set_local_internal_options_dict(local_internal_options)
 
     yield
-
 
     logger.error('Configure Local Internal Options: DEBUG - Restore local_internal_option to '  +
                     f"{str(backup_local_internal_options)}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -610,7 +610,7 @@ def configure_local_internal_options_module(request):
 
     It uses the test variable local_internal_options. This should be
     a dictionary wich keys and values corresponds to the internal option configuration, For example:
-    local_internal_options = ['monitord.rotate_log': '0', 'syscheck.debug': '0' ]
+    local_internal_options = {'monitord.rotate_log': '0', 'syscheck.debug': '0' }
     """
     try:
         local_internal_options = getattr(request.module, 'local_internal_options')


### PR DESCRIPTION
|Related issue|
|---|
|#1829|

## Description

This PR closes #1829. It adds a common Wazuh `local_internal_options` configuration handler fixture for all integration tests.

## Usage

In order to use this fixture, it is necessary to define a `local_internal_options` variable. This should be a dictionary with the necessary internal options for the test. For example:

```
local_internal_options = {'monitord.rotate_log': '0', 'syscheck.debug': '0' }
```
With this variable defined the fixture will works for each test which calls it.

This fixture is defined for module scope cases. In those tests that changes `local_internal_options` according to a list, it is recommended to use the currently defined fixture.

## Tests

- [x] Proven that this fixture works correctly
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.