### PR TITLE
Add set mode as controlled_ack for Agentd test

### DIFF
--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -453,7 +453,8 @@ def test_agentd_connection_retries_pre_enrollment(configure_authd_server, config
     REMOTED_KEYS_SYNC_TIME = 10
 
     # Start Remoted mock
-    remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], client_keys=CLIENT_KEYS_PATH)
+    remoted_server = RemotedSimulator(protocol=get_configuration['metadata']['PROTOCOL'], mode='CONTROLLED_ACK',
+                                      client_keys=CLIENT_KEYS_PATH)
     # Stop target Agent
     control_service('stop')
     # Clean logs
@@ -465,9 +466,6 @@ def test_agentd_connection_retries_pre_enrollment(configure_authd_server, config
     log_monitor = FileMonitor(LOG_FILE_PATH)
     # Start whole Agent service to check other daemons status after initialization
     control_service('start')
-    # Simulate time of Remoted to synchronize keys by waiting previous to start responding
-    remoted_server.set_mode('CONTROLLED_ACK')
-    sleep(REMOTED_KEYS_SYNC_TIME)
 
     # Check Agentd is finally communicating
     log_monitor.start(timeout=120, callback=wait_notify, error_message="Notify message from agent was never sent!")


### PR DESCRIPTION
|Related issue|
|---|
|[1905](https://github.com/wazuh/wazuh-qa/issues/1905)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the Agentd test "test agentd reconnection". Following the issue [#1905](https://github.com/wazuh/wazuh-qa/issues/1905) it was found that in `test_agentd_connection_retries_pre_enrollment` the mode was not set. The absence of a set_mode made the test fail because by default the set_mode is "REJECT". In the "REJECT" mode any connection will be rejected, causing the failure. As a fix Set_mode was set as 'CONTROLLED_ACK'. 

| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Server | rpm | x86_64 | v4.2.2 |40215| v4.2.2-rc1 | wazuh-manager-4.2.2-1.x86_64.rpm |
| Agent | rpm | x86_64 | v4.2.2 | 40215| v4.2.2-rc1 | wazuh-agent-4.2.2-1.x86_64.rpm |
| Agent | msi (Windows) | x86_64 | v4.2.2 |40215| v4.2.2-rc1 | wazuh-agent-4.2.2-1.msi|



### Environment 

Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant |  gusztavvargadr/windows-10 | Windows | 2 | 1024 |

## Configuration options
### local_internal_options.conf

> agent.debug=2
execd.debug=2
monitord.rotate_log=0
<!--
When proceed, this section should include new configuration parameters.
-->

## Tests results

| Name  |Type|  State | Date| Result
|--|--|--|--|--|
|test_agentd|Agent-Windows| 🟢 |2021/09/22|[ResultsAgentd1](https://github.com/wazuh/wazuh-qa/files/7211396/ResultsAgentd.zip)| 
|test_agentd|Agent-Windows| 🟢 |2021/09/22|[ResultsAgentd2](https://github.com/wazuh/wazuh-qa/files/7211402/Resultsagentd.zip)
|test_agentd|Agent-Windows| 🟢 |2021/09/22|[ResultsAgentd3](https://github.com/wazuh/wazuh-qa/files/7218282/ResultsAgentd3.zip)
|test_agentd|Agent-Linux| 🟢 |2021/09/23|[ResultsAgentd4](https://github.com/wazuh/wazuh-qa/files/7219419/ResultsAgentdLinux.zip)
<!--
Paste here related logs and alerts
-->

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.