### PR TITLE
Solve Problems with WPK - Update README.md 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -288,3 +288,16 @@ def load_tests(path):
     """
     with open(path) as f:
         return yaml.safe_load(f)
+
+
+def count_file_lines(filepath):
+    """Count number of lines of a specified file.
+
+    Args:
+        filepath (str): Absolute path of the file.
+
+    Returns:
+        Integer: Number of lines of the file.
+    """
+    with open(filepath, "r") as file:
+        return sum(1 for line in file if line.strip())

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numpydoc==0.9.2
 pandas>=1.1.5
 pillow>=6.2.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 psutil==5.6.6
-pycryptodome==3.9.8
+pycryptodome>=3.9.8
 pyOpenSSL==19.1.0
 pytest-html==2.0.1
 pytest==6.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ netifaces==0.10.9
 numpydoc==0.9.2
 pandas>=1.1.5
 pillow>=6.2.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-psutil==5.6.6
+psutil>=5.6.6
 pycryptodome>=3.9.8
 pyOpenSSL==19.1.0
 pytest-html==2.0.1

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -149,14 +149,16 @@ our [testing environment guide](#setting-up-a-test-environment).
 
 Our newest integration tests are located in `wazuh-qa/tests/integration/`. They are organized by capabilities:
 
+- _test_active_response_
 - _test_agentd_
 - _test_analysisd_
 - _test_api_
 - _test_authd_
-- _test_cluster_
+- _test_enrollment_
 - _test_fim_
 - _test_gcloud_
 - _test_logtest_
+- _test_remoted_
 - _test_rids_
 - _test_rootcheck_
 - _test_vulnerability_detector_
@@ -397,6 +399,10 @@ python3 -m pytest [options] [file_or_dir] [file_or_dir] [...]
 - `--wpk_version`: Specify the WPK package version used to upgrade on WPK tests. (ex. --wpk_version=v4.2.0). Note: This
   field is required to execute any WPK test and the WPK package must be previously created in
   the [repository](packages-dev.wazuh.com/trash/wpk/).
+- `--wpk_package_path`: Specify the WPK package path used to upgrade on WPK tests. (ex. --wpk_package_path='packages-dev.wazuh.com/trash/wpk/'). 
+   This field is required to execute any WPK test.
+- `--save-file`: Specify the files of execution of the tests that you need to download. (ex. --save-file=archives.json). 
+   If the file does not exist while the test was executed,  the test will run without problems but not save this file in the report.
 
 _Use `-h` to see the rest or check its [documentation](https://docs.pytest.org/en/latest/usage.html)._
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -210,6 +210,14 @@ def pytest_addoption(parser):
         type=str,
         help="add file to the HTML report"
     )
+    parser.addoption(
+        "--wpk_package_path",
+        action="append",
+        metavar="wpk_package_path",
+        default=None,
+        type=str,
+        help="run tests using a specific WPK package path"
+    )
 
 
 def pytest_configure(config):
@@ -270,6 +278,10 @@ def pytest_configure(config):
     # Set files to add to the HTML report
     set_report_files(config.getoption("--save-file"))
 
+   # Set WPK package path
+    global_parameters.wpk_package_path = config.getoption("--wpk_package_path")
+    if global_parameters.wpk_package_path:
+        global_parameters.wpk_package_path = global_parameters.wpk_package_path
 
 def pytest_html_results_table_header(cells):
     cells.insert(4, html.th('Tier', class_='sortable tier', col='tier'))

--- a/tests/integration/test_wpk/data/wazuh_agent_conf.yaml
+++ b/tests/integration/test_wpk/data/wazuh_agent_conf.yaml
@@ -26,3 +26,29 @@
       #  elements:
       #  - enabled:
       #      value: 'yes'
+      - section: sca
+        elements:
+        - enabled:
+            value: 'no'
+      - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+      - section: syscheck
+        elements:
+        - disabled:
+            value: 'yes'
+      - section: wodle
+        attributes:
+          - name: 'syscollector'
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: auth
+        elements:
+        - disabled:
+            value: 'yes'
+      - section: rule_test
+        elements:
+        - enabled:
+            value: 'no'

--- a/tests/integration/test_wpk/data/wazuh_agent_conf.yaml
+++ b/tests/integration/test_wpk/data/wazuh_agent_conf.yaml
@@ -26,29 +26,3 @@
       #  elements:
       #  - enabled:
       #      value: 'yes'
-      - section: sca
-        elements:
-        - enabled:
-            value: 'no'
-      - section: rootcheck
-        elements:
-        - disabled:
-            value: 'yes'
-      - section: syscheck
-        elements:
-        - disabled:
-            value: 'yes'
-      - section: wodle
-        attributes:
-          - name: 'syscollector'
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: auth
-        elements:
-        - disabled:
-            value: 'yes'
-      - section: rule_test
-        elements:
-        - enabled:
-            value: 'no'

--- a/tests/integration/test_wpk/data/wazuh_manager_conf.yaml
+++ b/tests/integration/test_wpk/data/wazuh_manager_conf.yaml
@@ -18,33 +18,6 @@
             value: WPK_REPOSITORY
         - chunk_size:
             value: CHUNK_SIZE
-      - section: sca
-          elements:
-              - enabled:
-                value: 'no'
-      - section: rootcheck
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: syscheck
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: wodle
-        attributes:
-          - name: 'syscollector'
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: auth
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: rule_test
-        elements:
-          - enabled:
-              value: 'no'
-
     - tags:
       - all
       apply_to_modules:
@@ -66,29 +39,3 @@
             value: CHUNK_SIZE
         - max_threads:
             value: MAX_THREADS
-      - section: sca
-          elements:
-              - enabled:
-                value: 'no'
-      - section: rootcheck
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: syscheck
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: wodle
-        attributes:
-          - name: 'syscollector'
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: auth
-        elements:
-          - disabled:
-              value: 'yes'
-      - section: rule_test
-        elements:
-          - enabled:
-              value: 'no'

--- a/tests/integration/test_wpk/data/wazuh_manager_conf.yaml
+++ b/tests/integration/test_wpk/data/wazuh_manager_conf.yaml
@@ -18,6 +18,33 @@
             value: WPK_REPOSITORY
         - chunk_size:
             value: CHUNK_SIZE
+      - section: sca
+          elements:
+              - enabled:
+                value: 'no'
+      - section: rootcheck
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: syscheck
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: wodle
+        attributes:
+          - name: 'syscollector'
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: auth
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: rule_test
+        elements:
+          - enabled:
+              value: 'no'
+
     - tags:
       - all
       apply_to_modules:
@@ -39,3 +66,29 @@
             value: CHUNK_SIZE
         - max_threads:
             value: MAX_THREADS
+      - section: sca
+          elements:
+              - enabled:
+                value: 'no'
+      - section: rootcheck
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: syscheck
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: wodle
+        attributes:
+          - name: 'syscollector'
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: auth
+        elements:
+          - disabled:
+              value: 'yes'
+      - section: rule_test
+        elements:
+          - enabled:
+              value: 'no'

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -254,7 +254,7 @@ def download_wpk(get_configuration):
     agent_version = metadata['agent_version']
     current_plaform = sys_platform.lower()
     protocol = 'http://' if metadata['use_http'] else 'https://'
-    wpk_repo = 'packages-dev.wazuh.com/trash/wpk/'
+    wpk_repo = global_parameters.wpk_package_path[0]
     architecture = 'x86_64'
     wpk_file_path = ''
     # Generating file name

--- a/tests/integration/test_wpk/test_wpk_agent.py
+++ b/tests/integration/test_wpk/test_wpk_agent.py
@@ -47,8 +47,11 @@ mark_skip_agentLinux = pytest.mark.skipif(get_service() == 'wazuh-agent' and
 
 if not global_parameters.wpk_version:
     raise Exception("The WPK package version must be defined by parameter. See README.md")
-version_to_upgrade = global_parameters.wpk_version[0]
+if global_parameters.wpk_package_path is None:
+    raise ValueError("The WPK package path must be defined by parameter. See README.md")
 
+version_to_upgrade = global_parameters.wpk_version[0]
+package_path = global_parameters.wpk_package_path[0]
 
 _agent_version = get_version()
 
@@ -254,7 +257,7 @@ def download_wpk(get_configuration):
     agent_version = metadata['agent_version']
     current_plaform = sys_platform.lower()
     protocol = 'http://' if metadata['use_http'] else 'https://'
-    wpk_repo = global_parameters.wpk_package_path[0]
+    wpk_repo = package_path
     architecture = 'x86_64'
     wpk_file_path = ''
     # Generating file name

--- a/tests/integration/test_wpk/test_wpk_manager.py
+++ b/tests/integration/test_wpk/test_wpk_manager.py
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 UPGRADE_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'upgrade')
 TASK_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'task')
 SERVER_ADDRESS = 'localhost'
-WPK_REPOSITORY_4x = 'packages-dev.wazuh.com/trash/wpk/'
+WPK_REPOSITORY_4x = global_parameters.wpk_package_path[0]
 WPK_REPOSITORY_3x = 'packages.wazuh.com/wpk/'
 CRYPTO = "aes"
 CHUNK_SIZE = 16384
@@ -40,6 +40,8 @@ max_upgrade_result_status_retries = 30
 
 if global_parameters.wpk_version is None:
     raise ValueError("The WPK package version must be defined by parameter. See README.md")
+if global_parameters.wpk_package_path is None:
+    raise ValueError("The WPK package path must be defined by parameter. See README.md")
 version_to_upgrade = global_parameters.wpk_version[0]
 
 MANAGER_VERSION = get_version()

--- a/tests/integration/test_wpk/test_wpk_manager_task_states.py
+++ b/tests/integration/test_wpk/test_wpk_manager_task_states.py
@@ -13,13 +13,14 @@ from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.agent_simulator import Sender, Injector
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.services import control_service
+from wazuh_testing import global_parameters
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
 UPGRADE_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'upgrade')
 TASK_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'task')
 SERVER_ADDRESS = 'localhost'
-WPK_REPOSITORY_4x = 'packages-dev.wazuh.com/trash/wpk/'
+WPK_REPOSITORY_4x = global_parameters.wpk_package_path[0]
 CRYPTO = "aes"
 CHUNK_SIZE = 16384
 TASK_TIMEOUT = '15m'


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/1898|

## Description
I detected methods deleted. Also that the test failed because some paths were hardcoded. For that reason, I applied new changes and also modified README.md because it was required.


## Packages Details 

Details of branch after to apply merged with package used it. 

| Wazuh QA: Branch | Wazuh QA: Commit | Wazuh: Tag | Wazuh: Commit |
|:--:|:--:|:--:|:--:|
| 4.2 | https://github.com/wazuh/wazuh-qa/commit/c6981d83a644cd9fe9b2644680ae26e4bd5ea217 |v4.2.2-rc1 |https://github.com/wazuh/wazuh/commit/411389188f449c3e7a2d97ff059c25035d32f38a |

| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Server | rpm | x86_64 | v4.2.2 |40215| v4.2.2-rc1 | wazuh-manager-4.2.2-1.x86_64.rpm |
| Agent | rpm | x86_64 | v4.2.2 | 40215| v4.2.2-rc1 | wazuh-agent-4.2.2-1.x86_64.rpm |
| Agent | msi (Windows) | x86_64 | v4.2.2 |40215| v4.2.2-rc1 | wazuh-agent-4.2.2-1.msi|

We are going to check that after to add this method all wpk tests work successfully. 

### local_internal_options.conf

<table>
 <tr>
  <td rowspan="2">WPK</td>
  <td>(Manager, Agent) - Linux</td>
  <td>wazuh_modules.debug=2</td>
    <td>--wpk_version=v4.x.x  --wpk_package_path="packages-dev.wazuh.com/pre-release/wpk/"</td>
 </tr>
  <td>Agent - Windows</td>
  <td>windows.debug=2</td>
  <td>--wpk_version=v4.x.x  --wpk_package_path="packages-dev.wazuh.com/pre-release/wpk/"</td>
 </tr>

</table>

### Environment 

Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | "gusztavvargadr/windows-10" | Windows | 2 | 2048 |
Vagrant | centos/8 | CentOS 8 | 2 | 1024 |

## Logs example

To run it now, you need to add the package path. I attach a sample: 

> python3 -m pytest -svx test_wpk/ >  /vagrant/ResutsWpk.log --wpk_version=v4.2.2 --wpk_package_path="packages-dev.wazuh.com/pre-release/wpk/"

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
