### PR TITLE
FIM Windows Agent - Fix test_restrict

### DIFF
--- a/tests/integration/test_fim/test_files/test_restrict/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_restrict/data/wazuh_conf.yaml
@@ -15,6 +15,21 @@
         - check_all: 'yes'
         - FIM_MODE
         - restrict: ""
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+
 # conf 2
 - tags:
   - valid_regex
@@ -32,6 +47,21 @@
         - check_all: 'yes'
         - FIM_MODE
         - restrict: ".restricted$"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+
 # conf 3
 - tags:
   - valid_regex
@@ -49,6 +79,21 @@
         - check_all: 'yes'
         - FIM_MODE
         - restrict: "^restricted"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+
 # conf 4
 - tags:
   - valid_regex
@@ -66,6 +111,21 @@
         - check_all: 'yes'
         - FIM_MODE
         - restrict: "filerestricted|other_restricted$"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+
 # conf 5
 - tags:
   - valid_regex_incomplete_unix
@@ -82,6 +142,21 @@
         - check_all: 'yes'
         - FIM_MODE
         - restrict: "^/testdir1/f|^/testdir1/subdir/f|^/testdir2/f|^/testdir2/subdir/f"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+
 # conf 6
 - tags:
   - valid_regex_incomplete_win
@@ -98,3 +173,17 @@
         - check_all: 'yes'
         - FIM_MODE
         - restrict: "^c:\\testdir1\\f|^c:\\testdir1\\subdir\\f|^c:\\testdir2\\f|^c:\\testdir2\\subdir\\f"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1884 |

## Description
As explained in issue #1884, some tests from `test_fim/test_files/test_restrict` fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

### Test results
| Results | Date | By | Status |
|:--:|:--:|:--:|:--:|
| [ResultsRestrict_3](https://github.com/wazuh/wazuh-qa/files/7260528/ResultsRestrict_3.zip) | 2021/09/30 | @MizugorouZ | :green_circle: |
| [ResultsRestrict_4](https://github.com/wazuh/wazuh-qa/files/7260530/ResultsRestrict_4.zip) | 2021/09/30 | @MizugorouZ | :green_circle: |
