### PR TITLE
Add wazuh-db IT for syscollector deltas support

### DIFF
--- a/docs/tests/integration/test_wazuh_db/index.md
+++ b/docs/tests/integration/test_wazuh_db/index.md
@@ -11,3 +11,4 @@ These tests check the Wazuh-db commands syntax, valid responses and error messag
 - **agent_messages.yaml**: tests for agents DB, general commands
 - **fim_messages.yaml**: tests for agents DB, FIM module commands
 - **global_messages.yaml**: tests for the Global DB, using `global` commands
+- **syscollector_deltas_messages.yaml**: tests for agents DB, Syscollector deltas (dbsync) commands

--- a/docs/tests/integration/test_wazuh_db/test_wazuh_db.md
+++ b/docs/tests/integration/test_wazuh_db/test_wazuh_db.md
@@ -29,7 +29,7 @@ Confirm that `wazuh-db` is able to save, update and erase the necessary informat
 
 |Tier | Number of tests | Time spent |
 |:--:|:--:|:--:|
-| 0 | 30 | 45s |
+| 0 | 37 | 60s |
 
 ## Expected behavior
 
@@ -55,6 +55,17 @@ The **insert** and **clear** commands for `vuln_cves` table are tested:
 ### Checks FIM
 
 ### Checks global_messages
+
+### Checks Syscollector delta messages
+
+The tests cover different operations against agent's inventory tables product of incoming information deltas:
+
+- Operations against invalid db tables
+- Invalid syscollector operations against db
+- Valid INSERTED, CREATE, and MODIFIED operations to valid tables
+- Invalid MODIFIED operations: nonexistent data, wrong number or arguments, invalid type
+- Invalid INSERTED operations: duplicated entry, wrong number or arguments, invalid types
+- Invalid DELETED operations: nonexistent data, wrong number of arguments, invalid type
 
 ### Checks chunks
 

