### PR TITLE
Migrate `test_agentd` documentation to `qa-docs`

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -3,10 +3,10 @@ Project path: "../../tests/integration"
 Output path: "../output"
 
 Include paths:
-  - "../../tests/integration/test_active_response"
-#  - "../../tests/integration/test_agentd"
+#  - "../../tests/integration/test_active_response"
+  - "../../tests/integration/test_agentd"
 #  - "../../tests/integration/test_analysisd"
-  - "../../tests/integration/test_api"
+#  - "../../tests/integration/test_api"
 
 Include regex:
   - "^test_.*py$"
@@ -51,7 +51,6 @@ Output fields:
       - tier
       - modules
       - components
-      - path
       - daemons
       - os_platform
       - os_version

--- a/tests/integration/test_agentd/test_agent_auth_enrollment.py
+++ b/tests/integration/test_agentd/test_agent_auth_enrollment.py
@@ -1,56 +1,59 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    These tests will verify different situations that may occur at `agent-auth` during enrollment.
-    The objective is to check if the parameters sent by the `agent-auth` to the `wazuh-authd` daemon
-    are consistent with its responses.
+brief: These tests will verify different situations that may occur at `agent-auth` program during enrollment.
+       The objective is to check if the parameters sent by the `agent-auth` program to the `wazuh-authd` daemon
+       are consistent with its responses.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
+modules:
+    - agentd
 
-path:
-    tests/integration/test_agentd/
+components:
+    - agent
 
 daemons:
-    - agentd
-    - authd
+    - wazuh-agentd
+    - wazuh-authd
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
+    - windows
 
-coverage:
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
-pytest_args:
+references:
+    - https://documentation.wazuh.com/current/user-manual/registering/index.html
 
 tags:
     - enrollment
@@ -121,41 +124,37 @@ def configure_authd_server(request):
 @pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_auth_enrollment(configure_authd_server, configure_environment, test_case: list):
     '''
-    description:
-        Test different situations that can occur on the `agent-auth` program during agent enrollment.
+    description: Check different situations that can occur during agent enrollment.
+                 The tests are based on using certain parameters to enroll
+                 the agent with the manager. The enrollment is then started,
+                 and the response received is compared with the expected one.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
             brief: Initializes a simulated authd connection.
-
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - test_case:
             type: list
             brief: List of tests to be performed.
 
     assertions:
-        - Check that the responses received are consistent with the parameters sent.
+        - Verify that expected enrollment request message occurs.
 
-    test_input:
-        The tests are based on using certain parameters to enroll the agent with the manager.
-        The enrollment is then started, and the response received is compared with
-        the expected one. Both parameters and responses are found in a YAML file.
+    input_description: Different test cases are contained in an external `YAML` file (wazuh_enrollment_tests.yaml)
+                       which includes enrollment parameters.
 
-    logging:
-        - ossec.log:
-            - r"Multiple values located in the wazuh_enrollment_tests.yaml file."
+    expected_output:
+        - Multiple messages corresponding to each test case, located in the external input data file.
 
     tags:
-        - enrollment
         - simulator
         - ssl
+        - keys
     '''
     print(f'Test: {test_case["name"]}')
     if 'agent-auth' in test_case.get("skips", []):

--- a/tests/integration/test_agentd/test_agent_auth_enrollment.py
+++ b/tests/integration/test_agentd/test_agent_auth_enrollment.py
@@ -22,6 +22,7 @@ components:
 daemons:
     - wazuh-agentd
     - wazuh-authd
+    - wazuh-remoted
 
 os_platform:
     - linux
