### PR TITLE
Migrate `test_authd` documentation to qa-docs

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -7,6 +7,7 @@ Include paths:
   - "../../tests/integration/test_agentd"
   - "../../tests/integration/test_analysisd"
   - "../../tests/integration/test_api"
+  - "../../tests/integration/test_authd"
 
 Include regex:
   - "^test_.*py$"
@@ -41,6 +42,7 @@ Ignore paths:
   - "../../tests/integration/test_api/test_config/test_rbac/data" 
   - "../../tests/integration/test_api/test_config/test_request_timeout/data"
   - "../../tests/integration/test_api/test_config/test_use_only_authd/data"
+  - "../../tests/integration/test_authd/data"
 
 Output fields:
   Module:

--- a/tests/integration/test_authd/conftest.py
+++ b/tests/integration/test_authd/conftest.py
@@ -8,6 +8,7 @@ from wazuh_testing.tools.services import control_service
 
 DAEMON_NAME = 'wazuh-authd'
 
+
 @pytest.fixture(scope='function')
 def wait_for_agentd_startup(request):
     """Wait until agentd has begun"""

--- a/tests/integration/test_authd/test_authd.py
+++ b/tests/integration/test_authd/test_authd.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `wazuh-authd` daemon correctly handles the enrollment requests,
+       generating consistent responses to the requests received on its IP v4 network socket.
+       The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide
+       the key to the agent. It’s used along with the `agent-auth` application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
+
+tags:
+    - enrollment
+'''
 import os
 import subprocess
 import time
@@ -83,12 +135,49 @@ def clean_client_keys_file():
 
 def test_ossec_auth_messages(clean_client_keys_file, get_configuration, set_up_groups, configure_environment,
                              configure_sockets_environment, connect_to_sockets_module, wait_for_agentd_startup):
-    """Check that every input message in authd port generates the adequate output
+    '''
+    description: Check if when the `wazuh-authd` daemon receives different kinds of enrollment requests,
+                 it responds appropriately to them. In this case, the enrollment requests
+                 are sent to an IP v4 network socket.
 
