### PR TITLE
FIM Windows Agent - Fix test_env_variables

### DIFF
--- a/tests/integration/test_fim/test_files/test_env_variables/data/wazuh_conf_dir.yaml
+++ b/tests/integration/test_fim/test_files/test_env_variables/data/wazuh_conf_dir.yaml
@@ -12,3 +12,17 @@
         value: TEST_ENV_VARIABLES
         attributes:
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_env_variables/data/wazuh_conf_ignore.yaml
+++ b/tests/integration/test_fim/test_files/test_env_variables/data/wazuh_conf_ignore.yaml
@@ -14,3 +14,17 @@
         - FIM_MODE
     - ignore:
         value: TEST_ENV_VARIABLES
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_env_variables/data/wazuh_conf_nodiff.yaml
+++ b/tests/integration/test_fim/test_files/test_env_variables/data/wazuh_conf_nodiff.yaml
@@ -15,3 +15,17 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1957 |

## Description
As explained in issue #1957, some tests from `test_fim/test_files/test_env_variables` fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
windows.debug=2
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

### Test results
| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_env_variables` | 2021/10/01 | @MizugorouZ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7268212/R1-1965.zip) | - |
| R2 | Windows 10 - Agent - `test_fim/test_files/test_env_variables` | 2021/10/01 | @MizugorouZ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7268213/R2-1965.zip) | - |
| R3 | Windows 10 - Agent - `test_fim/test_files/test_env_variables` | 2021/10/01 | @MizugorouZ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7268214/R3-1965.zip) | - |