### PR TITLE
Few test examples to test QADOCS

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/config.yaml
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/config.yaml
@@ -3,6 +3,8 @@ Project path: "../../tests/integration"
 Output path: "wazuh_testing/qa_docs/output"
 
 Include paths:
+  - "../../tests/integration/test_active_response"
+  - "../../tests/integration/test_api"
   - "../../tests/integration/test_wazuh_db"
   - "../../tests/integration/test_vulnerability_detector"
   - "../../tests/integration/test_remoted"
@@ -18,6 +20,20 @@ Function regex:
   - "^test_"
 
 Ignore paths:
+  - "../../tests/integration/test_active_response/test_execd/data"
+  - "../../tests/integration/test_api/test_config/test_bruteforce_blocking_system/data"
+  - "../../tests/integration/test_api/test_config/test_cache/data"
+  - "../../tests/integration/test_api/test_config/test_cors/data"
+  - "../../tests/integration/test_api/test_config/test_DOS_blocking_system/data"
+  - "../../tests/integration/test_api/test_config/test_drop_privileges/data"
+  - "../../tests/integration/test_api/test_config/test_experimental_features/data"
+  - "../../tests/integration/test_api/test_config/test_host_port/data"
+  - "../../tests/integration/test_api/test_config/test_https/data"
+  - "../../tests/integration/test_api/test_config/test_jwt_token_exp_timeout/data"
+  - "../../tests/integration/test_api/test_config/test_logs/data"
+  - "../../tests/integration/test_api/test_config/test_rbac/data" 
+  - "../../tests/integration/test_api/test_config/test_request_timeout/data"
+  - "../../tests/integration/test_api/test_config/test_use_only_authd/data"
   - "../../tests/integration/test_wazuh_db/data"
 
 Output fields:

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -14,7 +14,6 @@ category:
     integration
 os_platform:
     - linux
-    - windows
 os_vendor:
     - redhat
     - debian
@@ -22,7 +21,6 @@ os_vendor:
     - alas
     - arch-linux
     - centos
-    - windows
 os_version:
     - centos6
     - centos7
@@ -38,12 +36,6 @@ os_version:
     - trusty
     - amazon-linux-1
     - amazon-linux-2
-    - 7
-    - 8
-    - 10
-    - server-2003
-    - server-2012
-    - server-2016
 tiers:
     - 0
 tags:

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+'''
+brief:
+    These tests will check if the active responses, which are executed by
+    the `wazuh-execd` program via scripts, run correctly.
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
+    Created by Wazuh, Inc. <info@wazuh.com>.
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+modules:
+    - active response
+daemons:
+    - wazuh-execd
+category:
+    integration
+os_platform:
+    - linux
+    - windows
+os_vendor:
+    - redhat
+    - debian
+    - ubuntu
+    - alas
+    - arch-linux
+    - centos
+    - windows
+os_version:
+    - centos6
+    - centos7
+    - centos8
+    - rhel6
+    - rhel7
+    - rhel8
+    - buster
+    - stretch
+    - wheezy
+    - bionic
+    - xenial
+    - trusty
+    - amazon-linux-1
+    - amazon-linux-2
+    - 7
+    - 8
+    - 10
+    - server-2003
+    - server-2012
+    - server-2016
+tiers:
+    - 0
+tags:
+    - log_monitor
+    - active_response
+component:
+    - agent
+'''
 import json
 import os
 import platform
@@ -189,15 +239,37 @@ def build_message(metadata, expected):
 
 def test_execd_firewall_drop(set_debug_mode, get_configuration, test_version, configure_environment,
                              remove_ip_from_iptables, start_agent, set_ar_conf_mode):
