### PR TITLE
Disable fim test invalid unstable results

### DIFF
--- a/tests/integration/test_fim/test_files/test_invalid/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_invalid/data/wazuh_conf.yaml
@@ -27,6 +27,10 @@
         elements:
         - disabled:
             value: 'yes'
+    - section: active-response
+        elements:
+        - disabled:
+            value: 'yes'
     - section: wodle
         attributes:
         - name: 'syscollector'
@@ -62,6 +66,10 @@
         elements:
         - disabled:
             value: 'yes'
+    - section: active-response
+        elements:
+        - disabled:
+            value: 'yes'
     - section: wodle
         attributes:
         - name: 'syscollector'
@@ -90,6 +98,10 @@
         - enabled:
             value: 'no'
     - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: active-response
         elements:
         - disabled:
             value: 'yes'
@@ -124,6 +136,10 @@
         elements:
         - disabled:
             value: 'yes'
+    - section: active-response
+        elements:
+        - disabled:
+            value: 'yes'
     - section: wodle
         attributes:
         - name: 'syscollector'
@@ -154,6 +170,10 @@
         - enabled:
             value: 'no'
     - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: active-response
         elements:
         - disabled:
             value: 'yes'

--- a/tests/integration/test_fim/test_files/test_invalid/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_invalid/data/wazuh_conf.yaml
@@ -19,6 +19,20 @@
         value: "aaaa"
         attributes:
         - type: "sregexxxx"
+    - section: sca
+        elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+        attributes:
+        - name: 'syscollector'
+        elements:
+        - disabled:
+            value: 'yes'
 # conf 2
 - tags:
   - invalid_no_regex
@@ -40,6 +54,20 @@
         value: "aaaa"
         attributes:
         - type: "sregexxxx"
+    - section: sca
+        elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+        attributes:
+        - name: 'syscollector'
+        elements:
+        - disabled:
+            value: 'yes'
 # conf 3
 - tags:
   - invalid_scan
@@ -57,6 +85,20 @@
         value: TEST_DIRECTORIES
         attributes:
         - check_all: 'yes'
+    - section: sca
+        elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+        attributes:
+        - name: 'syscollector'
+        elements:
+        - disabled:
+            value: 'yes'
 # conf 4
 - tags:
   - invalid_scan
@@ -74,6 +116,20 @@
         value: TEST_DIRECTORIES
         attributes:
         - check_all: 'yes'
+    - section: sca
+        elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+        attributes:
+        - name: 'syscollector'
+        elements:
+        - disabled:
+            value: 'yes'
 
 # conf 5
 - tags:
@@ -93,3 +149,17 @@
             value: 'yes'
         - entries:
             value: '-10'
+    - section: sca
+        elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+        elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+        attributes:
+        - name: 'syscollector'
+        elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_fim/test_files/test_invalid/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_invalid/data/wazuh_conf.yaml
@@ -6,6 +6,24 @@
   apply_to_modules:
   - test_invalid
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+        - name: 'syscollector'
+    elements:
+    - disabled:
+        value: 'yes'
   - section: syscheck
     elements:
     - disabled:
@@ -19,24 +37,6 @@
         value: "aaaa"
         attributes:
         - type: "sregexxxx"
-    - section: sca
-        elements:
-        - enabled:
-            value: 'no'
-    - section: rootcheck
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: active-response
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: wodle
-        attributes:
-        - name: 'syscollector'
-        elements:
-        - disabled:
-            value: 'yes'
 # conf 2
 - tags:
   - invalid_no_regex
@@ -58,24 +58,24 @@
         value: "aaaa"
         attributes:
         - type: "sregexxxx"
-    - section: sca
-        elements:
-        - enabled:
-            value: 'no'
-    - section: rootcheck
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: active-response
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: wodle
-        attributes:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
         - name: 'syscollector'
-        elements:
-        - disabled:
-            value: 'yes'
+    elements:
+    - disabled:
+        value: 'yes'
 # conf 3
 - tags:
   - invalid_scan
@@ -93,24 +93,24 @@
         value: TEST_DIRECTORIES
         attributes:
         - check_all: 'yes'
-    - section: sca
-        elements:
-        - enabled:
-            value: 'no'
-    - section: rootcheck
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: active-response
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: wodle
-        attributes:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
         - name: 'syscollector'
-        elements:
-        - disabled:
-            value: 'yes'
+    elements:
+    - disabled:
+        value: 'yes'
 # conf 4
 - tags:
   - invalid_scan
