### PR TITLE
Migrate `test_cluster` documentation to qa-docs

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -8,6 +8,7 @@ Include paths:
   - "../../tests/integration/test_analysisd"
   - "../../tests/integration/test_api"
   - "../../tests/integration/test_authd"
+  - "../../tests/integration/test_cluster"
 
 Include regex:
   - "^test_.*py$"
@@ -43,6 +44,7 @@ Ignore paths:
   - "../../tests/integration/test_api/test_config/test_request_timeout/data"
   - "../../tests/integration/test_api/test_config/test_use_only_authd/data"
   - "../../tests/integration/test_authd/data"
+  - "../../tests/integration/test_cluster/test_key_polling/data"
 
 Output fields:
   Module:

--- a/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the DOS (Denial-of-service attack) blocking feature
-    of the API handled by the `wazuh-apid` daemon is working properly.
+brief: These tests will check if the `DOS` (Denial-of-service attack) blocking feature of the API handled
+       by the `wazuh-apid` daemon is working properly. The Wazuh API is an open source `RESTful` API
+       that allows for interaction with the Wazuh manager from a web browser, command line tool
+       like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -95,13 +91,11 @@ def get_configuration(request):
 def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                              wait_for_start, get_api_details):
     '''
-    description:
-        Check if the API blocking system for IP addresses detected as DOS attack works.
-        For this purpose, the test causes an IP blocking, makes a request within
-        the same minute, makes a request after the minute.
+    description: Check if the API blocking system for IP addresses detected as `DOS` attack works.
+                 For this purpose, the test causes an IP blocking, makes a request within
+                 the same minute, makes a request after the minute.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -128,13 +122,12 @@ def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_env
         - Verify that the IP address is still blocked within the one-minute block time.
         - Verify that the IP address is not blocked when expires the blocking time.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters.
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters.
 
     expected_output:
-        - r'429' ('Too Many Requests' HTTP status code)
-        - r'200' ('OK' HTTP status code)
+        - r'429' (`Too Many Requests` HTTP status code)
+        - r'200' (`OK` HTTP status code)
 
     tags:
         - dos_attack

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the IP blocking feature of the API handled
-    by the `wazuh-apid` daemon is working properly.
+brief: These tests will check if the IP blocking feature of the API handled by the `wazuh-apid` daemon
+       is working properly. The Wazuh API is an open source `RESTful` API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -93,13 +89,11 @@ def get_configuration(request):
 def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                                     wait_for_start, get_api_details):
     '''
-    description:
-        Check if the blocking time for IP addresses detected as brute-force attack works.
-        For this purpose, the test causes an IP blocking, make a request before
-        the blocking time finishes and one after the blocking time.
+    description: Check if the blocking time for IP addresses detected as brute-force attack works.
+                 For this purpose, the test causes an IP blocking, make a request before
+                 the blocking time finishes and one after the blocking time.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -126,9 +120,8 @@ def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_
         - Verify that the IP address is still blocked even when using
           the correct credentials within the blocking time.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters.
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters.
 
     expected_output:
         - r"Error obtaining login token"

--- a/tests/integration/test_api/test_config/test_cache/test_cache.py
+++ b/tests/integration/test_api/test_config/test_cache/test_cache.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the cache feature of the API handled
-    by the `wazuh-apid` daemon is working properly.
+brief: These tests will check if the cache feature of the API handled by the `wazuh-apid` daemon
+       is working properly. The Wazuh API is an open source `RESTful` API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_cache/test_cache.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -111,15 +107,13 @@ def extra_configuration_after_yield():
 def test_cache(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                wait_for_start, get_api_details):
     '''
-    description:
-        Check if the stored response is returned when the cache is enabled.
-        Calls to rules endpoints can be cached. This test verifies if the result
-        of the first call to the rule endpoint is equal to the second call within
-        a period established in the configuration, even though a new file
-        has been created during the process.
+    description: Check if the stored response is returned when the cache is enabled.
+                 Calls to rules endpoints can be cached. This test verifies if the result
+                 of the first call to the rule endpoint is equal to the second call within
+                 a period established in the configuration, even though a new file
+                 has been created during the process.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -144,9 +138,8 @@ def test_cache(tags_to_apply, get_configuration, configure_api_environment, rest
     assertions:
         - Verify that the stored response is returned when the cache is enabled.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters.
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters.
 
     expected_output:
         - Number of rule files (if caching is enabled).

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -1,29 +1,25 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
 brief:
-    These tests will check if the CORS (Cross-origin resource sharing) feature
-    of the API handled by the `wazuh-apid` daemon is working properly.
+    These tests will check if the `CORS` (Cross-origin resource sharing) feature of the API handled
+    by the `wazuh-apid` daemon is working properly. The Wazuh API is an open source `RESTful` API
+    that allows for interaction with the Wazuh manager from a web browser, command line tool
+    like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_cors/test_cors.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +31,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -95,14 +92,12 @@ def get_configuration(request):
 def test_cors(origin, tags_to_apply, get_configuration, configure_api_environment,
               restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if expected headers are returned when CORS is enabled.
-        When CORS is enabled, special headers must be returned in case the
-        request origin matches the one established in the CORS configuration
-        of the API.
+    description: Check if expected headers are returned when `CORS` is enabled.
+                 When `CORS` is enabled, special headers must be returned in case the
+                 request origin matches the one established in the `CORS` configuration
+                 of the API.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - origin:
@@ -133,9 +128,8 @@ def test_cors(origin, tags_to_apply, get_configuration, configure_api_environmen
         - Verify that when CORS is enabled, the `Access-Control-Allow-Credentials` header is received.
         - Verify that when CORS is disabled, the `Access-Control-Allow-Origin` header is not received.
 
-    input_description:
-        A test case is contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters.
+    input_description: A test case is contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters.
 
     expected_output:
         - r'Access-Control-Allow-Origin'

--- a/tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.py
+++ b/tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.py
@@ -1,30 +1,25 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `drop_privileges` setting of the API is working properly.
-    This setting allows the user who starts the `wazuh-apid` daemon
-    to be different from the `root` user.
+brief: These tests will check if the `drop_privileges` setting of the API is working properly.
+       This setting allows the user who starts the `wazuh-apid` daemon to be different from
+       the `root` user. The Wazuh API is an open source `RESTful` API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.py
 
 daemons:
     - wazuh-apid
@@ -36,22 +31,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -95,14 +91,12 @@ def get_configuration(request):
 def test_drop_privileges(tags_to_apply, get_configuration, configure_api_environment,
                          restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if `drop_privileges` affects the user of the API process.
-        In this test, the PID of the API process is obtained. After that,
-        it gets the user (root or wazuh) and checks if it matches the
-        `drop_privileges` setting.
+    description: Check if `drop_privileges` affects the user of the API process.
+                 In this test, the `PID` of the API process is obtained. After that,
+                 it gets the user (`root` or `wazuh`) and checks if it matches the
+                 `drop_privileges` setting.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -128,9 +122,8 @@ def test_drop_privileges(tags_to_apply, get_configuration, configure_api_environ
         - Verify that when `drop_privileges` is enabled the user who has started the `wazuh-apid` daemon is `wazuh`.
         - Verify that when `drop_privileges` is disabled the user who has started the `wazuh-apid` daemon is `root`.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters.
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters.
 
     expected_output:
         - PID of the `wazuh-apid` process.

--- a/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
+++ b/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `experimental_features` setting of the API is working properly.
-    This setting allows users to access API endpoints containing features that are under development.
+brief: These tests will check if the `experimental_features` setting of the API is working properly.
+       This setting allows users to access API endpoints containing features that are under development.
+       The Wazuh API is an open source `RESTful` API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -93,13 +89,11 @@ def get_configuration(request):
 def test_experimental_features(tags_to_apply, get_configuration, configure_api_environment,
                                restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if requests to an experimental API endpoint are allowed according
-        to the configuration. For this purpose, it configures the API to use
-        this functionality and makes requests to it, waiting for a correct response.
+    description: Check if requests to an experimental API endpoint are allowed according
+                 to the configuration. For this purpose, it configures the API to use
+                 this functionality and makes requests to it, waiting for a correct response.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -127,9 +121,8 @@ def test_experimental_features(tags_to_apply, get_configuration, configure_api_e
         - Verify that when `experimental_features` is disabled,
           it is not possible to access experimental API endpoints.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters.
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters.
 
     expected_output:
         - r'200' ('OK' HTTP status code if `experimental_features == true`)

--- a/tests/integration/test_api/test_config/test_host_port/test_host_port.py
+++ b/tests/integration/test_api/test_config/test_host_port/test_host_port.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check that the settings related to the API
-    host address and listening port are working correctly.
+brief: These tests will check that the settings related to the API host address and listening port
+       are working correctly. The Wazuh API is an open source `RESTful` API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_host_port/test_host_port.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -100,13 +96,11 @@ def get_configuration(request):
 def test_host_port(expected_exception, tags_to_apply,
                    get_configuration, configure_api_environment, restart_api, get_api_details):
     '''
