### PR TITLE
Full Yellow Jenkins on 4.2

### DIFF
--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -15,7 +15,7 @@ from wazuh_testing.tools.remoted_sim import RemotedSimulator
 from wazuh_testing.tools.services import control_service
 
 from conftest import *
-
+import sys
 # Marks
 
 pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0), pytest.mark.agent]
@@ -178,7 +178,7 @@ def check_log_error_conf(msg):
 
 
 @pytest.mark.parametrize('test_case', [case for case in tests])
-@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -178,7 +178,7 @@ def check_log_error_conf(msg):
 
 
 @pytest.mark.parametrize('test_case', [case for case in tests])
-@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -178,6 +178,7 @@ def check_log_error_conf(msg):
 
 
 @pytest.mark.parametrize('test_case', [case for case in tests])
+@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -178,7 +178,7 @@ def check_log_error_conf(msg):
 
 
 @pytest.mark.parametrize('test_case', [case for case in tests])
-@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,7 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,6 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
+@pytest.mark.skip(reason="Test disabled by #1678 until #1593 and #8746 are fixed")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,7 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
+@pytest.mark.skipif(sys.platform == 'win32', reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -81,7 +81,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-@pytest.mark.skip(reason="Test disabled by #1678 until #1593 and #8746 are fixed")
+@pytest.mark.skipif(pytest.mark.win32, reason="It will be blocked by #1593 and wazuh/wazuh#8746.")
 def test_agentd_state_config(test_case, set_local_internal_options):
 
     control_service('stop', 'wazuh-agentd')

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -346,6 +346,10 @@ def prepare_agent_version(get_configuration):
                             '-C', '/'])
 
 
+mark_skip_agentLinux = pytest.mark.skipif(
+    pytest.mark.linux and pytest.mark.agent, reason="It will be blocked by wazuh/wazuh#9763")
+
+
 @mark_skip_agentLinux
 def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                    configure_environment, start_agent):

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -14,7 +14,7 @@ import json
 from wazuh_testing import tools
 from wazuh_testing.tools.monitoring import make_callback, FileMonitor
 from datetime import datetime
-from wazuh_testing.tools import WAZUH_PATH, get_version
+from wazuh_testing.tools import WAZUH_PATH, get_version, get_service
 from wazuh_testing.tools.authd_sim import AuthdSimulator
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.file import truncate_file, count_file_lines
@@ -42,6 +42,8 @@ UPGRADE_RESULT_PATH = os.path.join(WAZUH_PATH, upgrade_result_folder, 'upgrade_r
 CRYPTO = "aes"
 SERVER_ADDRESS = 'localhost'
 PROTOCOL = "tcp"
+mark_skip_agentLinux = pytest.mark.skipif(get_service() == 'wazuh-agent' and
+                                          sys_platform == 'Linux', reason="It will be blocked by wazuh/wazuh#9763")
 
 if not global_parameters.wpk_version:
     raise Exception("The WPK package version must be defined by parameter. See README.md")
@@ -342,10 +344,6 @@ def prepare_agent_version(get_configuration):
         if len(backups_files) > 0:
             subprocess.call(['tar', 'xzf', f'{WAZUH_PATH}/backup/{backups_files[-1]}',
                             '-C', '/'])
-
-
-mark_skip_agentLinux = pytest.mark.skipif(
-    pytest.mark.linux and pytest.mark.agent, reason="It will be blocked by wazuh/wazuh#9763")
 
 
 @mark_skip_agentLinux

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -344,6 +344,11 @@ def prepare_agent_version(get_configuration):
                             '-C', '/'])
 
 
+mark_skip_agentLinux = pytest.mark.skipif(
+    pytest.mark.linux and pytest.mark.agent, reason="It will be blocked by wazuh/wazuh#9763")
+
+
+@mark_skip_agentLinux
 def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                    configure_environment, start_agent):
     metadata = get_configuration['metadata']

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -346,10 +346,6 @@ def prepare_agent_version(get_configuration):
                             '-C', '/'])
 
 
-mark_skip_agentLinux = pytest.mark.skipif(
-    pytest.mark.linux and pytest.mark.agent, reason="It will be blocked by wazuh/wazuh#9763")
-
-
 @mark_skip_agentLinux
 def test_wpk_agent(get_configuration, prepare_agent_version, download_wpk,
                    configure_environment, start_agent):


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1677 |

## Description

The branch `1677-4.2.0-full-yellow-jenkins` has all changes apply on this `1516-4.2.0-full-green` branch until the change `43a6d78`. Also, there have new changes fixing some warnings.



## Disabled by Core Issue

**Agentd:**

- test_agentd_state_config (Only on window by Core issue)   
- test_agent_agentd_enrollment (Only on window by Core issue)
    
  **PRs merged:**
     - https://github.com/wazuh/wazuh-qa/pull/1766
     - https://github.com/wazuh/wazuh-qa/pull/1763
 
-----------------------------------------------------------------------------------

**WPK**:
- test_wpk_agent (Only on Linux Agent by Core issue)
    
   **PRs merged:**
      - https://github.com/wazuh/wazuh-qa/pull/1767