-    Raises:
-        ConnectionResetError: if wazuh-authd does not send the response to the agent through the socket.
-        AssertionError: if the response does not match the expected message.
-    """
+    wazuh_min_version: 4.2
+
+    parameters:
+        - clean_client_keys_file:
+            type: fixture
+            brief: Delete the agent keys stored in the `client.keys` file.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents and provide the test case list.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of `connect_to_sockets` fixture.
+        - wait_for_agentd_startup:
+            type: fixture
+            brief: Wait until the `wazuh-agentd` has begun.
+
+    assertions:
+        - Verify that the response messages are consistent with the enrollment requests received.
+
+    input_description: Different test cases are contained in an external `YAML` file (enroll_messages.yaml)
+                       that includes enrollment events and the expected output.
+
+    expected_output:
+        - Multiple values located in the `enroll_messages.yaml` file.
+
+    tags:
+        - keys
+        - ssl
+    '''
     test_case = set_up_groups['test_case']
     for stage in test_case:
         # Reopen socket (socket is closed by manager after sending message with client key)

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `wazuh-authd` daemon handles correctly the enrollment requests
+       from agents with pre-existing IP addresses or names. The `wazuh-authd` daemon can automatically
+       add a Wazuh agent to a Wazuh manager and provide the key to the agent. It’is used along with
+       the `agent-auth` application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-remoted
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
+
+tags:
+    - enrollment
+'''
 import os
 import shutil
 import subprocess
@@ -349,6 +400,45 @@ def duplicate_name_agent_delete_test(server):
 
 def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure_environment,
                                      configure_sockets_environment, connect_to_sockets_module):
+    '''
+    description: Check if when the `wazuh-authd` daemon receives an enrollment request from an agent
+                 that has an IP address or name that is already registered, `authd` creates a record
+                 for the new agent and deletes the old one. In this case, the enrollment requests
+                 are sent to an IP v4 network socket.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of `connect_to_sockets` fixture.
+
+    assertions:
+        - Verify that agents using an already registered IP address can successfully enroll.
+        - Verify that agents using an already registered name can successfully enroll.
+
+    input_description: Different test cases are contained in an external `YAML` file (wazuh_conf.yaml)
+                       which includes configuration settings for the `wazuh-authd` daemon.
+
+    expected_output:
+        - r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready to accept enrollments)
+        - r'OSSEC K' (When the agent has enrolled)
+    tags:
+        - keys
+        - ssl
+    '''
     control_service('stop', daemon='wazuh-authd')
     check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     time.sleep(1)
@@ -368,6 +458,44 @@ def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure
 
 def test_ossec_authd_agents_ctx_local(get_configuration, set_up_groups, configure_environment,
                                       configure_sockets_environment, connect_to_sockets_module):
+    '''
+    description: Check if when the `wazuh-authd` daemon receives an enrollment request from an agent
+                 that has an IP address or name that is already registered, `authd` creates a record
+                 for the new agent and deletes the old one. In this case, the enrollment requests
+                 are sent to a local `UNIX` socket.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of `connect_to_sockets` fixture.
+
+    assertions:
+        - Verify that agents using an already registered IP address can successfully enroll.
+        - Verify that agents using an already registered name can successfully enroll.
+
+    input_description: Different test cases are contained in an external `YAML` file (wazuh_conf.yaml)
+                       which includes configuration settings for the `wazuh-authd` daemon.
+
+    expected_output:
+        - r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready to accept enrollments)
+        - r'{"error":0,' (When the agent has enrolled)
+    tags:
+        - keys
+    '''
     control_service('stop', daemon='wazuh-authd')
     check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     time.sleep(1)

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `wazuh-authd` daemon handles correctly the enrollment requests
+brief: These tests will check if the `wazuh-authd` daemon correctly handles the enrollment requests
        from agents with pre-existing IP addresses or names. The `wazuh-authd` daemon can automatically
-       add a Wazuh agent to a Wazuh manager and provide the key to the agent. It’is used along with
+       add a Wazuh agent to a Wazuh manager and provide the key to the agent. It’s used along with
        the `agent-auth` application.
 
 tier: 0
@@ -22,7 +22,8 @@ components:
 
 daemons:
     - wazuh-authd
-    - wazuh-remoted
+    - wazuh-db
+    - wazuh-modulesd
 
 os_platform:
     - linux
@@ -434,7 +435,7 @@ def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure
 
     expected_output:
         - r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready to accept enrollments)
-        - r'OSSEC K' (When the agent has enrolled)
+        - r'OSSEC K:' (When the agent has enrolled in the manager)
     tags:
         - keys
         - ssl

--- a/tests/integration/test_authd/test_authd_ssl_certs.py
+++ b/tests/integration/test_authd/test_authd_ssl_certs.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `wazuh-authd` daemon is able to handle secure connections using
+       the `SSL` (Secure Socket Layer) protocol. The `wazuh-authd` daemon can automatically add
+       a Wazuh agent to a Wazuh manager and provide the key to the agent.
+       It’s used along with the `agent-auth` application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/registering/host-verification-registration.html
+
+tags:
+    - enrollment
+'''
 import os
 import ssl
 import time
@@ -113,8 +165,37 @@ def override_wazuh_conf(configuration):
 
 
 def test_authd_ssl_certs(get_configuration, generate_ca_certificate):
-    """
-    """
+    '''
+    description: Check if the `wazuh-authd` daemon can manage `SSL` connections with agents
+                 and the `host verification` feature is working properly. For this purpose,
+                 it generates and signs the necessary certificates and builds the
+                 enrollment requests using them.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - generate_ca_certificate:
+            type: fixture
+            brief: Build the `CA` (Certificate of Authority) and sign the certificate used by the testing agent.
+
+    assertions:
+        - Verify that the agent can only connect to the `wazuh-authd` daemon socket using a valid certificate.
+        - Verify that using a valid certificate the agent can only enroll using the IP address linked to it.
+
+    input_description: Different test cases are found in the test module and include
+                       parameters for the environment setup, the requests
+                       to be made, and the expected result.
+
+    expected_output:
+        - r'OSSEC K:' (When the agent has enrolled in the manager)
+
+    tags:
+        - keys
+        - ssl
+    '''
     verify_host = (get_configuration['metadata']['verify_host'] == 'yes')
     option = get_configuration['metadata']['sim_option']
     override_wazuh_conf(get_configuration)

--- a/tests/integration/test_authd/test_authd_ssl_options.py
+++ b/tests/integration/test_authd/test_authd_ssl_options.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `SSL` (Secure Socket Layer) protocol-related settings of
+       the `wazuh-authd` daemon are working correctly. The `wazuh-authd` daemon can
+       automatically add a Wazuh agent to a Wazuh manager and provide the key
+       to the agent. It’s used along with the `agent-auth` application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html
+
+tags:
+    - enrollment
+'''
 import os
 import ssl
 import time
@@ -107,20 +159,38 @@ def override_wazuh_conf(configuration):
 
 
 def test_ossec_auth_configurations(get_configuration, configure_environment, configure_sockets_environment):
-    """Check that every input message in authd port generates the adequate output
+    '''
+    description: Check if the `SSL` settings of the `wazuh-authd` daemon work correctly by enrolling agents
+                 that use different values for these settings. Different types of encryption and secure
+                 connection protocols are tested, in addition to the `ssl_auto_negotiate` option
+                 that automatically chooses the protocol to be used.
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_cases, dict with following keys:
-            - expect: What we are expecting to happen
-                1. open_error: Should fail when trying to do ssl handshake
-                2. output: Expects an output message from the manager
-            - ciphers: Value for ssl ciphers
-            - protocol: Value for ssl protocol
-            - input: message that will be tried to send to the manager
-            - output: expected response (if any)
-    """
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+
+    assertions:
+        - Verify that the response messages are consistent with the enrollment requests received.
+
+    input_description: Different test cases are contained in an external `YAML` file (enroll_ssl_options_tests.yaml)
+                       that includes enrollment events and the expected output.
+
+    expected_output:
+        - Multiple values located in the `enroll_ssl_options_tests.yaml` file.
+
+    tags:
+        - keys
+        - ssl
+    '''
     current_test = get_current_test()
 
     test_case = ssl_configuration_tests[current_test]['test_case']

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if a Wazuh cluster `worker` node correctly handles agent enrollment requests
+       sent to the `wazuh-authd` daemon socket. The `wazuh-authd` daemon can automatically add
+       a Wazuh agent to a Wazuh manager and provide the key to the agent.
+       It’s used along with the `agent-auth` application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-clusterd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html#worker
+
+tags:
+    - enrollment
+'''
 import os
 import subprocess
 import time
@@ -100,13 +153,47 @@ def get_configuration(request):
 
 def test_ossec_auth_messages(get_configuration, set_up_groups, configure_environment, configure_sockets_environment,
                              connect_to_sockets_module, wait_for_agentd_startup):
-    """Check that every input message in authd port generates the adequate output
+    '''
+    description: Check if a `worker` node in the Wazuh cluster correctly redirects agent enrollment requests
+                 to the `master` node, which is the only one responsible for enrolling agents.
+                 For this purpose, a cluster environment is simulated in where a worker node sends
+                 enrollment requests to the `wazuh-authd` daemon socket of the master node.
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys).
-    """
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents and provide the test case list.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of `connect_to_sockets` fixture.
+        - wait_for_agentd_startup:
+            type: fixture
+            brief: Wait until the `wazuh-agentd` has begun.
+
+    assertions:
+        - Verify that the response messages are consistent with the enrollment requests received.
+
+    input_description: Different test cases are contained in an external `YAML` file (worker_messages.yaml)
+                       that includes enrollment events and the expected output.
+
+    expected_output:
+        - Multiple values located in the `worker_messages.yaml` file.
+
+    tags:
+        - keys
+        - ssl
+    '''
     test_case = set_up_groups['test_case']
     for stage in test_case:
         # Push expected info to mitm queue


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1807|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_authd_agents_ctx.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment requests from agents with pre-existing IP addresses or names. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_agents_ctx.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when the `wazuh-authd` daemon receives an enrollment request from an agent that has an IP address or name that is already registered, `authd` creates a record for the new agent and deletes the old one. In this case, the enrollment requests are sent to an IP v4 network socket.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of `connect_to_sockets` fixture."
                    }
                }
            ],
            "assertions": [
                "Verify that agents using an already registered IP address can successfully enroll.",
                "Verify that agents using an already registered name can successfully enroll."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (wazuh_conf.yaml) which includes configuration settings for the `wazuh-authd` daemon.",
            "expected_output": [
                "r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready to accept enrollments)",
                "r'OSSEC K:' (When the agent has enrolled in the manager)"
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_authd_agents_ctx_main",
            "inputs": [
                "get_configuration0"
            ]
        },
        {
            "description": "Check if when the `wazuh-authd` daemon receives an enrollment request from an agent that has an IP address or name that is already registered, `authd` creates a record for the new agent and deletes the old one. In this case, the enrollment requests are sent to a local `UNIX` socket.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of `connect_to_sockets` fixture."
                    }
                }
            ],
            "assertions": [
                "Verify that agents using an already registered IP address can successfully enroll.",
                "Verify that agents using an already registered name can successfully enroll."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (wazuh_conf.yaml) which includes configuration settings for the `wazuh-authd` daemon.",
            "expected_output": [
                "r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready to accept enrollments)",
                "r'{\"error\":0,' (When the agent has enrolled)"
            ],
            "tags": [
                "keys"
            ],
            "name": "test_ossec_authd_agents_ctx_local",
            "inputs": [
                "get_configuration0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_agents_ctx.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment\
  \ requests from agents with pre-existing IP addresses or names. The `wazuh-authd`\
  \ daemon can automatically add a Wazuh agent to a Wazuh manager and provide the\
  \ key to the agent. It\u2019s used along with the `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 2
modules:
- authd
name: test_authd_agents_ctx.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
tags:
- enrollment
tests:
- assertions:
  - Verify that agents using an already registered IP address can successfully enroll.
  - Verify that agents using an already registered name can successfully enroll.
  description: Check if when the `wazuh-authd` daemon receives an enrollment request
    from an agent that has an IP address or name that is already registered, `authd`
    creates a record for the new agent and deletes the old one. In this case, the
    enrollment requests are sent to an IP v4 network socket.
  expected_output:
  - r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready
    to accept enrollments)
  - r'OSSEC K:' (When the agent has enrolled in the manager)
  input_description: Different test cases are contained in an external `YAML` file
    (wazuh_conf.yaml) which includes configuration settings for the `wazuh-authd`
    daemon.
  inputs:
  - get_configuration0
  name: test_ossec_authd_agents_ctx_main
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of `connect_to_sockets` fixture.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
- assertions:
  - Verify that agents using an already registered IP address can successfully enroll.
  - Verify that agents using an already registered name can successfully enroll.
  description: Check if when the `wazuh-authd` daemon receives an enrollment request
    from an agent that has an IP address or name that is already registered, `authd`
    creates a record for the new agent and deletes the old one. In this case, the
    enrollment requests are sent to a local `UNIX` socket.
  expected_output:
  - r'Accepting connections on port 1515' (When the `wazuh-authd` daemon is ready
    to accept enrollments)
  - r'{"error":0,' (When the agent has enrolled)
  input_description: Different test cases are contained in an external `YAML` file
    (wazuh_conf.yaml) which includes configuration settings for the `wazuh-authd`
    daemon.
  inputs:
  - get_configuration0
  name: test_ossec_authd_agents_ctx_local
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of `connect_to_sockets` fixture.
      type: fixture
  tags:
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_local.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment requests, generating consistent responses to the requests received on its local UNIX socket. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_local.py",
    "id": 3,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when the `wazuh-authd` daemon receives different kinds of enrollment requests, it responds appropriately to them. In this case, the enrollment requests are sent to a local `UNIX` socket.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "clean_client_keys_file": {
                        "type": "fixture",
                        "brief": "Delete the agent keys stored in the `client.keys` file."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents and provide the test case list."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of `connect_to_sockets` fixture."
                    }
                },
                {
                    "wait_for_agentd_startup": {
                        "type": "fixture",
                        "brief": "Wait until the `wazuh-agentd` has begun."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (local_enroll_messages.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the `local_enroll_messages.yaml` file."
            ],
            "tags": [
                "keys"
            ],
            "name": "test_ossec_auth_messages",
            "inputs": [
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups10",
                "get_configuration0-set_up_groups11",
                "get_configuration0-set_up_groups12",
                "get_configuration0-set_up_groups13",
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_local.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment\
  \ requests, generating consistent responses to the requests received on its local\
  \ UNIX socket. The `wazuh-authd` daemon can automatically add a Wazuh agent to a\
  \ Wazuh manager and provide the key to the agent. It\u2019s used along with the\
  \ `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 3
modules:
- authd
name: test_authd_local.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if when the `wazuh-authd` daemon receives different kinds of
    enrollment requests, it responds appropriately to them. In this case, the enrollment
    requests are sent to a local `UNIX` socket.
  expected_output:
  - Multiple values located in the `local_enroll_messages.yaml` file.
  input_description: Different test cases are contained in an external `YAML` file
    (local_enroll_messages.yaml) that includes enrollment events and the expected
    output.
  inputs:
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups10
  - get_configuration0-set_up_groups11
  - get_configuration0-set_up_groups12
  - get_configuration0-set_up_groups13
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  name: test_ossec_auth_messages
  parameters:
  - clean_client_keys_file:
      brief: Delete the agent keys stored in the `client.keys` file.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents and provide the test case list.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of `connect_to_sockets` fixture.
      type: fixture
  - wait_for_agentd_startup:
      brief: Wait until the `wazuh-agentd` has begun.
      type: fixture
  tags:
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_name_ip_pass.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment requests under different conditions that affect the name and IP address used by the agents. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_name_ip_pass.py",
    "id": 4,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when the `wazuh-authd` daemon receives different kinds of enrollment requests, it responds appropriately to them. The requests include different combinations of hostname, IP address, and password (if any) used by the agent.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (name_ip_pass_tests.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the `name_ip_pass_tests.yaml` file."
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_auth_name_ip_pass",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8",
                "get_configuration9",
                "get_configuration10",
                "get_configuration11",
                "get_configuration12",
                "get_configuration13",
                "get_configuration14",
                "get_configuration15",
                "get_configuration16",
                "get_configuration17",
                "get_configuration18",
                "get_configuration19",
                "get_configuration20",
                "get_configuration21",
                "get_configuration22",
                "get_configuration23",
                "get_configuration24",
                "get_configuration25",
                "get_configuration26",
                "get_configuration27",
                "get_configuration28",
                "get_configuration29",
                "get_configuration30",
                "get_configuration31",
                "get_configuration32",
                "get_configuration33",
                "get_configuration34",
                "get_configuration35",
                "get_configuration36",
                "get_configuration37",
                "get_configuration38",
                "get_configuration39",
                "get_configuration40",
                "get_configuration41",
                "get_configuration42"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_name_ip_pass.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment\
  \ requests under different conditions that affect the name and IP address used by\
  \ the agents. The `wazuh-authd` daemon can automatically add a Wazuh agent to a\
  \ Wazuh manager and provide the key to the agent. It\u2019s used along with the\
  \ `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 4
modules:
- authd
name: test_authd_name_ip_pass.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if when the `wazuh-authd` daemon receives different kinds of
    enrollment requests, it responds appropriately to them. The requests include different
    combinations of hostname, IP address, and password (if any) used by the agent.
  expected_output:
  - Multiple values located in the `name_ip_pass_tests.yaml` file.
  input_description: Different test cases are contained in an external `YAML` file
    (name_ip_pass_tests.yaml) that includes enrollment events and the expected output.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  - get_configuration9
  - get_configuration10
  - get_configuration11
  - get_configuration12
  - get_configuration13
  - get_configuration14
  - get_configuration15
  - get_configuration16
  - get_configuration17
  - get_configuration18
  - get_configuration19
  - get_configuration20
  - get_configuration21
  - get_configuration22
  - get_configuration23
  - get_configuration24
  - get_configuration25
  - get_configuration26
  - get_configuration27
  - get_configuration28
  - get_configuration29
  - get_configuration30
  - get_configuration31
  - get_configuration32
  - get_configuration33
  - get_configuration34
  - get_configuration35
  - get_configuration36
  - get_configuration37
  - get_configuration38
  - get_configuration39
  - get_configuration40
  - get_configuration41
  - get_configuration42
  name: test_ossec_auth_name_ip_pass
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_ssl_certs.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `wazuh-authd` daemon is able to handle secure connections using the `SSL` (Secure Socket Layer) protocol. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/registering/host-verification-registration.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_ssl_certs.py",
    "id": 5,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `wazuh-authd` daemon can manage `SSL` connections with agents and the `host verification` feature is working properly. For this purpose, it generates and signs the necessary certificates and builds the enrollment requests using them.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "generate_ca_certificate": {
                        "type": "fixture",
                        "brief": "Build the `CA` (Certificate of Authority) and sign the certificate used by the testing agent."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent can only connect to the `wazuh-authd` daemon socket using a valid certificate.",
                "Verify that using a valid certificate the agent can only enroll using the IP address linked to it."
            ],
            "input_description": "Different test cases are found in the test module and include parameters for the environment setup, the requests to be made, and the expected result.",
            "expected_output": [
                "r'OSSEC K:' (When the agent has enrolled in the manager)"
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_authd_ssl_certs",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_ssl_certs.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `wazuh-authd` daemon is able to handle secure\
  \ connections using the `SSL` (Secure Socket Layer) protocol. The `wazuh-authd`\
  \ daemon can automatically add a Wazuh agent to a Wazuh manager and provide the\
  \ key to the agent. It\u2019s used along with the `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 5
modules:
- authd
name: test_authd_ssl_certs.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/registering/host-verification-registration.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the agent can only connect to the `wazuh-authd` daemon socket using
    a valid certificate.
  - Verify that using a valid certificate the agent can only enroll using the IP address
    linked to it.
  description: Check if the `wazuh-authd` daemon can manage `SSL` connections with
    agents and the `host verification` feature is working properly. For this purpose,
    it generates and signs the necessary certificates and builds the enrollment requests
    using them.
  expected_output:
  - r'OSSEC K:' (When the agent has enrolled in the manager)
  input_description: Different test cases are found in the test module and include
    parameters for the environment setup, the requests to be made, and the expected
    result.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  name: test_authd_ssl_certs
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - generate_ca_certificate:
      brief: Build the `CA` (Certificate of Authority) and sign the certificate used
        by the testing agent.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_ssl_options.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `SSL` (Secure Socket Layer) protocol-related settings of the `wazuh-authd` daemon are working correctly. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_ssl_options.py",
    "id": 6,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `SSL` settings of the `wazuh-authd` daemon work correctly by enrolling agents that use different values for these settings. Different types of encryption and secure connection protocols are tested, in addition to the `ssl_auto_negotiate` option that automatically chooses the protocol to be used.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (enroll_ssl_options_tests.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the `enroll_ssl_options_tests.yaml` file."
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_auth_configurations",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_ssl_options.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `SSL` (Secure Socket Layer) protocol-related\
  \ settings of the `wazuh-authd` daemon are working correctly. The `wazuh-authd`\
  \ daemon can automatically add a Wazuh agent to a Wazuh manager and provide the\
  \ key to the agent. It\u2019s used along with the `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 6
modules:
- authd
name: test_authd_ssl_options.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if the `SSL` settings of the `wazuh-authd` daemon work correctly
    by enrolling agents that use different values for these settings. Different types
    of encryption and secure connection protocols are tested, in addition to the `ssl_auto_negotiate`
    option that automatically chooses the protocol to be used.
  expected_output:
  - Multiple values located in the `enroll_ssl_options_tests.yaml` file.
  input_description: Different test cases are contained in an external `YAML` file
    (enroll_ssl_options_tests.yaml) that includes enrollment events and the expected
    output.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  name: test_ossec_auth_configurations
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_worker.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if a Wazuh cluster `worker` node correctly handles agent enrollment requests sent to the `wazuh-authd` daemon socket. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-clusterd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html#worker"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_worker.py",
    "id": 7,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if a `worker` node in the Wazuh cluster correctly redirects agent enrollment requests to the `master` node, which is the only one responsible for enrolling agents. For this purpose, a cluster environment is simulated in where a worker node sends enrollment requests to the `wazuh-authd` daemon socket of the master node.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents and provide the test case list."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of `connect_to_sockets` fixture."
                    }
                },
                {
                    "wait_for_agentd_startup": {
                        "type": "fixture",
                        "brief": "Wait until the `wazuh-agentd` has begun."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (worker_messages.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the `worker_messages.yaml` file."
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_auth_messages",
            "inputs": [
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups10",
                "get_configuration0-set_up_groups11",
                "get_configuration0-set_up_groups12",
                "get_configuration0-set_up_groups13",
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_worker.yaml</summary>
<p>

```yaml
brief: "These tests will check if a Wazuh cluster `worker` node correctly handles\
  \ agent enrollment requests sent to the `wazuh-authd` daemon socket. The `wazuh-authd`\
  \ daemon can automatically add a Wazuh agent to a Wazuh manager and provide the\
  \ key to the agent. It\u2019s used along with the `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-clusterd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 7
modules:
- authd
name: test_authd_worker.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html#worker
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if a `worker` node in the Wazuh cluster correctly redirects agent
    enrollment requests to the `master` node, which is the only one responsible for
    enrolling agents. For this purpose, a cluster environment is simulated in where
    a worker node sends enrollment requests to the `wazuh-authd` daemon socket of
    the master node.
  expected_output:
  - Multiple values located in the `worker_messages.yaml` file.
  input_description: Different test cases are contained in an external `YAML` file
    (worker_messages.yaml) that includes enrollment events and the expected output.
  inputs:
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups10
  - get_configuration0-set_up_groups11
  - get_configuration0-set_up_groups12
  - get_configuration0-set_up_groups13
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  name: test_ossec_auth_messages
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents and provide the test case list.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of `connect_to_sockets` fixture.
      type: fixture
  - wait_for_agentd_startup:
      brief: Wait until the `wazuh-agentd` has begun.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment requests, generating consistent responses to the requests received on its IP v4 network socket. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when the `wazuh-authd` daemon receives different kinds of enrollment requests, it responds appropriately to them. In this case, the enrollment requests are sent to an IP v4 network socket.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "clean_client_keys_file": {
                        "type": "fixture",
                        "brief": "Delete the agent keys stored in the `client.keys` file."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents and provide the test case list."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of `connect_to_sockets` fixture."
                    }
                },
                {
                    "wait_for_agentd_startup": {
                        "type": "fixture",
                        "brief": "Wait until the `wazuh-agentd` has begun."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (enroll_messages.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the `enroll_messages.yaml` file."
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_auth_messages",
            "inputs": [
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups10",
                "get_configuration0-set_up_groups11",
                "get_configuration0-set_up_groups12",
                "get_configuration0-set_up_groups13"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `wazuh-authd` daemon correctly handles the enrollment\
  \ requests, generating consistent responses to the requests received on its IP v4\
  \ network socket. The `wazuh-authd` daemon can automatically add a Wazuh agent to\
  \ a Wazuh manager and provide the key to the agent. It\u2019s used along with the\
  \ `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 1
modules:
- authd
name: test_authd.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if when the `wazuh-authd` daemon receives different kinds of
    enrollment requests, it responds appropriately to them. In this case, the enrollment
    requests are sent to an IP v4 network socket.
  expected_output:
  - Multiple values located in the `enroll_messages.yaml` file.
  input_description: Different test cases are contained in an external `YAML` file
    (enroll_messages.yaml) that includes enrollment events and the expected output.
  inputs:
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups10
  - get_configuration0-set_up_groups11
  - get_configuration0-set_up_groups12
  - get_configuration0-set_up_groups13
  name: test_ossec_auth_messages
  parameters:
  - clean_client_keys_file:
      brief: Delete the agent keys stored in the `client.keys` file.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents and provide the test case list.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of `connect_to_sockets` fixture.
      type: fixture
  - wait_for_agentd_startup:
      brief: Wait until the `wazuh-agentd` has begun.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_remote_enrollment.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `remote enrollment` option of the `wazuh-authd` daemon settings is working properly. The `wazuh-authd` daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019s used along with the `agent-auth` application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html#remote-enrollment"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_remote_enrollment.py",
    "id": 8,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `wazuh-authd` daemon remote enrollment is enabled/disabled according to the configuration. By default, remote enrollment is enabled. When disabled, the `authd` `TLS` port (1515 by default) won't be listening to new connections, but requests to the local socket will still be attended.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_authd": {
                        "type": "fixture",
                        "brief": "Restart the `wazuh-authd` daemon, clear the `ossec.log` file and start a new file monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that the port `1515` opens or closes depending on the value of the `remote_enrollment` option.",
                "Verify that when a `worker` node receives an enrollment request, it tries to connect to the `master` node."
            ],
            "input_description": "Different test cases are found in the test module and include parameters for the environment setup, the requests to be made, and the expected result.",
            "expected_output": [
                "r'Accepting connections on port 1515. No password required.' (When the `wazuh-authd` daemon)",
                "r'OSSEC K:' (When the agent has enrolled in the manager)",
                "r'.*Port 1515 was set as disabled.*' (When remote enrollment is disabled)",
                {
                    "r'ERROR": "Cannot comunicate with master'"
                }
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_remote_enrollment",
            "inputs": [
                "no_remote_enrollment_standalone",
                "yes_remote_enrollment_standalone",
                "no_remote_enrollment_cluster_master",
                "yes_remote_enrollment_cluster_master",
                "no_remote_enrollment_cluster_worker",
                "yes_remote_enrollment_cluster_worker"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_remote_enrollment.yaml</summary>
<p>

```yaml
brief: "These tests will check if the `remote enrollment` option of the `wazuh-authd`\
  \ daemon settings is working properly. The `wazuh-authd` daemon can automatically\
  \ add a Wazuh agent to a Wazuh manager and provide the key to the agent. It\u2019\
  s used along with the `agent-auth` application."
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 8
modules:
- authd
name: test_remote_enrollment.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html#remote-enrollment
tags:
- enrollment
tests:
- assertions:
  - Verify that the port `1515` opens or closes depending on the value of the `remote_enrollment`
    option.
  - Verify that when a `worker` node receives an enrollment request, it tries to connect
    to the `master` node.
  description: Check if the `wazuh-authd` daemon remote enrollment is enabled/disabled
    according to the configuration. By default, remote enrollment is enabled. When
    disabled, the `authd` `TLS` port (1515 by default) won't be listening to new connections,
    but requests to the local socket will still be attended.
  expected_output:
  - r'Accepting connections on port 1515. No password required.' (When the `wazuh-authd`
    daemon)
  - r'OSSEC K:' (When the agent has enrolled in the manager)
  - r'.*Port 1515 was set as disabled.*' (When remote enrollment is disabled)
  - r'ERROR: Cannot comunicate with master'
  input_description: Different test cases are found in the test module and include
    parameters for the environment setup, the requests to be made, and the expected
    result.
  inputs:
  - no_remote_enrollment_standalone
  - yes_remote_enrollment_standalone
  - no_remote_enrollment_cluster_master
  - yes_remote_enrollment_cluster_master
  - no_remote_enrollment_cluster_worker
  - yes_remote_enrollment_cluster_worker
  name: test_remote_enrollment
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_authd:
      brief: Restart the `wazuh-authd` daemon, clear the `ossec.log` file and start
        a new file monitor.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`