### PR TITLE
Migrate `test_fim/test_files/test_ambiguous_confs` documentation to qa-docs

### DIFF
--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
@@ -61,16 +61,8 @@ references:
 
 pytest_args:
     - fim_mode:
-<<<<<<< Updated upstream
-        value: realtime
-        brief: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
-    - fim_mode:
-        value: whodata
-        brief: Implies real-time monitoring but adding the who-data information.
-=======
         realtime: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
         whodata: Implies real-time monitoring but adding the who-data information.
->>>>>>> Stashed changes
 
 tags:
     - fim

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
@@ -7,9 +7,10 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if Wazuh’s File integrity monitoring (`FIM`) system watches selected
-       files and triggering alerts when these files are modified. In particular, ambiguous
-       configurations will be tested along with complex directory paths.
+brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using complex directory paths and ambiguous directory configurations, such as directories and
+       subdirectories with opposite monitoring settings.
        The FIM capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
        for changes to the checksums, permissions, and ownership.
 
@@ -60,11 +61,16 @@ references:
 
 pytest_args:
     - fim_mode:
+<<<<<<< Updated upstream
         value: realtime
         brief: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
     - fim_mode:
         value: whodata
         brief: Implies real-time monitoring but adding the who-data information.
+=======
+        realtime: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the who-data information.
+>>>>>>> Stashed changes
 
 tags:
     - fim
@@ -270,6 +276,7 @@ def test_ambiguous_complex(tags_to_apply,
                            get_configuration, configure_environment,
                            restart_syscheckd, wait_for_fim_start):
     '''
+<<<<<<< Updated upstream
     description: Check if the `wazuh-syscheck` daemon applies different configurations between
                  subdirectories properly. Example:
                  <directories
@@ -283,6 +290,14 @@ def test_ambiguous_complex(tags_to_apply,
                     check_owner='yes'> /testdir/subdir </directories>
                  For this purpose, it specifies different `FIM` settings for each subdirectory and
                  finally verifies that these have been applied correctly.
+=======
+    description: Check if the `wazuh-syscheckd` daemon applies different configurations between
+                 subdirectories properly. For example, `realtime=yes report_changes=yes check_owner=no`
+                 for the `/testdir` directory and `report_changes=no check_owner=yes` for
+                 the `/testdir/subdir` directory. For this purpose, it applies different
+                 `FIM` settings for each subdirectory and finally verifies that
+                 these have been applied correctly.
+>>>>>>> Stashed changes
 
     wazuh_min_version: 4.2
 

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
-       files and triggering alerts when these files are modified. All these tests will be performed
-       using complex directory paths and ambiguous directory configurations, such as directories and
+brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files
+       and triggering alerts when these files are modified. All these tests will be performed using
+       complex directory paths and ambiguous directory configurations, such as directories and
        subdirectories with opposite monitoring settings.
        The FIM capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
        for changes to the checksums, permissions, and ownership.

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
@@ -1,7 +1,74 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if Wazuh’s File integrity monitoring (`FIM`) system watches selected
+       files and triggering alerts when these files are modified. In particular, ambiguous
+       configurations will be tested along with complex directory paths.
+       The FIM capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-agentd
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        value: realtime
+        brief: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
+    - fim_mode:
+        value: whodata
+        brief: Implies real-time monitoring but adding the who-data information.
+
+tags:
+    - fim
+'''
 import os
 import sys
 
@@ -202,14 +269,54 @@ def get_checkers(check_list):
 def test_ambiguous_complex(tags_to_apply,
                            get_configuration, configure_environment,
                            restart_syscheckd, wait_for_fim_start):
-    """Automatic test for each configuration given in the yaml.
+    '''
+    description: Check if the `wazuh-syscheck` daemon applies different configurations between
+                 subdirectories properly. Example:
+                 <directories
+                    realtime='yes'
+                    report_changes='yes'
+                    check_all='yes'
+                    check_owner='no'> /testdir </directories>
+                 <directories realtime='yes'
+                    report_changes='no'
+                    check_sum='no'
+                    check_owner='yes'> /testdir/subdir </directories>
+                 For this purpose, it specifies different `FIM` settings for each subdirectory and
+                 finally verifies that these have been applied correctly.
 
-    The main purpose of this test is to check that syscheck will apply different configurations between subdirectories
-    properly. Example:
+    wazuh_min_version: 4.2
 
-    <directories realtime='yes' report_changes='yes' check_all='yes' check_owner='no'> /testdir </directories>
-    <directories realtime='yes' report_changes='no' check_sum='no' check_owner='yes'> /testdir/subdir </directories>
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the `wazuh-syscheckd` daemon apply different configurations between subdirectories properly.
+
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_complex.yaml or wazuh_conf_complex_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+
+    tags:
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # Standard params for each test

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_complex.py
@@ -268,28 +268,12 @@ def test_ambiguous_complex(tags_to_apply,
                            get_configuration, configure_environment,
                            restart_syscheckd, wait_for_fim_start):
     '''
-<<<<<<< Updated upstream
-    description: Check if the `wazuh-syscheck` daemon applies different configurations between
-                 subdirectories properly. Example:
-                 <directories
-                    realtime='yes'
-                    report_changes='yes'
-                    check_all='yes'
-                    check_owner='no'> /testdir </directories>
-                 <directories realtime='yes'
-                    report_changes='no'
-                    check_sum='no'
-                    check_owner='yes'> /testdir/subdir </directories>
-                 For this purpose, it specifies different `FIM` settings for each subdirectory and
-                 finally verifies that these have been applied correctly.
-=======
     description: Check if the `wazuh-syscheckd` daemon applies different configurations between
                  subdirectories properly. For example, `realtime=yes report_changes=yes check_owner=no`
                  for the `/testdir` directory and `report_changes=no check_owner=yes` for
                  the `/testdir/subdir` directory. For this purpose, it applies different
                  `FIM` settings for each subdirectory and finally verifies that
                  these have been applied correctly.
->>>>>>> Stashed changes
 
     wazuh_min_version: 4.2
 

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
@@ -237,6 +237,7 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
 
     tags:
         - scheduled
+        - time_travel
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     file_list = ['example.csv']
@@ -300,6 +301,7 @@ def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_e
 
     tags:
         - scheduled
+        - time_travel
     '''
     def report_changes_validator(event):
         """Validate content_changes event property exists in the event."""
@@ -391,6 +393,7 @@ def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_env
 
     tags:
         - scheduled
+        - time_travel
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
@@ -611,6 +614,7 @@ def test_ambiguous_check(dirname, checkers, tags_to_apply, get_configuration, co
 
     tags:
         - scheduled
+        - time_travel
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
-       files and triggering alerts when these files are modified. All these tests will be performed
-       using ambiguous directory configurations, such as directories and subdirectories with opposite
+brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files
+       and triggering alerts when these files are modified. All these tests will be performed using
+       ambiguous directory configurations, such as directories and subdirectories with opposite
        monitoring settings. In particular, it will be tested that changes in the files are correctly
        detected through their properties. Several monitoring attribute are also tested,
        such as recursion level, file restrictions, tags, or changes reporting.

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_simple.py
@@ -1,7 +1,74 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using ambiguous directory configurations, such as directories and subdirectories with opposite
+       monitoring settings. In particular, it will be tested that changes in the files are correctly
+       detected through their properties. Several monitoring attribute are also tested,
+       such as recursion level, file restrictions, tags, or changes reporting.
+       The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-agentd
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the who-data information.
+
+tags:
+    - fim
+'''
 import os
 import sys
 
@@ -123,24 +190,54 @@ def _test_recursion_cud(ini, fin, path, recursion_subdir, scheduled,
 ])
 def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                             wait_for_fim_start):
-    """Check restrict configuration events.
+    '''
+    description: Check if the `wazuh-syscheckd` daemon detects regular file changes (add, modify, delete) depending
+                 on the value set in the `restrict` attribute. This attribute limit checks to files containing
+                 the entered string in the file name.
+                 For example, if `/testdir` has a `restrict` configuration and `/testdir/subdir` has not,
+                 only /testdir/subdir events should appear in the `ossec.log`file.
+                 For this purpose, the two previous paths are monitored, and modifications are made to the files
+                 to check if alerts are generated when required.
 
-    Check if syscheck detects regular file changes (add, modify, delete) depending on its restrict configuration.
+    wazuh_min_version: 4.2
 
-    /testdir -> has a restrict configuration
-    /testdir/subdir -> has no restrict configuration
-    Only /testdir/subdir events should appear in ossec.log
+    parameters:
+        - folders:
+            type: list
+            brief: Monitored directories.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    This test is intended to be used with valid configurations files. Each execution of this test will configure
-    the environment properly, restart the service and wait for the initial scan.
+    assertions:
+        - Verify that no alerts are generated after modifying files in the directory specified in the `restrict` option.
+        - Verify that alerts are generated after modifying files in the subdirectory that is not specified
+          in the `restrict` option, but whose parent directory is restricted.
 
-    Parameters
-    ----------
-    folders : list
-        Monitored directories
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+        - Multiple logs of `FIM` events in the monitored directories.
+
+    tags:
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     file_list = ['example.csv']
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
@@ -159,22 +256,51 @@ def test_ambiguous_restrict(folders, tags_to_apply, get_configuration, configure
 ])
 def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                           wait_for_fim_start):
-    """Check content_changes field for each event
+    '''
+    description: Check if the `wazuh-syscheckd` daemon detects or not the `content_changes` field for each event
+                 depending on the value set in the `report_changes` attribute. This attribute allows reporting
+                 the modifications made on a monitored file. For this purpose, two folders are monitored,
+                 and modifications are made to the files to check if the `content_changes` field
+                 is generated in the events when required.
 
-    Check if syscheck detects or not the content_changes field for each event depending on its report_changes
-    attribute.
+    wazuh_min_version: 4.2
 
-    This test validates both situations, making sure that if report_changes='no', there won't be a
-    content_changes event property.
+    parameters:
+        - folders:
+            type: list
+            brief: Monitored directories.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    Parameters
-    ----------
-    folders : list
-        Monitored directories
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    assertions:
+        - Verify that the `content_changes` field is not generated in events when `report_changes == no`.
+        - Verify that the `content_changes` field is generated in events when `report_changes == yes`.
 
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+        - Multiple logs of `FIM` events in the monitored directories.
+
+    tags:
+        - scheduled
+    '''
     def report_changes_validator(event):
         """Validate content_changes event property exists in the event."""
         for file in file_list:
@@ -221,18 +347,51 @@ def test_ambiguous_report(folders, tags_to_apply, get_configuration, configure_e
 ])
 def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                         wait_for_fim_start):
-    """Check if syscheck detects the event property 'tags' for each event.
+    '''
+    description: Check if the `wazuh-syscheckd` daemon detects or not the `tags` field for each event
+                 depending on the value(s) set in the `tags` attribute. This attribute allows adding
+                 tags to alerts for monitored directories. For this purpose, two folders are monitored,
+                 and modifications are made to the files to check if the `tags` field is generated
+                 in the events when required.
 
-    This test validates both situations, making sure that if tags='no', there won't be a
-    tags event property.
+    wazuh_min_version: 4.2
 
-    Parameters
-    ----------
-    folders : list
-        Monitored directories
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    parameters:
+        - folders:
+            type: list
+            brief: Monitored directories.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the `tags` field is not generated in events when the `tags` attribute not exists or is empty.
+        - Verify that the `tags` field is generated in events when the `tags` attribute has content.
+
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+        - Multiple logs of `FIM` events in the monitored directories.
+
+    tags:
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 
@@ -253,24 +412,55 @@ def test_ambiguous_tags(folders, tags_to_apply, get_configuration, configure_env
 ])
 def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_configuration, configure_environment,
                              restart_syscheckd, wait_for_fim_start):
