### PR TITLE
FIM Windows Agent - Fix test_tags

### DIFF
--- a/tests/integration/test_fim/test_files/test_tags/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_tags/data/wazuh_conf.yaml
@@ -16,3 +16,17 @@
         - check_all: 'yes'
         - FIM_MODE
         - tags: FIM_TAGS
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_tags/test_tags.py
+++ b/tests/integration/test_fim/test_files/test_tags/test_tags.py
@@ -26,6 +26,7 @@ test_directories = [os.path.join(PREFIX, 'testdir_tags'),
 
 directory_str = ','.join([test_directories[0], test_directories[2]])
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+timeout = 20
 
 # configurations
 
@@ -80,5 +81,5 @@ def test_tags(folder, name, content,
 
     regular_file_cud(folder, wazuh_log_monitor, file_list=files,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
-                     min_timeout=global_parameters.default_timeout, validators_after_cud=[tag_validator]
+                     min_timeout=timeout, validators_after_cud=[tag_validator]
                      )


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1951 |

## Description
As explained in issue #1951, some tests from `test_fim/test_files/test_tags` fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
windows.debug=2
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

### Test results
| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_tags` | 2021/10/04 | @MizugorouZ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7279265/R1_1966.zip) | - |
| R2 | Windows 10 - Agent - `test_fim/test_files/test_tags` | 2021/10/04 | @MizugorouZ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7279266/R2_1966.zip) | - |
| R3 | Windows 10 - Agent - `test_fim/test_files/test_tags` | 2021/10/04 | @MizugorouZ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7279268/R3_1966.zip) | - |