### PR TITLE
Fix get local internal option dictionary function error handling

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -557,7 +557,7 @@ def get_local_internal_options_dict():
                     option_name, option_value = configuration_option.split('=')
                     local_internal_option_dict[option_name] = option_value
                 except ValueError as invalid_option:
-                    logger.error("Invalid local_internal_options value: {configuration_option}")
+                    logger.error(f"Invalid local_internal_options value: {configuration_option}")
                     raise invalid_option
 
     return local_internal_option_dict

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -556,9 +556,9 @@ def get_local_internal_options_dict():
                 try:
                     option_name, option_value = configuration_option.split('=')
                     local_internal_option_dict[option_name] = option_value
-                except ValueError as invalid_option:
+                except ValueError:
                     logger.error(f"Invalid local_internal_options value: {configuration_option}")
-                    raise invalid_option
+                    raise ValueError('Invalid local_internal_option')
 
     return local_internal_option_dict
 

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -11,7 +11,7 @@ from typing import List, Any, Set
 
 import pytest
 import yaml
-from wazuh_testing import global_parameters
+from wazuh_testing import global_parameters, logger
 from wazuh_testing.tools import WAZUH_PATH, GEN_OSSEC, WAZUH_CONF, PREFIX, WAZUH_LOCAL_INTERNAL_OPTIONS
 
 
@@ -553,8 +553,11 @@ def get_local_internal_options_dict():
         configuration_options = local_internal_option_file.readlines()
         for configuration_option in configuration_options:
             if not configuration_option.startswith('#'):
-                option_name, option_value = configuration_option.split('=')
-                local_internal_option_dict[option_name] = option_value
+                try:
+                    option_name, option_value = configuration_option.split('=')
+                    local_internal_option_dict[option_name] = option_value
+                except ValueError:
+                    logger.error("Invalid local_internal_options value: {configuration_option}")
 
     return local_internal_option_dict
 

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -552,12 +552,13 @@ def get_local_internal_options_dict():
     with open(WAZUH_LOCAL_INTERNAL_OPTIONS, 'r') as local_internal_option_file:
         configuration_options = local_internal_option_file.readlines()
         for configuration_option in configuration_options:
-            if not configuration_option.startswith('#'):
+            if not configuration_option.startswith('#') and not configuration_option == '\n':
                 try:
                     option_name, option_value = configuration_option.split('=')
                     local_internal_option_dict[option_name] = option_value
-                except ValueError:
+                except ValueError as invalid_option:
                     logger.error("Invalid local_internal_options value: {configuration_option}")
+                    raise invalid_option
 
     return local_internal_option_dict
 


### PR DESCRIPTION
## Description

This PR fix bad error handling of `get_local_internal_options_dict` function. Now in case of empty or invalid lines in the `local_internal_options` file, these are ignored.