-    """Check if firewall-drop Active Response is executed correctly.
-
-    Args:
-        set_debug_mode (fixture): Set execd daemon in debug mode.
-        test_version (fixture): Validate Wazuh version.
-        set_ar_conf_mode (fixture): Configure Active Responses used in tests.
-        start_agent (fixture): Create Remoted and Authd simulators, register agent and start it.
-        remove_ip_from_iptables (fixture): Remove the test IP from iptables if it exist
-    """
+    '''
+    description:
+        Check if `firewall-drop` command of Active Response is executed correctly.
+    parameters:
+        - set_debug_mode:
+            type: fixture
+            brief: Set execd daemon in debug mode.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - test_version:
+            type: fixture
+            brief: Validate Wazuh version.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - start_agent:
+            type: fixture
+            brief: Create Remoted and Authd simulators, register agent and start it.
+        - set_ar_conf_mode:
+            type: fixture
+            brief: Configure Active Responses used in tests.
+    wazuh_min_version:
+        4.2
+    behaviour:
+        - Verify that Active Response is enabled by looking in the `ossec.log` and `active-responses.log` files.
+        - Check that `firewall-drop` works by verifying that it adds/deletes the IP sent in iptables.
+    expected_behaviour:
+        - The sent IP is added to iptables.
+        - the sent IP is removed from iptables.
+    '''
     metadata = get_configuration['metadata']
     expected = metadata['results']
     ossec_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+'''
+brief:
+    These tests will check if the active responses, which are executed by
+    the `wazuh-execd` program via scripts, run correctly.
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
+    Created by Wazuh, Inc. <info@wazuh.com>.
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+modules:
+    - active response
+daemons:
+    - wazuh-execd
+category:
+    integration
+os_platform:
+    - linux
+    - windows
+os_vendor:
+    - redhat
+    - debian
+    - ubuntu
+    - alas
+    - arch-linux
+    - centos
+    - windows
+os_version:
+    - centos6
+    - centos7
+    - centos8
+    - rhel6
+    - rhel7
+    - rhel8
+    - buster
+    - stretch
+    - wheezy
+    - bionic
+    - xenial
+    - trusty
+    - amazon-linux-1
+    - amazon-linux-2
+    - 7
+    - 8
+    - 10
+    - server-2003
+    - server-2012
+    - server-2016
+tiers:
+    - 0
+tags:
+    - log_monitor
+    - active_response
+component:
+    - agent
+'''
 import os
 import platform
 import pytest
@@ -144,16 +194,37 @@ def build_message(metadata, expected):
 
 def test_execd_restart(set_debug_mode, get_configuration, test_version,
                        configure_environment, start_agent, set_ar_conf_mode):
-    """Check if restart-wazuh Active Response is executed correctly.
-
-    Args:
-        set_debug_mode (fixture): Set execd daemon in debug mode.
-        get_configuration (fixture): Get configurations from the module.
-        test_version (fixture): Validate Wazuh version.
-        configure_environment (fixture): Configure a custom environment for testing.
-        start_agent (fixture): Create Remoted and Authd simulators, register agent and start it.
-        set_ar_conf_mode (fixture): Configure Active Responses used in tests.
-    """
+    '''
+    description:
+        Check if `restart-wazuh` command of Active Response is executed correctly.
+    parameters:
+        - set_debug_mode:
+            type: fixture
+            brief: Set execd daemon in debug mode.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - test_version:
+            type: fixture
+            brief: Validate Wazuh version.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - start_agent:
+            type: fixture
+            brief: Create Remoted and Authd simulators, register agent and start it.
+        - set_ar_conf_mode:
+            type: fixture
+            brief: Configure Active Responses used in tests.
+    wazuh_min_version:
+        4.2
+    behaviour:
+        - Verify that Active Response is enabled by looking in the `ossec.log` and `active-responses.log` files.
+        - Check that `restart-wazuh` works by verifying that it restarts the agent.
+    expected_behaviour:
+        - The active response `restart-wazuh` is received.
+        - The agent is ready to restart.
+    '''
     metadata = get_configuration['metadata']
     expected = metadata['results']
     ossec_log_monitor = FileMonitor(LOG_FILE_PATH)

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -14,7 +14,6 @@ category:
     integration
 os_platform:
     - linux
-    - windows
 os_vendor:
     - redhat
     - debian
@@ -22,7 +21,6 @@ os_vendor:
     - alas
     - arch-linux
     - centos
-    - windows
 os_version:
     - centos6
     - centos7
@@ -38,12 +36,6 @@ os_version:
     - trusty
     - amazon-linux-1
     - amazon-linux-2
-    - 7
-    - 8
-    - 10
-    - server-2003
-    - server-2012
-    - server-2016
 tiers:
     - 0
 tags:

