### PR TITLE
Fix warnings of API test on 4.2

### DIFF
--- a/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
@@ -34,6 +34,7 @@ def get_configuration(request):
     {'config1'},
     {'config2'}
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                              wait_for_start, get_api_details):
     """Check the correct functionality of the DOS blocking system.

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -33,6 +33,7 @@ def get_configuration(request):
     {'config1'},
     {'config2'}
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                                     wait_for_start, get_api_details):
     """Check that the blocking time for IPs detected as brute-force attack works.

--- a/tests/integration/test_api/test_config/test_cache/test_cache.py
+++ b/tests/integration/test_api/test_config/test_cache/test_cache.py
@@ -51,6 +51,7 @@ def extra_configuration_after_yield():
     {'cache_enabled'},
     {'cache_disabled'}
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_cache(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                wait_for_start, get_api_details):
     """Verify that the stored response is returned when cache is enabled.

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -34,6 +34,7 @@ def get_configuration(request):
     ('https://test_url.com', {'cors'}),
     ('http://other_url.com', {'cors'}),
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_cors(origin, tags_to_apply, get_configuration, configure_api_environment,
               restart_api, wait_for_start, get_api_details):
     """Check if expected headers are returned when CORS is enabled.

--- a/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
+++ b/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
@@ -33,6 +33,7 @@ def get_configuration(request):
     {'experimental_enabled'},
     {'experimental_disabled'},
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_experimental_features(tags_to_apply, get_configuration, configure_api_environment,
                                restart_api, wait_for_start, get_api_details):
     """Check if requests to an experimental endpoint are allowed according to the configuration.

--- a/tests/integration/test_api/test_config/test_host_port/test_host_port.py
+++ b/tests/integration/test_api/test_config/test_host_port/test_host_port.py
@@ -40,6 +40,7 @@ def get_configuration(request):
     (False, {'conf_1'}),
     (True, {'conf_2'}),
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_host_port(expected_exception, tags_to_apply,
                    get_configuration, configure_api_environment, restart_api, get_api_details):
     """Try different host and port configurations.

--- a/tests/integration/test_api/test_config/test_https/test_https.py
+++ b/tests/integration/test_api/test_config/test_https/test_https.py
@@ -38,6 +38,7 @@ def get_configuration(request):
     {'https_disabled'},
     {'https_enabled'},
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_https(tags_to_apply, get_configuration, configure_api_environment,
                restart_api, wait_for_start, get_api_details):
     """Check that the API works with http and https protocols.

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
@@ -34,6 +34,7 @@ def get_configuration(request):
     {'short_exp_time'},
     {'long_exp_time'}
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                                wait_for_start, get_api_details):
     """Verify that the JWT token expires after defined time.

--- a/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
+++ b/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
@@ -59,6 +59,7 @@ def extra_configuration_after_yield():
     {'rbac_white'},
     {'rbac_black'}
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                    wait_for_start, get_api_details):
     """Verify that the RBAC mode selected in api.yaml is applied.

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -49,6 +49,7 @@ def extra_configuration_after_yield():
     {'only_authd_enabled'},
     {'only_authd_disabled'},
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
                    restart_api, wait_for_start, get_api_details):
     """Check if use_only_authd forces the use of wazuh-authd when adding an agent.
@@ -94,6 +95,7 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
     {'only_authd_enabled'},
     {'only_authd_disabled'},
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_insert_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
     """Check if use_only_authd forces the use of wazuh-authd when inserting an agent.
@@ -139,6 +141,7 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
     {'only_authd_enabled'},
     {'only_authd_disabled'},
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_environment,
                             restart_api, wait_for_start, get_api_details):
     """Check if use_only_authd forces the use of wazuh-authd when quick inserting an agent.
