### PR TITLE
Modify windows yaml file and check recursion level on windows test

### DIFF
--- a/tests/integration/test_fim/test_files/test_recursion_level/data/wazuh_recursion_windows.yaml
+++ b/tests/integration/test_fim/test_files/test_recursion_level/data/wazuh_recursion_windows.yaml
@@ -2,6 +2,24 @@
 - apply_to_modules:
   - test_recursion_level
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:
@@ -43,14 +61,14 @@
         - recursion_level: "5"
         - FIM_MODE
     - directories:
-        value: "c:\\test_recursion_320"
+        value: "c:\\test_recursion_32"
         attributes:
         - CHECK
-        - recursion_level: "320"
+        - recursion_level: "32"
         - FIM_MODE
     - directories:
-        value: "c:\\test recursion 320"
+        value: "c:\\test recursion 32"
         attributes:
         - CHECK
-        - recursion_level: "320"
+        - recursion_level: "32"
         - FIM_MODE

--- a/tests/integration/test_fim/test_files/test_recursion_level/test_recursion_level.py
+++ b/tests/integration/test_fim/test_files/test_recursion_level/test_recursion_level.py
@@ -21,19 +21,19 @@ pytestmark = pytest.mark.tier(level=2)
 dir_no_recursion = os.path.join(PREFIX, 'test_no_recursion')
 dir_recursion_1 = os.path.join(PREFIX, 'test_recursion_1')
 dir_recursion_5 = os.path.join(PREFIX, 'test_recursion_5')
-dir_recursion_320 = os.path.join(PREFIX, 'test_recursion_32') if sys.platform == "win32" else os.path.join(PREFIX, 'test_recursion_320')
+dir_recursion_max = os.path.join(PREFIX, 'test_recursion_32') if sys.platform == "win32" else os.path.join(PREFIX, 'test_recursion_320')
 subdir = "dir"
 
 dir_no_recursion_space = os.path.join(PREFIX, 'test no recursion')
 dir_recursion_1_space = os.path.join(PREFIX, 'test recursion 1')
 dir_recursion_5_space = os.path.join(PREFIX, 'test recursion 5')
-dir_recursion_320_space = os.path.join(PREFIX, 'test recursion 32') if sys.platform == "win32" else os.path.join(PREFIX, 'test recursion 320')
+dir_recursion_max_space = os.path.join(PREFIX, 'test recursion 32') if sys.platform == "win32" else os.path.join(PREFIX, 'test recursion 320')
 subdir_space = "dir "
 
-recursion_320 = 32 if sys.platform == "win32" else 320
+max_recursion = 32 if sys.platform == "win32" else 320
 
-test_directories = [dir_no_recursion, dir_recursion_1, dir_recursion_5, dir_recursion_320, dir_no_recursion_space,
-                    dir_recursion_1_space, dir_recursion_5_space, dir_recursion_320_space]
+test_directories = [dir_no_recursion, dir_recursion_1, dir_recursion_5, dir_recursion_max, dir_no_recursion_space,
+                    dir_recursion_1_space, dir_recursion_5_space, dir_recursion_max_space]
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 conf_name = "wazuh_recursion_windows.yaml" if sys.platform == "win32" else "wazuh_recursion.yaml"
@@ -155,8 +155,8 @@ def get_configuration(request):
     (dir_recursion_1_space, subdir_space, 1),
     (dir_recursion_5, subdir, 5),
     (dir_recursion_5_space, subdir_space, 5),
-    (dir_recursion_320, subdir, recursion_320),
-    (dir_recursion_320_space, subdir_space, recursion_320)
+    (dir_recursion_max, subdir, max_recursion),
+    (dir_recursion_max_space, subdir_space, max_recursion)
 ])
 def test_recursion_level(dirname, subdirname, recursion_level, get_configuration, configure_environment,
                          restart_syscheckd, wait_for_fim_start):

--- a/tests/integration/test_fim/test_files/test_recursion_level/test_recursion_level.py
+++ b/tests/integration/test_fim/test_files/test_recursion_level/test_recursion_level.py
@@ -21,14 +21,16 @@ pytestmark = pytest.mark.tier(level=2)
 dir_no_recursion = os.path.join(PREFIX, 'test_no_recursion')
 dir_recursion_1 = os.path.join(PREFIX, 'test_recursion_1')
 dir_recursion_5 = os.path.join(PREFIX, 'test_recursion_5')
