### PR TITLE
FIM Windows Agent - Fix test_basic_usage

### DIFF
--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf.yaml
@@ -14,6 +14,20 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 
 # conf 2
 - tags:
@@ -30,3 +44,17 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_inodes.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_inodes.yaml
@@ -16,3 +16,17 @@
         - check_all: 'yes'
         - check_mtime: CHECK_TYPE
         - check_inode: CHECK_TYPE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_disabled.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_disabled.yaml
@@ -13,3 +13,17 @@
         value: TEST_DIRECTORIES
         attributes:
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_new_dirs.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_new_dirs.yaml
@@ -16,3 +16,17 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_new_dirs_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_new_dirs_win32.yaml
@@ -18,3 +18,17 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_win32.yaml
@@ -16,3 +16,17 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_no_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_no_dir.py
@@ -60,15 +60,16 @@ def test_new_directory(tags_to_apply, get_configuration, configure_environment, 
 
     # Check that the warning is displayed when there is no directory.
     for section in get_configuration['sections']:
-        if not section['elements'][1]['directories']['value']:
-            wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                    callback=callback_empty_directories,
-                                    error_message='Did not receive expected '
-                                                  '"DEBUG: (6338): Empty directories tag found in the configuration" '
-                                                  'event').result()
-        # Check that the message is not displayed when the directory is specified.
-        else:
-            with pytest.raises(TimeoutError):
-                event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                                callback=callback_empty_directories).result()
-                raise AttributeError(f'Unexpected event {event}')
+        if section['section'] == 'syscheck':
+            if not section['elements'][1]['directories']['value']:
+                wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                        callback=callback_empty_directories,
+                                        error_message='Did not receive expected '
+                                                      '"DEBUG: (6338): Empty directories tag found in the configuration" '
+                                                      'event').result()
+            # Check that the message is not displayed when the directory is specified.
+            else:
+                with pytest.raises(TimeoutError):
+                    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+                                                    callback=callback_empty_directories).result()
+                    raise AttributeError(f'Unexpected event {event}')


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1861 |

## Description
As explained in issue #1861, some tests from `test_fim/test_files/test_basic_usage` fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

### Test results
| Results | Date | By | Status |
|:--:|:--:|:--:|:--:|
| [ResultsBasicUsage_1](https://github.com/wazuh/wazuh-qa/files/7252974/ResultsBasicUsage_1.zip) | 2021/09/29 | @MizugorouZ | :green_circle: |
| [ResultsBasicUsage_2](https://github.com/wazuh/wazuh-qa/files/7252976/ResultsBasicUsage_2.zip) | 2021/09/29 | @MizugorouZ | :green_circle: |
