### PR TITLE
Disable unused Wazuh Modules for test_max_files_per_second test

### DIFF
--- a/tests/integration/test_fim/test_files/test_max_files_per_second/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/data/wazuh_conf.yaml
@@ -16,3 +16,21 @@
         - check_all: 'yes'
     - max_files_per_second:
         value: MAX_FILES_PER_SEC
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -30,6 +30,7 @@ daemons:
 
 os_platform:
     - linux
+    - windows
 
 os_version:
     - Amazon Linux 1
@@ -62,9 +63,6 @@ pytest_args:
     - fim_mode:
         value: "whodata"
         brief: Uses whodata file monitoring option.
-
-tags:
-    - 
 '''
 
 
@@ -119,10 +117,7 @@ def test_max_files_per_second(inode_collision, get_configuration, configure_envi
     """ 
     description: 
         Check that FIM sleeps for one second when the option max_files_per_second is enabled
-    
-    wazuh_min_verion:
-        4.2
-    
+
     parameters:
         - inode_collision:
             type: boolean
@@ -145,12 +140,6 @@ def test_max_files_per_second(inode_collision, get_configuration, configure_envi
         - No output if max_files_per_second=0
         - In case not events are found it Raises:
             TimeoutError: If an expected event couldn't be captured.
-    tags:
-        -
-    """
-
-    """TODO Fix test - It does not properly check that the ammount of tests found in a second matches max_files_per_second
-       TODO Add assertions - It works by raising exceptions instead of assertions.
     """
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -32,24 +32,6 @@ os_platform:
     - linux
     - windows
 
-os_version:
-    - Amazon Linux 1
-    - Amazon Linux 2
-    - Arch Linux
-    - CentOS 6
-    - CentOS 7
-    - CentOS 8
-    - Debian Buster
-    - Debian Stretch
-    - Debian Jessie
-    - Debian Wheezy
-    - Red Hat 6
-    - Red Hat 7
-    - Red Hat 8
-    - Ubuntu Bionic
-    - Ubuntu Trusty
-    - Ubuntu Xenial
-
 references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#max-files-per-second
 

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -1,11 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright:
+    Copyright (C) 2015-2021, Wazuh Inc.
+
+    Created by Wazuh, Inc. <info@wazuh.com>.
+
+    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type:
+    integration
+
+brief:
+    Check that FIM sleeps for one second when the option max_files_per_second is enabled
+
+tier:
+    1
+
+modules:
+    - syscheck
+
+components:
+    - manager
+
+path:
+    tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Amazon Linux 1
+    - Amazon Linux 2
+    - Arch Linux
+    - CentOS 6
+    - CentOS 7
+    - CentOS 8
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 6
+    - Red Hat 7
+    - Red Hat 8
+    - Ubuntu Bionic
+    - Ubuntu Trusty
+    - Ubuntu Xenial
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#max-files-per-second
+
+pytest_args:
+    - fim_mode:
+        value: "realtime"
+        brief: Uses real-time file monitoring.
+    - fim_mode:
+        value: "scheduled"
+        brief: Uses scheduled file monitoring.
+    - fim_mode:
+        value: "whodata"
+        brief: Uses whodata file monitoring option.
+
+tags:
+    - 
+'''
+
+
+
 
 import os
 import pytest
-import wazuh_testing.fim as fim
 
+import wazuh_testing.fim as fim
 from wazuh_testing import global_parameters
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -48,16 +116,41 @@ def get_configuration(request):
                          ])
 def test_max_files_per_second(inode_collision, get_configuration, configure_environment, restart_syscheckd,
                               wait_for_fim_start):
-    """ Check that FIM sleeps for one second when the option max_files_per_second is enabled
+    """ 
+    description: 
+        Check that FIM sleeps for one second when the option max_files_per_second is enabled
+    
+    wazuh_min_verion:
+        4.2
+    
+    parameters:
+        - inode_collision:
+            type: boolean
+            brief: Signals if the test should check the limit while running inode collisions.
+        - get_configuration:
+            type: fixture
+            brief: Gets the current configuration of the test.
+        - configure_enviroment:
+            type: fixture
+            brief: Configure the environment for the execution of the test.
+        - restart_syscheckd:
+            type: fixture
+            brief: Reset ossec.log and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start or end of initial FIM scan.
+    input_description:
+        Several files are created, to check if the ammount of files scanned per second is equal to the limit sent on option "max_files_per_second"
+    expected_output
+        - No output if max_files_per_second=0
+        - In case not events are found it Raises:
+            TimeoutError: If an expected event couldn't be captured.
+    tags:
+        -
+    """
 
-    Args:
-        inode_collision (boolean): Signals if the test should check the limit while running inode collisions.
-        get_configuration (fixture): Gets the current configuration of the test.
-        configure_environment (fixture): Configure the environment for the execution of the test.
-        restart_syscheckd (fixture): Restarts syscheck.
-        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
-    Raises:
-        TimeoutError: If an expected event couldn't be captured.
+    """TODO Fix test - It does not properly check that the ammount of tests found in a second matches max_files_per_second
+       TODO Add assertions - It works by raising exceptions instead of assertions.
     """
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 
@@ -110,3 +203,4 @@ def test_max_files_per_second(inode_collision, get_configuration, configure_envi
                 pass
             else:
                 raise e
+                


### PR DESCRIPTION
|Related issue|
|---|
| [#1883](https://github.com/wazuh/wazuh-qa/issues/1883)  & PR [#1919](https://github.com/wazuh/wazuh-qa/pull/1919)  |

## Description

During testing of PR 1919, there were failing tests for the reviewer, because leaving modules running causes FileMonitor to timeout. This PR changes the config YAML file to disable modules at the start of the test.

### Test Results 
Thre instances of tests have been run, from clean VMs with modules enabled, to make sure the YAML file disabled them correctly and the tests passed.

| Results | Status| Date | By 
|--|--|--|--|
| [ResultsMaxFPS.zip](https://github.com/wazuh/wazuh-qa/files/7238275/ResultsMaxFPS.zip) | :green_circle: | 2021/09/27 | @Deblintrake09 
| [ResultsMaxFPS2.zip](https://github.com/wazuh/wazuh-qa/files/7238276/ResultsMaxFPS2.zip) | :green_circle: | 2021/09/27 | @Deblintrake09 
| [ResultsMaxFPS3.zip](https://github.com/wazuh/wazuh-qa/files/7238277/ResultsMaxFPS3.zip) | :green_circle: | 2021/09/27 | @Deblintrake09 