-    description:
-        Check different host and port configurations. For this purpose, apply multiple
-        combinations of host and port, verify that the `aiohttp` http framework correctly
-        publishes that value in the `api.log` and check that the request returns the expected one.
+    description: Check different host and port configurations. For this purpose, apply multiple
+                 combinations of host and port, verify that the `aiohttp` http framework correctly
+                 publishes that value in the `api.log` and check that the request returns the expected one.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         -  expected_exception:
@@ -133,14 +127,13 @@ def test_host_port(expected_exception, tags_to_apply,
         - Verify that using a valid configuration, the API requests are performed correctly.
         - Verify that no unexpected exceptions occur.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (IP addresses and ports).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (IP addresses and ports).
 
     expected_output:
         - r'.*INFO: Listening on (.+)..'
         - r'{host}{port}' (`host` and `port` are obtained from each test_case.)
-        - r'200' ('OK' HTTP status code)
+        - r'200' (`OK` HTTP status code)
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     host = get_configuration['configuration']['host']

--- a/tests/integration/test_api/test_config/test_https/test_https.py
+++ b/tests/integration/test_api/test_config/test_https/test_https.py
@@ -1,28 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check that the API works correctly using the `HTTPS` protocol.
+brief: These tests will check that the API works correctly using the `HTTPS` protocol.
+       The Wazuh API is an open source `RESTful` API that allows for interaction with
+       the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_https/test_https.py
 
 daemons:
     - wazuh-apid
@@ -34,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -128,9 +125,8 @@ def test_https(tags_to_apply, get_configuration, configure_api_environment,
     assertions:
         - Verify that the API requests are made correctly using both `HTTP` and `HTTPS` protocols.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (HTTPS settings).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (HTTPS settings).
 
     expected_output:
         - r'200' ('OK' HTTP status code)

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `auth_token_exp_timeout` setting of the API is working properly.
-    This setting allows specifying the expiration time of the `JWT` token used for authentication.
+brief: These tests will check if the `auth_token_exp_timeout` setting of the API is working properly.
+       This setting allows specifying the expiration time of the `JWT` token used for authentication.
+       The Wazuh API is an open source `RESTful` API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -95,13 +91,11 @@ def get_configuration(request):
 def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                                wait_for_start, get_api_details):
     '''
-    description:
-        Check if the API `JWT` token expires after defined time. For this purpose,
-        an expiration time is set for the token, and API requests are made before
-        and after the expiration time, waiting for a valid `HTTP status code`.
+    description: Check if the API `JWT` token expires after defined time. For this purpose,
+                 an expiration time is set for the token, and API requests are made before
+                 and after the expiration time, waiting for a valid `HTTP status code`.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -126,13 +120,12 @@ def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_e
     assertions:
         - Verify that the API requests are successful if the `JWT` token has not expired and vice versa.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf_exp_timeout.yaml)
-        which includes API configuration parameters (timeouts for token expiration).
+    input_description: Different test cases are contained in an external `YAML` file (conf_exp_timeout.yaml)
+                       which includes API configuration parameters (timeouts for token expiration).
 
     expected_output:
-        - r'200' ('OK' HTTP status code if the token has not expired)
-        - r'401' ('Unauthorized' HTTP status code if the token has expired)
+        - r'200' (`OK` HTTP status code if the token has not expired)
+        - r'401' (`Unauthorized` HTTP status code if the token has expired)
 
     tags:
         - token

--- a/tests/integration/test_api/test_config/test_logs/test_logs.py
+++ b/tests/integration/test_api/test_config/test_logs/test_logs.py
@@ -1,30 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `level` setting of the API is working properly.
-    This setting allows specifying the level of detail (INFO, DEBUG)
-    of the messages written to the `api.log` file.
+brief: These tests will check if the `level` setting of the API is working properly. This setting
+       allows specifying the level of detail (INFO, DEBUG) of the messages written to the `api.log` file.
+       The Wazuh API is an open source `RESTful` API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_logs/test_logs.py
 
 daemons:
     - wazuh-apid
@@ -36,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -113,14 +108,12 @@ def extra_configuration_before_yield():
 ])
 def test_logs(tags_to_apply, get_configuration, configure_api_environment, restart_api):
     '''
-    description:
-        Check if the logs are saved in the desired path and with desired level.
-        Logs are usually store in `/var/ossec/logs/api.log` and with level `info`.
-        In this test the API log has a different path and `debug` level configured.
-        It checks if logs are saved in the new path and with `debug` level.
+    description: Check if the logs are saved in the desired path and with desired level.
+                 Logs are usually store in `/var/ossec/logs/api.log` and with level `info`.
+                 In this test the API log has a different path and `debug` level configured.
+                 It checks if logs are saved in the new path and with `debug` level.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -140,9 +133,8 @@ def test_logs(tags_to_apply, get_configuration, configure_api_environment, resta
         - Verify that no `DEBUG` messages are written when the value of the `level` setting is set to `info`.
         - Verify that `DEBUG` messages are written when the value of the `level` setting is set to `debug`.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (log paths and log levels).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (log paths and log levels).
 
     expected_output:
         - r'.*DEBUG: (.*)'

--- a/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
+++ b/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
@@ -1,30 +1,25 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `rbac_mode` (Role-Based Access Control) setting
-    of the API is working properly. This setting allows you to specify the
-    operating mode between `whitelist mode` and `blacklist mode`.
+brief: These tests will check if the `rbac_mode` (Role-Based Access Control) setting of the API
+       is working properly. This setting allows you to specify the operating mode between
+       `whitelist mode` and `blacklist mode`. The Wazuh API is an open source `RESTful` API
+       that allows for interaction with the Wazuh manager from a web browser, command line tool
+       like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
 
 daemons:
     - wazuh-apid
@@ -36,22 +31,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -121,15 +117,13 @@ def extra_configuration_after_yield():
 def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                    wait_for_start, get_api_details):
     '''
-    description:
-        Check if the `RBAC` mode selected in `api.yaml` is applied. This test creates a user
-        without any assigned permission. For this reason, when `RBAC` is in `white mode`,
-        there is no endpoint that the user can execute, so the `HTTP status code`
-        must be 403 (forbidden). On the other hand, when it is in `black mode`,
-        there is no endpoint that has it denied, so the status code must be 200 (ok).
+    description: Check if the `RBAC` mode selected in `api.yaml` is applied. This test creates a user
+                 without any assigned permission. For this reason, when `RBAC` is in `white mode`,
+                 there is no endpoint that the user can execute, so the `HTTP status code`
+                 must be 403 (`forbidden`). On the other hand, when it is in `black mode`,
+                 there is no endpoint that has it denied, so the status code must be 200 (`ok`).
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -157,15 +151,14 @@ def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, 
         - Verify that when the value of the `rbac_mode` setting is set to `black`,
           the API requests are performed correctly.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf_mode.yaml)
-        which includes API configuration parameters (rbac operation modes).
-        Two `SQL` scripts are also used to add (schema_add_user.sql)
-        and remove (schema_delete_user.sql) the testing user.
+    input_description: Different test cases are contained in an external `YAML` file (conf_mode.yaml)
+                       which includes API configuration parameters (rbac operation modes).
+                       Two `SQL` scripts are also used to add (schema_add_user.sql)
+                       and remove (schema_delete_user.sql) the testing user.
 
     expected_output:
-        - r'200' ('OK' HTTP status code if `rbac_white == True`)
-        - r'403' ('Forbidden' HTTP status code if `rbac_white == False`)
+        - r'200' (`OK` HTTP status code if `rbac_white == True`)
+        - r'403' (`Forbidden` HTTP status code if `rbac_white == False`)
 
     tags:
         - rbac

--- a/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
+++ b/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
@@ -1,29 +1,25 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `request_timeout` setting of the API is working properly.
-    This setting allows specifying the time limit for the API to process a request.
+brief: These tests will check if the `request_timeout` setting of the API is working properly.
+       This setting allows specifying the time limit for the API to process a request.
+       The Wazuh API is an open source `RESTful` API that allows for interaction with
+       the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
 
 daemons:
     - wazuh-apid
@@ -35,22 +31,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -95,13 +92,11 @@ def get_configuration(request):
 def test_request_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                          wait_for_start, get_api_details):
     '''
-    description:
-        Check if the maximum request time for an API request works.
-        For this purpose, a value of `0` seconds is set for the `request_timeout`
-        setting, and a request is made to the API, expecting an error in the response.
+    description: Check if the maximum request time for an API request works.
+                 For this purpose, a value of `0` seconds is set for the `request_timeout`
+                 setting, and a request is made to the API, expecting an error in the response.
 
-    wazuh_min_version:
-        4.3
+    wazuh_min_version: 4.3
 
     parameters:
         - tags_to_apply:
@@ -126,13 +121,12 @@ def test_request_timeout(tags_to_apply, get_configuration, configure_api_environ
     assertions:
         - Verify that the request cannot finish successfully, resulting in a timeout error.
 
-    input_description:
-        A test case is contained in an external `YAML` file (conf.yaml) which includes
-        API configuration parameters (`request_timeout` set to `0` seconds).
+    input_description: A test case is contained in an external `YAML` file (conf.yaml) which includes
+                       API configuration parameters (`request_timeout` set to `0` seconds).
 
     expected_output:
-        - r'500' ('Internal server error' HTTP status code)
-        - r'3021' ('timeout error' in the response body)
+        - r'500' (`Internal server error` HTTP status code)
+        - r'3021' (`timeout error` in the response body)
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     get_response = requests.get(f'{api.API_PROTOCOL}://{api.API_HOST}:{api.API_PORT}{api.API_LOGIN_ENDPOINT}',

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -1,29 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `use_only_authd` setting of the API is working properly.
-    This setting allows forcing the use of `wazuh-authd` daemon when registering and removing agents.
+brief: These tests will check if the `use_only_authd` setting of the API is working properly.
+       This setting allows forcing the use of `wazuh-authd` daemon when registering and removing agents.
+       The Wazuh API is an open source `RESTful` API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like `cURL` or any script or program that can make web requests.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
 
 daemons:
     - wazuh-authd
@@ -36,22 +31,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -110,13 +106,11 @@ def extra_configuration_after_yield():
 def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
                    restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if `use_only_authd` forces the use of the `wazuh-authd` daemon when adding an agent.
-        Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
-        is stopped, the request made is not completed correctly.
+    description: Check if `use_only_authd` forces the use of the `wazuh-authd` daemon when adding an agent.
+                 Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
+                 is stopped, the request made is not completed correctly.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -145,14 +139,13 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
           when the `use_only_authd` setting is disabled.
         - Verify that the request to remove the testing agent is processed correctly.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (`use_only_authd`).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (`use_only_authd`).
 
     expected_output:
-        - r'400' ('Internal server error' HTTP status code if `use_only_authd == yes` and `wazuh-authd` is stopped)
-        - r'200' ('OK' HTTP status code if `use_only_authd == no`)
-        - r'200' ('OK' HTTP status code if the testing agent is removed successfully)
+        - r'400' (`Internal server error` HTTP status code if `use_only_authd == yes` and `wazuh-authd` is stopped)
+        - r'200' (`OK` HTTP status code if `use_only_authd == no`)
+        - r'200' (`OK` HTTP status code if the testing agent is removed successfully)
 
     tags:
         - authd
@@ -193,13 +186,11 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
 def test_insert_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if `use_only_authd` forces the use of `wazuh-authd` daemon when inserting an agent.
-        Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
-        is stopped, the request made is not completed correctly.
+    description: Check if `use_only_authd` forces the use of `wazuh-authd` daemon when inserting an agent.
+                 Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
+                 is stopped, the request made is not completed correctly.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -227,13 +218,12 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
         - Verify that the request to insert the testing agent is successfully processed
           when the `use_only_authd` setting is disabled.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (`use_only_authd`).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (`use_only_authd`).
 
     expected_output:
-        - r'400' ('Internal server error' HTTP status code if `use_only_authd == yes` and `wazuh-authd` is stopped)
-        - r'200' ('OK' HTTP status code if `use_only_authd == no`)
+        - r'400' (`Internal server error` HTTP status code if `use_only_authd == yes` and `wazuh-authd` is stopped)
+        - r'200' (`OK` HTTP status code if `use_only_authd == no`)
 
     tags:
         - authd
@@ -274,13 +264,12 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
 def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_environment,
                             restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if `use_only_authd` forces the use of `wazuh-authd` daemon when quickly inserting an agent.
-        Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
-        is stopped, the request made is not completed correctly.
+    description: Check if `use_only_authd` forces the use of `wazuh-authd` daemon when
+                 quickly inserting an agent. Verify that when `use_only_authd` option
+                 is enabled and the `wazuh-authd` daemon is stopped,
+                 the request made is not completed correctly.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -308,13 +297,12 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
         - Verify that the request to quickly inserting the testing agent is successfully processed
           when the `use_only_authd` setting is disabled.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (`use_only_authd`).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (`use_only_authd`).
 
     expected_output:
-        - r'400' ('Internal server error' HTTP status code if `use_only_authd == yes` and `wazuh-authd` is stopped)
-        - r'200' ('OK' HTTP status code if `use_only_authd == no`)
+        - r'400' (`Internal server error` HTTP status code if `use_only_authd == yes` and `wazuh-authd` is stopped)
+        - r'200' (`OK` HTTP status code if `use_only_authd == no`)
 
     tags:
         - authd
@@ -351,14 +339,12 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
 def test_delete_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
     '''
-    description:
-        Check if `use_only_authd` forces the use of `wazuh-authd` daemon when deleting an agent.
-        Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
-        is not active, an error is returned. In this test, `wazuh-authd` daemon is started
-        in order to create an agent before it can be deleted.
+    description: Check if `use_only_authd` forces the use of `wazuh-authd` daemon when deleting an agent.
+                 Verify that when `use_only_authd` option is enabled and the `wazuh-authd` daemon
+                 is not active, an error is returned. In this test, `wazuh-authd` daemon is started
+                 in order to create an agent before it can be deleted.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - tags_to_apply:
@@ -387,12 +373,11 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
         - Verify that the request to delete the testing agent cannot finish successfully when
           the `use_only_authd` setting is enabled and the `wazuh-authd` daemon is stopped.
 
-    input_description:
-        Different test cases are contained in an external `YAML` file (conf.yaml)
-        which includes API configuration parameters (`use_only_authd`).
+    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+                       which includes API configuration parameters (`use_only_authd`).
 
     expected_output:
-        - r'200' ('OK' HTTP status code at inserting the testing agent)
+        - r'200' (`OK` HTTP status code at inserting the testing agent)
         - r '1' (Value of the 'total_affected_items' field in the response body when `use_only_authd == yes`)
         - r '1726' (Error code in the response body when `use_only_authd == yes` and `wazuh-authd` is stopped)
 

--- a/tests/integration/test_api/test_rbac/test_add_old_resource.py
+++ b/tests/integration/test_api/test_rbac/test_add_old_resource.py
@@ -1,33 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `RBAC` (Role-Based Access Control) feature
-    of the API is working properly. Specifically, they will verify that when
-    resources are added with the same identifier of previously existing ones,
-    the previous relationships are not maintained. The `RBAC` capability
-    allows users accessing the API to be assigned a role that will
-    define the privileges they have.
+brief: These tests will check if the `RBAC` (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that when resources are added with the same identifier of previously
+       existing ones, the previous relationships are not maintained. The `RBAC` capability allows users
+       accessing the API to be assigned a role that will define the privileges they have.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_rbac/test_add_old_resource.py
 
 daemons:
     - wazuh-apid
@@ -39,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -74,12 +66,10 @@ user_id, role_id, policy_id, rule_id = None, None, None, None
 # Tests
 def test_add_old_user(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the security relationships of a previous user are maintained
-        in the system after adding a new user with the same ID.
+    description: Check if the security relationships of a previous user are maintained
+                 in the system after adding a new user with the same ID.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -98,14 +88,13 @@ def test_add_old_user(set_security_resources, get_api_details):
     inputs:
         - The testing `user_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `user_id`.
+    input_description: From the `set_security_resources` fixture information is obtained to perform
+                       the test, concretely the `user_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the old user.
-        - r'200' ('OK' HTTP status code at deleting the old user)
-        - r'200' ('OK' HTTP status code at inserting the old user)
+        - r'200' (`OK` HTTP status code at deleting the old user)
+        - r'200' (`OK` HTTP status code at inserting the old user)
 
     tags:
         - rbac
@@ -131,12 +120,10 @@ def test_add_old_user(set_security_resources, get_api_details):
 
 def test_add_old_role(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the security relationships of a previous role are maintained
-        in the system after adding a new role with the same ID.
+    description: Check if the security relationships of a previous role are maintained
+                 in the system after adding a new role with the same ID.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -155,14 +142,13 @@ def test_add_old_role(set_security_resources, get_api_details):
     inputs:
         - The testing `role_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `role_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `role_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the old role.
-        - r'200' ('OK' HTTP status code at deleting the old role)
-        - r'200' ('OK' HTTP status code at inserting the old role)
+        - r'200' (`OK` HTTP status code at deleting the old role)
+        - r'200' (`OK` HTTP status code at inserting the old role)
 
     tags:
         - rbac
@@ -187,12 +173,10 @@ def test_add_old_role(set_security_resources, get_api_details):
 
 def test_add_old_policy(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the security relationships of a previous policy are maintained
-        in the system after adding a new policy with the same ID.
+    description: Check if the security relationships of a previous policy are maintained
+                 in the system after adding a new policy with the same ID.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -211,14 +195,13 @@ def test_add_old_policy(set_security_resources, get_api_details):
     inputs:
         - The testing `policy_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `policy_id`.
+    input_description: From the `set_security_resources` fixture information is obtained to perform the test,
+                       concretely the `policy_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the old policy.
-        - r'200' ('OK' HTTP status code at deleting the old policy)
-        - r'200' ('OK' HTTP status code at inserting the old policy)
+        - r'200' (`OK` HTTP status code at deleting the old policy)
+        - r'200' (`OK` HTTP status code at inserting the old policy)
 
     tags:
         - rbac
@@ -246,12 +229,10 @@ def test_add_old_policy(set_security_resources, get_api_details):
 
 def test_add_old_rule(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the security relationships of a previous rule are maintained
-        in the system after adding a new rule with the same ID.
+    description: Check if the security relationships of a previous rule are maintained
+                 in the system after adding a new rule with the same ID.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -270,14 +251,13 @@ def test_add_old_rule(set_security_resources, get_api_details):
     inputs:
         - The testing `rule_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `rule_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `rule_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the old rule.
-        - r'200' ('OK' HTTP status code at deleting the old rule)
-        - r'200' ('OK' HTTP status code at inserting the old rule)
+        - r'200' (`OK` HTTP status code at deleting the old rule)
+        - r'200' (`OK` HTTP status code at inserting the old rule)
 
     tags:
         - rbac

--- a/tests/integration/test_api/test_rbac/test_admin_resources.py
+++ b/tests/integration/test_api/test_rbac/test_admin_resources.py
@@ -1,33 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `RBAC` (Role-Based Access Control) feature
-    of the API is working properly. Specifically, they will verify that
-    the different actions that can be performed with admin resources
-    are working correctly. The `RBAC` capability allows users
-    accessing the API to be assigned a role that will define
-    the privileges they have.
+brief: These tests will check if the `RBAC` (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that the different actions that can be performed with admin resources
+       are working correctly. The `RBAC` capability allows users accessing the API to be assigned a role
+       that will define the privileges they have.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_rbac/test_admin_resources.py
 
 daemons:
     - wazuh-apid
@@ -39,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -141,12 +133,10 @@ def modify_admin_resources(api_details, admin_ids, endpoint, body):
 # Tests
 def test_admin_users(restart_api, get_api_details):
     '''
-    description:
-        Check if the admin security users can be removed. For this purpose,
-        it tries to delete these users, expecting an error as a response.
+    description: Check if the admin security users can be removed. For this purpose,
+                 it tries to delete these users, expecting an error as a response.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - restart_api:
@@ -164,13 +154,12 @@ def test_admin_users(restart_api, get_api_details):
     inputs:
         - The data are obtained from within the test.
 
-    input_description:
-        From the `get_admin_resources` function information is obtained to perform the test,
-        concretely the `admin_ids`.
+    input_description: From the `get_admin_resources` function information is obtained to perform
+                       the test, concretely the `admin_ids`.
 
     expected_output:
-        - r'200' ('OK' HTTP status code at collect the admin security users information)
-        - r'200' ('OK' HTTP status code when trying to delete the admin security users)
+        - r'200' (`OK` HTTP status code at collect the admin security users information)
+        - r'200' (`OK` HTTP status code when trying to delete the admin security users)
         - r'1' (Size of the `failed_items` array from the response body)
         - r'5004' (Error code of the `failed_items[0]` array from the response body)
 
@@ -187,12 +176,10 @@ def test_admin_users(restart_api, get_api_details):
 
 def test_admin_roles(restart_api, get_api_details):
     '''
-    description:
-        Check if the admin security roles can be removed. For this purpose,
-        it tries to delete these roles, expecting an error as a response.
+    description: Check if the admin security roles can be removed. For this purpose,
+                 it tries to delete these roles, expecting an error as a response.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - restart_api:
@@ -210,13 +197,12 @@ def test_admin_roles(restart_api, get_api_details):
     inputs:
         - The data are obtained from within the test.
 
-    input_description:
-        From the `get_admin_resources` function information is obtained to perform the test,
-        concretely the `role_ids`.
+    input_description: From the `get_admin_resources` function information is obtained
+                       to perform the test, concretely the `role_ids`.
 
     expected_output:
-        - r'200' ('OK' HTTP status code at collect the admin security roles information)
-        - r'200' ('OK' HTTP status code when trying to delete the admin security roles)
+        - r'200' (`OK` HTTP status code at collect the admin security roles information)
+        - r'200' (`OK` HTTP status code when trying to delete the admin security roles)
         - r'1' (Size of the `failed_items` array from the response body)
         - r'4008' (Error code of the `failed_items[0]` array from the response body)
 
@@ -236,12 +222,10 @@ def test_admin_roles(restart_api, get_api_details):
 
 def test_admin_policies(restart_api, get_api_details):
     '''
-    description:
-        Check if the admin security policies can be removed. For this purpose,
-        it tries to delete these policies, expecting an error as a response.
+    description: Check if the admin security policies can be removed. For this purpose,
+                 it tries to delete these policies, expecting an error as a response.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - restart_api:
@@ -259,13 +243,12 @@ def test_admin_policies(restart_api, get_api_details):
     inputs:
         - The data are obtained from within the test.
 
-    input_description:
-        From the `get_admin_resources` function information is obtained to perform the test,
-        concretely the `policy_ids`.
+    input_description: From the `get_admin_resources` function information is obtained
+                       to perform the test, concretely the `policy_ids`.
 
     expected_output:
-        - r'200' ('OK' HTTP status code at collect the admin security policies information)
-        - r'200' ('OK' HTTP status code when trying to delete the admin security policies)
+        - r'200' (`OK` HTTP status code at collect the admin security policies information)
+        - r'200' (`OK` HTTP status code when trying to delete the admin security policies)
         - r'1' (Size of the `failed_items` array from the response body)
         - r'4008' (Error code of the `failed_items[0]` array from the response body)
 
@@ -286,12 +269,10 @@ def test_admin_policies(restart_api, get_api_details):
 
 def test_admin_rules(restart_api, get_api_details):
     '''
-    description:
-        Check if the admin security rules can be removed. For this purpose,
-        it tries to delete these rules, expecting an error as a response.
+    description: Check if the admin security rules can be removed. For this purpose,
+                 it tries to delete these rules, expecting an error as a response.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - restart_api:
@@ -309,13 +290,12 @@ def test_admin_rules(restart_api, get_api_details):
     inputs:
         - The data are obtained from within the test.
 
-    input_description:
-        From the `get_admin_resources` function information is obtained to perform the test,
-        concretely the `rule_ids`.
+    input_description: From the `get_admin_resources` function information is obtained
+                       to perform the test, concretely the `rule_ids`.
 
     expected_output:
-        - r'200' ('OK' HTTP status code at collect the admin security rules information)
-        - r'200' ('OK' HTTP status code when trying to delete the admin security rules)
+        - r'200' (`OK` HTTP status code at collect the admin security rules information)
+        - r'200' (`OK` HTTP status code when trying to delete the admin security rules)
         - r'1' (Size of the `failed_items` array from the response body)
         - r'4008' (Error code of the `failed_items[0]` array from the response body)
 

--- a/tests/integration/test_api/test_rbac/test_policy_position.py
+++ b/tests/integration/test_api/test_rbac/test_policy_position.py
@@ -1,32 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `RBAC` (Role-Based Access Control) feature
-    of the API is working properly. Specifically, they will verify that
-    that the policies are applied to the roles in the right order.
-    The `RBAC` capability allows users accessing the API to be assigned
-    a role that will define the privileges they have.
+brief: These tests will check if the `RBAC` (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that that the policies are applied to the roles in the right order.
+       The `RBAC` capability allows users accessing the API to be assigned a role
+       that will define the privileges they have.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_rbac/test_policy_position.py
 
 daemons:
     - wazuh-apid
@@ -38,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -137,12 +130,10 @@ def add_role_policy(api_details, p_id, position):
 # Tests
 def test_policy_position(set_security_resources, add_new_policies, get_api_details):
     '''
-    description:
-        Check if the correct order between role-policy relationships remain after
-        removing some of them and adding others using the `position` parameter.
+    description: Check if the correct order between role-policy relationships remain after
+                 removing some of them and adding others using the `position` parameter.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -162,12 +153,11 @@ def test_policy_position(set_security_resources, add_new_policies, get_api_detai
     inputs:
         - The testing `policy_ids` array as a module variable.
 
-    input_description:
-        From the `add_new_policies`, `remove_role_policy` and `add_role_policy` fixtures information
-        is obtained to perform the test, concretely the `policy_ids` array.
+    input_description: From the `add_new_policies`, `remove_role_policy` and `add_role_policy` fixtures
+                       information is obtained to perform the test, concretely the `policy_ids` array.
 
     expected_output:
-        - r'200' ('OK' HTTP status code when deleting or adding a role-policy)
+        - r'200' (`OK` HTTP status code when deleting or adding a role-policy)
         - An integer array with the role-policy positions.
 
     tags:

--- a/tests/integration/test_api/test_rbac/test_remove_relationship.py
+++ b/tests/integration/test_api/test_rbac/test_remove_relationship.py
@@ -1,32 +1,24 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `RBAC` (Role-Based Access Control) feature of the API
-    is working properly. Specifically, they will verify that the different relationships
-    between users-roles-policies can be correctly removed.
-    The `RBAC` capability allows users accessing the API to be assigned a role that
-    will define the privileges they have.
+brief: These tests will check if the `RBAC` (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that the different relationships between users-roles-policies can be
+       correctly removed. The `RBAC` capability allows users accessing the API to be assigned a role
+       that will define the privileges they have.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
 
 components:
     - manager
-
-path:
-    tests/integration/test_api/test_rbac/test_remove_relationship.py
 
 daemons:
     - wazuh-apid
@@ -38,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -105,11 +98,9 @@ def remove_relationship(api_details, endpoint, resource, related_resource, relat
 # Tests
 def test_remove_user_role_relationship(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the user and role still exist after removing their relationship.
+    description: Check if the user and role still exist after removing their relationship.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -128,13 +119,12 @@ def test_remove_user_role_relationship(set_security_resources, get_api_details):
         - The testing `user_id` as a module attribute.
         - The testing `role_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `user_id` and `role_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `user_id` and `role_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the user-role relationship.
-        - r'200' ('OK' HTTP status code when deleting the user-role relationship)
+        - r'200' (`OK` HTTP status code when deleting the user-role relationship)
         - A `JSON` string in the response body with information of the role.
         - A `JSON` string in the response body with information of the user.
 
@@ -152,11 +142,9 @@ def test_remove_user_role_relationship(set_security_resources, get_api_details):
 
 def test_remove_role_policy_relationship(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the role and policy still exist after removing their relationship.
+    description: Check if the role and policy still exist after removing their relationship.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -175,13 +163,12 @@ def test_remove_role_policy_relationship(set_security_resources, get_api_details
         - The testing `role_id` as a module attribute.
         - The testing `policy_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `role_id` and `policy_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `role_id` and `policy_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the role-policy relationship.
-        - r'200' ('OK' HTTP status code when deleting the role-policy relationship)
+        - r'200' (`OK` HTTP status code when deleting the role-policy relationship)
         - A `JSON` string in the response body with information of the role.
         - A `JSON` string in the response body with information of the policy.
 
@@ -199,11 +186,9 @@ def test_remove_role_policy_relationship(set_security_resources, get_api_details
 
 def test_remove_role_rule_relationship(set_security_resources, get_api_details):
     '''
-    description:
-        Check if the role and rule still exist after removing their relationship.
+    description: Check if the role and rule still exist after removing their relationship.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -222,13 +207,12 @@ def test_remove_role_rule_relationship(set_security_resources, get_api_details):
         - The testing `role_id` as a module attribute.
         - The testing `rule_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `role_id` and `rule_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `role_id` and `rule_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the role-rule relationship.
-        - r'200' ('OK' HTTP status code when deleting the role-rule relationship)
+        - r'200' (`OK` HTTP status code when deleting the role-rule relationship)
         - A `JSON` string in the response body with information of the role.
         - A `JSON` string in the response body with information of the rule.
 

--- a/tests/integration/test_api/test_rbac/test_remove_resource.py
+++ b/tests/integration/test_api/test_rbac/test_remove_resource.py
@@ -1,23 +1,18 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
-    Created by Wazuh, Inc. <info@wazuh.com>.
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-type:
-    integration
+type: integration
 
-brief:
-    These tests will check if the `RBAC` (Role-Based Access Control) feature of the API
-    is working properly. Specifically, they will verify that the different security
-    resources (users, roles, policies, and rules) can be correctly removed.
-    The `RBAC` capability allows users accessing the API to be assigned a role that
-    will define the privileges they have.
+brief: These tests will check if the `RBAC` (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that the different security resources (users, roles, policies, and rules)
+       can be correctly removed. The `RBAC` capability allows users accessing the API to be assigned a role that
+       will define the privileges they have.
 
-tier:
-    0
+tier: 0
 
 modules:
     - api
@@ -25,8 +20,6 @@ modules:
 components:
     - manager
 
-path:
-    tests/integration/test_api/test_rbac/test_remove_resource.py
 daemons:
     - wazuh-apid
     - wazuh-analysisd
@@ -37,22 +30,23 @@ os_platform:
     - linux
 
 os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
     - Arch Linux
-    - CentOS 6
-    - CentOS 7
+    - Amazon Linux 2
+    - Amazon Linux 1
     - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
     - Debian Buster
     - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
     - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
+    - Red Hat 7
+    - Red Hat 6
 
 references:
     - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
@@ -113,11 +107,10 @@ def check_resources(deleted_resource, resource_id):
 # Tests
 def test_remove_rule(set_security_resources, get_api_details):
     '''
-    description:
-        Check if relationships between security resources stay the same after removing the linked rule.
+    description: Check if relationships between security resources stay the same
+                 after removing the linked rule.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -138,13 +131,12 @@ def test_remove_rule(set_security_resources, get_api_details):
         - The testing `role_id` as a module attribute.
         - The testing `rule_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `role_id` and the `rule_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `role_id` and the `rule_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the role-based relationships.
-        - r'200' ('OK' HTTP status code when deleting the linked rule)
+        - r'200' (`OK` HTTP status code when deleting the linked rule)
 
     tags:
         - rbac
@@ -166,11 +158,10 @@ def test_remove_rule(set_security_resources, get_api_details):
 
 def test_remove_policy(set_security_resources, get_api_details):
     '''
-    description:
-        Check if relationships between security resources stay the same after removing the linked policy.
+    description: Check if relationships between security resources stay the same
+                 after removing the linked policy.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -191,13 +182,12 @@ def test_remove_policy(set_security_resources, get_api_details):
         - The testing `role_id` as a module attribute.
         - The testing `policy_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `role_id` and the `policy_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `role_id` and the `policy_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the role-based relationships.
-        - r'200' ('OK' HTTP status code when deleting the linked policy)
+        - r'200' (`OK` HTTP status code when deleting the linked policy)
 
     tags:
         - rbac
@@ -219,11 +209,10 @@ def test_remove_policy(set_security_resources, get_api_details):
 
 def test_remove_user(set_security_resources, get_api_details):
     '''
-    description:
-        Check if relationships between security resources stay the same after removing the linked user.
+    description: Check if relationships between security resources stay the same
+                 after removing the linked user.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -244,13 +233,12 @@ def test_remove_user(set_security_resources, get_api_details):
         - The testing `role_id` as a module attribute.
         - The testing `user_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `role_id` and the `user_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `role_id` and the `user_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the role-based relationships.
-        - r'200' ('OK' HTTP status code when deleting the linked user)
+        - r'200' (`OK` HTTP status code when deleting the linked user)
 
     tags:
         - rbac
@@ -272,11 +260,10 @@ def test_remove_user(set_security_resources, get_api_details):
 
 def test_remove_role(set_security_resources, get_api_details):
     '''
-    description:
-        Check if relationships between security resources stay the same after removing the linked role.
+    description: Check if relationships between security resources stay the same
+                 after removing the linked role.
 
-    wazuh_min_version:
-        4.2
+    wazuh_min_version: 4.2
 
     parameters:
         - set_security_resources:
@@ -297,13 +284,12 @@ def test_remove_role(set_security_resources, get_api_details):
         - The testing `user_id` as a module attribute.
         - The testing `role_id` as a module attribute.
 
-    input_description:
-        From the `set_security_resources` fixture information is obtained to perform the test,
-        concretely the `user_id` and the `role_id`.
+    input_description: From the `set_security_resources` fixture information is obtained
+                       to perform the test, concretely the `user_id` and the `role_id`.
 
     expected_output:
         - A `JSON` string in the response body with information of the role-based relationships.
-        - r'200' ('OK' HTTP status code when deleting the linked role)
+        - r'200' (`OK` HTTP status code when deleting the linked role)
 
     tags:
         - rbac


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1808|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_key_polling_master.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will verify if the `agent-key-polling` module works correctly in a cluster environment, specifically using a `master` node. This module allows retrieving the agent information from an external database, like `MySQL` or any database engine, for registering it to the `client.keys` file.",
    "tier": 0,
    "modules": [
        "cluster"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-clusterd",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/agent-key-polling.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-agent-key-polling.html",
        "https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html",
        "https://documentation.wazuh.com/current/development/wazuh-cluster.html#master"
    ],
    "tags": [
        "key-polling",
        "master"
    ],
    "name": "test_key_polling_master.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the Wazuh master node correctly handles the `agent-key-polling` module to retrieve externally stored agent information. For this purpose, a simulated worker node is used to send key-polling requests to the master node. After sending such requests, the test checks if the socket managed by the `wazuh-modulesd` daemon has received them correctly.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "cmd": {
                        "type": "bytes",
                        "brief": "Cluster message command."
                    }
                },
                {
                    "counter": {
                        "type": "int",
                        "brief": "Cluster message counter."
                    }
                },
                {
                    "payload": {
                        "type": "bytes",
                        "brief": "Cluster message payload data."
                    }
                },
                {
                    "expected": {
                        "type": "str",
                        "brief": "Expected message in krequest socket."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "detect_initial_master_serving": {
                        "type": "fixture",
                        "brief": "Make sure that the master node is serving after restarting the `wazuh-clusterd` daemon."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of the `connect_to_sockets` fixture."
                    }
                },
                {
                    "send_initial_worker_hello": {
                        "type": "fixture",
                        "brief": "Send initial hello message to the master node."
                    }
                }
            ],
            "assertions": [
                "Verify that the master node correctly receives key-polling messages by agent ID.",
                "Verify that the master node correctly receives key-polling messages by agent IP address."
            ],
            "input_description": "Two test cases are found in the test module and include the requests to be made and the expected result.",
            "expected_output": [
                "r'id:001'",
                "r'ip:124.0.0.1'"
            ],
            "tags": [
                "keys",
                "fernet"
            ],
            "name": "test_key_polling_master",
            "inputs": [
                "get_configuration0-run_keypoll-1-{\"message\": \"id:001\"}-id:001",
                "get_configuration0-run_keypoll-2-{\"message\": \"ip:124.0.0.1\"}-ip:124.0.0.1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_key_polling_master.yaml</summary>
<p>

```yaml
brief: These tests will verify if the `agent-key-polling` module works correctly in
  a cluster environment, specifically using a `master` node. This module allows retrieving
  the agent information from an external database, like `MySQL` or any database engine,
  for registering it to the `client.keys` file.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-clusterd
- wazuh-modulesd
group_id: 0
id: 1
modules:
- cluster
name: test_key_polling_master.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/agent-key-polling.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-agent-key-polling.html
- https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html
- https://documentation.wazuh.com/current/development/wazuh-cluster.html#master
tags:
- key-polling
- master
tests:
- assertions:
  - Verify that the master node correctly receives key-polling messages by agent ID.
  - Verify that the master node correctly receives key-polling messages by agent IP
    address.
  description: Check if the Wazuh master node correctly handles the `agent-key-polling`
    module to retrieve externally stored agent information. For this purpose, a simulated
    worker node is used to send key-polling requests to the master node. After sending
    such requests, the test checks if the socket managed by the `wazuh-modulesd` daemon
    has received them correctly.
  expected_output:
  - r'id:001'
  - r'ip:124.0.0.1'
  input_description: Two test cases are found in the test module and include the requests
    to be made and the expected result.
  inputs:
  - 'get_configuration0-run_keypoll-1-{"message": "id:001"}-id:001'
  - 'get_configuration0-run_keypoll-2-{"message": "ip:124.0.0.1"}-ip:124.0.0.1'
  name: test_key_polling_master
  parameters:
  - cmd:
      brief: Cluster message command.
      type: bytes
  - counter:
      brief: Cluster message counter.
      type: int
  - payload:
      brief: Cluster message payload data.
      type: bytes
  - expected:
      brief: Expected message in krequest socket.
      type: str
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - detect_initial_master_serving:
      brief: Make sure that the master node is serving after restarting the `wazuh-clusterd`
        daemon.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of the `connect_to_sockets` fixture.
      type: fixture
  - send_initial_worker_hello:
      brief: Send initial hello message to the master node.
      type: fixture
  tags:
  - keys
  - fernet
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_key_polling_worker.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will verify if the `agent-key-polling` module works correctly in a cluster environment, specifically using a `worker` node. This module allows retrieving the agent information from an external database, like `MySQL` or any database engine, for registering it to the `client.keys` file.",
    "tier": 0,
    "modules": [
        "cluster"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-clusterd",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/agent-key-polling.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-agent-key-polling.html",
        "https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html",
        "https://documentation.wazuh.com/current/development/wazuh-cluster.html#worker"
    ],
    "tags": [
        "key-polling",
        "worker"
    ],
    "name": "test_key_polling_worker.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the Wazuh worker node correctly forwards agent key-polling requests to the master node. For this purpose, a simulated master node is used to receive key-polling requests from the worker node. After sending such requests, the test checks if the master node has received them correctly.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "cmd": {
                        "type": "bytes",
                        "brief": "Cluster message command."
                    }
                },
                {
                    "counter": {
                        "type": "int",
                        "brief": "Cluster message counter."
                    }
                },
                {
                    "payload": {
                        "type": "bytes",
                        "brief": "Cluster message payload data."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "detect_initial_worker_connected": {
                        "type": "fixture",
                        "brief": "Make sure that the worker node is connected to master one after restarting the `wazuh-clusterd` daemon."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of the `connect_to_sockets` fixture."
                    }
                }
            ],
            "assertions": [
                "Verify that the master node correctly receives the payload of key-polling by agent ID.",
                "Verify that the master node correctly receives the payload of key-polling by agent IP address."
            ],
            "input_description": "Two test cases are found in the test module and include the requests to be made and the expected result.",
            "expected_output": [
                "The payload of key-polling by agent ID (001) in the body response.",
                "The payload of key-polling by agent IP address (124.0.0.1) in the body response."
            ],
            "tags": [
                "keys"
            ],
            "name": "test_key_polling_worker",
            "inputs": [
                "get_configuration0-run_keypoll-1-{\"message\": \"id:001\"}",
                "get_configuration0-run_keypoll-2-{\"message\": \"ip:124.0.0.1\"}"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_key_polling_worker.yaml</summary>
<p>

```yaml
brief: These tests will verify if the `agent-key-polling` module works correctly in
  a cluster environment, specifically using a `worker` node. This module allows retrieving
  the agent information from an external database, like `MySQL` or any database engine,
  for registering it to the `client.keys` file.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-clusterd
- wazuh-modulesd
group_id: 0
id: 2
modules:
- cluster
name: test_key_polling_worker.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/agent-key-polling.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-agent-key-polling.html
- https://documentation.wazuh.com/current/user-manual/configuring-cluster/basics.html
- https://documentation.wazuh.com/current/development/wazuh-cluster.html#worker
tags:
- key-polling
- worker
tests:
- assertions:
  - Verify that the master node correctly receives the payload of key-polling by agent
    ID.
  - Verify that the master node correctly receives the payload of key-polling by agent
    IP address.
  description: Check if the Wazuh worker node correctly forwards agent key-polling
    requests to the master node. For this purpose, a simulated master node is used
    to receive key-polling requests from the worker node. After sending such requests,
    the test checks if the master node has received them correctly.
  expected_output:
  - The payload of key-polling by agent ID (001) in the body response.
  - The payload of key-polling by agent IP address (124.0.0.1) in the body response.
  input_description: Two test cases are found in the test module and include the requests
    to be made and the expected result.
  inputs:
  - 'get_configuration0-run_keypoll-1-{"message": "id:001"}'
  - 'get_configuration0-run_keypoll-2-{"message": "ip:124.0.0.1"}'
  name: test_key_polling_worker
  parameters:
  - cmd:
      brief: Cluster message command.
      type: bytes
  - counter:
      brief: Cluster message counter.
      type: int
  - payload:
      brief: Cluster message payload data.
      type: bytes
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - detect_initial_worker_connected:
      brief: Make sure that the worker node is connected to master one after restarting
        the `wazuh-clusterd` daemon.
      type: fixture
  - connect_to_sockets_function:
      brief: Function scope version of the `connect_to_sockets` fixture.
      type: fixture
  tags:
  - keys
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`