@@ -128,25 +128,24 @@
         value: TEST_DIRECTORIES
         attributes:
         - check_all: 'yes'
-    - section: sca
-        elements:
-        - enabled:
-            value: 'no'
-    - section: rootcheck
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: active-response
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: wodle
-        attributes:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
         - name: 'syscollector'
-        elements:
-        - disabled:
-            value: 'yes'
-
+    elements:
+    - disabled:
+        value: 'yes'
 # conf 5
 - tags:
   - invalid_file_limit
@@ -165,21 +164,21 @@
             value: 'yes'
         - entries:
             value: '-10'
-    - section: sca
-        elements:
-        - enabled:
-            value: 'no'
-    - section: rootcheck
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: active-response
-        elements:
-        - disabled:
-            value: 'yes'
-    - section: wodle
-        attributes:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
         - name: 'syscollector'
-        elements:
-        - disabled:
-            value: 'yes'
+    elements:
+    - disabled:
+        value: 'yes'

--- a/tests/integration/test_fim/test_files/test_invalid/test_invalid.py
+++ b/tests/integration/test_fim/test_files/test_invalid/test_invalid.py
@@ -44,7 +44,7 @@ def get_configuration(request):
 
 
 # tests
-
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 @pytest.mark.parametrize('tags_to_apply', [
     ({'invalid_no_regex', 'invalid_scan', 'invalid_file_limit'})
 ])


### PR DESCRIPTION
|Related issue|
|---|
|[#1890](https://github.com/wazuh/wazuh-qa/pull/1890)|

## Description

When running the tests in the related issue: `test_fim/test_files/test_invalid/test_invalid.py`, it was detected that it has erratic behaviour caused by File Monitor.

1. When the test was first ran, the error message stated that the configuration error message was not found, but after looking at the logs, it was verified that the configuration error was present.
2. A bigger timeout was added (Timeout 20, instead of the default 10), and the test passed.
3. Another run with a timeout of 10 was made to make sure it failed on 10, but this time it passed.
4. the test ran with a Timeout of 10 again, and it failed.

The PR disables the test, according to Issue [#1602](https://github.com/wazuh/wazuh-qa/issues/1890). Also, it modifies the config.yaml file for the test, so that it automatically disables all modules not related to FIM (since that is also is a cause for FIM tests to fail).


**Test Results**

| Results | Date | By | Status | Notes |
|--|--|--|--|--|
| [ResultsTestInvalid.zip](https://github.com/wazuh/wazuh-qa/files/7237015/ResultsTestInvalid.zip) | 2021/09/24 | @Deblintrake09 | :red_circle: | Test run with disabled modules and Timetout = 10
| [ResultsTestInvalid20Secs.zip](https://github.com/wazuh/wazuh-qa/files/7237018/ResultsTestInvalid20Secs.zip) | 2021/09/27 | @Deblintrake09 | :green_circle:  | Test run with disabled modules and Timetout = 20
| [ResultsTestInvalid10Secs.zip](https://github.com/wazuh/wazuh-qa/files/7237017/ResultsTestInvalid10Secs.zip) | 2021/09/27 | @Deblintrake09 | :green_circle:  | Test run with disabled modules and Timetout = 10
| [ResultsInvalid10secs-2.zip](https://github.com/wazuh/wazuh-qa/files/7236993/ResultsInvalid10secs-2.zip) | 2021/09/27 | @Deblintrake09 | :red_circle: | Test run with disabled modules and Timetout = 10
| [ResultsInvalid10secs-3.zip](https://github.com/wazuh/wazuh-qa/files/7237001/ResultsInvalid10secs-3.zip) | 2021/09/27 | @Deblintrake09 | :red_circle: | Test run with disabled modules and Timetout = 10

**Tests Results after Changes** 
| Results | Date | By | Status | Notes |
|--|--|--|--|--|
| [ResultsTestInvalidFix.zip](https://github.com/wazuh/wazuh-qa/files/7237466/ResultsTestInvalidFix.zip)| 2021/09/27 | @Deblintrake09 | :green_circle: | Tests skipped as expected
[ResultsTestInvalidFix2.zip](https://github.com/wazuh/wazuh-qa/files/7237467/ResultsTestInvalidFix2.zip) | 2021/09/27 | @Deblintrake09 | :green_circle:  | Tests skipped as expected