@@ -134,7 +135,7 @@ def test_agent_auth_enrollment(configure_authd_server, configure_environment, te
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -1,56 +1,59 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    These tests will verify different situations that may occur at `wazuh-agentd` during enrollment.
-    The objective is to check the enrollment of the agent using certain settings
-    in the configuration file produces the expected responses from the server.
+brief: These tests will verify different situations that may occur at `wazuh-agentd` daemon
+       during enrollment. The objective is to check if the enrollment of the agent using
+       certain settings in the configuration file produces the expected responses from the server.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
+modules:
+    - agentd
 
-path:
-    tests/integration/test_agentd/
+components:
+    - agent
 
 daemons:
-    - agentd
-    - authd
+    - wazuh-agentd
+    - wazuh-authd
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
+    - windows
 
-coverage:
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
-pytest_args:
+references:
+    - https://documentation.wazuh.com/current/user-manual/registering/index.html
 
 tags:
     - enrollment
@@ -265,40 +268,37 @@ def check_log_error_conf(msg):
 @pytest.mark.parametrize('test_case', tests, ids=[case['description'] for case in tests])
 def test_agent_agentd_enrollment(configure_authd_server, configure_environment, test_case: list):
     '''
-    description:
-        Test different situations that can occur on the `wazuh-agentd` daemon during agent enrollment.
+    description: Check different situations that can occur on the `wazuh-agentd` daemon
+                 during agent enrollment. The tests are based on using specific configurations
+                 for the agent, initiate the agent enrollment with the manager, and finally,
+                 verify that the response received matches the expected one.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
             brief: Initializes a simulated authd connection.
-
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - test_case:
             type: list
             brief: List of tests to be performed.
 
     assertions:
-        - Check that the responses received are consistent with the parameters sent.
+        - Verify that expected enrollment request message occurs.
 
-    test_input:
-        The tests are based on using specific configurations for the agent, initiate the agent enrollment
-        with the manager, and finally, verify that the response received matches the expected one.
-        Both configurations and responses are found in a YAML file.
+    input_description: Different test cases are contained in an external `YAML` file (wazuh_enrollment_tests.yaml)
+                       which includes enrollment parameters.
 
-    logging:
-        - ossec.log:
-            - r"Multiple values located in the wazuh_enrollment_tests.yaml file."
+    expected_output:
+        - Multiple messages corresponding to each test case, located in the external input data file.
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     global remoted_server
     print(f'Test: {test_case["name"]}')

--- a/tests/integration/test_agentd/test_agentd_enrollment_params.py
+++ b/tests/integration/test_agentd/test_agentd_enrollment_params.py
@@ -22,6 +22,7 @@ components:
 daemons:
     - wazuh-agentd
     - wazuh-authd
+    - wazuh-remoted
 
 os_platform:
     - linux
@@ -278,7 +279,7 @@ def test_agent_agentd_enrollment(configure_authd_server, configure_environment, 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -1,55 +1,59 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    These tests will check the agent's enrollment and connection to a manager in a multi-server environment.
-    The objective is to check how the agent manages the connections to the servers depending on their status.
+brief: These tests will check the agent's enrollment and connection to a manager in a multi-server environment.
+       The objective is to check how the agent manages the connections to the servers depending on their status.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
+modules:
+    - agentd
 
-path:
-    tests/integration/test_agentd/
+components:
+    - agent
 
 daemons:
-    - agentd
-    - authd
+    - wazuh-agentd
+    - wazuh-authd
+    - wazuh-remoted
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
+    - windows
 
-coverage:
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
-pytest_args:
+references:
+    - https://documentation.wazuh.com/current/user-manual/registering/index.html
 
 tags:
     - enrollment
@@ -394,75 +398,65 @@ def wait_until(x, log_str):
 def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id, clean_keys, configure_environment,
                              get_configuration):
     '''
-    description:
-        Check the agent's enrollment and connection to a manager in a multi-server environment.
-        Initialize an environment with multiple simulated servers in which the agent is forced to enroll
-        under different test conditions, verifying the agent's behavior through its log files.
+    description: Check the agent's enrollment and connection to a manager in a multi-server environment.
+                 Initialize an environment with multiple simulated servers in which the agent is forced to enroll
+                 under different test conditions, verifying the agent's behavior through its log files.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - add_hostnames:
             type: fixture
-            brief: Adds to the OS hosts file the names and IP's of the test servers.
-
+            brief: Adds to the `hosts` file the names and the IP addresses of the testing servers.
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - set_authd_id:
             type: fixture
-            brief: Sets the agent id to 101 in authd simulated connection.
-
+            brief: Sets the agent id to `101` in the `wazuh-authd` simulated connection.
         - clean_keys:
             type: fixture
-            brief: Clears the client.key file used by the simulated remote connections.
-
+            brief: Clears the `client.keys` file used by the simulated remote connections.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
 
     assertions:
-        - Agent without keys. All servers will refuse the connection to remoted but will accept enrollment.
-          The agent should try to connect and enroll to each of them.
-
-        - Agent without keys. The first server only has enrollment available, and the third server only
-          has remoted available. The agent should enroll in the first server and connect to the third one.
-
-        - Agent without keys. The agent should enroll and connect to the first server, and then the first server
-          will disconnect, agent should connect to the second server with the same key.
-
-        - Agent without keys. The agent should enroll and connect to the first server, and then the first server
-          will disconnect, agent should try to enroll to the first server again,
+        - Agent without keys. Verify that all servers will refuse the connection to the `wazuh-remoted` daemon
+          but will accept enrollment. The agent should try to connect and enroll each of them.
+        - Agent without keys. Verify that the first server only has enrollment available, and the third server
+          only has the `wazuh-remoted` daemon available. The agent should enroll in the first server and
+          connect to the third one.
+        - Agent without keys. Verify that the agent should enroll and connect to the first server, and then
+          the first server will disconnect. The agent should connect to the second server with the same key.
+        - Agent without keys. Verify that the agent should enroll and connect to the first server, and then
+          the first server will disconnect. The agent should try to enroll in the first server again,
           and then after failure, move to the second server and connect.
+        - Agent with keys. Verify that the agent should enroll and connect to the last server.
+        - Agent with keys. Verify that the first server is available, but it disconnects, and the second and
+          third servers are not responding. The agent on disconnection should try the second and third servers
+          and go back finally to the first server.
 
-        - Agent with keys. The agent should enroll and connect to the last server.
+    input_description: Different test cases are found in the test module and include
+                       parameters for the environment setup, the requests
+                       to be made, and the expected result.
 
-        - Agent with keys. The first server is available, but it disconnects, the second and third servers
-          are not responding. The agent on disconnection, should try the second and
-          third servers and go back finally to the first server.
-
-    test_input:
-        Several settings are used for the servers and the requests to be made along with the expected responses.
-
-    logging:
-        - ossec.log:
-            - r"Requesting a key from server"
-            - r"Valid key received"
-            - r"Trying to connect to server"
-            - r"Connected to the server"
-            - r"Received message"
-            - r"Server responded. Releasing lock."
-            - r"Unable to connect to"
+    expected_output:
+        - r'Requesting a key from server'
+        - r'Valid key received'
+        - r'Trying to connect to server'
+        - r'Connected to the server'
+        - r'Received message'
+        - r'Server responded. Releasing lock.'
+        - r'Unable to connect to'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     log_monitor = FileMonitor(LOG_FILE_PATH)
 

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections.py
@@ -1,57 +1,61 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    These tests will check that the connection is finally made when
-    there are delays between connection attempts to the server.
-    The objective is to check how `wazuh-agentd` behaves when there are delays between connection attempts
-    to `wazuh-remoted` using `TCP` and `UDP` protocols.
+brief: These tests will check that the connection is finally made when there are delays
+       between connection attempts to the server. The objective is to check how
+       the `wazuh-agentd` daemon behaves when there are delays between connection
+       attempts to `wazuh-remoted` using `TCP` and `UDP` protocols.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
+modules:
+    - agentd
 
-path:
-    tests/integration/test_agentd/
+components:
+    - agent
 
 daemons:
-    - agentd
-    - remoted
+    - wazuh-agentd
+    - wazuh-authd
+    - wazuh-remoted
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
+    - windows
 
-coverage:
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
-pytest_args:
+references:
+    - https://documentation.wazuh.com/current/user-manual/registering/index.html
 
 tags:
     - enrollment
@@ -311,55 +315,50 @@ This test covers different options of delays between server connection attempts:
 def test_agentd_parametrized_reconnections(configure_authd_server, start_authd, stop_agent, set_keys,
                                            configure_environment, get_configuration):
     '''
-    description:
-        Check how the agent behaves when there are delays between connection attempts to the server.
-        For this purpose, different values for `max_retries` and `retry_interval` parameters are tested.
+    description: Check how the agent behaves when there are delays between connection
+                 attempts to the server. For this purpose, different values for
+                 `max_retries` and `retry_interval` parameters are tested.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - start_authd:
             type: fixture
-            brief: Enable authd to accept connections and perform enrollments.
-
+            brief: Enable the `wazuh-authd` daemon to accept connections and perform enrollments.
         - stop_agent:
             type: fixture
             brief: Stop Wazuh's agent.
-
         - set_keys:
             type: fixture
-            brief: Write to client.keys file the agent's enrollment details.
-
+            brief: Write to `client.keys` file the agent's enrollment details.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
 
     assertions:
-        - Check for unsuccessful connection retries in agentd initialization.
-        - If auto enrollment is enabled, verify successfully enrollment.
-        - Check the server rollback feature.
+        - Verify that when the `wazuh-agentd` daemon initializes, it connects to
+          the `wazuh-remoted` daemon of the manager before reaching the maximum number of attempts.
+        - Verify the successful enrollment of the agent if the auto-enrollment option is enabled.
+        - Verify that the rollback feature of the server works correctly.
 
-    test_input:
-        Different parameters are used for the server using the `TCP` and `UDP` protocols.
+    input_description: Different test cases are found in the test module and include parameters
+                       for the environment setup using the `TCP` and `UDP` protocols.
 
-    logging:
-        - ossec.log:
-            - r"Valid key received"
-            - r"Trying to connect to server"
-            - r"Unable to connect to any server"
+    expected_output:
+        - r'Valid key received'
+        - r'Trying to connect to server'
+        - r'Unable to connect to any server'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     DELTA = 1
     RECV_TIMEOUT = 5

--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -1,57 +1,61 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    These tests will check if, during enrollment, the agent re-establishes communication with the manager
-    under different situations that interrupt it.
-    The objective is to check that, with different states in the `clients.key` file, the agent
-    successfully enrolls after losing connection with remoted.
+brief: These tests will check if, during enrollment, the agent re-establishes communication
+       with the manager under different situations that interrupt it. The objective is
+       to check that, with different states in the `clients.keys` file, the agent
+       successfully enrolls after losing connection with the `wazuh-remoted` daemon.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
+modules:
+    - agentd
 
-path:
-    tests/integration/test_agentd/
+components:
+    - agent
 
 daemons:
-    - agentd
-    - remoted
+    - wazuh-agentd
+    - wazuh-authd
+    - wazuh-remoted
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
+    - windows
 
-coverage:
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
-pytest_args:
+references:
+    - https://documentation.wazuh.com/current/user-manual/registering/index.html
 
 tags:
     - enrollment
@@ -236,22 +240,20 @@ when misses communication with Remoted and a new enrollment is sent to Authd.
 
 def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configure_environment, get_configuration):
     '''
-    description:
-        Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
-        In this case, the agent starts with keys.
+    description: Check how the agent behaves when losing communication with
+                 the `wazuh-remoted` daemon and a new enrollment is sent to
+                 the `wazuh-authd` daemon.
+                 In this case, the agent starts with keys.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
@@ -259,17 +261,17 @@ def test_agentd_reconection_enrollment_with_keys(configure_authd_server, configu
     assertions:
         - Verify that the agent enrollment is successful.
 
-    test_input:
-        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+    input_description: Two test cases are found in the test module and include parameters
+                       for the environment setup using the `TCP` and `UDP` protocols.
 
-    logging:
-        - ossec.log:
-            - r"Valid key received"
-            - r"Sending keep alive"
+    expected_output:
+        - r'Valid key received'
+        - r'Sending keep alive'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     global remoted_server
 
@@ -320,22 +322,20 @@ and an enrollment is sent to Authd to start communicating with Remoted
 
 def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, configure_environment, get_configuration):
     '''
-    description:
-        Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
-        In this case, the agent doesn't have client.keys file.
+    description: Check how the agent behaves when losing communication with
+                 the `wazuh-remoted` daemon and a new enrollment is sent to
+                 the `wazuh-authd` daemon.
+                 In this case, the agent doesn't have the `client.keys` file.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
@@ -343,17 +343,17 @@ def test_agentd_reconection_enrollment_no_keys_file(configure_authd_server, conf
     assertions:
         - Verify that the agent enrollment is successful.
 
-    test_input:
-        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+    input_description: Two test cases are found in the test module and include parameters
+                       for the environment setup using the `TCP` and `UDP` protocols.
 
-    logging:
-        - ossec.log:
-            - r"Valid key received"
-            - r"Sending keep alive"
+    expected_output:
+        - r'Valid key received'
+        - r'Sending keep alive'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     global remoted_server
 
@@ -407,22 +407,20 @@ and an enrollment is sent to Authd to start communicating with Remoted
 
 def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure_environment, get_configuration):
     '''
-    description:
-        Check how the agent behaves when losing communication with remoted and a new enrollment is sent to authd.
-        In this case, the agent has its client.keys file empty.
+    description: Check how the agent behaves when losing communication with
+                 the `wazuh-remoted` daemon and a new enrollment is sent to
+                 the `wazuh-authd` daemon.
+                 In this case, the agent has its `client.keys` file empty.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
@@ -430,17 +428,17 @@ def test_agentd_reconection_enrollment_no_keys(configure_authd_server, configure
     assertions:
         - Verify that the agent enrollment is successful.
 
-    test_input:
-        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+    input_description: Two test cases are found in the test module and include parameters
+                       for the environment setup using the `TCP` and `UDP` protocols.
 
-    logging:
-        - ossec.log:
-            - r"Valid key received"
-            - r"Sending keep alive"
+    expected_output:
+        - r'Valid key received'
+        - r'Sending keep alive'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     global remoted_server
 
@@ -495,23 +493,20 @@ and multiple retries are required until the new key is obtained to start communi
 
 def test_agentd_initial_enrollment_retries(configure_authd_server, configure_environment, get_configuration):
     '''
-    description:
-        Check how the agent behaves when it makes multiple enrollment attempts before getting its key.
-        For this, the agent starts without keys and perform multiple enrollment requests
-        to authd before getting the new key to communicate with remoted.
+    description: Check how the agent behaves when it makes multiple enrollment attempts
+                 before getting its key. For this, the agent starts without keys and
+                 performs multiple enrollment requests to the `wazuh-authd` daemon before
+                 getting the new key to communicate with the `wazuh-remoted` daemon.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
@@ -519,18 +514,18 @@ def test_agentd_initial_enrollment_retries(configure_authd_server, configure_env
     assertions:
         - Verify that the agent enrollment is successful.
 
-    test_input:
-        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+    input_description: Two test cases are found in the test module and include parameters
+                       for the environment setup using the `TCP` and `UDP` protocols.
 
-    logging:
-        - ossec.log:
-            - r"Requesting a key"
-            - r"Valid key received"
-            - r"Sending keep alive"
+    expected_output:
+        - r'Requesting a key'
+        - r'Valid key received'
+        - r'Sending keep alive'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     global remoted_server
 
@@ -589,23 +584,20 @@ and multiple connection retries are required prior to requesting a new enrollmen
 
 def test_agentd_connection_retries_pre_enrollment(configure_authd_server, configure_environment, get_configuration):
     '''
-    description:
-        Check how the agent behaves when Remoted is not available and performs multiple connection attempts to it.
-        For this, the agent starts with keys but `remoted` is not available for several seconds,
-        then the agent performs multiple connection retries before requesting a new enrollment.
+    description: Check how the agent behaves when the `wazuh-remoted` daemon is not available
+                 and performs multiple connection attempts to it. For this, the agent starts
+                 with keys but the `wazuh-remoted` daemon is not available for several seconds,
+                 then the agent performs multiple connection retries before requesting a new enrollment.
 
-    wazuh_min_version:
-        4.1
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_authd_server:
             type: fixture
-            brief: Initializes a simulated authd connection.
-
+            brief: Initializes a simulated `wazuh-authd` connection.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
@@ -613,16 +605,16 @@ def test_agentd_connection_retries_pre_enrollment(configure_authd_server, config
     assertions:
         - Verify that the agent enrollment is successful.
 
-    test_input:
-        An IP address and port are used for the server using the `TCP` and `UDP` protocols.
+    input_description: Two test cases are found in the test module and include parameters
+                       for the environment setup using the `TCP` and `UDP` protocols.
 
-    logging:
-        - ossec.log:
-            - r"Sending keep alive"
+    expected_output:
+        - r'Sending keep alive'
 
     tags:
-        - enrollment
         - simulator
+        - ssl
+        - keys
     '''
     global remoted_server
     REMOTED_KEYS_SYNC_TIME = 10

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -1,55 +1,58 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    The statistics files are documents that show real-time information about the Wazuh environment.
-    These tests will check if the content of the `wazuh-agentd` statistics file is valid.
+brief: These tests will check if the content of the `wazuh-agentd` daemon statistics file is valid.
+       The statistics files are documents that show real-time information about the Wazuh environment.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
+modules:
+    - agentd
 
-path:
-    tests/integration/test_agentd/
+components:
+    - agent
 
 daemons:
-    - agentd
-    - remoted
+    - wazuh-agentd
+    - wazuh-remoted
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+os_platform:
+    - linux
+    - windows
 
-coverage:
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
-pytest_args:
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/statistics-files/wazuh-agentd-state.html
 
 tags:
     - stats_file
@@ -132,37 +135,31 @@ def add_custom_key():
                          ids=[test_case['name'] for test_case in test_cases])
 def test_agentd_state(configure_environment, test_case: list):
     '''
-    description:
-        Check that the statistics file `wazuh-agentd.state` is created automatically
-        and verify that the content of its fields is correct.
+    description: Check that the statistics file `wazuh-agentd.state` is created automatically
+                 and verify that the content of its fields is correct.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - test_case:
             type: list
             brief: List of tests to be performed.
 
     assertions:
-        - Verify the creation of the statistics file.
-        - Check that the fields in the statistics file are consistent with the connection to remoted.
+        - Verify that the `wazuh-agentd.state` statistics file has been created.
+        - Verify that the information stored in the `wazuh-agentd.state` statistics file
+          is consistent with the connection status to the `wazuh-remoted` daemon.
 
-    test_input:
-        Different use cases that are contained in an external `YAML` file
-        that includes the parameters and expected responses.
+    input_description: Different test cases that are contained in an external
+                       `YAML` file (wazuh_state_tests.yaml) that includes
+                       the parameters and their expected responses.
 
-    logging:
-        - ossec.log:
-            - r"pending"
-            - r"connected"
-
-    tags:
-        - simulator
+    expected_output:
+        - r'pending'
+        - r'connected'
     '''
     global remoted_server
     if remoted_server is not None:

--- a/tests/integration/test_agentd/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config.py
@@ -1,55 +1,58 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-description:
-    The statistics files are documents that show real-time information about the Wazuh environment.
-    These tests will check if the configuration options related to the `wazuh-agentd`
-    statistics file are working properly.
+brief: These tests will check if the configuration options related to the `wazuh-agentd` daemon
+       statistics file are working properly. The statistics files are documents that
+       show real-time information about the Wazuh environment.
 
-tiers:
-    - 0
+tier: 0
 
-component:
-    agent
-
-path:
-    tests/integration/test_agentd/
-
-daemons:
+modules:
     - agentd
 
-os_support:
-    - linux, rhel5
-    - linux, rhel6
-    - linux, rhel7
-    - linux, rhel8
-    - linux, amazon linux 1
-    - linux, amazon linux 2
-    - linux, debian buster
-    - linux, debian stretch
-    - linux, debian wheezy
-    - linux, ubuntu bionic
-    - linux, ubuntu xenial
-    - linux, ubuntu trusty
-    - linux, arch linux
-    - windows, 7
-    - windows, 8
-    - windows, 10
-    - windows, server 2003
-    - windows, server 2012
-    - windows, server 2016
+components:
+    - agent
 
-coverage:
+daemons:
+    - wazuh-agentd
 
-pytest_args:
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/statistics-files/wazuh-agentd-state.html
 
 tags:
     - stats_file
@@ -126,39 +129,32 @@ def get_configuration(request):
                          ids=[test_case['name'] for test_case in test_cases])
 def test_agentd_state_config(configure_environment, test_case: list):
     '''
-    description:
-        Check that the statistics file `wazuh-agentd.state` is created automatically
-        and verify that the update intervals work properly.
+    description: Check that the `wazuh-agentd.state` statistics file is created
+                 automatically and verify that it is updated at the set intervals.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-
         - test_case:
             type: list
             brief: List of tests to be performed.
 
     assertions:
-        - Verify the creation of the statistics file.
-        - Check update intervals of the statistics file.
+        - Verify that the `wazuh-agentd.state` statistics file has been created.
+        - Verify that the `wazuh-agentd.state` statistics file is updated at the specified intervals.
 
-    test_input:
-        Different use cases that are contained in an external `YAML` file
-        that includes the parameters and expected responses.
+    input_description: Different test cases that are contained in an external
+                       `YAML` file (wazuh_state_config_tests.yaml) that includes
+                       the parameters and their expected responses.
 
-    logging:
-        - ossec.log:
-            - r"interval_not_found"
-            - r"interval_not_valid"
-            - r"file_enabled"
-            - r"file_not_enabled"
-
-    tags:
-
+    expected_output:
+        - r'interval_not_found'
+        - r'interval_not_valid'
+        - r'file_enabled'
+        - r'file_not_enabled'
     '''
     control_service('stop', 'wazuh-agentd')
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1868|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation

<details><summary>test_agent_auth_enrollment.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will verify different situations that may occur at `agent-auth` program during enrollment. The objective is to check if the parameters sent by the `agent-auth` program to the `wazuh-authd` daemon are consistent with its responses.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-authd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/registering/index.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_agent_auth_enrollment.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check different situations that can occur during agent enrollment. The tests are based on using certain parameters to enroll the agent with the manager. The enrollment is then started, and the response received is compared with the expected one.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of tests to be performed."
                    }
                }
            ],
            "assertions": [
                "Verify that expected enrollment request message occurs."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (wazuh_enrollment_tests.yaml) which includes enrollment parameters.",
            "expected_output": [
                "Multiple messages corresponding to each test case, located in the external input data file."
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agent_auth_enrollment",
            "inputs": [
                "-No agent name in auto enrollment configuration",
                "-Check a valid agent_address configurations",
                "-Check a valid agent_address configurations CIDR",
                "-Check a invalid CIDR agent_address in auto enrollment configuration",
                "-Check a invalid agent_address in auto enrollment configuration",
                "-Check a valid manager_address configurations",
                "-Agent groups in auto enrollment configuration",
                "-Agent multi groups in auto enrollment configuration",
                "-Check a invalid enabled in auto enrollment configuration",
                "-Check a valid agent_name configurations",
                "-Check a valid agent_name configurations max length",
                "-Check a invalid agent_name configurations",
                "-Check a invalid agent_name configurations too short",
                "-Check a invalid agent_name configurations too long",
                "-Try auto negotiation option using TLSv1_1",
                "-Try auto negotiation option using TLSv1_2",
                "-Try TLSv1_1 without auto_negotiation",
                "-Try connecting with Compatible ciphers",
                "-Try connecting with Incompatible ciphers",
                "-Try validating server with a valid certificate",
                "-Try validating server with an invalid certificate",
                "-Try validating agent with an invalid certificate0",
                "-Try validating agent with an invalid certificate1",
                "-Check that source IP is sent by agent",
                "-Use source IP option while trying to set an IP",
                "-Check that configured password is sent on string",
                "-Check that password file is open and read successfully0",
                "-Check that password file is open and read successfully1",
                "-Check a valid port configurations",
                "-Check a invalid port configurations 65536",
                "-Check a invalid port configurations 0",
                "-Check a invalid port configurations -1515",
                "-Check a valid delay_after_enrollment configurations 10",
                "-Check a invalid delay_after_enrollment configurations -30",
                "-Check enrollment with all parameters configurations"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agent_auth_enrollment.yaml</summary>
<p>

```yaml
brief: These tests will verify different situations that may occur at `agent-auth`
  program during enrollment. The objective is to check if the parameters sent by the
  `agent-auth` program to the `wazuh-authd` daemon are consistent with its responses.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-authd
- wazuh-remoted
group_id: 0
id: 1
modules:
- agentd
name: test_agent_auth_enrollment.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/registering/index.html
tags:
- enrollment
tests:
- assertions:
  - Verify that expected enrollment request message occurs.
  description: Check different situations that can occur during agent enrollment.
    The tests are based on using certain parameters to enroll the agent with the manager.
    The enrollment is then started, and the response received is compared with the
    expected one.
  expected_output:
  - Multiple messages corresponding to each test case, located in the external input
    data file.
  input_description: Different test cases are contained in an external `YAML` file
    (wazuh_enrollment_tests.yaml) which includes enrollment parameters.
  inputs:
  - -No agent name in auto enrollment configuration
  - -Check a valid agent_address configurations
  - -Check a valid agent_address configurations CIDR
  - -Check a invalid CIDR agent_address in auto enrollment configuration
  - -Check a invalid agent_address in auto enrollment configuration
  - -Check a valid manager_address configurations
  - -Agent groups in auto enrollment configuration
  - -Agent multi groups in auto enrollment configuration
  - -Check a invalid enabled in auto enrollment configuration
  - -Check a valid agent_name configurations
  - -Check a valid agent_name configurations max length
  - -Check a invalid agent_name configurations
  - -Check a invalid agent_name configurations too short
  - -Check a invalid agent_name configurations too long
  - -Try auto negotiation option using TLSv1_1
  - -Try auto negotiation option using TLSv1_2
  - -Try TLSv1_1 without auto_negotiation
  - -Try connecting with Compatible ciphers
  - -Try connecting with Incompatible ciphers
  - -Try validating server with a valid certificate
  - -Try validating server with an invalid certificate
  - -Try validating agent with an invalid certificate0
  - -Try validating agent with an invalid certificate1
  - -Check that source IP is sent by agent
  - -Use source IP option while trying to set an IP
  - -Check that configured password is sent on string
  - -Check that password file is open and read successfully0
  - -Check that password file is open and read successfully1
  - -Check a valid port configurations
  - -Check a invalid port configurations 65536
  - -Check a invalid port configurations 0
  - -Check a invalid port configurations -1515
  - -Check a valid delay_after_enrollment configurations 10
  - -Check a invalid delay_after_enrollment configurations -30
  - -Check enrollment with all parameters configurations
  name: test_agent_auth_enrollment
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_agentd_enrollment_params.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will verify different situations that may occur at `wazuh-agentd` daemon during enrollment. The objective is to check if the enrollment of the agent using certain settings in the configuration file produces the expected responses from the server.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-authd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/registering/index.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_agentd_enrollment_params.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check different situations that can occur on the `wazuh-agentd` daemon during agent enrollment. The tests are based on using specific configurations for the agent, initiate the agent enrollment with the manager, and finally, verify that the response received matches the expected one.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of tests to be performed."
                    }
                }
            ],
            "assertions": [
                "Verify that expected enrollment request message occurs."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (wazuh_enrollment_tests.yaml) which includes enrollment parameters.",
            "expected_output": [
                "Multiple messages corresponding to each test case, located in the external input data file."
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agent_agentd_enrollment",
            "inputs": [
                "-No agent name in auto enrollment configuration",
                "-Check a valid agent_address configurations",
                "-Check a valid agent_address configurations CIDR",
                "-Check a invalid CIDR agent_address in auto enrollment configuration",
                "-Check a invalid agent_address in auto enrollment configuration",
                "-Check a valid manager_address configurations",
                "-Agent groups in auto enrollment configuration",
                "-Agent multi groups in auto enrollment configuration",
                "-Check a invalid enabled in auto enrollment configuration",
                "-Check a valid agent_name configurations",
                "-Check a valid agent_name configurations max length",
                "-Check a invalid agent_name configurations",
                "-Check a invalid agent_name configurations too short",
                "-Check a invalid agent_name configurations too long",
                "-Try auto negotiation option using TLSv1_1",
                "-Try auto negotiation option using TLSv1_2",
                "-Try TLSv1_1 without auto_negotiation",
                "-Try connecting with Compatible ciphers",
                "-Try connecting with Incompatible ciphers",
                "-Try validating server with a valid certificate",
                "-Try validating server with an invalid certificate",
                "-Try validating agent with an invalid certificate0",
                "-Try validating agent with an invalid certificate1",
                "-Check that source IP is sent by agent",
                "-Use source IP option while trying to set an IP",
                "-Check that configured password is sent on string",
                "-Check that password file is open and read successfully0",
                "-Check that password file is open and read successfully1",
                "-Check a valid port configurations",
                "-Check a invalid port configurations 65536",
                "-Check a invalid port configurations 0",
                "-Check a invalid port configurations -1515",
                "-Check a valid delay_after_enrollment configurations 10",
                "-Check a invalid delay_after_enrollment configurations -30",
                "-Check enrollment with all parameters configurations"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agentd_enrollment_params.yaml</summary>
<p>

```yaml
brief: These tests will verify different situations that may occur at `wazuh-agentd`
  daemon during enrollment. The objective is to check if the enrollment of the agent
  using certain settings in the configuration file produces the expected responses
  from the server.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-authd
- wazuh-remoted
group_id: 0
id: 2
modules:
- agentd
name: test_agentd_enrollment_params.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/registering/index.html
tags:
- enrollment
tests:
- assertions:
  - Verify that expected enrollment request message occurs.
  description: Check different situations that can occur on the `wazuh-agentd` daemon
    during agent enrollment. The tests are based on using specific configurations
    for the agent, initiate the agent enrollment with the manager, and finally, verify
    that the response received matches the expected one.
  expected_output:
  - Multiple messages corresponding to each test case, located in the external input
    data file.
  input_description: Different test cases are contained in an external `YAML` file
    (wazuh_enrollment_tests.yaml) which includes enrollment parameters.
  inputs:
  - -No agent name in auto enrollment configuration
  - -Check a valid agent_address configurations
  - -Check a valid agent_address configurations CIDR
  - -Check a invalid CIDR agent_address in auto enrollment configuration
  - -Check a invalid agent_address in auto enrollment configuration
  - -Check a valid manager_address configurations
  - -Agent groups in auto enrollment configuration
  - -Agent multi groups in auto enrollment configuration
  - -Check a invalid enabled in auto enrollment configuration
  - -Check a valid agent_name configurations
  - -Check a valid agent_name configurations max length
  - -Check a invalid agent_name configurations
  - -Check a invalid agent_name configurations too short
  - -Check a invalid agent_name configurations too long
  - -Try auto negotiation option using TLSv1_1
  - -Try auto negotiation option using TLSv1_2
  - -Try TLSv1_1 without auto_negotiation
  - -Try connecting with Compatible ciphers
  - -Try connecting with Incompatible ciphers
  - -Try validating server with a valid certificate
  - -Try validating server with an invalid certificate
  - -Try validating agent with an invalid certificate0
  - -Try validating agent with an invalid certificate1
  - -Check that source IP is sent by agent
  - -Use source IP option while trying to set an IP
  - -Check that configured password is sent on string
  - -Check that password file is open and read successfully0
  - -Check that password file is open and read successfully1
  - -Check a valid port configurations
  - -Check a invalid port configurations 65536
  - -Check a invalid port configurations 0
  - -Check a invalid port configurations -1515
  - -Check a valid delay_after_enrollment configurations 10
  - -Check a invalid delay_after_enrollment configurations -30
  - -Check enrollment with all parameters configurations
  name: test_agent_agentd_enrollment
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_agentd_multi_server.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check the agent's enrollment and connection to a manager in a multi-server environment. The objective is to check how the agent manages the connections to the servers depending on their status.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-authd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/registering/index.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_agentd_multi_server.py",
    "id": 3,
    "group_id": 0,
    "tests": [
        {
            "description": "Check the agent's enrollment and connection to a manager in a multi-server environment. Initialize an environment with multiple simulated servers in which the agent is forced to enroll under different test conditions, verifying the agent's behavior through its log files.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "add_hostnames": {
                        "type": "fixture",
                        "brief": "Adds to the `hosts` file the names and the IP addresses of the testing servers."
                    }
                },
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "set_authd_id": {
                        "type": "fixture",
                        "brief": "Sets the agent id to `101` in the `wazuh-authd` simulated connection."
                    }
                },
                {
                    "clean_keys": {
                        "type": "fixture",
                        "brief": "Clears the `client.keys` file used by the simulated remote connections."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Agent without keys. Verify that all servers will refuse the connection to the `wazuh-remoted` daemon but will accept enrollment. The agent should try to connect and enroll each of them.",
                "Agent without keys. Verify that the first server only has enrollment available, and the third server only has the `wazuh-remoted` daemon available. The agent should enroll in the first server and connect to the third one.",
                "Agent without keys. Verify that the agent should enroll and connect to the first server, and then the first server will disconnect. The agent should connect to the second server with the same key.",
                "Agent without keys. Verify that the agent should enroll and connect to the first server, and then the first server will disconnect. The agent should try to enroll in the first server again, and then after failure, move to the second server and connect.",
                "Agent with keys. Verify that the agent should enroll and connect to the last server.",
                "Agent with keys. Verify that the first server is available, but it disconnects, and the second and third servers are not responding. The agent on disconnection should try the second and third servers and go back finally to the first server."
            ],
            "input_description": "Different test cases are found in the test module and include parameters for the environment setup, the requests to be made, and the expected result.",
            "expected_output": [
                "r'Requesting a key from server'",
                "r'Valid key received'",
                "r'Trying to connect to server'",
                "r'Connected to the server'",
                "r'Received message'",
                "r'Server responded. Releasing lock.'",
                "r'Unable to connect to'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_multi_server",
            "inputs": [
                "refuse_remoted_accept_enrollment",
                "only_enrollment_and_only_remoted",
                "server_down_fallback_tcp",
                "server_down_fallback_udp",
                "only_one_server_available",
                "unique_available_server_disconnects"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agentd_multi_server.yaml</summary>
<p>

```yaml
brief: These tests will check the agent's enrollment and connection to a manager in
  a multi-server environment. The objective is to check how the agent manages the
  connections to the servers depending on their status.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-authd
- wazuh-remoted
group_id: 0
id: 3
modules:
- agentd
name: test_agentd_multi_server.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/registering/index.html
tags:
- enrollment
tests:
- assertions:
  - Agent without keys. Verify that all servers will refuse the connection to the
    `wazuh-remoted` daemon but will accept enrollment. The agent should try to connect
    and enroll each of them.
  - Agent without keys. Verify that the first server only has enrollment available,
    and the third server only has the `wazuh-remoted` daemon available. The agent
    should enroll in the first server and connect to the third one.
  - Agent without keys. Verify that the agent should enroll and connect to the first
    server, and then the first server will disconnect. The agent should connect to
    the second server with the same key.
  - Agent without keys. Verify that the agent should enroll and connect to the first
    server, and then the first server will disconnect. The agent should try to enroll
    in the first server again, and then after failure, move to the second server and
    connect.
  - Agent with keys. Verify that the agent should enroll and connect to the last server.
  - Agent with keys. Verify that the first server is available, but it disconnects,
    and the second and third servers are not responding. The agent on disconnection
    should try the second and third servers and go back finally to the first server.
  description: Check the agent's enrollment and connection to a manager in a multi-server
    environment. Initialize an environment with multiple simulated servers in which
    the agent is forced to enroll under different test conditions, verifying the agent's
    behavior through its log files.
  expected_output:
  - r'Requesting a key from server'
  - r'Valid key received'
  - r'Trying to connect to server'
  - r'Connected to the server'
  - r'Received message'
  - r'Server responded. Releasing lock.'
  - r'Unable to connect to'
  input_description: Different test cases are found in the test module and include
    parameters for the environment setup, the requests to be made, and the expected
    result.
  inputs:
  - refuse_remoted_accept_enrollment
  - only_enrollment_and_only_remoted
  - server_down_fallback_tcp
  - server_down_fallback_udp
  - only_one_server_available
  - unique_available_server_disconnects
  name: test_agentd_multi_server
  parameters:
  - add_hostnames:
      brief: Adds to the `hosts` file the names and the IP addresses of the testing
        servers.
      type: fixture
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - set_authd_id:
      brief: Sets the agent id to `101` in the `wazuh-authd` simulated connection.
      type: fixture
  - clean_keys:
      brief: Clears the `client.keys` file used by the simulated remote connections.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_agentd_parametrized_reconnections.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check that the connection is finally made when there are delays between connection attempts to the server. The objective is to check how the `wazuh-agentd` daemon behaves when there are delays between connection attempts to `wazuh-remoted` using `TCP` and `UDP` protocols.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-authd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/registering/index.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_agentd_parametrized_reconnections.py",
    "id": 4,
    "group_id": 0,
    "tests": [
        {
            "description": "Check how the agent behaves when there are delays between connection attempts to the server. For this purpose, different values for `max_retries` and `retry_interval` parameters are tested.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "start_authd": {
                        "type": "fixture",
                        "brief": "Enable the `wazuh-authd` daemon to accept connections and perform enrollments."
                    }
                },
                {
                    "stop_agent": {
                        "type": "fixture",
                        "brief": "Stop Wazuh's agent."
                    }
                },
                {
                    "set_keys": {
                        "type": "fixture",
                        "brief": "Write to `client.keys` file the agent's enrollment details."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Verify that when the `wazuh-agentd` daemon initializes, it connects to the `wazuh-remoted` daemon of the manager before reaching the maximum number of attempts.",
                "Verify the successful enrollment of the agent if the auto-enrollment option is enabled.",
                "Verify that the rollback feature of the server works correctly."
            ],
            "input_description": "Different test cases are found in the test module and include parameters for the environment setup using the `TCP` and `UDP` protocols.",
            "expected_output": [
                "r'Valid key received'",
                "r'Trying to connect to server'",
                "r'Unable to connect to any server'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_parametrized_reconnections",
            "inputs": [
                "udp_max-retry=1_interval=1_enroll=no",
                "udp_max-retry=5_interval=5_enroll=no",
                "udp_max-retry=10_interval=4_enroll=no",
                "udp_max-retry=3_interval=12_enroll=no",
                "tcp_max-retry=3_interval=3_enroll=no",
                "tcp_max-retry=5_interval=5_enroll=no",
                "tcp_max-retry=10_interval=10_enroll=no",
                "udp_max-retry=2_interval=2_enroll=yes",
                "tcp_max-retry=5_interval=5_enroll=yes"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agentd_parametrized_reconnections.yaml</summary>
<p>

```yaml
brief: These tests will check that the connection is finally made when there are delays
  between connection attempts to the server. The objective is to check how the `wazuh-agentd`
  daemon behaves when there are delays between connection attempts to `wazuh-remoted`
  using `TCP` and `UDP` protocols.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-authd
- wazuh-remoted
group_id: 0
id: 4
modules:
- agentd
name: test_agentd_parametrized_reconnections.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/registering/index.html
tags:
- enrollment
tests:
- assertions:
  - Verify that when the `wazuh-agentd` daemon initializes, it connects to the `wazuh-remoted`
    daemon of the manager before reaching the maximum number of attempts.
  - Verify the successful enrollment of the agent if the auto-enrollment option is
    enabled.
  - Verify that the rollback feature of the server works correctly.
  description: Check how the agent behaves when there are delays between connection
    attempts to the server. For this purpose, different values for `max_retries` and
    `retry_interval` parameters are tested.
  expected_output:
  - r'Valid key received'
  - r'Trying to connect to server'
  - r'Unable to connect to any server'
  input_description: Different test cases are found in the test module and include
    parameters for the environment setup using the `TCP` and `UDP` protocols.
  inputs:
  - udp_max-retry=1_interval=1_enroll=no
  - udp_max-retry=5_interval=5_enroll=no
  - udp_max-retry=10_interval=4_enroll=no
  - udp_max-retry=3_interval=12_enroll=no
  - tcp_max-retry=3_interval=3_enroll=no
  - tcp_max-retry=5_interval=5_enroll=no
  - tcp_max-retry=10_interval=10_enroll=no
  - udp_max-retry=2_interval=2_enroll=yes
  - tcp_max-retry=5_interval=5_enroll=yes
  name: test_agentd_parametrized_reconnections
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - start_authd:
      brief: Enable the `wazuh-authd` daemon to accept connections and perform enrollments.
      type: fixture
  - stop_agent:
      brief: Stop Wazuh's agent.
      type: fixture
  - set_keys:
      brief: Write to `client.keys` file the agent's enrollment details.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_agentd_reconnection.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if, during enrollment, the agent re-establishes communication with the manager under different situations that interrupt it. The objective is to check that, with different states in the `clients.keys` file, the agent successfully enrolls after losing connection with the `wazuh-remoted` daemon.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-authd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/registering/index.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_agentd_reconnection.py",
    "id": 5,
    "group_id": 0,
    "tests": [
        {
            "description": "Check how the agent behaves when losing communication with the `wazuh-remoted` daemon and a new enrollment is sent to the `wazuh-authd` daemon. In this case, the agent starts with keys.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent enrollment is successful."
            ],
            "input_description": "Two test cases are found in the test module and include parameters for the environment setup using the `TCP` and `UDP` protocols.",
            "expected_output": [
                "r'Valid key received'",
                "r'Sending keep alive'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_reconection_enrollment_with_keys",
            "inputs": [
                "tcp",
                "udp"
            ]
        },
        {
            "description": "Check how the agent behaves when losing communication with the `wazuh-remoted` daemon and a new enrollment is sent to the `wazuh-authd` daemon. In this case, the agent doesn't have the `client.keys` file.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent enrollment is successful."
            ],
            "input_description": "Two test cases are found in the test module and include parameters for the environment setup using the `TCP` and `UDP` protocols.",
            "expected_output": [
                "r'Valid key received'",
                "r'Sending keep alive'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_reconection_enrollment_no_keys_file",
            "inputs": [
                "tcp",
                "udp"
            ]
        },
        {
            "description": "Check how the agent behaves when losing communication with the `wazuh-remoted` daemon and a new enrollment is sent to the `wazuh-authd` daemon. In this case, the agent has its `client.keys` file empty.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent enrollment is successful."
            ],
            "input_description": "Two test cases are found in the test module and include parameters for the environment setup using the `TCP` and `UDP` protocols.",
            "expected_output": [
                "r'Valid key received'",
                "r'Sending keep alive'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_reconection_enrollment_no_keys",
            "inputs": [
                "tcp",
                "udp"
            ]
        },
        {
            "description": "Check how the agent behaves when it makes multiple enrollment attempts before getting its key. For this, the agent starts without keys and performs multiple enrollment requests to the `wazuh-authd` daemon before getting the new key to communicate with the `wazuh-remoted` daemon.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent enrollment is successful."
            ],
            "input_description": "Two test cases are found in the test module and include parameters for the environment setup using the `TCP` and `UDP` protocols.",
            "expected_output": [
                "r'Requesting a key'",
                "r'Valid key received'",
                "r'Sending keep alive'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_initial_enrollment_retries",
            "inputs": [
                "tcp",
                "udp"
            ]
        },
        {
            "description": "Check how the agent behaves when the `wazuh-remoted` daemon is not available and performs multiple connection attempts to it. For this, the agent starts with keys but the `wazuh-remoted` daemon is not available for several seconds, then the agent performs multiple connection retries before requesting a new enrollment.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_authd_server": {
                        "type": "fixture",
                        "brief": "Initializes a simulated `wazuh-authd` connection."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent enrollment is successful."
            ],
            "input_description": "Two test cases are found in the test module and include parameters for the environment setup using the `TCP` and `UDP` protocols.",
            "expected_output": [
                "r'Sending keep alive'"
            ],
            "tags": [
                "simulator",
                "ssl",
                "keys"
            ],
            "name": "test_agentd_connection_retries_pre_enrollment",
            "inputs": [
                "tcp",
                "udp"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agentd_reconnection.yaml</summary>
<p>

```yaml
brief: These tests will check if, during enrollment, the agent re-establishes communication
  with the manager under different situations that interrupt it. The objective is
  to check that, with different states in the `clients.keys` file, the agent successfully
  enrolls after losing connection with the `wazuh-remoted` daemon.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-authd
- wazuh-remoted
group_id: 0
id: 5
modules:
- agentd
name: test_agentd_reconnection.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/registering/index.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when losing communication with the `wazuh-remoted`
    daemon and a new enrollment is sent to the `wazuh-authd` daemon. In this case,
    the agent starts with keys.
  expected_output:
  - r'Valid key received'
  - r'Sending keep alive'
  input_description: Two test cases are found in the test module and include parameters
    for the environment setup using the `TCP` and `UDP` protocols.
  inputs:
  - tcp
  - udp
  name: test_agentd_reconection_enrollment_with_keys
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when losing communication with the `wazuh-remoted`
    daemon and a new enrollment is sent to the `wazuh-authd` daemon. In this case,
    the agent doesn't have the `client.keys` file.
  expected_output:
  - r'Valid key received'
  - r'Sending keep alive'
  input_description: Two test cases are found in the test module and include parameters
    for the environment setup using the `TCP` and `UDP` protocols.
  inputs:
  - tcp
  - udp
  name: test_agentd_reconection_enrollment_no_keys_file
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when losing communication with the `wazuh-remoted`
    daemon and a new enrollment is sent to the `wazuh-authd` daemon. In this case,
    the agent has its `client.keys` file empty.
  expected_output:
  - r'Valid key received'
  - r'Sending keep alive'
  input_description: Two test cases are found in the test module and include parameters
    for the environment setup using the `TCP` and `UDP` protocols.
  inputs:
  - tcp
  - udp
  name: test_agentd_reconection_enrollment_no_keys
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when it makes multiple enrollment attempts
    before getting its key. For this, the agent starts without keys and performs multiple
    enrollment requests to the `wazuh-authd` daemon before getting the new key to
    communicate with the `wazuh-remoted` daemon.
  expected_output:
  - r'Requesting a key'
  - r'Valid key received'
  - r'Sending keep alive'
  input_description: Two test cases are found in the test module and include parameters
    for the environment setup using the `TCP` and `UDP` protocols.
  inputs:
  - tcp
  - udp
  name: test_agentd_initial_enrollment_retries
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
- assertions:
  - Verify that the agent enrollment is successful.
  description: Check how the agent behaves when the `wazuh-remoted` daemon is not
    available and performs multiple connection attempts to it. For this, the agent
    starts with keys but the `wazuh-remoted` daemon is not available for several seconds,
    then the agent performs multiple connection retries before requesting a new enrollment.
  expected_output:
  - r'Sending keep alive'
  input_description: Two test cases are found in the test module and include parameters
    for the environment setup using the `TCP` and `UDP` protocols.
  inputs:
  - tcp
  - udp
  name: test_agentd_connection_retries_pre_enrollment
  parameters:
  - configure_authd_server:
      brief: Initializes a simulated `wazuh-authd` connection.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  tags:
  - simulator
  - ssl
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_agentd_state_config.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the configuration options related to the `wazuh-agentd` daemon statistics file are working properly. The statistics files are documents that show real-time information about the Wazuh environment.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/statistics-files/wazuh-agentd-state.html"
    ],
    "tags": [
        "stats_file"
    ],
    "name": "test_agentd_state_config.py",
    "id": 7,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that the `wazuh-agentd.state` statistics file is created automatically and verify that it is updated at the set intervals.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of tests to be performed."
                    }
                }
            ],
            "assertions": [
                "Verify that the `wazuh-agentd.state` statistics file has been created.",
                "Verify that the `wazuh-agentd.state` statistics file is updated at the specified intervals."
            ],
            "input_description": "Different test cases that are contained in an external `YAML` file (wazuh_state_config_tests.yaml) that includes the parameters and their expected responses.",
            "expected_output": [
                "r'interval_not_found'",
                "r'interval_not_valid'",
                "r'file_enabled'",
                "r'file_not_enabled'"
            ],
            "name": "test_agentd_state_config",
            "inputs": [
                "get_configuration0-Negative state interval",
                "get_configuration0-Undefined state interval value",
                "get_configuration0-State interval option dont exist",
                "get_configuration0-Zero state interval",
                "get_configuration0-Too big state interval",
                "get_configuration0-Default state interval"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agentd_state_config.yaml</summary>
<p>

```yaml
brief: These tests will check if the configuration options related to the `wazuh-agentd`
  daemon statistics file are working properly. The statistics files are documents
  that show real-time information about the Wazuh environment.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
group_id: 0
id: 7
modules:
- agentd
name: test_agentd_state_config.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/reference/statistics-files/wazuh-agentd-state.html
tags:
- stats_file
tests:
- assertions:
  - Verify that the `wazuh-agentd.state` statistics file has been created.
  - Verify that the `wazuh-agentd.state` statistics file is updated at the specified
    intervals.
  description: Check that the `wazuh-agentd.state` statistics file is created automatically
    and verify that it is updated at the set intervals.
  expected_output:
  - r'interval_not_found'
  - r'interval_not_valid'
  - r'file_enabled'
  - r'file_not_enabled'
  input_description: Different test cases that are contained in an external `YAML`
    file (wazuh_state_config_tests.yaml) that includes the parameters and their expected
    responses.
  inputs:
  - get_configuration0-Negative state interval
  - get_configuration0-Undefined state interval value
  - get_configuration0-State interval option dont exist
  - get_configuration0-Zero state interval
  - get_configuration0-Too big state interval
  - get_configuration0-Default state interval
  name: test_agentd_state_config
  parameters:
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_agentd_state.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the content of the `wazuh-agentd` daemon statistics file is valid. The statistics files are documents that show real-time information about the Wazuh environment.",
    "tier": 0,
    "modules": [
        "agentd"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-remoted"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/statistics-files/wazuh-agentd-state.html"
    ],
    "tags": [
        "stats_file"
    ],
    "name": "test_agentd_state.py",
    "id": 6,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that the statistics file `wazuh-agentd.state` is created automatically and verify that the content of its fields is correct.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of tests to be performed."
                    }
                }
            ],
            "assertions": [
                "Verify that the `wazuh-agentd.state` statistics file has been created.",
                "Verify that the information stored in the `wazuh-agentd.state` statistics file is consistent with the connection status to the `wazuh-remoted` daemon."
            ],
            "input_description": "Different test cases that are contained in an external `YAML` file (wazuh_state_tests.yaml) that includes the parameters and their expected responses.",
            "expected_output": [
                "r'pending'",
                "r'connected'"
            ],
            "name": "test_agentd_state",
            "inputs": [
                "-No connection with remoted",
                "-Successful connection with remoted",
                "-Only remote request available"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_agentd_state.yaml</summary>
<p>

```yaml
brief: These tests will check if the content of the `wazuh-agentd` daemon statistics
  file is valid. The statistics files are documents that show real-time information
  about the Wazuh environment.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-remoted
group_id: 0
id: 6
modules:
- agentd
name: test_agentd_state.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
references:
- https://documentation.wazuh.com/current/user-manual/reference/statistics-files/wazuh-agentd-state.html
tags:
- stats_file
tests:
- assertions:
  - Verify that the `wazuh-agentd.state` statistics file has been created.
  - Verify that the information stored in the `wazuh-agentd.state` statistics file
    is consistent with the connection status to the `wazuh-remoted` daemon.
  description: Check that the statistics file `wazuh-agentd.state` is created automatically
    and verify that the content of its fields is correct.
  expected_output:
  - r'pending'
  - r'connected'
  input_description: Different test cases that are contained in an external `YAML`
    file (wazuh_state_tests.yaml) that includes the parameters and their expected
    responses.
  inputs:
  - -No connection with remoted
  - -Successful connection with remoted
  - -Only remote request available
  name: test_agentd_state
  parameters:
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - test_case:
      brief: List of tests to be performed.
      type: list
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`