@@ -180,6 +183,7 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
     {'only_authd_enabled'},
     {'only_authd_disabled'},
 ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_delete_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
     """Check if use_only_authd forces the use of wazuh-authd when deleting an agent.

--- a/tests/integration/test_api/test_rbac/test_add_old_resource.py
+++ b/tests/integration/test_api/test_rbac/test_add_old_resource.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import requests
+import pytest
 from wazuh_testing.api import get_security_resource_information
 
 # Variables
@@ -9,6 +10,7 @@ user_id, role_id, policy_id, rule_id = None, None, None, None
 
 
 # Tests
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_user(set_security_resources, get_api_details):
     """Remove a user with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
@@ -30,6 +32,7 @@ def test_add_old_user(set_security_resources, get_api_details):
             assert not value, f'Relationships are not empty: {key}->{value}'
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_role(set_security_resources, get_api_details):
     """Remove a role with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
@@ -50,6 +53,7 @@ def test_add_old_role(set_security_resources, get_api_details):
             assert not value, f'Relationships are not empty: {key}->{value}'
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_policy(set_security_resources, get_api_details):
     """Remove a policy with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()
@@ -73,6 +77,7 @@ def test_add_old_policy(set_security_resources, get_api_details):
             assert not value, f'Relationships are not empty: {key}->{value}'
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_rule(set_security_resources, get_api_details):
     """Remove a rule with defined relationships and create it with the same ID to see if said relationships remain."""
     api_details = get_api_details()

--- a/tests/integration/test_api/test_rbac/test_admin_resources.py
+++ b/tests/integration/test_api/test_rbac/test_admin_resources.py
@@ -76,6 +76,7 @@ def modify_admin_resources(api_details, admin_ids, endpoint, body):
 
 
 # Tests
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_users(restart_api, get_api_details):
     """Test if admin security users can be removed."""
     api_details = get_api_details()
@@ -86,6 +87,7 @@ def test_admin_users(restart_api, get_api_details):
     remove_admin_resources(api_details, admin_ids, endpoint, resource, 5004)
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_roles(restart_api, get_api_details):
     """Test if admin security roles can be removed."""
     api_details = get_api_details()
@@ -99,6 +101,7 @@ def test_admin_roles(restart_api, get_api_details):
     modify_admin_resources(api_details, admin_ids, endpoint, body)
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_policies(restart_api, get_api_details):
     """Test if admin security policies can be removed."""
     api_details = get_api_details()
@@ -113,6 +116,7 @@ def test_admin_policies(restart_api, get_api_details):
     modify_admin_resources(api_details, admin_ids, endpoint, body)
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_rules(restart_api, get_api_details):
     """Test if admin security rules can be removed."""
     api_details = get_api_details()

--- a/tests/integration/test_api/test_rbac/test_policy_position.py
+++ b/tests/integration/test_api/test_rbac/test_policy_position.py
@@ -73,6 +73,7 @@ def add_role_policy(api_details, p_id, position):
 
 
 # Tests
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_policy_position(set_security_resources, add_new_policies, get_api_details):
     """Test if the correct order between role-policy relationships remain after removing some of them and adding others
     using the `position` parameter."""

--- a/tests/integration/test_api/test_rbac/test_remove_relationship.py
+++ b/tests/integration/test_api/test_rbac/test_remove_relationship.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import requests
+import pytest
 from wazuh_testing.api import get_security_resource_information
 
 # Variables
