### PR TITLE
Migrate `test_active_response` documentation to QA Docs

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -3,7 +3,7 @@ Project path: "../../tests/integration"
 Output path: "../output"
 
 Include paths:
-#  - "../../tests/integration/test_active_response"
+  - "../../tests/integration/test_active_response"
 #  - "../../tests/integration/test_agentd"
 #  - "../../tests/integration/test_analysisd"
   - "../../tests/integration/test_api"

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -286,11 +286,11 @@ def test_execd_firewall_drop(set_debug_mode, get_configuration, test_version, co
         parameters for `firewall-drop` command and the expected result.
 
     expected_output:
-        - r"DEBUG: Received message"
-        - r"Starting"
-        - r"active-response/bin/firewall-drop"
-        - r"Ended"
-        - r"Cannot read 'srcip' from data" (If the `active response` fails)
+        - r'DEBUG: Received message'
+        - r'Starting'
+        - r'active-response/bin/firewall-drop'
+        - r'Ended'
+        - r'Cannot read 'srcip' from data' (If the `active response` fails)
 
     tags:
         - simulator

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -238,12 +238,12 @@ def test_execd_restart(set_debug_mode, get_configuration, test_version,
         parameters for `restart-wazuh` command and the expected result.
 
     expected_output:
-        - r"DEBUG: Received message"
-        - r"Shutdown received. Deleting responses."
-        - r"Starting"
-        - r"active-response/bin/restart-wazuh"
-        - r"Ended"
-        - r"Invalid input format" (If the `active response` fails)
+        - r'DEBUG: Received message'
+        - r'Shutdown received. Deleting responses.'
+        - r'Starting'
+        - r'active-response/bin/restart-wazuh'
+        - r'Ended'
+        - r'Invalid input format' (If the `active response` fails)
 
     tags:
         - simulator

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -9,49 +9,53 @@ copyright:
 type:
     integration
 
-description:
+brief:
     These tests will check if the active responses, which are executed by
-    the `wazuh-execd` program via scripts, run correctly.
+    the `wazuh-execd` daemon via scripts, run correctly. Active responses
+    execute a script in response to the triggering of specific alerts
+    based on the alert level or rule group.
 
-tiers:
-    - 0
+tier:
+    0
 
-component:
-    agent
+modules:
+    - active_response
+
+components:
+    - agent
 
 path:
-    tests/integration/test_active_response/test_execd/
+    tests/integration/test_active_response/test_execd/test_execd_restart.py
 
 daemons:
-    - execd
+    - wazuh-analysisd
+    - wazuh-authd
+    - wazuh-execd
+    - wazuh-remoted
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
 
-coverage:
+os_version:
+    - Amazon Linux 1
+    - Amazon Linux 2
+    - Arch Linux
+    - CentOS 6
+    - CentOS 7
+    - CentOS 8
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 6
+    - Red Hat 7
+    - Red Hat 8
+    - Ubuntu Bionic
+    - Ubuntu Trusty
+    - Ubuntu Xenial
 
-pytest_args:
-
-tags:
-    - active_response
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response
 '''
 import os
 import platform
@@ -197,7 +201,10 @@ def test_execd_restart(set_debug_mode, get_configuration, test_version,
                        configure_environment, start_agent, set_ar_conf_mode):
     '''
     description:
-        Check if `restart-wazuh` command of Active Response is executed correctly.
+        Check if `restart-wazuh` command of `active response` is executed correctly.
+        For this purpose, a simulated agent is used, to which the active response is sent.
+        This response includes the order to restart the Wazuh agent,
+        which must restart after receiving this response.
 
     wazuh_min_version:
         4.2
@@ -206,47 +213,40 @@ def test_execd_restart(set_debug_mode, get_configuration, test_version,
         - set_debug_mode:
             type: fixture
             brief: Set execd daemon in debug mode.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
-
         - test_version:
             type: fixture
             brief: Validate Wazuh version.
-
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - start_agent:
             type: fixture
             brief: Create Remoted and Authd simulators, register agent and start it.
-
         - set_ar_conf_mode:
             type: fixture
             brief: Configure Active Responses used in tests.
 
     assertions:
-        - Check that the active response restart-wazuh is received.
+        - Check that the active response `restart-wazuh` is received.
         - Check that the agent is ready to restart.
 
-    test_input:
-        Several `restart-wazuh` commands with different parameters and the expected result after running them.
+    input_description:
+        Different use cases are found in the test module and include
+        parameters for `restart-wazuh` command and the expected result.
 
-    logging:
-        - ossec.log:
-            - r"DEBUG: Received message "
-            - r"Shutdown received. Deleting responses."
-
-        - active-responses.log:
-            - r"Starting"
-            - r"active-response/bin/restart-wazuh "
-            - r"Ended"
-            - r"Invalid input format"
+    expected_output:
+        - r"DEBUG: Received message"
+        - r"Shutdown received. Deleting responses."
+        - r"Starting"
+        - r"active-response/bin/restart-wazuh"
+        - r"Ended"
+        - r"Invalid input format" (If the `active response` fails)
 
     tags:
-        - active_response
+        - simulator
     '''
     metadata = get_configuration['metadata']
     expected = metadata['results']


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1870|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **QA Docs**. 
The schema used is the one defined in issue #1694


# Generated documentation

## test_analysisd

<details><summary>test_os_exec.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `wazuh-analysisd` daemon processes `active response` messages correctly. Active responses perform various countermeasures to address active threats, such as blocking access to an agent from the threat source when certain criteria are met.",
    "tier": 0,
    "modules": [
        "active_response"
    ],
    "components": [
        "manager"
    ],
    "path": "tests/integration/test_active_response/test_analysisd/test_os_exec.py",
    "daemons": [
        "wazuh-analysisd",
        "wazuh-authd",
        "wazuh-execd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response"
    ],
    "name": "test_os_exec.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if `active response` messages are sent in the correct format depending on the agent version used. For this purpose, simulated agents with different properties are created, and messages in two formats (string and `JSON`) are sent to the socket of the `wazuh-analisysd` daemon, which should process them correctly.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "set_debug_mode": {
                        "type": "fixture",
                        "brief": "Set execd daemon in debug mode."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_service": {
                        "type": "fixture",
                        "brief": "Restart the Wazuh manager and clean the ossec.log file."
                    }
                },
                {
                    "configure_agents": {
                        "type": "fixture",
                        "brief": "Create simulated agents for testing."
                    }
                }
            ],
            "assertions": [
                "Verify that the `active response` messages in the old string format are valid.",
                "Verify that the `active response` messages in the new `JSON` format are valid."
            ],
            "input_description": "Different use cases are found in the test module and include parameters for `active response` messages and metadata to configure the testing environment.",
            "expected_output": [
                "r'Active response request received'",
                "Active response message with the structure defined in the validate_new_ar_message function (for Wazuh versions >= 4.2).",
                "Active response message with the structure defined in the validate_old_ar_message function (for Wazuh versions < 4.2)."
            ],
            "tags": [
                "simulator"
            ],
            "name": "test_os_exec",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_os_exec.yaml</summary>
<p>

```yaml
brief: These tests will check if the `wazuh-analysisd` daemon processes `active response`
  messages correctly. Active responses perform various countermeasures to address
  active threats, such as blocking access to an agent from the threat source when
  certain criteria are met.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-authd
- wazuh-execd
- wazuh-remoted
group_id: 0
id: 1
modules:
- active_response
name: test_os_exec.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
path: tests/integration/test_active_response/test_analysisd/test_os_exec.py
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response
tests:
- assertions:
  - Verify that the `active response` messages in the old string format are valid.
  - Verify that the `active response` messages in the new `JSON` format are valid.
  description: Check if `active response` messages are sent in the correct format
    depending on the agent version used. For this purpose, simulated agents with different
    properties are created, and messages in two formats (string and `JSON`) are sent
    to the socket of the `wazuh-analisysd` daemon, which should process them correctly.
  expected_output:
  - r'Active response request received'
  - Active response message with the structure defined in the validate_new_ar_message
    function (for Wazuh versions >= 4.2).
  - Active response message with the structure defined in the validate_old_ar_message
    function (for Wazuh versions < 4.2).
  input_description: Different use cases are found in the test module and include
    parameters for `active response` messages and metadata to configure the testing
    environment.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  name: test_os_exec
  parameters:
  - set_debug_mode:
      brief: Set execd daemon in debug mode.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_service:
      brief: Restart the Wazuh manager and clean the ossec.log file.
      type: fixture
  - configure_agents:
      brief: Create simulated agents for testing.
      type: fixture
  tags:
  - simulator
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


## test_execd

<details><summary>test_execd_firewall_drop.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the active responses, which are executed by the `wazuh-execd` daemon via scripts, run correctly. Active responses execute a script in response to the triggering of specific alerts based on the alert level or rule group.",
    "tier": 0,
    "modules": [
        "active_response"
    ],
    "components": [
        "agent"
    ],
    "path": "tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py",
    "daemons": [
        "wazuh-analysisd",
        "wazuh-authd",
        "wazuh-execd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response"
    ],
    "name": "test_execd_firewall_drop.py",
    "id": 3,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if `firewall-drop` command of `active response` is executed correctly. For this purpose, a simulated agent is used and the active response is sent to it. This response includes an IP address that must be added and removed from iptables, the Linux firewall.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "set_debug_mode": {
                        "type": "fixture",
                        "brief": "Set the `wazuh-execd` daemon in debug mode."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "test_version": {
                        "type": "fixture",
                        "brief": "Validate the Wazuh version."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "remove_ip_from_iptables": {
                        "type": "fixture",
                        "brief": "Remove the testing IP address from `iptables` if it exists."
                    }
                },
                {
                    "start_agent": {
                        "type": "fixture",
                        "brief": "Create `wazuh-remoted` and `wazuh-authd` simulators, register agent and start it."
                    }
                },
                {
                    "set_ar_conf_mode": {
                        "type": "fixture",
                        "brief": "Configure the active responses used in the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the testing IP address is added to `iptables`.",
                "Verify that the testing IP address is removed from `iptables`."
            ],
            "input_description": "Different use cases are found in the test module and include parameters for `firewall-drop` command and the expected result.",
            "expected_output": [
                {
                    "r'DEBUG": "Received message'"
                },
                "r'Starting'",
                "r'active-response/bin/firewall-drop'",
                "r'Ended'",
                "r'Cannot read 'srcip' from data' (If the `active response` fails)"
            ],
            "tags": [
                "simulator"
            ],
            "name": "test_execd_firewall_drop",
            "inputs": [
                "get_configuration0",
                "get_configuration1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_execd_firewall_drop.yaml</summary>
<p>

```yaml
brief: These tests will check if the active responses, which are executed by the `wazuh-execd`
  daemon via scripts, run correctly. Active responses execute a script in response
  to the triggering of specific alerts based on the alert level or rule group.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-authd
- wazuh-execd
- wazuh-remoted
group_id: 0
id: 3
modules:
- active_response
name: test_execd_firewall_drop.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
path: tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response
tests:
- assertions:
  - Verify that the testing IP address is added to `iptables`.
  - Verify that the testing IP address is removed from `iptables`.
  description: Check if `firewall-drop` command of `active response` is executed correctly.
    For this purpose, a simulated agent is used and the active response is sent to
    it. This response includes an IP address that must be added and removed from iptables,
    the Linux firewall.
  expected_output:
  - r'DEBUG: Received message'
  - r'Starting'
  - r'active-response/bin/firewall-drop'
  - r'Ended'
  - r'Cannot read 'srcip' from data' (If the `active response` fails)
  input_description: Different use cases are found in the test module and include
    parameters for `firewall-drop` command and the expected result.
  inputs:
  - get_configuration0
  - get_configuration1
  name: test_execd_firewall_drop
  parameters:
  - set_debug_mode:
      brief: Set the `wazuh-execd` daemon in debug mode.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - test_version:
      brief: Validate the Wazuh version.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - remove_ip_from_iptables:
      brief: Remove the testing IP address from `iptables` if it exists.
      type: fixture
  - start_agent:
      brief: Create `wazuh-remoted` and `wazuh-authd` simulators, register agent and
        start it.
      type: fixture
  - set_ar_conf_mode:
      brief: Configure the active responses used in the test.
      type: fixture
  tags:
  - simulator
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_execd_restart.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the active responses, which are executed by the `wazuh-execd` daemon via scripts, run correctly. Active responses execute a script in response to the triggering of specific alerts based on the alert level or rule group.",
    "tier": 0,
    "modules": [
        "active_response"
    ],
    "components": [
        "agent"
    ],
    "path": "tests/integration/test_active_response/test_execd/test_execd_restart.py",
    "daemons": [
        "wazuh-analysisd",
        "wazuh-authd",
        "wazuh-execd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response"
    ],
    "name": "test_execd_restart.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if `restart-wazuh` command of `active response` is executed correctly. For this purpose, a simulated agent is used, to which the active response is sent. This response includes the order to restart the Wazuh agent, which must restart after receiving this response.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "set_debug_mode": {
                        "type": "fixture",
                        "brief": "Set execd daemon in debug mode."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "test_version": {
                        "type": "fixture",
                        "brief": "Validate Wazuh version."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "start_agent": {
                        "type": "fixture",
                        "brief": "Create Remoted and Authd simulators, register agent and start it."
                    }
                },
                {
                    "set_ar_conf_mode": {
                        "type": "fixture",
                        "brief": "Configure Active Responses used in tests."
                    }
                }
            ],
            "assertions": [
                "Check that the active response `restart-wazuh` is received.",
                "Check that the agent is ready to restart."
            ],
            "input_description": "Different use cases are found in the test module and include parameters for `restart-wazuh` command and the expected result.",
            "expected_output": [
                {
                    "r'DEBUG": "Received message'"
                },
                "r'Shutdown received. Deleting responses.'",
                "r'Starting'",
                "r'active-response/bin/restart-wazuh'",
                "r'Ended'",
                "r'Invalid input format' (If the `active response` fails)"
            ],
            "tags": [
                "simulator"
            ],
            "name": "test_execd_restart",
            "inputs": [
                "get_configuration0",
                "get_configuration1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_execd_restart.yaml</summary>
<p>

```yaml
brief: These tests will check if the active responses, which are executed by the `wazuh-execd`
  daemon via scripts, run correctly. Active responses execute a script in response
  to the triggering of specific alerts based on the alert level or rule group.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-authd
- wazuh-execd
- wazuh-remoted
group_id: 0
id: 2
modules:
- active_response
name: test_execd_restart.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
path: tests/integration/test_active_response/test_execd/test_execd_restart.py
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/active-response/#active-response
tests:
- assertions:
  - Check that the active response `restart-wazuh` is received.
  - Check that the agent is ready to restart.
  description: Check if `restart-wazuh` command of `active response` is executed correctly.
    For this purpose, a simulated agent is used, to which the active response is sent.
    This response includes the order to restart the Wazuh agent, which must restart
    after receiving this response.
  expected_output:
  - r'DEBUG: Received message'
  - r'Shutdown received. Deleting responses.'
  - r'Starting'
  - r'active-response/bin/restart-wazuh'
  - r'Ended'
  - r'Invalid input format' (If the `active response` fails)
  input_description: Different use cases are found in the test module and include
    parameters for `restart-wazuh` command and the expected result.
  inputs:
  - get_configuration0
  - get_configuration1
  name: test_execd_restart
  parameters:
  - set_debug_mode:
      brief: Set execd daemon in debug mode.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - test_version:
      brief: Validate Wazuh version.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - start_agent:
      brief: Create Remoted and Authd simulators, register agent and start it.
      type: fixture
  - set_ar_conf_mode:
      brief: Configure Active Responses used in tests.
      type: fixture
  tags:
  - simulator
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`