--- a/tests/integration/test_wazuh_db/data/syscollector_deltas_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/syscollector_deltas_messages.yaml
@@ -1,0 +1,297 @@
+---
+-
+  name: 'miscellaneous'
+  description: 'Test successfull and error while dealing with deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync this_table_doesnot_exist test NULL'
+    output: 'error'
+    stage: 'invalid table.'
+  -
+    input: 'agent 000 dbsync'
+    output: 'error'
+    stage: 'missing table.'
+  -
+    input: 'agent 000 dbsync ports'
+    output: 'error'
+    stage: 'missing operation.'
+  -
+    input: 'agent 000 dbsync ports CUSTOMOPERATION'
+    output: 'error'
+    stage: 'invalid operation.'
+-
+  name: 'ports'
+  description: 'Test successfull and error while dealing with ports deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync ports INSERTED 2021/10/01 00:00:00|udp|172.28.128.3|2323|0.0.0.0|0|0|0|9915982|NULL|0|NULL|260dd8c746ffab4eff64c34591f241736bfb0fa0|65daafcf10313a3804ad1caf7f36fdc2a0bf600c|'
+    output: 'ok'
+    stage: 'insert port.'
+  -
+    input: 'agent 000 dbsync ports INSERTED 2021/10/01 00:00:00|udp|172.28.128.3|2323|0.0.0.0|0|0|0|9915982|NULL|0|NULL|260dd8c746ffab4eff64c34591f241736bfb0fa0|65daafcf10313a3804ad1caf7f36fdc2a0bf600c|'
+    output: 'error'
+    stage: 'insert duplicated port.'
+  -
+    input: 'agent 000 dbsync ports INSERTED 2021/10/01 00:00:00|udp|172.28.128.3|-1|0.0.0.0|0|0|0|inode|NULL|0|NULL|260dd8c746ffab4eff64c34591f241736bfb0fa0|'
+    output: 'error'
+    stage: 'insert port without enough fields.'
+  -
+    input: 'agent 000 dbsync ports INSERTED 2021/10/01 00:00:00|udp|172.28.128.3|2323|0.0.0.0|0|0|0|9915982|NULL|0|NULL|260dd8c746ffab4eff64c34591f241736bfb0fa0|65daafcf10313a3804ad1caf7f36fdc2a0bf600c|'
+    output: 'ok'
+    stage: 'insert port with invalid field type.'
+  -
+    input: 'agent 000 dbsync ports MODIFIED 2021/10/01 00:00:20|udp|172.28.128.3|2323|NULL|NULL|NULL|5000|9915982|NULL|NULL|NULL|aaaaa8c746ffab4eff64c34591f241736bfb0fa0|aaaaacf10313a3804ad1caf7f36fdc2a0bf600c|'
+    output: 'ok'
+    stage: 'modify port.'
+  -
+    input: 'agent 000 dbsync ports MODIFIED 2021/10/01 00:00:20|udp|172.28.128.3|2323|NULL|NULL|NULL|5000|9915982|NULL|NULL|NULL|260dd8c746ffab4eff64c34591f241736bfb0fa0|'
+    output: 'error'
+    stage: 'modify port without enough fields.'
+  -
+    input: 'agent 000 dbsync ports MODIFIED 2021/10/01 00:00:20|tcp|172.28.128.3|2323|NULL|NULL|NULL|5000|9915982|NULL|NULL|NULL|aaaaa8c746ffab4eff64c34591f241736bfb0fa0|aaaaacf10313a3804ad1caf7f36fdc2a0bf600c|'
+    output: 'error'
+    stage: 'modify nonexistent port.'
+  -
+    input: 'agent 000 dbsync ports MODIFIED 2021/10/01 00:00:20|tcp|172.28.128.3|2323|NULL|NULL|NULL|5000|9915982|NULL|pid|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'modify port with invalid field type.'
+  -
+    input: 'agent 000 dbsync ports DELETED NULL|udp|172.28.128.3|2323|NULL|NULL|NULL|NULL|9915982|'
+    output: 'error'
+    stage: 'delete port without enough fields.'
+  -
+    input: 'agent 000 dbsync ports DELETED NULL|udp|172.28.128.3|2323|NULL|NULL|NULL|NULL|9915982|NULL|NULL|NULL|NULL|NULL|'
+    output: 'ok'
+    stage: 'delete port.'
+  -
+    input: 'agent 000 dbsync ports DELETED NULL|udp|172.28.128.3|2323|NULL|NULL|NULL|NULL|9915982|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete already deleted port.'
+-
+  name: 'processes'
+  description: 'Test successfull and error while dealing with processes deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync processes INSERTED 2021/10/01 00:00:00|999999|sleep|S|2776|0|0|sleep|180|root|root|root|root|root|root|root|20|0|2019|8076|129|114|2828728|2774|2774|1|139540|0|3|89688b8b6aab34a626629d1de406699c60e06be3|'
+    output: 'ok'
+    stage: 'insert process.'
+  -
+    input: 'agent 000 dbsync processes INSERTED 2021/10/01 00:00:00|999999|sleep|S|2776|0|0|sleep|180|root|root|root|root|root|root|root|20|0|2019|8076|129|114|2828728|2774|2774|1|139540|0|3|'
+    output: 'error'
+    stage: 'insert process without enough fields.'
+  -
+    input: 'agent 000 dbsync processes INSERTED 2021/10/01 00:00:00|999999|sleep|S|2776|0|0|sleep|180|root|root|root|root|root|root|root|20|0|2019|8076|129|114|2828728|2774|2774|1|139540|0|3|89688b8b6aab34a626629d1de406699c60e06be3|'
+    output: 'error'
+    stage: 'insert duplicated process.'
+  -
+    input: 'agent 000 dbsync processes INSERTED 2021/10/01 00:00:00|999999|sleep|S|2776|0|0|sleep|180|root|root|root|root|root|root|root|20|0|2019|8076|129|114|2828728|pgrp|session|nlwp|tgid|tty|processor|NULL|'
+    output: 'error'
+    stage: 'insert process with invalid field type.'
+  -
+    input: 'agent 000 dbsync processes MODIFIED 2021/10/01 00:00:20|999999|NULL|R|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|aaaa8b8b6aab34a626629d1de406699c60e06be3|'
+    output: 'ok'
+    stage: 'modify process.'
+  -
+    input: 'agent 000 dbsync processes MODIFIED 2021/10/01 00:00:20|999999|NULL|R|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|tgid|tty|processor|NULL|'
+    output: 'ok'
+    stage: 'modify process with invalid field type.'
+  -
+    input: 'agent 000 dbsync processes MODIFIED 2021/10/01 00:00:20|999999|NULL|R|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'modify process without enough fields.'
+  -
+    input: 'agent 000 dbsync processes MODIFIED 2021/10/01 00:00:20|999998|NULL|R|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|aaaa8b8b6aab34a626629d1de406699c60e06be3|'
+    output: 'error'
+    stage: 'modify nonexistent process.'
+  -
+    input: 'agent 000 dbsync processes DELETED NULL|999999|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete process without enough fields.'
+  -
+    input: 'agent 000 dbsync processes DELETED NULL|999999|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'ok'
+    stage: 'delete process.'
+  -
+    input: 'agent 000 dbsync processes DELETED NULL|999999|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete already deleted process.'
+-
+  name: 'packages'
+  description: 'Test successfull and error while dealing with packages deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync packages INSERTED 2021/10/01 00:00:00|deb|test-wazuh-1|optional|x11|223|Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>|NULL|1.1.1-2|all|foreign|NULL|Base X bitmaps|NULL|NULL|NULL|NULL|024a61b68678180d2debd374df900daa6fe35d73|759e5ea454e47141b5c6a8afefd6bd08e87057f9|'
+    output: 'ok'
+    stage: 'insert package.'
+  -
+    input: 'agent 000 dbsync packages INSERTED 2021/10/01 00:00:00|deb|test-wazuh-1|optional|x11|223|Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>|NULL|1.1.1-2|all|foreign|NULL|Base X bitmaps|NULL|NULL|NULL|NULL|024a61b68678180d2debd374df900daa6fe35d73|'
+    output: 'error'
+    stage: 'insert package without enough fields.'
+  -
+    input: 'agent 000 dbsync packages INSERTED 2021/10/01 00:00:00|deb|test-wazuh-1|optional|x11|223|Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>|NULL|1.1.1-2|all|foreign|NULL|Base X bitmaps|NULL|NULL|NULL|NULL|024a61b68678180d2debd374df900daa6fe35d73|759e5ea454e47141b5c6a8afefd6bd08e87057f9|'
+    output: 'error'
+    stage: 'insert duplicated package.'
+  -
+    input: 'agent 000 dbsync packages INSERTED 2021/10/01 00:00:00|nonexistentpkg|test-wazuh-1|optional|x11|size|Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>|NULL|1.1.1-2|all|foreign|NULL|Base X bitmaps|NULL|NULL|NULL|NULL|024a61b68678180d2debd374df900daa6fe35d73|759e5ea454e47141b5c6a8afefd6bd08e87057f9|'
+    output: 'ok'
+    stage: 'insert package with invalid field type.'
+  -
+    input: 'agent 000 dbsync packages MODIFIED 2021/10/01 00:00:20|NULL|test-wazuh-1|NULL|NULL|1000|NULL|NULL|1.1.1-2|all|NULL|NULL|NULL|NULL|NULL|NULL|NULL|aaaa61b68678180d2debd374df900daa6fe35d73|759e5ea454e47141b5c6a8afefd6bd08e87057f9|'
+    output: 'ok'
+    stage: 'modify package.'
+  -
+    input: 'agent 000 dbsync packages MODIFIED 2021/10/01 00:00:20|NULL|test-wazuh-1|NULL|NULL|1000|NULL|NULL|1.1.1-2|all|NULL|NULL|NULL|NULL|NULL|NULL|NULL|aaaa61b68678180d2debd374df900daa6fe35d73|'
+    output: 'error'
+    stage: 'modify package without enough fields.'
+  -
+    input: 'agent 000 dbsync packages MODIFIED 2021/10/01 00:00:20|NULL|test-wazuh-2|NULL|NULL|1000|NULL|NULL|1.1.1-2|all|NULL|NULL|NULL|NULL|NULL|NULL|NULL|aaaa61b68678180d2debd374df900daa6fe35d73|759e5ea454e47141b5c6a8afefd6bd08e87057f9|'
+    output: 'error'
+    stage: 'modify nonexistent packages.'
+  -
+    input: 'agent 000 dbsync packages MODIFIED 2021/10/01 00:00:20|NULL|test-wazuh-1|NULL|NULL|size|NULL|NULL|1.1.1-2|all|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'ok'
+    stage: 'modify package with invalid field type.'
+  -
+    input: 'agent 000 dbsync packages DELETED 2021/10/01 00:00:30|NULL|test-wazuh-1|NULL|NULL|NULL|NULL|NULL|1.1.1-2|all|NULL|NULL|'
+    output: 'error'
+    stage: 'delete package without enough fields.'
+  -
+    input: 'agent 000 dbsync packages DELETED 2021/10/01 00:00:30|NULL|test-wazuh-1|NULL|NULL|NULL|NULL|NULL|1.1.1-2|all|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'ok'
+    stage: 'delete package.'
+  -
+    input: 'agent 000 dbsync packages DELETED 2021/10/01 00:00:30|NULL|test-wazuh-1|NULL|NULL|NULL|NULL|NULL|1.1.1-2|all|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete already deleted package.'
+-
+  name: 'osinfo'
+  description: 'Test successfull and error while dealing with osinfo deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1633433046844390706|'
+    output: 'ok'
+    stage: 'insert osinfo.'
+  -
+    input: 'agent 000 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||'
+    output: 'error'
+    stage: 'insert osinfo without enough fields.'
+  -
+    input: 'agent 000 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|NULL|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1633433046844390706|'
+    output: 'error'
+    stage: 'insert osinfo with invalid field type.'
+  -
+    input: 'agent 000 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1633433046844300000|'
+    output: 'ok'
+    stage: 'modify osinfo.'
+  -
+    input: 'agent 000 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'modify osinfo without enough fields.'
+  -
+    input: 'agent 000 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu-nonexistent|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1633433046844300000|'
+    output: 'error'
+    stage: 'modify nonexistent osinfo.'
+  -
+    input: 'agent 000 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1633433046844300000|'
+    output: 'error'
+    stage: 'modify osinfo with invalid field type.'
+  -
+    input: 'agent 000 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'modify osinfo without enough fields.'
+  -
+    input: 'agent 000 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete osinfo.'
+  -
+    input: 'agent 000 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete osinfo.'
+-
+  name: 'hwinfo'
+  description: 'Test successfull and error while dealing with hwinfo deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync hwinfo INSERTED 2021/10/01 00:00:00|0|AMD Ryzen 7 PRO 4750U with Radeon Graphics|8|1697.0|7957428|138384|99|78793071d887ba34f60a67da99c4068a93a92f30|'
+    output: 'ok'
+    stage: 'insert hwinfo.'
+  -
+    input: 'agent 000 dbsync hwinfo INSERTED 2021/10/01 00:00:00|0|AMD Ryzen 7 PRO 4750U with Radeon Graphics|8|1697.0|7957428|138384|99|'
+    output: 'error'
+    stage: 'insert hwinfo without enough fields.'
+  -
+    input: 'agent 000 dbsync hwinfo INSERTED 2021/10/01 00:00:00|0|AMD Ryzen 7 PRO 4750U with Radeon Graphics|-8|1697.0|ram_total|138384|99|78793071d887ba34f60a67da99c4068a93a92f30|'
+    output: 'error'
+    stage: 'insert hwinfo with invalid field type.'
+  -
+    input: 'agent 000 dbsync hwinfo MODIFIED 2021/10/01 00:00:20|0|NULL|NULL|NULL|NULL|NULL|50|78793071d887ba34f60a67da99c4068a93aaaaaa|'
+    output: 'ok'
+    stage: 'modify hwinfo.'
+  -
+    input: 'agent 000 dbsync hwinfo MODIFIED 2021/10/01 00:00:20|0|NULL|NULL|NULL|NULL|NULL|50|'
+    output: 'error'
+    stage: 'modify hwinfo without enough fields.'
+  -
+    input: 'agent 000 dbsync hwinfo MODIFIED 2021/10/01 00:00:20|0|NULL|NULL|NULL|NULL|ram_usage|110|78793071d887ba34f60a67da99c4068a93aaaaaa|'
+    output: 'error'
+    stage: 'modify hwinfo with invalid field type.'
+  -
+    input: 'agent 000 dbsync hwinfo MODIFIED 2021/10/01 00:00:20|1|NULL|NULL|NULL|NULL|NULL|50|78793071d887ba34f60a67da99c4068a93aaaaaa|'
+    output: 'error'
+    stage: 'modify nonexistent hwinfo.'
+  -
+    input: 'agent 000 dbsync hwinfo DELETED 2021/10/01 NULL|0|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete hwinfo without enough fields.'
+  -
+    input: 'agent 000 dbsync hwinfo DELETED 2021/10/01 NULL|0|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    output: 'error'
+    stage: 'delete hwinfo.'
+-
+  name: 'hotfixes'
+  description: 'Test successfull and error while dealing with hotfixes deltas'
+  test_case:
+  -
+    input: 'agent 000 dbsync hotfixes INSERTED 2021/10/01 00:00:00|KBTEST|test-checksum|'
+    output: 'ok'
+    stage: 'insert hotfix.'
+  -
+    input: 'agent 000 dbsync hotfixes INSERTED 2021/10/01 00:00:00|KBTEST|'
+    output: 'error'
+    stage: 'insert hotfix without enough fields.'
+  -
+    input: 'agent 000 dbsync hotfixes INSERTED 2021/10/01 00:00:00|KBTEST|test-checksum|'
+    output: 'error'
+    stage: 'insert duplicated hotfix.'
+  -
+    input: 'agent 000 dbsync hotfixes INSERTED 2021/10/01 00:00:00|KBTEST|NULL|'
+    output: 'ok'
+    stage: 'insert hotfix with invalid field type.'
+  -
+    input: 'agent 000 dbsync hotfixes MODIFIED 2021/10/01 00:00:20|KBTEST|test-checksum|'
+    output: 'ok'
+    stage: 'modify hotfix.'
+  -
+    input: 'agent 000 dbsync hotfixes MODIFIED 2021/10/01 00:00:20|KBTEST|NULL|'
+    output: 'ok'
+    stage: 'modify hotfix with invalid field type.'
+  -
+    input: 'agent 000 dbsync hotfixes MODIFIED 2021/10/01 00:00:20|KBTEST|'
+    output: 'error'
+    stage: 'modify hotfix without enough fields.'
+  -
+    input: 'agent 000 dbsync hotfixes MODIFIED 2021/10/01 00:00:35|KBTEST-NONEXISTENT|test-checksum|'
+    output: 'error'
+    stage: 'modify nonexistent hotfix.'
+  -
+    input: 'agent 000 dbsync hotfixes DELETED NULL|KBTEST|'
+    output: 'ok'
+    stage: 'delete hotfix without enough fields.'
+  -
+    input: 'agent 000 dbsync hotfixes DELETED NULL|KBTEST|NULL|'
+    output: 'ok'
+    stage: 'delete hotfix.'
+  -
+    input: 'agent 000 dbsync hotfixes DELETED NULL|KBTEST|NULL|'
+    output: 'error'
+    stage: 'delete already deleted hotfix.'


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1942|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!
This PR aims to add syscollector deltas messages input and expected output to wazuh-db tests.

- Miscelanous
- Ports
- Processes
- Packages
- Network (interfaces, addresses, protocol)
- Hotfixes
- Osinfo
- Hwinfo

## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] ~Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.~
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.