--- a/tests/integration/test_api/test_config/test_cache/test_cache.py
+++ b/tests/integration/test_api/test_config/test_cache/test_cache.py
@@ -1,7 +1,50 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+'''
+brief:
+    These tests will check if the cache feature of the API handled by the `apid` daemon is working properly.
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
+    Created by Wazuh, Inc. <info@wazuh.com>.
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+modules:
+    - api
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-wazuh-db
+category:
+    integration
+os_platform:
+    - linux
+os_vendor:
+    - redhat
+    - debian
+    - ubuntu
+    - alas
+    - arch-linux
+    - centos
+os_version:
+    - centos6
+    - centos7
+    - centos8
+    - rhel6
+    - rhel7
+    - rhel8
+    - buster
+    - stretch
+    - wheezy
+    - bionic
+    - xenial
+    - trusty
+    - amazon-linux-1
+    - amazon-linux-2
+tiers:
+    - 0
+tags:
+    - api
+component:
+    - manager
+'''
 import os
 import time
 
@@ -53,18 +96,39 @@ def extra_configuration_after_yield():
 ])
 def test_cache(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                wait_for_start, get_api_details):
-    """Verify that the stored response is returned when cache is enabled.
-
-    Calls to rules endpoints can be cached. This test verifies that the result
-    of the first call to a rule endpoint is equal to the second within a period
-    established in the configuration, even though a new file has been created
-    during the process.
-
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    '''
+    description:
+        Verify that the stored response is returned when the cache is enabled.
+        Calls to rules endpoints can be cached. This test verifies if the result
+        of the first call to a rule endpoint is equal to the second within a period
+        established in the configuration, even though a new file has been created during the process.
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset `api.log` and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+    wazuh_min_version:
+        3.13
+    behaviour:
+        - Gets the total number of stored rules, creates a new rule and rechecks the number of stored rules.
+          It must get the same value in both requests.
+    expected_behaviour:
+        - The stored response is returned when the cache is enabled.
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     cache = get_configuration['configuration']['cache']['enabled']
     api_details = get_api_details()

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -1,7 +1,51 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+'''
+brief:
+    These tests will check if the CORS (Cross-origin resource sharing) feature
+    of the API handled by the `apid` daemon is working properly.
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
+    Created by Wazuh, Inc. <info@wazuh.com>.
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+modules:
+    - api
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-wazuh-db
+category:
+    integration
+os_platform:
+    - linux
+os_vendor:
+    - redhat
+    - debian
+    - ubuntu
+    - alas
+    - arch-linux
+    - centos
+os_version:
+    - centos6
+    - centos7
+    - centos8
+    - rhel6
+    - rhel7
+    - rhel8
+    - buster
+    - stretch
+    - wheezy
+    - bionic
+    - xenial
+    - trusty
+    - amazon-linux-1
+    - amazon-linux-2
+tiers:
+    - 0
+tags:
+    - api
+component:
+    - manager
+'''
 import os
 
 import pytest
@@ -36,19 +80,41 @@ def get_configuration(request):
 ])
 def test_cors(origin, tags_to_apply, get_configuration, configure_api_environment,
               restart_api, wait_for_start, get_api_details):
-    """Check if expected headers are returned when CORS is enabled.
-
-    When CORS is enabled, special headers must be returned in case the
-    request origin matches the one established in the CORS configuration
-    of the API.
-
-    Parameters
-    ----------
-    origin : str
-        Origin path to be appended as a header in the request.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    '''
+    description:
+        Check if expected headers are returned when CORS is enabled.
+        When CORS is enabled, special headers must be returned in case the
+        request origin matches the one established in the CORS configuration
+        of the API.
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset `api.log` and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+    wazuh_min_version:
+        3.13
+    behaviour:
+        - Perform different requests with CORS enabled and disabled, then check the responses for matching headers.
+    expected_behaviour:
+        - The `Access-Control-Allow-Origin` header is received when CORS is enabled.
+        - The `Access-Control-Expose-Headers` header is received when CORS is enabled.
+        - The `Access-Control-Allow-Credentials` header is received when CORS is enabled.
+        - the `Access-Control-Allow-Origin` header is not received when CORS is disabled.
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     api_details = get_api_details()
     api_details['auth_headers']['origin'] = origin


### PR DESCRIPTION
|Related issue|
|---|
|#1840|

## Description

To test the QADOCS tool, some tests have been documented. It has been integrated into wazuh framework so it needs to be tested with completed tests.