-    """Check alerts for each level defined in recursion_level
+    '''
+    description: Check if the `wazuh-syscheckd` daemon detects alerts for each directory level defined in
+                 the `recursion_level` attribute. This attribute limits the maximum level of recursion allowed.
+                 For example, if `recursion_level=1` is set, and the `/testdir` directory is monitored,
+                 it will only monitor `/testdir` and `/testdir/subdir`.
+                 If `/testdir/subdir/subdir2` exists, `/subdir2` wouldn't be monitored.
+                 For this purpose, a testing folder with several levels of subdirectories is monitored,
+                 and modifications are made in each level to see if events are generated when required.
 
-    Check if syscheck detects alerts for each level defined in the recursion_level attribute.
-    This overwrites the default value, restricting it.
+    wazuh_min_version: 4.2
 
-    If we set recursion_level=1 and we have this monitored directory /testdir
-    It will only monitor /testdir and /testdir/subdir
-    If we had /testdir/subdir/subdir2, /subdir2 wouldn't be monitored
+    parameters:
+        - dirname:
+            type: string
+            brief: Name of the monitored directory.
+        - recursion_level:
+            type: int
+            brief: Value of the `recursion_level` attribute.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    Parameters
-    ----------
-    dirname : string
-        Name of the monitored directory
-    recursion_level : int
-        Value of the recursion_level attribute
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    assertions:
+        - Verify that `FIM` events are generated up to the specified subdirectory depth.
+
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+        - Multiple logs of `FIM` events in the monitored directories.
+
+    tags:
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     recursion_subdir = 'subdir'
@@ -296,23 +486,60 @@ def test_ambiguous_recursion(dirname, recursion_level, tags_to_apply, get_config
 ])
 def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags_to_apply, get_configuration,
                                  configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check alerts for each level defined in recursion_level with tags
+    '''
+    description: Check if the `wazuh-syscheckd` daemon detects alerts for each directory level defined in
+                 the `recursion_level` attribute and if it detects the 'tags' field for each of them.
+                 The `tags` attribute allows adding tags to alerts for monitored directories,
+                 and the `recursion_level` attribute limits the maximum level of recursion allowed.
+                 For this purpose, a testing folder with several levels of subdirectories is monitored,
+                 and modifications are made in each level to see if events are generated when required.
+                 Once the events have been generated, they are checked to see whether or not they
+                 should include the `tag` field.
 
-    Check if syscheck detects alerts for each level defined in the recursion_level attribute and
-    if it detects the event property 'tags' for each of them.
-    This overwrites the default value, restricting it.
+    wazuh_min_version: 4.2
 
-    Parameters
-    ----------
-    dirnames : list
-        Monitored directories
-    recursion_level : int
-        Value of the recursion_level attribute
-    triggers_event : bool
-        determine if the event should be raised or not.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    parameters:
+        - dirnames:
+            type: list
+            brief: Monitored directories.
+        - recursion_level:
+            type: int
+            brief: Value of the `recursion_level` attribute.
+        - triggers_event:
+            type: bool
+            brief: Determine if the event should be raised or not.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that `FIM` events are generated up to the specified subdirectory depth.
+        - Verify that the generated `FIM` events should or not contain the `tag` field.
+
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+        - Multiple logs of `FIM` events in the monitored directories.
+
+    tags:
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     recursion_subdir = 'subdir'
@@ -336,22 +563,55 @@ def test_ambiguous_recursion_tag(dirnames, recursion_level, triggers_event, tags
 @pytest.mark.parametrize('dirname, checkers', parametrize_list)
 def test_ambiguous_check(dirname, checkers, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                          wait_for_fim_start):
-    """Check if syscheck detects every check set in the configuration.
+    '''
+    description: Check if the `wazuh-syscheckd` daemon detects in the generated events the checks specified in
+                 the configuration. These checks are attributes indicating that a monitored file has been modified.
+                 For example, if `check_all=yes` and `check_inode=no` are set for the same directory, `syscheck` must
+                 send an event containing every possible check except the inode one.
+                 For this purpose, different `checks` are set in several subdirectories, and files are modified
+                 to generate events. Finally, verification is performed to ensure that the events contain only
+                 the fields of the `checks` specified for the monitored folder.
 
-    Check are read from left to right, overwriting any ambiguous configuration.
+    wazuh_min_version: 4.2
 
-    If we set check_all='yes' and then check_inode='no' for the same directory, syscheck must send an event
-    containing every possible check without inode.
+    parameters:
+        - dirname:
+            type: string
+            brief: Name of the monitored directory.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list (the one we get from the event).
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    Parameters
-    ----------
-    dirname : string
-        Name of the monitored directory
-    checkers : set
-        Checks to be compared to the actual event check list (the one we get from the event)
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    assertions:
+        - Verify that the `FIM` events generated contain only the `check` fields specified in the configuration.
+
+    input_description: Different test cases are contained in external `YAML` files
+                       (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes
+                       configuration settings for the `wazuh-syscheckd` daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
+        - Multiple logs of `FIM` events in the monitored directories.
+
+    tags:
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_whodata_thread.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_whodata_thread.py
@@ -7,11 +7,11 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `who-data` feature of Wazuh’s File Integrity Monitoring (`FIM`)
-       system works properly. `who-data` information contains the user who made the changes on
-       the monitored files and also the program name or process used to carry them out.
-       The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
-       for changes to the checksums, permissions, and ownership.
+brief: These tests will check if the `who-data` feature of the File Integrity Monitoring (`FIM`)
+       system works properly. `who-data` information contains the user who made the changes
+       on the monitored files and also the program name or process used to carry them out.
+       The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
 
 tier: 2
 

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_whodata_thread.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ambiguous_whodata_thread.py
@@ -26,6 +26,7 @@ daemons:
 
 os_platform:
     - linux
+    - windows
 
 os_version:
     - Arch Linux
@@ -45,6 +46,12 @@ os_version:
     - Red Hat 8
     - Red Hat 7
     - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/auditing-whodata/who-linux.html

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_duplicate_entries.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_duplicate_entries.py
@@ -1,7 +1,73 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using ambiguous directory configurations, such as directories and subdirectories with opposite
+       monitoring settings. In particular, it will check that duplicate events are not generated when
+       multiple configurations are used to monitor the same directory.
+       The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-agentd
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the who-data information.
+
+tags:
+    - fim
+'''
 import codecs
 import os
 from pathlib import Path