@@ -42,6 +43,7 @@ def remove_relationship(api_details, endpoint, resource, related_resource, relat
 
 
 # Tests
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_user_role_relationship(set_security_resources, get_api_details):
     """Test if the user and role still exist after removing their relationship."""
     api_details = get_api_details()
@@ -53,6 +55,7 @@ def test_remove_user_role_relationship(set_security_resources, get_api_details):
     remove_relationship(api_details, endpoint, resource, related_resource, relation)
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_role_policy_relationship(set_security_resources, get_api_details):
     """Test if the role and policy still exist after removing their relationship."""
     api_details = get_api_details()
@@ -64,6 +67,7 @@ def test_remove_role_policy_relationship(set_security_resources, get_api_details
     remove_relationship(api_details, endpoint, resource, related_resource, relation)
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_role_rule_relationship(set_security_resources, get_api_details):
     """Test if the role and rule still exist after removing their relationship."""
     api_details = get_api_details()

--- a/tests/integration/test_api/test_rbac/test_remove_resource.py
+++ b/tests/integration/test_api/test_rbac/test_remove_resource.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import requests
+import pytest
 from wazuh_testing.api import get_security_resource_information
 
 # Variables
@@ -51,6 +52,7 @@ def check_resources(deleted_resource, resource_id):
 
 
 # Tests
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_rule(set_security_resources, get_api_details):
     """Test if relationships between security resources stay the same after removing the linked rule."""
     api_details = get_api_details()
@@ -68,6 +70,7 @@ def test_remove_rule(set_security_resources, get_api_details):
     check_relationships(relationships, new_relationships, 'rules')
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_policy(set_security_resources, get_api_details):
     """Test if relationships between security resources stay the same after removing the linked policy."""
     api_details = get_api_details()
@@ -85,6 +88,7 @@ def test_remove_policy(set_security_resources, get_api_details):
     check_relationships(relationships, new_relationships, 'policies')
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_user(set_security_resources, get_api_details):
     """Test if relationships between security resources stay the same after removing the linked user."""
     api_details = get_api_details()
@@ -102,6 +106,7 @@ def test_remove_user(set_security_resources, get_api_details):
     check_relationships(relationships, new_relationships, 'users')
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_role(set_security_resources, get_api_details):
     """Test if relationships between security resources stay the same after removing the linked role."""
     api_details = get_api_details()


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1858 |

## Description
Trying the FileMonitor fix for [PR#1721](https://github.com/wazuh/wazuh-qa/pull/1721) in the branch `4.2` (it was `1774-4.2-full-green-local` before merging changes) we found that API tests were giving warnings:
```
test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py: 2 warnings
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py: 2 warnings
test_api/test_config/test_cache/test_cache.py: 2 warnings
test_api/test_config/test_cors/test_cors.py: 2 warnings
test_api/test_config/test_experimental_features/test_experimental_features.py: 2 warnings
test_api/test_config/test_https/test_https.py: 1 warning
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py: 2 warnings
test_api/test_config/test_rbac/test_rbac_mode.py: 2 warnings
test_api/test_config/test_use_only_authd/test_use_only_authd.py: 8 warnings
test_api/test_rbac/test_add_old_resource.py: 4 warnings
test_api/test_rbac/test_admin_resources.py: 4 warnings
test_api/test_rbac/test_policy_position.py: 1 warning
test_api/test_rbac/test_remove_relationship.py: 3 warnings
test_api/test_rbac/test_remove_resource.py: 4 warnings
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning,

test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration0-False-tags_to_apply0]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration1-False-tags_to_apply0]
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host '0.0.0.0'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
This PR fixes all these warnings with the objetive of having a full-green for 4.2.

## Packages details

Type | Format | Architecture | Version | Revision | Tag | File name
-- | -- | -- | -- | -- | -- | --
Server | rpm | x86_64 | 4.2.0 | 40207 | v4.2.0-rc8 | wazuh-manager-4.2.0-1.1493.x86_64.rpm

## Environment

| Provider | Box | OS | CPU | Memory | 
|--|--|--|--|--|
| Vagrant | generic/centos8 | CentOS 8 | 2 | 1024 |

## Local configuration
```
monitord.rotate_log=0
```

## Test results
| Round | Date | Executed by | Status | Results |
|:--:|:--:|:--:|:--:|:--:|
| R1 | 2021/09/10 | @MizugorouZ  | :green_circle: | [Test results](https://github.com/wazuh/wazuh-qa/files/7143087/r1_api.zip) |
| R2 | 2021/09/10 | @MizugorouZ  | :green_circle: | [Test results](https://github.com/wazuh/wazuh-qa/files/7143088/r2_api.zip) |
| R3 | 2021/09/10 | @MizugorouZ  | :green_circle: | [Test results](https://github.com/wazuh/wazuh-qa/files/7143089/r3_api.zip) |