-dir_recursion_320 = os.path.join(PREFIX, 'test_recursion_320')
+dir_recursion_320 = os.path.join(PREFIX, 'test_recursion_32') if sys.platform == "win32" else os.path.join(PREFIX, 'test_recursion_320')
 subdir = "dir"
 
 dir_no_recursion_space = os.path.join(PREFIX, 'test no recursion')
 dir_recursion_1_space = os.path.join(PREFIX, 'test recursion 1')
 dir_recursion_5_space = os.path.join(PREFIX, 'test recursion 5')
-dir_recursion_320_space = os.path.join(PREFIX, 'test recursion 320')
+dir_recursion_320_space = os.path.join(PREFIX, 'test recursion 32') if sys.platform == "win32" else os.path.join(PREFIX, 'test recursion 320')
 subdir_space = "dir "
+
+recursion_320 = 32 if sys.platform == "win32" else 320
 
 test_directories = [dir_no_recursion, dir_recursion_1, dir_recursion_5, dir_recursion_320, dir_no_recursion_space,
                     dir_recursion_1_space, dir_recursion_5_space, dir_recursion_320_space]
@@ -153,8 +155,8 @@ def get_configuration(request):
     (dir_recursion_1_space, subdir_space, 1),
     (dir_recursion_5, subdir, 5),
     (dir_recursion_5_space, subdir_space, 5),
-    (dir_recursion_320, subdir, 320),
-    (dir_recursion_320_space, subdir_space, 320)
+    (dir_recursion_320, subdir, recursion_320),
+    (dir_recursion_320_space, subdir_space, recursion_320)
 ])
 def test_recursion_level(dirname, subdirname, recursion_level, get_configuration, configure_environment,
                          restart_syscheckd, wait_for_fim_start):
@@ -169,7 +171,8 @@ def test_recursion_level(dirname, subdirname, recursion_level, get_configuration
     subdirname : str
         The name of the subdirectories that will be created during the execution for testing purposes.
     recursion_level : int
-        Recursion level. Also used as the number of subdirectories to be created and checked for the current test.
+        Recursion level. Also used as the number of subdirectories to be created and checked for the current test. 
+        Max recursion level for Windows is 32. When testing on windows the last case tests 32 folders deep instead of 320.
     """
     recursion_test(dirname, subdirname, recursion_level, timeout=global_parameters.default_timeout,
                    is_scheduled=get_configuration['metadata']['fim_mode'] == 'scheduled')


### PR DESCRIPTION
|Related issue|
|---|
| [#1950](https://github.com/wazuh/wazuh-qa/issues/1950)  |

## Description

During testing, on windows systems, the test failed. 
- Initially, with other modules activated, it failed with Timeout Errors. 
- After disabling modules, only the test cases with `recursion_level = 320` failed. 
- It was found that this is due to windows having a recursion limit of `32` folders deep.

The current fix, modifies the `wazuh_recursion_windows.yaml` file to disable modules, and fixes the test to test up to` recursion_level = 32`

### Environment 

Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | "gusztavvargadr/windows-10" | Windows | 2 | 2048 |

## Tests
|Windows Agent | Report | Date | By | Notes |
|--|--|--|--|--|
| R1 | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7269349/1967-1.zip)  | 2021/10/01 | @Deblintrake09 | Tested with fim modes `realtime`, `scheduled`, and `whodata`
| R2 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7269350/1967-2.zip) | 2021/10/01 | @Deblintrake09 | Tested with fim modes `realtime`, `scheduled`, and `whodata`
| R3 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7269351/1967-3.zip) | 2021/10/01 | @Deblintrake09 | Tested with fim modes `realtime`, `scheduled`, and `whodata`
| R4 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7269352/1967-no-modes.zip) | 2021/10/01 | @Deblintrake09 | Tested without using fim modes as parameter
| R5-6-7 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7269353/1967-single-modes.zip) | 2021/10/01 | @Deblintrake09 | Three test runs. Each with a different with fim mode: `realtime`, `scheduled`, and `whodata`
| R8-9-10 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7269354/1967-two-modes.zip) | 2021/10/01 | @Deblintrake09 | Three test runs. Each with a different combination of two fim modes: `realtime`, `scheduled`, and `whodata`


- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.