@@ -102,15 +168,44 @@ def check_event(previous_mode: str, previous_event: dict, file: str):
 
 
 def test_duplicate_entries(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check if syscheckd ignores duplicate entries.
-       For instance:
-           - The second entry should prevail over the first one.
-            <directories realtime="yes">/home/user</directories> (IGNORED)
-            <directories whodata="yes">/home/user</directories>
-        OR
-           - Just generate one event.
-            <directories realtime="yes">/home/user,/home/user</directories>
-    """
+    '''
+    description: Check if when using multiple configurations on the same directory that can generate the same event,
+                 only one is finally generated. For example, when monitoring the same directory using the `whodata`
+                 and `realtime` attributes and modifying a file, two `FIM` events should not be generated.
+                 For this purpose, it applies the test case configuration, adds a test file in the directory,
+                 and finally checks that only one `FIM` event has been generated.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that only one `FIM` event is generated when the testing file is created.
+
+    input_description: One test cases (ossec_conf_duplicate_simple) is contained in external `YAML` file
+                       (wazuh_conf_dup_entries.yaml) which includes configuration settings
+                       for the `wazuh-syscheckd` daemon and testing directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$'
+
+    tags:
+        - scheduled
+        - realtime
+        - time_travel
+    '''
     logger.info('Applying the test configuration')
     check_apply_test({'ossec_conf_duplicate_simple'}, get_configuration['tags'])
     file = 'hello'
@@ -138,13 +233,46 @@ def test_duplicate_entries(get_configuration, configure_environment, restart_sys
 
 def test_duplicate_entries_sregex(get_configuration, configure_environment,
                                   restart_syscheckd, wait_for_fim_start):
-    """Check if syscheckd ignores duplicate entries, sregex patterns of restrict.
-       For instance:
-           - The second entry should prevail over the first one.
-            <directories restrict="^good.*$">/home/user</directories> (IGNORED)
-            <directories restrict="^he.*$">/home/user</directories>
-       In this case, only the filenames that match with this regex '^he.*$'
-    """
+    '''
+    description: Check if when using multiple `sregex` patterns of the `restrict` attribute in the same directory,
+                 and that these can match the same file, only one `FIM` event is generated. For example, when
+                 monitoring the same directory using `restrict="^good.*$"` and `restrict="^he.*$"`, only
+                 the filenames that match with this regex `^he.*$` should generate `FIM` events.
+                 For this purpose, it applies the test case configuration, adds and modifies a test file in
+                 the directory, checks that only one `FIM` event has been generated for each operation, and finally
+                 verifies that only one `FIM` event has been generated for each operation.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that only one `FIM` event is generated when the testing file is created.
+        - Verify that only one `FIM` event is generated when the testing file is modified.
+
+    input_description: One test case (ossec_conf_duplicate_sregex) is contained in external `YAML` file
+                       (wazuh_conf_dup_entries.yaml) which includes configuration settings
+                       for the `wazuh-syscheckd` daemon and testing directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     logger.info('Applying the test configuration')
     check_apply_test({'ossec_conf_duplicate_sregex'}, get_configuration['tags'])
     file = 'hello'
@@ -175,12 +303,47 @@ def test_duplicate_entries_sregex(get_configuration, configure_environment,
 
 
 def test_duplicate_entries_report(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check if syscheckd ignores duplicate entries, report changes.
-       For instance:
-           - The second entry should prevail over the first one.
-            <directories report_changes="yes">/home/user</directories> (IGNORED)
-            <directories report_changes="no">/home/user</directories>
-    """
+    '''
+    description: Check if when using multiple configurations using the `report_changes` attribute
+                 in the same directory, only the last configuration is taken into account. For example,
+                 when monitoring the same directory using `report_changes="yes"` and `report_changes="no"`,
+                 no `diff` files should be generated when modifying a file since `report_changes="no"` is
+                 the last detected configuration.
+                 For this purpose, it applies the test case configuration, adds and modifies a test file
+                 in the directory, checks that `FIM` event has been generated for each operation,
+                 and finally verifies that a `diff` file has not been created.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that `FIM` events are generated when the testing file is created and modified.
+        - Verify that a `diff` file has not been created when modifying the test file.
+
+    input_description: One test case (ossec_conf_duplicate_report) is contained in external `YAML` file
+                       (wazuh_conf_dup_entries.yaml) which includes configuration settings
+                       for the `wazuh-syscheckd` daemon and testing directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     logger.info('Applying the test configuration')
     check_apply_test({'ossec_conf_duplicate_report'}, get_configuration['tags'])
     file = 'hello'
@@ -211,14 +374,52 @@ def test_duplicate_entries_report(get_configuration, configure_environment, rest
 
 def test_duplicate_entries_complex(get_configuration, configure_environment, restart_syscheckd,
                                    wait_for_fim_start):
-    """Check if syscheckd ignores duplicate entries, complex entries.
-       For instance:
-           - The second entry should prevail over the first one.
-            <directories check_all="no" check_owner="yes" check_inode="yes">/home/user</directories> (IGNORED)
-            <directories check_all="no" check_size="yes" check_perm="yes">/home/user</directories>
-       In this case, it only check if the permissions or the size of the file changes
-    """
+    '''
+    description: Check if when using multiple configurations using diferent `check_` attributes in
+                 the same directory, only the last configuration is taken into account. For example,
+                 when monitoring the same directory using `check_owner="yes" check_inode="yes"` and
+                 `check_size="yes" check_perm="yes"`, only `size` and `permissions` fields files
+                 should be generated in the `FIM` events since `check_size="yes" check_perm="yes"`
+                 is the last detected configuration.
+                 For this purpose, it applies the test case configuration, adds and modifies
+                 a testing file in the directory, checks that one `FIM` event is generated when
+                 modifying the size or permissions of the test file, and finally verify that
+                 the `size` and `permissions` fields have been generated in that event.
 
+    wazuh_min_version: 4.2
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that `FIM` event is generated when the testing file is added.
+        - Verify that modifications not related to the size or permissions
+          of the testing file do not generate `FIM` events.
+        - Verify that `FIM` events are generated that include the `size` and `permissions` fields
+          when these are modified in the test file.
+
+    input_description: One test case (ossec_conf_duplicate_complex) is contained in external `YAML` file
+                       (wazuh_conf_dup_entries.yaml) which includes configuration settings
+                       for the `wazuh-syscheckd` daemon and testing directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     def replace_character(old, new, path):
         f = codecs.open(path, encoding='utf-8')
         content = f.read()

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_duplicate_entries.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_duplicate_entries.py
@@ -7,11 +7,11 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
-       files and triggering alerts when these files are modified. All these tests will be performed
-       using ambiguous directory configurations, such as directories and subdirectories with opposite
-       monitoring settings. In particular, it will check that duplicate events are not generated when
-       multiple configurations are used to monitor the same directory.
+brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files
+       and triggering alerts when these files are modified. All these tests will be performed using
+       ambiguous directory configurations, such as directories and subdirectories with opposite
+       monitoring settings. In particular, it will check that duplicate events are not generated
+       when multiple configurations are used to monitor the same directory.
        The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
        for changes to the checksums, permissions, and ownership.
 

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -1,7 +1,73 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using ambiguous directory configurations, such as directories and subdirectories with opposite
+       monitoring settings. In particular, it will be verified that the value of the `ignore` attribute
+       prevails over the `restrict` one.
+       The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-agentd
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the who-data information.
+
+tags:
+    - fim
+'''
 import os
 import sys
 
@@ -21,9 +87,9 @@ pytestmark = pytest.mark.tier(level=2)
 # Variables
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_conf_ignore_restrict_win32.yaml' if sys.platform == 'win32'
-else 'wazuh_conf_ignore_restrict.yaml')
-
+configurations_path = os.path.join(
+    test_data_path, 'wazuh_conf_ignore_restrict_win32.yaml'
+    if sys.platform == 'win32' else 'wazuh_conf_ignore_restrict.yaml')
 test_directories = [os.path.join(PREFIX, 'testdir1'), os.path.join(PREFIX, 'testdir2')]
 testdir1, testdir2 = test_directories
 
@@ -54,23 +120,58 @@ def get_configuration(request):
 ])
 def test_ignore_works_over_restrict(folder, filename, triggers_event, tags_to_apply, get_configuration,
                                     configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check if the ignore tag prevails over the restrict one when using both in the same directory.
+    '''
+    description: Check if the `ignore` tag prevails over the `restrict` one when using both in the same directory.
+                 For example, when a directory is ignored and at the same time monitoring is restricted to a file
+                 that is in that directory, no `FIM` events should be generated when that file is modified.
+                 For this purpose, the test case configuration is applied, and it is checked if `FIM` events
+                 are generated when required.
 
-    This test is intended to be used with valid configurations files. Each execution of this test will configure
-    the environment properly, restart the service and wait for the initial scan.
+    wazuh_min_version: 4.2
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the file is being created
-    filename : str
-        Name of the file to be created
-    triggers_event : bool
-        True if an event must be generated, False otherwise
-    tags_to_apply : set
-        Run test if it matches with a configuration identifier, skip otherwise
+    parameters:
+        - folder:
+            type: str
+            brief: Directory where the file is being created.
+        - filename:
+            type: str
+            brief: Name of the file to be created.
+        - triggers_event:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    """
+    assertions:
+        - Verify that when a directory is ignored, the `restrict` attribute
+          is not taken into account to generate `FIM` events.
+
+    input_description: Two test cases are contained in external `YAML` file
+                       (wazuh_conf_ignore_restrict.yaml or wazuh_conf_ignore_restrict_win32.yaml)
+                       which includes configuration settings for the `wazuh-syscheckd` daemon
+                       and testing directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (When the FIM event should be generated)
+        - r".*Ignoring '.*?' '(.*?)' due to( sregex)? '.*?'" (When the FIM event should be ignored)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     logger.info('Applying the test configuration')
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if Wazuh’s File Integrity Monitoring (`FIM`) system watches selected
-       files and triggering alerts when these files are modified. All these tests will be performed
-       using ambiguous directory configurations, such as directories and subdirectories with opposite
+brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files
+       and triggering alerts when these files are modified. All these tests will be performed using
+       ambiguous directory configurations, such as directories and subdirectories with opposite
        monitoring settings. In particular, it will be verified that the value of the `ignore` attribute
        prevails over the `restrict` one.
        The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
@@ -1,7 +1,64 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `who-data` feature of Wazuh’s File Integrity Monitoring (`FIM`)
+       system works properly. `who-data` information contains the user who made the changes on
+       the monitored files and also the program name or process used to carry them out.
+       The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/auditing-whodata/who-linux.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the who-data information.
+
+tags:
+    - fim
+'''
 import os
 
 import pytest
@@ -46,9 +103,49 @@ def get_configuration(request):
 ])
 def test_whodata_prevails_over_realtime(directory, get_configuration, put_env_variables, configure_environment,
                                         restart_syscheckd, wait_for_fim_start):
-    """
-    Test alerts are generated when monitor environment variables
-    """
+    '''
+    description: Check if when using the options who-data and real-time at the same time
+                 the value of `whodata` is the one used. For example, when using `whodata=yes`
+                 and `realtime=no` on the same directory, real-time file monitoring
+                 will be enabled, as who-data requires it.
+                 For this purpose, the configuration is applied and it is verified that when
+                 `who-data` is set to `yes`, the `realtime` value is not taken into account,
+                 enabling in this case the real-time file monitoring.
+
+    wazuh_min_version: 4.2
+
+    parameters:
+        - whodata_enabled:
+            type: bool
+            brief: Who-data status.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+
+    assertions:
+        - Verify that real-time file monitoring is active.
+
+    input_description: A test case is contained in external `YAML` file
+                       (wazuh_conf_whodata_prevails_over_realtime.yaml)
+                       which includes configuration settings for the `wazuh-syscheckd` daemon
+                       and testing directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$'
+
+    tags:
+        - realtime 
+        - who-data
+    '''
     filename = "testfile"
 
     create_file(REGULAR, directory, filename, content="")

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
@@ -7,10 +7,10 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `who-data` feature of Wazuh’s File Integrity Monitoring (`FIM`)
-       system works properly. `who-data` information contains the user who made the changes on
-       the monitored files and also the program name or process used to carry them out. In particular,
-       it will be verified that the value of the `whodata` attribute prevails over the `relatime` one.
+brief: These tests will check if the `who-data` feature of the File Integrity Monitoring (`FIM`) system
+       works properly. `who-data` information contains the user who made the changes on the monitored
+       files and also the program name or process used to carry them out. In particular, it will be
+       verified that the value of the `whodata` attribute prevails over the `relatime` one.
        The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
        for changes to the checksums, permissions, and ownership.
 

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_whodata_prevails_over_realtime.py
@@ -9,7 +9,8 @@ type: integration
 
 brief: These tests will check if the `who-data` feature of Wazuh’s File Integrity Monitoring (`FIM`)
        system works properly. `who-data` information contains the user who made the changes on
-       the monitored files and also the program name or process used to carry them out.
+       the monitored files and also the program name or process used to carry them out. In particular,
+       it will be verified that the value of the `whodata` attribute prevails over the `relatime` one.
        The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
        for changes to the checksums, permissions, and ownership.
 
@@ -115,21 +116,24 @@ def test_whodata_prevails_over_realtime(directory, get_configuration, put_env_va
     wazuh_min_version: 4.2
 
     parameters:
-        - whodata_enabled:
-            type: bool
-            brief: Who-data status.
-        - tags_to_apply:
-            type: set
-            brief: Run test if match with a configuration identifier, skip otherwise.
+        - directory:
+            type: str
+            brief: Testing directory.
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
+        - put_env_variables:
+            type: fixture
+            brief: Create environment variables.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
         - restart_syscheckd:
             type: fixture
             brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
     assertions:
         - Verify that real-time file monitoring is active.
@@ -143,7 +147,7 @@ def test_whodata_prevails_over_realtime(directory, get_configuration, put_env_va
         - r'.*Sending FIM event: (.+)$'
 
     tags:
-        - realtime 
+        - realtime
         - who-data
     '''
     filename = "testfile"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1914|

# Description
As part of issue #1810 and epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_ambiguous_complex.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files and triggering alerts when these files are modified. All these tests will be performed using complex directory paths and ambiguous directory configurations, such as directories and subdirectories with opposite monitoring settings. The FIM capability is managed by the `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the who-data information."
            }
        }
    ],
    "tags": [
        "fim"
    ],
    "name": "test_ambiguous_complex.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `wazuh-syscheckd` daemon applies different configurations between subdirectories properly. For example, `realtime=yes report_changes=yes check_owner=no` for the `/testdir` directory and `report_changes=no check_owner=yes` for the `/testdir/subdir` directory. For this purpose, it applies different `FIM` settings for each subdirectory and finally verifies that these have been applied correctly.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the `wazuh-syscheckd` daemon apply different configurations between subdirectories properly."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_complex.yaml or wazuh_conf_complex_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                }
            ],
            "tags": [
                "scheduled"
            ],
            "name": "test_ambiguous_complex",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration1-tags_to_apply0",
                "get_configuration2-tags_to_apply0",
                "get_configuration3-tags_to_apply0",
                "get_configuration4-tags_to_apply0",
                "get_configuration5-tags_to_apply0",
                "get_configuration6-tags_to_apply0",
                "get_configuration7-tags_to_apply0",
                "get_configuration8-tags_to_apply0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_ambiguous_complex.yaml</summary>
<p>

```yaml
brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches
  selected files and triggering alerts when these files are modified. All these tests
  will be performed using complex directory paths and ambiguous directory configurations,
  such as directories and subdirectories with opposite monitoring settings. The FIM
  capability is managed by the `wazuh-syscheckd` daemon, which checks configured files
  for changes to the checksums, permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-syscheckd
group_id: 0
id: 1
modules:
- fim
name: test_ambiguous_complex.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
pytest_args:
- fim_mode:
    realtime: Enable real-time/continuous monitoring on Linux (using the inotify system
      calls) and Windows systems.
    whodata: Implies real-time monitoring but adding the who-data information.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
tags:
- fim
tests:
- assertions:
  - Verify that the `wazuh-syscheckd` daemon apply different configurations between
    subdirectories properly.
  description: Check if the `wazuh-syscheckd` daemon applies different configurations
    between subdirectories properly. For example, `realtime=yes report_changes=yes
    check_owner=no` for the `/testdir` directory and `report_changes=no check_owner=yes`
    for the `/testdir/subdir` directory. For this purpose, it applies different `FIM`
    settings for each subdirectory and finally verifies that these have been applied
    correctly.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_complex.yaml
    or wazuh_conf_complex_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration1-tags_to_apply0
  - get_configuration2-tags_to_apply0
  - get_configuration3-tags_to_apply0
  - get_configuration4-tags_to_apply0
  - get_configuration5-tags_to_apply0
  - get_configuration6-tags_to_apply0
  - get_configuration7-tags_to_apply0
  - get_configuration8-tags_to_apply0
  name: test_ambiguous_complex
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  wazuh_min_version: 4.2
tier: 2
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_ambiguous_simple.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files and triggering alerts when these files are modified. All these tests will be performed using ambiguous directory configurations, such as directories and subdirectories with opposite monitoring settings. In particular, it will be tested that changes in the files are correctly detected through their properties. Several monitoring attribute are also tested, such as recursion level, file restrictions, tags, or changes reporting. The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the who-data information."
            }
        }
    ],
    "tags": [
        "fim"
    ],
    "name": "test_ambiguous_simple.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `wazuh-syscheckd` daemon detects regular file changes (add, modify, delete) depending on the value set in the `restrict` attribute. This attribute limit checks to files containing the entered string in the file name. For example, if `/testdir` has a `restrict` configuration and `/testdir/subdir` has not, only /testdir/subdir events should appear in the `ossec.log`file. For this purpose, the two previous paths are monitored, and modifications are made to the files to check if alerts are generated when required.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "folders": {
                        "type": "list",
                        "brief": "Monitored directories."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that no alerts are generated after modifying files in the directory specified in the `restrict` option.",
                "Verify that alerts are generated after modifying files in the subdirectory that is not specified in the `restrict` option, but whose parent directory is restricted."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                },
                "Multiple logs of `FIM` events in the monitored directories."
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ambiguous_restrict",
            "inputs": [
                "get_configuration0-folders0-tags_to_apply0",
                "get_configuration1-folders0-tags_to_apply0",
                "get_configuration2-folders0-tags_to_apply0",
                "get_configuration3-folders0-tags_to_apply0",
                "get_configuration4-folders0-tags_to_apply0",
                "get_configuration5-folders0-tags_to_apply0",
                "get_configuration6-folders0-tags_to_apply0",
                "get_configuration7-folders0-tags_to_apply0",
                "get_configuration8-folders0-tags_to_apply0",
                "get_configuration9-folders0-tags_to_apply0",
                "get_configuration10-folders0-tags_to_apply0",
                "get_configuration11-folders0-tags_to_apply0",
                "get_configuration12-folders0-tags_to_apply0",
                "get_configuration13-folders0-tags_to_apply0",
                "get_configuration14-folders0-tags_to_apply0",
                "get_configuration15-folders0-tags_to_apply0",
                "get_configuration16-folders0-tags_to_apply0",
                "get_configuration17-folders0-tags_to_apply0",
                "get_configuration18-folders0-tags_to_apply0",
                "get_configuration19-folders0-tags_to_apply0",
                "get_configuration20-folders0-tags_to_apply0",
                "get_configuration21-folders0-tags_to_apply0",
                "get_configuration22-folders0-tags_to_apply0",
                "get_configuration23-folders0-tags_to_apply0"
            ]
        },
        {
            "description": "Check if the `wazuh-syscheckd` daemon detects or not the `content_changes` field for each event depending on the value set in the `report_changes` attribute. This attribute allows reporting the modifications made on a monitored file. For this purpose, two folders are monitored, and modifications are made to the files to check if the `content_changes` field is generated in the events when required.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "folders": {
                        "type": "list",
                        "brief": "Monitored directories."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the `content_changes` field is not generated in events when `report_changes == no`.",
                "Verify that the `content_changes` field is generated in events when `report_changes == yes`."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                },
                "Multiple logs of `FIM` events in the monitored directories."
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ambiguous_report",
            "inputs": [
                "get_configuration0-folders0-tags_to_apply0",
                "get_configuration1-folders0-tags_to_apply0",
                "get_configuration2-folders0-tags_to_apply0",
                "get_configuration3-folders0-tags_to_apply0",
                "get_configuration4-folders0-tags_to_apply0",
                "get_configuration5-folders0-tags_to_apply0",
                "get_configuration6-folders0-tags_to_apply0",
                "get_configuration7-folders0-tags_to_apply0",
                "get_configuration8-folders0-tags_to_apply0",
                "get_configuration9-folders0-tags_to_apply0",
                "get_configuration10-folders0-tags_to_apply0",
                "get_configuration11-folders0-tags_to_apply0",
                "get_configuration12-folders0-tags_to_apply0",
                "get_configuration13-folders0-tags_to_apply0",
                "get_configuration14-folders0-tags_to_apply0",
                "get_configuration15-folders0-tags_to_apply0",
                "get_configuration16-folders0-tags_to_apply0",
                "get_configuration17-folders0-tags_to_apply0",
                "get_configuration18-folders0-tags_to_apply0",
                "get_configuration19-folders0-tags_to_apply0",
                "get_configuration20-folders0-tags_to_apply0",
                "get_configuration21-folders0-tags_to_apply0",
                "get_configuration22-folders0-tags_to_apply0",
                "get_configuration23-folders0-tags_to_apply0"
            ]
        },
        {
            "description": "Check if the `wazuh-syscheckd` daemon detects or not the `tags` field for each event depending on the value(s) set in the `tags` attribute. This attribute allows adding tags to alerts for monitored directories. For this purpose, two folders are monitored, and modifications are made to the files to check if the `tags` field is generated in the events when required.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "folders": {
                        "type": "list",
                        "brief": "Monitored directories."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the `tags` field is not generated in events when the `tags` attribute not exists or is empty.",
                "Verify that the `tags` field is generated in events when the `tags` attribute has content."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                },
                "Multiple logs of `FIM` events in the monitored directories."
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ambiguous_tags",
            "inputs": [
                "get_configuration0-folders0-tags_to_apply0",
                "get_configuration1-folders0-tags_to_apply0",
                "get_configuration2-folders0-tags_to_apply0",
                "get_configuration3-folders0-tags_to_apply0",
                "get_configuration4-folders0-tags_to_apply0",
                "get_configuration5-folders0-tags_to_apply0",
                "get_configuration6-folders0-tags_to_apply0",
                "get_configuration7-folders0-tags_to_apply0",
                "get_configuration8-folders0-tags_to_apply0",
                "get_configuration9-folders0-tags_to_apply0",
                "get_configuration10-folders0-tags_to_apply0",
                "get_configuration11-folders0-tags_to_apply0",
                "get_configuration12-folders0-tags_to_apply0",
                "get_configuration13-folders0-tags_to_apply0",
                "get_configuration14-folders0-tags_to_apply0",
                "get_configuration15-folders0-tags_to_apply0",
                "get_configuration16-folders0-tags_to_apply0",
                "get_configuration17-folders0-tags_to_apply0",
                "get_configuration18-folders0-tags_to_apply0",
                "get_configuration19-folders0-tags_to_apply0",
                "get_configuration20-folders0-tags_to_apply0",
                "get_configuration21-folders0-tags_to_apply0",
                "get_configuration22-folders0-tags_to_apply0",
                "get_configuration23-folders0-tags_to_apply0"
            ]
        },
        {
            "description": "Check if the `wazuh-syscheckd` daemon detects alerts for each directory level defined in the `recursion_level` attribute. This attribute limits the maximum level of recursion allowed. For example, if `recursion_level=1` is set, and the `/testdir` directory is monitored, it will only monitor `/testdir` and `/testdir/subdir`. If `/testdir/subdir/subdir2` exists, `/subdir2` wouldn't be monitored. For this purpose, a testing folder with several levels of subdirectories is monitored, and modifications are made in each level to see if events are generated when required.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "dirname": {
                        "type": "string",
                        "brief": "Name of the monitored directory."
                    }
                },
                {
                    "recursion_level": {
                        "type": "int",
                        "brief": "Value of the `recursion_level` attribute."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that `FIM` events are generated up to the specified subdirectory depth."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                },
                "Multiple logs of `FIM` events in the monitored directories."
            ],
            "tags": [
                "scheduled"
            ],
            "name": "test_ambiguous_recursion",
            "inputs": [
                "get_configuration0-/recursiondir-1-tags_to_apply0",
                "get_configuration0-/recursiondir-4-tags_to_apply1",
                "get_configuration1-/recursiondir-1-tags_to_apply0",
                "get_configuration1-/recursiondir-4-tags_to_apply1",
                "get_configuration2-/recursiondir-1-tags_to_apply0",
                "get_configuration2-/recursiondir-4-tags_to_apply1",
                "get_configuration3-/recursiondir-1-tags_to_apply0",
                "get_configuration3-/recursiondir-4-tags_to_apply1",
                "get_configuration4-/recursiondir-1-tags_to_apply0",
                "get_configuration4-/recursiondir-4-tags_to_apply1",
                "get_configuration5-/recursiondir-1-tags_to_apply0",
                "get_configuration5-/recursiondir-4-tags_to_apply1",
                "get_configuration6-/recursiondir-1-tags_to_apply0",
                "get_configuration6-/recursiondir-4-tags_to_apply1",
                "get_configuration7-/recursiondir-1-tags_to_apply0",
                "get_configuration7-/recursiondir-4-tags_to_apply1",
                "get_configuration8-/recursiondir-1-tags_to_apply0",
                "get_configuration8-/recursiondir-4-tags_to_apply1",
                "get_configuration9-/recursiondir-1-tags_to_apply0",
                "get_configuration9-/recursiondir-4-tags_to_apply1",
                "get_configuration10-/recursiondir-1-tags_to_apply0",
                "get_configuration10-/recursiondir-4-tags_to_apply1",
                "get_configuration11-/recursiondir-1-tags_to_apply0",
                "get_configuration11-/recursiondir-4-tags_to_apply1",
                "get_configuration12-/recursiondir-1-tags_to_apply0",
                "get_configuration12-/recursiondir-4-tags_to_apply1",
                "get_configuration13-/recursiondir-1-tags_to_apply0",
                "get_configuration13-/recursiondir-4-tags_to_apply1",
                "get_configuration14-/recursiondir-1-tags_to_apply0",
                "get_configuration14-/recursiondir-4-tags_to_apply1",
                "get_configuration15-/recursiondir-1-tags_to_apply0",
                "get_configuration15-/recursiondir-4-tags_to_apply1",
                "get_configuration16-/recursiondir-1-tags_to_apply0",
                "get_configuration16-/recursiondir-4-tags_to_apply1",
                "get_configuration17-/recursiondir-1-tags_to_apply0",
                "get_configuration17-/recursiondir-4-tags_to_apply1",
                "get_configuration18-/recursiondir-1-tags_to_apply0",
                "get_configuration18-/recursiondir-4-tags_to_apply1",
                "get_configuration19-/recursiondir-1-tags_to_apply0",
                "get_configuration19-/recursiondir-4-tags_to_apply1",
                "get_configuration20-/recursiondir-1-tags_to_apply0",
                "get_configuration20-/recursiondir-4-tags_to_apply1",
                "get_configuration21-/recursiondir-1-tags_to_apply0",
                "get_configuration21-/recursiondir-4-tags_to_apply1",
                "get_configuration22-/recursiondir-1-tags_to_apply0",
                "get_configuration22-/recursiondir-4-tags_to_apply1",
                "get_configuration23-/recursiondir-1-tags_to_apply0",
                "get_configuration23-/recursiondir-4-tags_to_apply1"
            ]
        },
        {
            "description": "Check if the `wazuh-syscheckd` daemon detects alerts for each directory level defined in the `recursion_level` attribute and if it detects the 'tags' field for each of them. The `tags` attribute allows adding tags to alerts for monitored directories, and the `recursion_level` attribute limits the maximum level of recursion allowed. For this purpose, a testing folder with several levels of subdirectories is monitored, and modifications are made in each level to see if events are generated when required. Once the events have been generated, they are checked to see whether or not they should include the `tag` field.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "dirnames": {
                        "type": "list",
                        "brief": "Monitored directories."
                    }
                },
                {
                    "recursion_level": {
                        "type": "int",
                        "brief": "Value of the `recursion_level` attribute."
                    }
                },
                {
                    "triggers_event": {
                        "type": "bool",
                        "brief": "Determine if the event should be raised or not."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that `FIM` events are generated up to the specified subdirectory depth.",
                "Verify that the generated `FIM` events should or not contain the `tag` field."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                },
                "Multiple logs of `FIM` events in the monitored directories."
            ],
            "tags": [
                "scheduled"
            ],
            "name": "test_ambiguous_recursion_tag",
            "inputs": [
                "get_configuration0-dirnames0-2-True-tags_to_apply0",
                "get_configuration0-dirnames1-2-False-tags_to_apply1",
                "get_configuration1-dirnames0-2-True-tags_to_apply0",
                "get_configuration1-dirnames1-2-False-tags_to_apply1",
                "get_configuration2-dirnames0-2-True-tags_to_apply0",
                "get_configuration2-dirnames1-2-False-tags_to_apply1",
                "get_configuration3-dirnames0-2-True-tags_to_apply0",
                "get_configuration3-dirnames1-2-False-tags_to_apply1",
                "get_configuration4-dirnames0-2-True-tags_to_apply0",
                "get_configuration4-dirnames1-2-False-tags_to_apply1",
                "get_configuration5-dirnames0-2-True-tags_to_apply0",
                "get_configuration5-dirnames1-2-False-tags_to_apply1",
                "get_configuration6-dirnames0-2-True-tags_to_apply0",
                "get_configuration6-dirnames1-2-False-tags_to_apply1",
                "get_configuration7-dirnames0-2-True-tags_to_apply0",
                "get_configuration7-dirnames1-2-False-tags_to_apply1",
                "get_configuration8-dirnames0-2-True-tags_to_apply0",
                "get_configuration8-dirnames1-2-False-tags_to_apply1",
                "get_configuration9-dirnames0-2-True-tags_to_apply0",
                "get_configuration9-dirnames1-2-False-tags_to_apply1",
                "get_configuration10-dirnames0-2-True-tags_to_apply0",
                "get_configuration10-dirnames1-2-False-tags_to_apply1",
                "get_configuration11-dirnames0-2-True-tags_to_apply0",
                "get_configuration11-dirnames1-2-False-tags_to_apply1",
                "get_configuration12-dirnames0-2-True-tags_to_apply0",
                "get_configuration12-dirnames1-2-False-tags_to_apply1",
                "get_configuration13-dirnames0-2-True-tags_to_apply0",
                "get_configuration13-dirnames1-2-False-tags_to_apply1",
                "get_configuration14-dirnames0-2-True-tags_to_apply0",
                "get_configuration14-dirnames1-2-False-tags_to_apply1",
                "get_configuration15-dirnames0-2-True-tags_to_apply0",
                "get_configuration15-dirnames1-2-False-tags_to_apply1",
                "get_configuration16-dirnames0-2-True-tags_to_apply0",
                "get_configuration16-dirnames1-2-False-tags_to_apply1",
                "get_configuration17-dirnames0-2-True-tags_to_apply0",
                "get_configuration17-dirnames1-2-False-tags_to_apply1",
                "get_configuration18-dirnames0-2-True-tags_to_apply0",
                "get_configuration18-dirnames1-2-False-tags_to_apply1",
                "get_configuration19-dirnames0-2-True-tags_to_apply0",
                "get_configuration19-dirnames1-2-False-tags_to_apply1",
                "get_configuration20-dirnames0-2-True-tags_to_apply0",
                "get_configuration20-dirnames1-2-False-tags_to_apply1",
                "get_configuration21-dirnames0-2-True-tags_to_apply0",
                "get_configuration21-dirnames1-2-False-tags_to_apply1",
                "get_configuration22-dirnames0-2-True-tags_to_apply0",
                "get_configuration22-dirnames1-2-False-tags_to_apply1",
                "get_configuration23-dirnames0-2-True-tags_to_apply0",
                "get_configuration23-dirnames1-2-False-tags_to_apply1"
            ]
        },
        {
            "description": "Check if the `wazuh-syscheckd` daemon detects in the generated events the checks specified in the configuration. These checks are attributes indicating that a monitored file has been modified. For example, if `check_all=yes` and `check_inode=no` are set for the same directory, `syscheck` must send an event containing every possible check except the inode one. For this purpose, different `checks` are set in several subdirectories, and files are modified to generate events. Finally, verification is performed to ensure that the events contain only the fields of the `checks` specified for the monitored folder.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "dirname": {
                        "type": "string",
                        "brief": "Name of the monitored directory."
                    }
                },
                {
                    "checkers": {
                        "type": "set",
                        "brief": "Checks to be compared to the actual event check list (the one we get from the event)."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the `FIM` events generated contain only the `check` fields specified in the configuration."
            ],
            "input_description": "Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml or wazuh_conf_simple_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (Initial scan when restarting Wazuh)"
                },
                "Multiple logs of `FIM` events in the monitored directories."
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ambiguous_check",
            "inputs": [
                "get_configuration0-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration0-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration0-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration0-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration1-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration1-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration1-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration1-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration2-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration2-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration2-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration2-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration3-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration3-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration3-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration3-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration4-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration4-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration4-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration4-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration5-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration5-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration5-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration5-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration6-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration6-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration6-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration6-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration7-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration7-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration7-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration7-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration8-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration8-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration8-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration8-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration9-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration9-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration9-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration9-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration10-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration10-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration10-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration10-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration11-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration11-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration11-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration11-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration12-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration12-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration12-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration12-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration13-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration13-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration13-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration13-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration14-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration14-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration14-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration14-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration15-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration15-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration15-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration15-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration16-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration16-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration16-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration16-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration17-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration17-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration17-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration17-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration18-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration18-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration18-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration18-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration19-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration19-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration19-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration19-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration20-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration20-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration20-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration20-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration21-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration21-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration21-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration21-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration22-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration22-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration22-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration22-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0",
                "get_configuration23-/checkdir_default-checkers0-tags_to_apply0",
                "get_configuration23-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0",
                "get_configuration23-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0",
                "get_configuration23-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_ambiguous_simple.yaml</summary>
<p>

```yaml
brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches
  selected files and triggering alerts when these files are modified. All these tests
  will be performed using ambiguous directory configurations, such as directories
  and subdirectories with opposite monitoring settings. In particular, it will be
  tested that changes in the files are correctly detected through their properties.
  Several monitoring attribute are also tested, such as recursion level, file restrictions,
  tags, or changes reporting. The `FIM` capability is managed by the `wazuh-syscheckd`
  daemon, which checks configured files for changes to the checksums, permissions,
  and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-syscheckd
group_id: 0
id: 2
modules:
- fim
name: test_ambiguous_simple.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
pytest_args:
- fim_mode:
    realtime: Enable real-time/continuous monitoring on Linux (using the inotify system
      calls) and Windows systems.
    whodata: Implies real-time monitoring but adding the who-data information.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
tags:
- fim
tests:
- assertions:
  - Verify that no alerts are generated after modifying files in the directory specified
    in the `restrict` option.
  - Verify that alerts are generated after modifying files in the subdirectory that
    is not specified in the `restrict` option, but whose parent directory is restricted.
  description: Check if the `wazuh-syscheckd` daemon detects regular file changes
    (add, modify, delete) depending on the value set in the `restrict` attribute.
    This attribute limit checks to files containing the entered string in the file
    name. For example, if `/testdir` has a `restrict` configuration and `/testdir/subdir`
    has not, only /testdir/subdir events should appear in the `ossec.log`file. For
    this purpose, the two previous paths are monitored, and modifications are made
    to the files to check if alerts are generated when required.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  - Multiple logs of `FIM` events in the monitored directories.
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml
    or wazuh_conf_simple_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-folders0-tags_to_apply0
  - get_configuration1-folders0-tags_to_apply0
  - get_configuration2-folders0-tags_to_apply0
  - get_configuration3-folders0-tags_to_apply0
  - get_configuration4-folders0-tags_to_apply0
  - get_configuration5-folders0-tags_to_apply0
  - get_configuration6-folders0-tags_to_apply0
  - get_configuration7-folders0-tags_to_apply0
  - get_configuration8-folders0-tags_to_apply0
  - get_configuration9-folders0-tags_to_apply0
  - get_configuration10-folders0-tags_to_apply0
  - get_configuration11-folders0-tags_to_apply0
  - get_configuration12-folders0-tags_to_apply0
  - get_configuration13-folders0-tags_to_apply0
  - get_configuration14-folders0-tags_to_apply0
  - get_configuration15-folders0-tags_to_apply0
  - get_configuration16-folders0-tags_to_apply0
  - get_configuration17-folders0-tags_to_apply0
  - get_configuration18-folders0-tags_to_apply0
  - get_configuration19-folders0-tags_to_apply0
  - get_configuration20-folders0-tags_to_apply0
  - get_configuration21-folders0-tags_to_apply0
  - get_configuration22-folders0-tags_to_apply0
  - get_configuration23-folders0-tags_to_apply0
  name: test_ambiguous_restrict
  parameters:
  - folders:
      brief: Monitored directories.
      type: list
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
- assertions:
  - Verify that the `content_changes` field is not generated in events when `report_changes
    == no`.
  - Verify that the `content_changes` field is generated in events when `report_changes
    == yes`.
  description: Check if the `wazuh-syscheckd` daemon detects or not the `content_changes`
    field for each event depending on the value set in the `report_changes` attribute.
    This attribute allows reporting the modifications made on a monitored file. For
    this purpose, two folders are monitored, and modifications are made to the files
    to check if the `content_changes` field is generated in the events when required.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  - Multiple logs of `FIM` events in the monitored directories.
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml
    or wazuh_conf_simple_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-folders0-tags_to_apply0
  - get_configuration1-folders0-tags_to_apply0
  - get_configuration2-folders0-tags_to_apply0
  - get_configuration3-folders0-tags_to_apply0
  - get_configuration4-folders0-tags_to_apply0
  - get_configuration5-folders0-tags_to_apply0
  - get_configuration6-folders0-tags_to_apply0
  - get_configuration7-folders0-tags_to_apply0
  - get_configuration8-folders0-tags_to_apply0
  - get_configuration9-folders0-tags_to_apply0
  - get_configuration10-folders0-tags_to_apply0
  - get_configuration11-folders0-tags_to_apply0
  - get_configuration12-folders0-tags_to_apply0
  - get_configuration13-folders0-tags_to_apply0
  - get_configuration14-folders0-tags_to_apply0
  - get_configuration15-folders0-tags_to_apply0
  - get_configuration16-folders0-tags_to_apply0
  - get_configuration17-folders0-tags_to_apply0
  - get_configuration18-folders0-tags_to_apply0
  - get_configuration19-folders0-tags_to_apply0
  - get_configuration20-folders0-tags_to_apply0
  - get_configuration21-folders0-tags_to_apply0
  - get_configuration22-folders0-tags_to_apply0
  - get_configuration23-folders0-tags_to_apply0
  name: test_ambiguous_report
  parameters:
  - folders:
      brief: Monitored directories.
      type: list
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
- assertions:
  - Verify that the `tags` field is not generated in events when the `tags` attribute
    not exists or is empty.
  - Verify that the `tags` field is generated in events when the `tags` attribute
    has content.
  description: Check if the `wazuh-syscheckd` daemon detects or not the `tags` field
    for each event depending on the value(s) set in the `tags` attribute. This attribute
    allows adding tags to alerts for monitored directories. For this purpose, two
    folders are monitored, and modifications are made to the files to check if the
    `tags` field is generated in the events when required.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  - Multiple logs of `FIM` events in the monitored directories.
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml
    or wazuh_conf_simple_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-folders0-tags_to_apply0
  - get_configuration1-folders0-tags_to_apply0
  - get_configuration2-folders0-tags_to_apply0
  - get_configuration3-folders0-tags_to_apply0
  - get_configuration4-folders0-tags_to_apply0
  - get_configuration5-folders0-tags_to_apply0
  - get_configuration6-folders0-tags_to_apply0
  - get_configuration7-folders0-tags_to_apply0
  - get_configuration8-folders0-tags_to_apply0
  - get_configuration9-folders0-tags_to_apply0
  - get_configuration10-folders0-tags_to_apply0
  - get_configuration11-folders0-tags_to_apply0
  - get_configuration12-folders0-tags_to_apply0
  - get_configuration13-folders0-tags_to_apply0
  - get_configuration14-folders0-tags_to_apply0
  - get_configuration15-folders0-tags_to_apply0
  - get_configuration16-folders0-tags_to_apply0
  - get_configuration17-folders0-tags_to_apply0
  - get_configuration18-folders0-tags_to_apply0
  - get_configuration19-folders0-tags_to_apply0
  - get_configuration20-folders0-tags_to_apply0
  - get_configuration21-folders0-tags_to_apply0
  - get_configuration22-folders0-tags_to_apply0
  - get_configuration23-folders0-tags_to_apply0
  name: test_ambiguous_tags
  parameters:
  - folders:
      brief: Monitored directories.
      type: list
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
- assertions:
  - Verify that `FIM` events are generated up to the specified subdirectory depth.
  description: Check if the `wazuh-syscheckd` daemon detects alerts for each directory
    level defined in the `recursion_level` attribute. This attribute limits the maximum
    level of recursion allowed. For example, if `recursion_level=1` is set, and the
    `/testdir` directory is monitored, it will only monitor `/testdir` and `/testdir/subdir`.
    If `/testdir/subdir/subdir2` exists, `/subdir2` wouldn't be monitored. For this
    purpose, a testing folder with several levels of subdirectories is monitored,
    and modifications are made in each level to see if events are generated when required.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  - Multiple logs of `FIM` events in the monitored directories.
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml
    or wazuh_conf_simple_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-/recursiondir-1-tags_to_apply0
  - get_configuration0-/recursiondir-4-tags_to_apply1
  - get_configuration1-/recursiondir-1-tags_to_apply0
  - get_configuration1-/recursiondir-4-tags_to_apply1
  - get_configuration2-/recursiondir-1-tags_to_apply0
  - get_configuration2-/recursiondir-4-tags_to_apply1
  - get_configuration3-/recursiondir-1-tags_to_apply0
  - get_configuration3-/recursiondir-4-tags_to_apply1
  - get_configuration4-/recursiondir-1-tags_to_apply0
  - get_configuration4-/recursiondir-4-tags_to_apply1
  - get_configuration5-/recursiondir-1-tags_to_apply0
  - get_configuration5-/recursiondir-4-tags_to_apply1
  - get_configuration6-/recursiondir-1-tags_to_apply0
  - get_configuration6-/recursiondir-4-tags_to_apply1
  - get_configuration7-/recursiondir-1-tags_to_apply0
  - get_configuration7-/recursiondir-4-tags_to_apply1
  - get_configuration8-/recursiondir-1-tags_to_apply0
  - get_configuration8-/recursiondir-4-tags_to_apply1
  - get_configuration9-/recursiondir-1-tags_to_apply0
  - get_configuration9-/recursiondir-4-tags_to_apply1
  - get_configuration10-/recursiondir-1-tags_to_apply0
  - get_configuration10-/recursiondir-4-tags_to_apply1
  - get_configuration11-/recursiondir-1-tags_to_apply0
  - get_configuration11-/recursiondir-4-tags_to_apply1
  - get_configuration12-/recursiondir-1-tags_to_apply0
  - get_configuration12-/recursiondir-4-tags_to_apply1
  - get_configuration13-/recursiondir-1-tags_to_apply0
  - get_configuration13-/recursiondir-4-tags_to_apply1
  - get_configuration14-/recursiondir-1-tags_to_apply0
  - get_configuration14-/recursiondir-4-tags_to_apply1
  - get_configuration15-/recursiondir-1-tags_to_apply0
  - get_configuration15-/recursiondir-4-tags_to_apply1
  - get_configuration16-/recursiondir-1-tags_to_apply0
  - get_configuration16-/recursiondir-4-tags_to_apply1
  - get_configuration17-/recursiondir-1-tags_to_apply0
  - get_configuration17-/recursiondir-4-tags_to_apply1
  - get_configuration18-/recursiondir-1-tags_to_apply0
  - get_configuration18-/recursiondir-4-tags_to_apply1
  - get_configuration19-/recursiondir-1-tags_to_apply0
  - get_configuration19-/recursiondir-4-tags_to_apply1
  - get_configuration20-/recursiondir-1-tags_to_apply0
  - get_configuration20-/recursiondir-4-tags_to_apply1
  - get_configuration21-/recursiondir-1-tags_to_apply0
  - get_configuration21-/recursiondir-4-tags_to_apply1
  - get_configuration22-/recursiondir-1-tags_to_apply0
  - get_configuration22-/recursiondir-4-tags_to_apply1
  - get_configuration23-/recursiondir-1-tags_to_apply0
  - get_configuration23-/recursiondir-4-tags_to_apply1
  name: test_ambiguous_recursion
  parameters:
  - dirname:
      brief: Name of the monitored directory.
      type: string
  - recursion_level:
      brief: Value of the `recursion_level` attribute.
      type: int
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  wazuh_min_version: 4.2
- assertions:
  - Verify that `FIM` events are generated up to the specified subdirectory depth.
  - Verify that the generated `FIM` events should or not contain the `tag` field.
  description: Check if the `wazuh-syscheckd` daemon detects alerts for each directory
    level defined in the `recursion_level` attribute and if it detects the 'tags'
    field for each of them. The `tags` attribute allows adding tags to alerts for
    monitored directories, and the `recursion_level` attribute limits the maximum
    level of recursion allowed. For this purpose, a testing folder with several levels
    of subdirectories is monitored, and modifications are made in each level to see
    if events are generated when required. Once the events have been generated, they
    are checked to see whether or not they should include the `tag` field.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  - Multiple logs of `FIM` events in the monitored directories.
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml
    or wazuh_conf_simple_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-dirnames0-2-True-tags_to_apply0
  - get_configuration0-dirnames1-2-False-tags_to_apply1
  - get_configuration1-dirnames0-2-True-tags_to_apply0
  - get_configuration1-dirnames1-2-False-tags_to_apply1
  - get_configuration2-dirnames0-2-True-tags_to_apply0
  - get_configuration2-dirnames1-2-False-tags_to_apply1
  - get_configuration3-dirnames0-2-True-tags_to_apply0
  - get_configuration3-dirnames1-2-False-tags_to_apply1
  - get_configuration4-dirnames0-2-True-tags_to_apply0
  - get_configuration4-dirnames1-2-False-tags_to_apply1
  - get_configuration5-dirnames0-2-True-tags_to_apply0
  - get_configuration5-dirnames1-2-False-tags_to_apply1
  - get_configuration6-dirnames0-2-True-tags_to_apply0
  - get_configuration6-dirnames1-2-False-tags_to_apply1
  - get_configuration7-dirnames0-2-True-tags_to_apply0
  - get_configuration7-dirnames1-2-False-tags_to_apply1
  - get_configuration8-dirnames0-2-True-tags_to_apply0
  - get_configuration8-dirnames1-2-False-tags_to_apply1
  - get_configuration9-dirnames0-2-True-tags_to_apply0
  - get_configuration9-dirnames1-2-False-tags_to_apply1
  - get_configuration10-dirnames0-2-True-tags_to_apply0
  - get_configuration10-dirnames1-2-False-tags_to_apply1
  - get_configuration11-dirnames0-2-True-tags_to_apply0
  - get_configuration11-dirnames1-2-False-tags_to_apply1
  - get_configuration12-dirnames0-2-True-tags_to_apply0
  - get_configuration12-dirnames1-2-False-tags_to_apply1
  - get_configuration13-dirnames0-2-True-tags_to_apply0
  - get_configuration13-dirnames1-2-False-tags_to_apply1
  - get_configuration14-dirnames0-2-True-tags_to_apply0
  - get_configuration14-dirnames1-2-False-tags_to_apply1
  - get_configuration15-dirnames0-2-True-tags_to_apply0
  - get_configuration15-dirnames1-2-False-tags_to_apply1
  - get_configuration16-dirnames0-2-True-tags_to_apply0
  - get_configuration16-dirnames1-2-False-tags_to_apply1
  - get_configuration17-dirnames0-2-True-tags_to_apply0
  - get_configuration17-dirnames1-2-False-tags_to_apply1
  - get_configuration18-dirnames0-2-True-tags_to_apply0
  - get_configuration18-dirnames1-2-False-tags_to_apply1
  - get_configuration19-dirnames0-2-True-tags_to_apply0
  - get_configuration19-dirnames1-2-False-tags_to_apply1
  - get_configuration20-dirnames0-2-True-tags_to_apply0
  - get_configuration20-dirnames1-2-False-tags_to_apply1
  - get_configuration21-dirnames0-2-True-tags_to_apply0
  - get_configuration21-dirnames1-2-False-tags_to_apply1
  - get_configuration22-dirnames0-2-True-tags_to_apply0
  - get_configuration22-dirnames1-2-False-tags_to_apply1
  - get_configuration23-dirnames0-2-True-tags_to_apply0
  - get_configuration23-dirnames1-2-False-tags_to_apply1
  name: test_ambiguous_recursion_tag
  parameters:
  - dirnames:
      brief: Monitored directories.
      type: list
  - recursion_level:
      brief: Value of the `recursion_level` attribute.
      type: int
  - triggers_event:
      brief: Determine if the event should be raised or not.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  wazuh_min_version: 4.2
- assertions:
  - Verify that the `FIM` events generated contain only the `check` fields specified
    in the configuration.
  description: Check if the `wazuh-syscheckd` daemon detects in the generated events
    the checks specified in the configuration. These checks are attributes indicating
    that a monitored file has been modified. For example, if `check_all=yes` and `check_inode=no`
    are set for the same directory, `syscheck` must send an event containing every
    possible check except the inode one. For this purpose, different `checks` are
    set in several subdirectories, and files are modified to generate events. Finally,
    verification is performed to ensure that the events contain only the fields of
    the `checks` specified for the monitored folder.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (Initial scan when restarting Wazuh)
  - Multiple logs of `FIM` events in the monitored directories.
  input_description: Different test cases are contained in external `YAML` files (wazuh_conf_simple.yaml
    or wazuh_conf_simple_win32.yaml) which includes configuration settings for the
    `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration0-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration0-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration0-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration1-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration1-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration1-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration1-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration2-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration2-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration2-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration2-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration3-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration3-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration3-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration3-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration4-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration4-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration4-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration4-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration5-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration5-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration5-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration5-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration6-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration6-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration6-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration6-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration7-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration7-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration7-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration7-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration8-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration8-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration8-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration8-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration9-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration9-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration9-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration9-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration10-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration10-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration10-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration10-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration11-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration11-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration11-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration11-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration12-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration12-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration12-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration12-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration13-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration13-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration13-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration13-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration14-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration14-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration14-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration14-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration15-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration15-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration15-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration15-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration16-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration16-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration16-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration16-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration17-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration17-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration17-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration17-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration18-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration18-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration18-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration18-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration19-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration19-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration19-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration19-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration20-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration20-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration20-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration20-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration21-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration21-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration21-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration21-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration22-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration22-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration22-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration22-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  - get_configuration23-/checkdir_default-checkers0-tags_to_apply0
  - get_configuration23-/checkdir_default/checkdir_checkall-checkers1-tags_to_apply0
  - get_configuration23-/checkdir_default/checkdir_checkall/checkdir_no_inode-checkers2-tags_to_apply0
  - get_configuration23-/checkdir_default/checkdir_checkall/checkdir_no_inode/checkdir_no_checksum-checkers3-tags_to_apply0
  name: test_ambiguous_check
  parameters:
  - dirname:
      brief: Name of the monitored directory.
      type: string
  - checkers:
      brief: Checks to be compared to the actual event check list (the one we get
        from the event).
      type: set
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
tier: 2
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_ambiguous_whodata_thread.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `who-data` feature of the File Integrity Monitoring (`FIM`) system works properly. `who-data` information contains the user who made the changes on the monitored files and also the program name or process used to carry them out. The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/auditing-whodata/who-linux.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the who-data information."
            }
        }
    ],
    "tags": [
        "fim"
    ],
    "name": "test_ambiguous_whodata_thread.py",
    "id": 3,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `wazuh-syscheckd` daemon starts the `whodata` thread when the configuration is ambiguous. For example, when using `whodata` on the same directory using conflicting values (`yes` and `no`). For this purpose, the configuration is applied and it checks that the last value detected for `whodata` in the `ossec.conf` file is the one used.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "whodata_enabled": {
                        "type": "bool",
                        "brief": "Who-data status."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that `whodata` thread is started when the last `whodata` value detected is set to `yes`.",
                "Verify that `whodata` thread is not started when the last `whodata` value detected is set to `no`."
            ],
            "input_description": "Two test cases are contained in external `YAML` file (wazuh_conf_whodata_thread.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                "r'File integrity monitoring real-time Whodata engine started'"
            ],
            "tags": [
                "who-data"
            ],
            "name": "test_ambiguous_whodata_thread",
            "inputs": [
                "get_configuration0-False-tags_to_apply0",
                "get_configuration0-True-tags_to_apply1",
                "get_configuration1-False-tags_to_apply0",
                "get_configuration1-True-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_ambiguous_whodata_thread.yaml</summary>
<p>

```yaml
brief: These tests will check if the `who-data` feature of the File Integrity Monitoring
  (`FIM`) system works properly. `who-data` information contains the user who made
  the changes on the monitored files and also the program name or process used to
  carry them out. The `FIM` capability is managed by the `wazuh-syscheckd` daemon,
  which checks configured files for changes to the checksums, permissions, and ownership.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 3
modules:
- fim
name: test_ambiguous_whodata_thread.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
pytest_args:
- fim_mode:
    realtime: Enable real-time/continuous monitoring on Linux (using the inotify system
      calls) and Windows systems.
    whodata: Implies real-time monitoring but adding the who-data information.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/auditing-whodata/who-linux.html
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
tags:
- fim
tests:
- assertions:
  - Verify that `whodata` thread is started when the last `whodata` value detected
    is set to `yes`.
  - Verify that `whodata` thread is not started when the last `whodata` value detected
    is set to `no`.
  description: Check if the `wazuh-syscheckd` daemon starts the `whodata` thread when
    the configuration is ambiguous. For example, when using `whodata` on the same
    directory using conflicting values (`yes` and `no`). For this purpose, the configuration
    is applied and it checks that the last value detected for `whodata` in the `ossec.conf`
    file is the one used.
  expected_output:
  - r'File integrity monitoring real-time Whodata engine started'
  input_description: Two test cases are contained in external `YAML` file (wazuh_conf_whodata_thread.yaml)
    which includes configuration settings for the `wazuh-syscheckd` daemon and testing
    directories to monitor.
  inputs:
  - get_configuration0-False-tags_to_apply0
  - get_configuration0-True-tags_to_apply1
  - get_configuration1-False-tags_to_apply0
  - get_configuration1-True-tags_to_apply1
  name: test_ambiguous_whodata_thread
  parameters:
  - whodata_enabled:
      brief: Who-data status.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  tags:
  - who-data
  wazuh_min_version: 4.2
tier: 2
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_duplicate_entries.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files and triggering alerts when these files are modified. All these tests will be performed using ambiguous directory configurations, such as directories and subdirectories with opposite monitoring settings. In particular, it will check that duplicate events are not generated when multiple configurations are used to monitor the same directory. The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the who-data information."
            }
        }
    ],
    "tags": [
        "fim"
    ],
    "name": "test_duplicate_entries.py",
    "id": 4,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when using multiple configurations on the same directory that can generate the same event, only one is finally generated. For example, when monitoring the same directory using the `whodata` and `realtime` attributes and modifying a file, two `FIM` events should not be generated. For this purpose, it applies the test case configuration, adds a test file in the directory, and finally checks that only one `FIM` event has been generated.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that only one `FIM` event is generated when the testing file is created."
            ],
            "input_description": "One test cases (ossec_conf_duplicate_simple) is contained in external `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$'"
                }
            ],
            "tags": [
                "scheduled",
                "realtime",
                "time_travel"
            ],
            "name": "test_duplicate_entries",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8",
                "get_configuration9",
                "get_configuration10",
                "get_configuration11",
                "get_configuration12",
                "get_configuration13",
                "get_configuration14",
                "get_configuration15",
                "get_configuration16",
                "get_configuration17",
                "get_configuration18",
                "get_configuration19",
                "get_configuration20",
                "get_configuration21",
                "get_configuration22",
                "get_configuration23",
                "get_configuration24",
                "get_configuration25",
                "get_configuration26",
                "get_configuration27",
                "get_configuration28",
                "get_configuration29",
                "get_configuration30",
                "get_configuration31",
                "get_configuration32",
                "get_configuration33",
                "get_configuration34",
                "get_configuration35"
            ]
        },
        {
            "description": "Check if when using multiple `sregex` patterns of the `restrict` attribute in the same directory, and that these can match the same file, only one `FIM` event is generated. For example, when monitoring the same directory using `restrict=\"^good.*$\"` and `restrict=\"^he.*$\"`, only the filenames that match with this regex `^he.*$` should generate `FIM` events. For this purpose, it applies the test case configuration, adds and modifies a test file in the directory, checks that only one `FIM` event has been generated for each operation, and finally verifies that only one `FIM` event has been generated for each operation.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that only one `FIM` event is generated when the testing file is created.",
                "Verify that only one `FIM` event is generated when the testing file is modified."
            ],
            "input_description": "One test case (ossec_conf_duplicate_sregex) is contained in external `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$'"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_duplicate_entries_sregex",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8",
                "get_configuration9",
                "get_configuration10",
                "get_configuration11",
                "get_configuration12",
                "get_configuration13",
                "get_configuration14",
                "get_configuration15",
                "get_configuration16",
                "get_configuration17",
                "get_configuration18",
                "get_configuration19",
                "get_configuration20",
                "get_configuration21",
                "get_configuration22",
                "get_configuration23",
                "get_configuration24",
                "get_configuration25",
                "get_configuration26",
                "get_configuration27",
                "get_configuration28",
                "get_configuration29",
                "get_configuration30",
                "get_configuration31",
                "get_configuration32",
                "get_configuration33",
                "get_configuration34",
                "get_configuration35"
            ]
        },
        {
            "description": "Check if when using multiple configurations using the `report_changes` attribute in the same directory, only the last configuration is taken into account. For example, when monitoring the same directory using `report_changes=\"yes\"` and `report_changes=\"no\"`, no `diff` files should be generated when modifying a file since `report_changes=\"no\"` is the last detected configuration. For this purpose, it applies the test case configuration, adds and modifies a test file in the directory, checks that `FIM` event has been generated for each operation, and finally verifies that a `diff` file has not been created.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that `FIM` events are generated when the testing file is created and modified.",
                "Verify that a `diff` file has not been created when modifying the test file."
            ],
            "input_description": "One test case (ossec_conf_duplicate_report) is contained in external `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$'"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_duplicate_entries_report",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8",
                "get_configuration9",
                "get_configuration10",
                "get_configuration11",
                "get_configuration12",
                "get_configuration13",
                "get_configuration14",
                "get_configuration15",
                "get_configuration16",
                "get_configuration17",
                "get_configuration18",
                "get_configuration19",
                "get_configuration20",
                "get_configuration21",
                "get_configuration22",
                "get_configuration23",
                "get_configuration24",
                "get_configuration25",
                "get_configuration26",
                "get_configuration27",
                "get_configuration28",
                "get_configuration29",
                "get_configuration30",
                "get_configuration31",
                "get_configuration32",
                "get_configuration33",
                "get_configuration34",
                "get_configuration35"
            ]
        },
        {
            "description": "Check if when using multiple configurations using diferent `check_` attributes in the same directory, only the last configuration is taken into account. For example, when monitoring the same directory using `check_owner=\"yes\" check_inode=\"yes\"` and `check_size=\"yes\" check_perm=\"yes\"`, only `size` and `permissions` fields files should be generated in the `FIM` events since `check_size=\"yes\" check_perm=\"yes\"` is the last detected configuration. For this purpose, it applies the test case configuration, adds and modifies a testing file in the directory, checks that one `FIM` event is generated when modifying the size or permissions of the test file, and finally verify that the `size` and `permissions` fields have been generated in that event.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that `FIM` event is generated when the testing file is added.",
                "Verify that modifications not related to the size or permissions of the testing file do not generate `FIM` events.",
                "Verify that `FIM` events are generated that include the `size` and `permissions` fields when these are modified in the test file."
            ],
            "input_description": "One test case (ossec_conf_duplicate_complex) is contained in external `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$'"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_duplicate_entries_complex",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8",
                "get_configuration9",
                "get_configuration10",
                "get_configuration11",
                "get_configuration12",
                "get_configuration13",
                "get_configuration14",
                "get_configuration15",
                "get_configuration16",
                "get_configuration17",
                "get_configuration18",
                "get_configuration19",
                "get_configuration20",
                "get_configuration21",
                "get_configuration22",
                "get_configuration23",
                "get_configuration24",
                "get_configuration25",
                "get_configuration26",
                "get_configuration27",
                "get_configuration28",
                "get_configuration29",
                "get_configuration30",
                "get_configuration31",
                "get_configuration32",
                "get_configuration33",
                "get_configuration34",
                "get_configuration35"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_duplicate_entries.yaml</summary>
<p>

```yaml
brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches
  selected files and triggering alerts when these files are modified. All these tests
  will be performed using ambiguous directory configurations, such as directories
  and subdirectories with opposite monitoring settings. In particular, it will check
  that duplicate events are not generated when multiple configurations are used to
  monitor the same directory. The `FIM` capability is managed by the `wazuh-syscheckd`
  daemon, which checks configured files for changes to the checksums, permissions,
  and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-syscheckd
group_id: 0
id: 4
modules:
- fim
name: test_duplicate_entries.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
pytest_args:
- fim_mode:
    realtime: Enable real-time/continuous monitoring on Linux (using the inotify system
      calls) and Windows systems.
    whodata: Implies real-time monitoring but adding the who-data information.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
tags:
- fim
tests:
- assertions:
  - Verify that only one `FIM` event is generated when the testing file is created.
  description: Check if when using multiple configurations on the same directory that
    can generate the same event, only one is finally generated. For example, when
    monitoring the same directory using the `whodata` and `realtime` attributes and
    modifying a file, two `FIM` events should not be generated. For this purpose,
    it applies the test case configuration, adds a test file in the directory, and
    finally checks that only one `FIM` event has been generated.
  expected_output:
  - r'.*Sending FIM event: (.+)$'
  input_description: One test cases (ossec_conf_duplicate_simple) is contained in
    external `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration
    settings for the `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  - get_configuration9
  - get_configuration10
  - get_configuration11
  - get_configuration12
  - get_configuration13
  - get_configuration14
  - get_configuration15
  - get_configuration16
  - get_configuration17
  - get_configuration18
  - get_configuration19
  - get_configuration20
  - get_configuration21
  - get_configuration22
  - get_configuration23
  - get_configuration24
  - get_configuration25
  - get_configuration26
  - get_configuration27
  - get_configuration28
  - get_configuration29
  - get_configuration30
  - get_configuration31
  - get_configuration32
  - get_configuration33
  - get_configuration34
  - get_configuration35
  name: test_duplicate_entries
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - realtime
  - time_travel
  wazuh_min_version: 4.2
- assertions:
  - Verify that only one `FIM` event is generated when the testing file is created.
  - Verify that only one `FIM` event is generated when the testing file is modified.
  description: Check if when using multiple `sregex` patterns of the `restrict` attribute
    in the same directory, and that these can match the same file, only one `FIM`
    event is generated. For example, when monitoring the same directory using `restrict="^good.*$"`
    and `restrict="^he.*$"`, only the filenames that match with this regex `^he.*$`
    should generate `FIM` events. For this purpose, it applies the test case configuration,
    adds and modifies a test file in the directory, checks that only one `FIM` event
    has been generated for each operation, and finally verifies that only one `FIM`
    event has been generated for each operation.
  expected_output:
  - r'.*Sending FIM event: (.+)$'
  input_description: One test case (ossec_conf_duplicate_sregex) is contained in external
    `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration settings
    for the `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  - get_configuration9
  - get_configuration10
  - get_configuration11
  - get_configuration12
  - get_configuration13
  - get_configuration14
  - get_configuration15
  - get_configuration16
  - get_configuration17
  - get_configuration18
  - get_configuration19
  - get_configuration20
  - get_configuration21
  - get_configuration22
  - get_configuration23
  - get_configuration24
  - get_configuration25
  - get_configuration26
  - get_configuration27
  - get_configuration28
  - get_configuration29
  - get_configuration30
  - get_configuration31
  - get_configuration32
  - get_configuration33
  - get_configuration34
  - get_configuration35
  name: test_duplicate_entries_sregex
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
- assertions:
  - Verify that `FIM` events are generated when the testing file is created and modified.
  - Verify that a `diff` file has not been created when modifying the test file.
  description: Check if when using multiple configurations using the `report_changes`
    attribute in the same directory, only the last configuration is taken into account.
    For example, when monitoring the same directory using `report_changes="yes"` and
    `report_changes="no"`, no `diff` files should be generated when modifying a file
    since `report_changes="no"` is the last detected configuration. For this purpose,
    it applies the test case configuration, adds and modifies a test file in the directory,
    checks that `FIM` event has been generated for each operation, and finally verifies
    that a `diff` file has not been created.
  expected_output:
  - r'.*Sending FIM event: (.+)$'
  input_description: One test case (ossec_conf_duplicate_report) is contained in external
    `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration settings
    for the `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  - get_configuration9
  - get_configuration10
  - get_configuration11
  - get_configuration12
  - get_configuration13
  - get_configuration14
  - get_configuration15
  - get_configuration16
  - get_configuration17
  - get_configuration18
  - get_configuration19
  - get_configuration20
  - get_configuration21
  - get_configuration22
  - get_configuration23
  - get_configuration24
  - get_configuration25
  - get_configuration26
  - get_configuration27
  - get_configuration28
  - get_configuration29
  - get_configuration30
  - get_configuration31
  - get_configuration32
  - get_configuration33
  - get_configuration34
  - get_configuration35
  name: test_duplicate_entries_report
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
- assertions:
  - Verify that `FIM` event is generated when the testing file is added.
  - Verify that modifications not related to the size or permissions of the testing
    file do not generate `FIM` events.
  - Verify that `FIM` events are generated that include the `size` and `permissions`
    fields when these are modified in the test file.
  description: Check if when using multiple configurations using diferent `check_`
    attributes in the same directory, only the last configuration is taken into account.
    For example, when monitoring the same directory using `check_owner="yes" check_inode="yes"`
    and `check_size="yes" check_perm="yes"`, only `size` and `permissions` fields
    files should be generated in the `FIM` events since `check_size="yes" check_perm="yes"`
    is the last detected configuration. For this purpose, it applies the test case
    configuration, adds and modifies a testing file in the directory, checks that
    one `FIM` event is generated when modifying the size or permissions of the test
    file, and finally verify that the `size` and `permissions` fields have been generated
    in that event.
  expected_output:
  - r'.*Sending FIM event: (.+)$'
  input_description: One test case (ossec_conf_duplicate_complex) is contained in
    external `YAML` file (wazuh_conf_dup_entries.yaml) which includes configuration
    settings for the `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  - get_configuration9
  - get_configuration10
  - get_configuration11
  - get_configuration12
  - get_configuration13
  - get_configuration14
  - get_configuration15
  - get_configuration16
  - get_configuration17
  - get_configuration18
  - get_configuration19
  - get_configuration20
  - get_configuration21
  - get_configuration22
  - get_configuration23
  - get_configuration24
  - get_configuration25
  - get_configuration26
  - get_configuration27
  - get_configuration28
  - get_configuration29
  - get_configuration30
  - get_configuration31
  - get_configuration32
  - get_configuration33
  - get_configuration34
  - get_configuration35
  name: test_duplicate_entries_complex
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
tier: 2
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_ignore_works_over_restrict.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the File Integrity Monitoring (`FIM`) system watches selected files and triggering alerts when these files are modified. All these tests will be performed using ambiguous directory configurations, such as directories and subdirectories with opposite monitoring settings. In particular, it will be verified that the value of the `ignore` attribute prevails over the `restrict` one. The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-agentd",
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the who-data information."
            }
        }
    ],
    "tags": [
        "fim"
    ],
    "name": "test_ignore_works_over_restrict.py",
    "id": 5,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the `ignore` tag prevails over the `restrict` one when using both in the same directory. For example, when a directory is ignored and at the same time monitoring is restricted to a file that is in that directory, no `FIM` events should be generated when that file is modified. For this purpose, the test case configuration is applied, and it is checked if `FIM` events are generated when required.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "folder": {
                        "type": "str",
                        "brief": "Directory where the file is being created."
                    }
                },
                {
                    "filename": {
                        "type": "str",
                        "brief": "Name of the file to be created."
                    }
                },
                {
                    "triggers_event": {
                        "type": "bool",
                        "brief": "True if an event must be generated, False otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that when a directory is ignored, the `restrict` attribute is not taken into account to generate `FIM` events."
            ],
            "input_description": "Two test cases are contained in external `YAML` file (wazuh_conf_ignore_restrict.yaml or wazuh_conf_ignore_restrict_win32.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' (When the FIM event should be generated)"
                },
                "r\".*Ignoring '.*?' '(.*?)' due to( sregex)? '.*?'\" (When the FIM event should be ignored)"
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ignore_works_over_restrict",
            "inputs": [
                "get_configuration0-/testdir1-testfile-False-tags_to_apply0",
                "get_configuration0-/testdir2-not_ignored_string-True-tags_to_apply1",
                "get_configuration0-/testdir1-testfile2-False-tags_to_apply2",
                "get_configuration0-/testdir1-ignore_testfile2-False-tags_to_apply3",
                "get_configuration0-/testdir2-not_ignored_sregex-True-tags_to_apply4",
                "get_configuration1-/testdir1-testfile-False-tags_to_apply0",
                "get_configuration1-/testdir2-not_ignored_string-True-tags_to_apply1",
                "get_configuration1-/testdir1-testfile2-False-tags_to_apply2",
                "get_configuration1-/testdir1-ignore_testfile2-False-tags_to_apply3",
                "get_configuration1-/testdir2-not_ignored_sregex-True-tags_to_apply4",
                "get_configuration2-/testdir1-testfile-False-tags_to_apply0",
                "get_configuration2-/testdir2-not_ignored_string-True-tags_to_apply1",
                "get_configuration2-/testdir1-testfile2-False-tags_to_apply2",
                "get_configuration2-/testdir1-ignore_testfile2-False-tags_to_apply3",
                "get_configuration2-/testdir2-not_ignored_sregex-True-tags_to_apply4",
                "get_configuration3-/testdir1-testfile-False-tags_to_apply0",
                "get_configuration3-/testdir2-not_ignored_string-True-tags_to_apply1",
                "get_configuration3-/testdir1-testfile2-False-tags_to_apply2",
                "get_configuration3-/testdir1-ignore_testfile2-False-tags_to_apply3",
                "get_configuration3-/testdir2-not_ignored_sregex-True-tags_to_apply4",
                "get_configuration4-/testdir1-testfile-False-tags_to_apply0",
                "get_configuration4-/testdir2-not_ignored_string-True-tags_to_apply1",
                "get_configuration4-/testdir1-testfile2-False-tags_to_apply2",
                "get_configuration4-/testdir1-ignore_testfile2-False-tags_to_apply3",
                "get_configuration4-/testdir2-not_ignored_sregex-True-tags_to_apply4",
                "get_configuration5-/testdir1-testfile-False-tags_to_apply0",
                "get_configuration5-/testdir2-not_ignored_string-True-tags_to_apply1",
                "get_configuration5-/testdir1-testfile2-False-tags_to_apply2",
                "get_configuration5-/testdir1-ignore_testfile2-False-tags_to_apply3",
                "get_configuration5-/testdir2-not_ignored_sregex-True-tags_to_apply4"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_ignore_works_over_restrict.yaml</summary>
<p>

```yaml
brief: These tests will check if the File Integrity Monitoring (`FIM`) system watches
  selected files and triggering alerts when these files are modified. All these tests
  will be performed using ambiguous directory configurations, such as directories
  and subdirectories with opposite monitoring settings. In particular, it will be
  verified that the value of the `ignore` attribute prevails over the `restrict` one.
  The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured
  files for changes to the checksums, permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-agentd
- wazuh-syscheckd
group_id: 0
id: 5
modules:
- fim
name: test_ignore_works_over_restrict.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
pytest_args:
- fim_mode:
    realtime: Enable real-time/continuous monitoring on Linux (using the inotify system
      calls) and Windows systems.
    whodata: Implies real-time monitoring but adding the who-data information.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
tags:
- fim
tests:
- assertions:
  - Verify that when a directory is ignored, the `restrict` attribute is not taken
    into account to generate `FIM` events.
  description: Check if the `ignore` tag prevails over the `restrict` one when using
    both in the same directory. For example, when a directory is ignored and at the
    same time monitoring is restricted to a file that is in that directory, no `FIM`
    events should be generated when that file is modified. For this purpose, the test
    case configuration is applied, and it is checked if `FIM` events are generated
    when required.
  expected_output:
  - r'.*Sending FIM event: (.+)$' (When the FIM event should be generated)
  - r".*Ignoring '.*?' '(.*?)' due to( sregex)? '.*?'" (When the FIM event should
    be ignored)
  input_description: Two test cases are contained in external `YAML` file (wazuh_conf_ignore_restrict.yaml
    or wazuh_conf_ignore_restrict_win32.yaml) which includes configuration settings
    for the `wazuh-syscheckd` daemon and testing directories to monitor.
  inputs:
  - get_configuration0-/testdir1-testfile-False-tags_to_apply0
  - get_configuration0-/testdir2-not_ignored_string-True-tags_to_apply1
  - get_configuration0-/testdir1-testfile2-False-tags_to_apply2
  - get_configuration0-/testdir1-ignore_testfile2-False-tags_to_apply3
  - get_configuration0-/testdir2-not_ignored_sregex-True-tags_to_apply4
  - get_configuration1-/testdir1-testfile-False-tags_to_apply0
  - get_configuration1-/testdir2-not_ignored_string-True-tags_to_apply1
  - get_configuration1-/testdir1-testfile2-False-tags_to_apply2
  - get_configuration1-/testdir1-ignore_testfile2-False-tags_to_apply3
  - get_configuration1-/testdir2-not_ignored_sregex-True-tags_to_apply4
  - get_configuration2-/testdir1-testfile-False-tags_to_apply0
  - get_configuration2-/testdir2-not_ignored_string-True-tags_to_apply1
  - get_configuration2-/testdir1-testfile2-False-tags_to_apply2
  - get_configuration2-/testdir1-ignore_testfile2-False-tags_to_apply3
  - get_configuration2-/testdir2-not_ignored_sregex-True-tags_to_apply4
  - get_configuration3-/testdir1-testfile-False-tags_to_apply0
  - get_configuration3-/testdir2-not_ignored_string-True-tags_to_apply1
  - get_configuration3-/testdir1-testfile2-False-tags_to_apply2
  - get_configuration3-/testdir1-ignore_testfile2-False-tags_to_apply3
  - get_configuration3-/testdir2-not_ignored_sregex-True-tags_to_apply4
  - get_configuration4-/testdir1-testfile-False-tags_to_apply0
  - get_configuration4-/testdir2-not_ignored_string-True-tags_to_apply1
  - get_configuration4-/testdir1-testfile2-False-tags_to_apply2
  - get_configuration4-/testdir1-ignore_testfile2-False-tags_to_apply3
  - get_configuration4-/testdir2-not_ignored_sregex-True-tags_to_apply4
  - get_configuration5-/testdir1-testfile-False-tags_to_apply0
  - get_configuration5-/testdir2-not_ignored_string-True-tags_to_apply1
  - get_configuration5-/testdir1-testfile2-False-tags_to_apply2
  - get_configuration5-/testdir1-ignore_testfile2-False-tags_to_apply3
  - get_configuration5-/testdir2-not_ignored_sregex-True-tags_to_apply4
  name: test_ignore_works_over_restrict
  parameters:
  - folder:
      brief: Directory where the file is being created.
      type: str
  - filename:
      brief: Name of the file to be created.
      type: str
  - triggers_event:
      brief: True if an event must be generated, False otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2
tier: 2
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_whodata_prevails_over_realtime.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `who-data` feature of the File Integrity Monitoring (`FIM`) system works properly. `who-data` information contains the user who made the changes on the monitored files and also the program name or process used to carry them out. In particular, it will be verified that the value of the `whodata` attribute prevails over the `relatime` one. The `FIM` capability is managed by the `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/auditing-whodata/who-linux.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time/continuous monitoring on Linux (using the inotify system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the who-data information."
            }
        }
    ],
    "tags": [
        "fim"
    ],
    "name": "test_whodata_prevails_over_realtime.py",
    "id": 6,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when using the options who-data and real-time at the same time the value of `whodata` is the one used. For example, when using `whodata=yes` and `realtime=no` on the same directory, real-time file monitoring will be enabled, as who-data requires it. For this purpose, the configuration is applied and it is verified that when `who-data` is set to `yes`, the `realtime` value is not taken into account, enabling in this case the real-time file monitoring.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "directory": {
                        "type": "str",
                        "brief": "Testing directory."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "put_env_variables": {
                        "type": "fixture",
                        "brief": "Create environment variables."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the `ossec.log` file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that real-time file monitoring is active."
            ],
            "input_description": "A test case is contained in external `YAML` file (wazuh_conf_whodata_prevails_over_realtime.yaml) which includes configuration settings for the `wazuh-syscheckd` daemon and testing directories to monitor.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$'"
                }
            ],
            "tags": [
                "realtime",
                "who-data"
            ],
            "name": "test_whodata_prevails_over_realtime",
            "inputs": [
                "get_configuration0-/testdir1",
                "get_configuration0-/testdir2"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_whodata_prevails_over_realtime.yaml</summary>
<p>

```yaml
brief: These tests will check if the `who-data` feature of the File Integrity Monitoring
  (`FIM`) system works properly. `who-data` information contains the user who made
  the changes on the monitored files and also the program name or process used to
  carry them out. In particular, it will be verified that the value of the `whodata`
  attribute prevails over the `relatime` one. The `FIM` capability is managed by the
  `wazuh-syscheckd` daemon, which checks configured files for changes to the checksums,
  permissions, and ownership.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 6
modules:
- fim
name: test_whodata_prevails_over_realtime.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
pytest_args:
- fim_mode:
    realtime: Enable real-time/continuous monitoring on Linux (using the inotify system
      calls) and Windows systems.
    whodata: Implies real-time monitoring but adding the who-data information.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/auditing-whodata/who-linux.html
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
tags:
- fim
tests:
- assertions:
  - Verify that real-time file monitoring is active.
  description: Check if when using the options who-data and real-time at the same
    time the value of `whodata` is the one used. For example, when using `whodata=yes`
    and `realtime=no` on the same directory, real-time file monitoring will be enabled,
    as who-data requires it. For this purpose, the configuration is applied and it
    is verified that when `who-data` is set to `yes`, the `realtime` value is not
    taken into account, enabling in this case the real-time file monitoring.
  expected_output:
  - r'.*Sending FIM event: (.+)$'
  input_description: A test case is contained in external `YAML` file (wazuh_conf_whodata_prevails_over_realtime.yaml)
    which includes configuration settings for the `wazuh-syscheckd` daemon and testing
    directories to monitor.
  inputs:
  - get_configuration0-/testdir1
  - get_configuration0-/testdir2
  name: test_whodata_prevails_over_realtime
  parameters:
  - directory:
      brief: Testing directory.
      type: str
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - put_env_variables:
      brief: Create environment variables.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the `ossec.log` file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - realtime
  - who-data
  wazuh_min_version: 4.2
tier: 2
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`