### PR TITLE
Fix test_moving_files config yaml - disable modules

### DIFF
--- a/tests/integration/test_fim/test_files/test_moving_files/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_moving_files/data/wazuh_conf.yaml
@@ -5,6 +5,24 @@
   apply_to_modules:
   - test_moving_files
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:


### PR DESCRIPTION
|Related issue|
|---|
| #1949 |

## Description
During the analysis of this test folder, it was shown that the results were unstable. It was proven that the test would fail if other modules, such as SCA, Rootcheck, Syscollector, and Active Response were not disabled.

In order to make them stable, we need to make sure the named modules are deactivated. By modifying the yaml file for the test, they are deactivated automatically at the start of each test.

## Configuration options

Tests were run locally from a clean VM. 
**Command:** ` python -m pytest --html=/c/vagrant/ResultsMovingFiles.html -svv test_fim/test_files/test_moving_files/ > /c/vagrant/ResultsMovingFiles.log --fim_mode="scheduled" --fim_mode="realtime" --fim_mode="whodata"`


## Tests 

| Result | Status | Date | By | Note|
|--|--|--|--|--|
| [ResultsMovingFiles.zip](https://github.com/wazuh/wazuh-qa/files/7259831/ResultsMovingFiles.zip)  | :green_circle: | 2021/09/30 | @Deblintrake09 | Using all three FIM modes. 
| [ResultsMovingFiles2.zip](https://github.com/wazuh/wazuh-qa/files/7259832/ResultsMovingFiles2.zip)  | :green_circle: | 2021/09/30 | @Deblintrake09 | Using all three FIM modes. 
| [ResultsMovingFiles3.zip](https://github.com/wazuh/wazuh-qa/files/7259833/ResultsMovingFiles3.zip) | :green_circle: | 2021/09/30 | @Deblintrake09 | Using all three FIM modes. 
| [ResultsMovingFiles-Realtime.zip](https://github.com/wazuh/wazuh-qa/files/7261454/ResultsMovingFiles-Realtime.zip) | :green_circle: | 2021/09/30 | @Deblintrake09 |  Run only with `realtime` mode
| [ResultsMovingFiles-Whodata.zip](https://github.com/wazuh/wazuh-qa/files/7261456/ResultsMovingFiles-Whodata.zip) | :green_circle: | 2021/09/30 | @Deblintrake09 | Run only with `whodata` mode
| [ResultsMovingFiles-Scheduled.zip](https://github.com/wazuh/wazuh-qa/files/7261455/ResultsMovingFiles-Scheduled.zip) | :green_circle: | 2021/09/30 | @Deblintrake09 | Run only with `scheduled` mode
| [ResultsMovingFiles-Whodata-Realtime.zip](https://github.com/wazuh/wazuh-qa/files/7261457/ResultsMovingFiles-Whodata-Realtime.zip) | :green_circle: | 2021/09/30 | @Deblintrake09 | Run with `realtime` mode and `whodata`
| [ResultsMovingFiles-Whodata-Scheduled.zip](https://github.com/wazuh/wazuh-qa/files/7261458/ResultsMovingFiles-Whodata-Scheduled.zip) | :green_circle: | 2021/09/30 | @Deblintrake09 | Run with `scheduled` mode and `whodata`

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
