### PR TITLE
Modify Report Changes config yaml to disable modules

### DIFF
--- a/tests/integration/test_fim/test_files/test_report_changes/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_report_changes/data/wazuh_conf.yaml
@@ -5,6 +5,24 @@
   apply_to_modules:
   - MODULE_NAME
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:
@@ -24,6 +42,24 @@
   apply_to_modules:
   - MODULE_NAME
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:
@@ -55,6 +91,24 @@
   apply_to_modules:
   - MODULE_NAME
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:
@@ -72,6 +126,24 @@
   apply_to_modules:
   - MODULE_NAME
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:


### PR DESCRIPTION
|Related issue|
|---|
| [#1886](https://github.com/wazuh/wazuh-qa/issues/1886) - Fim Windows Agent - Test Report Changes |

## Description

During the analysis of this test folder, it was shown that the results were unstable. It was proven that the test would fail if other modules, such as SCA, Rootcheck, Syscollector, and Active Response were not disabled.

In order to make them stable, we need to make sure the named modules are deactivated. By modifying the yaml file for the test, they are deactivated automatically at the start of each test.

## Configuration options

The tests have been run using all three FIM modes `scheduled`, `realtime`, and `whodata` together. Also, run using each mode alone, and a combination of two modes at once.


## Tests

| Results | Date | By | Status | Notes
|:--:|:--:|:--:|:--:|:--:|
| [ResultsReportChanges-Fix.zip](https://github.com/wazuh/wazuh-qa/files/7259120/ResultsReportChanges-Fix.zip) | 2021/09/29 | @Deblintrake09 | :green_circle: | Run foldear each test at a time - without resetting VM - all three modes|
| [ResultsReportChanges-Fix2.zip](https://github.com/wazuh/wazuh-qa/files/7259121/ResultsReportChanges-Fix2.zip) | 2021/09/29 | @Deblintrake09 | :green_circle: |  Run folder with all three modes passed as parameter |
| [ResultsReportChanges-Fix3.zip](https://github.com/wazuh/wazuh-qa/files/7259122/ResultsReportChanges-Fix3.zip) | 2021/09/29 | @Deblintrake09 | :green_circle: | Run folder with no mode passed as parameter|
| [ResultsReportChanges-2Modes.zip](https://github.com/wazuh/wazuh-qa/files/7259124/ResultsReportChanges-2Modes.zip) | 2021/09/29 | @Deblintrake09 | :green_circle: | Run folder with two modes activated `realtime` and `whodata` |
| [ResultsReportChanges-SingleModes.zip](https://github.com/wazuh/wazuh-qa/files/7259125/ResultsReportChanges-SingleModes.zip) | 2021/09/29 | @Deblintrake09 | :green_circle: | Run tests with a single mode each time. |


- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.