### PR TITLE
Add qa-branch parameter to the qa-ctl tool

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -66,22 +66,15 @@ class QACTLConfigGenerator:
         }
     }
 
-    def __init__(self, tests, wazuh_version, qa_files_path=f"{gettempdir()}/wazuh-qa"):
+    def __init__(self, tests, wazuh_version, qa_branch='master', qa_files_path=f"{gettempdir()}/wazuh-qa"):
         self.tests = tests
         self.wazuh_version = get_last_wazuh_version() if wazuh_version is None else wazuh_version
         self.qactl_used_ips_file = f"{gettempdir()}/qactl_used_ips.txt"
         self.config_file_path = f"{gettempdir()}/config_{get_current_timestamp()}.yaml"
         self.config = {}
         self.hosts = []
+        self.qa_branch = qa_branch
         self.qa_files_path = qa_files_path
-
-    def __get_qa_branch(self):
-        """Get Wazuh QA repository branch from Wazuh version.
-
-        Returns:
-            string: Wazuh QA repository branch.
-        """
-        return f"{self.wazuh_version.split('.')[0]}.{self.wazuh_version.split('.')[1]}".replace('v', '')
 
     def __get_test_info(self, test_name):
         """Get information from a documented test.
@@ -122,16 +115,13 @@ class QACTLConfigGenerator:
 
         return tests_info
 
-    def __validate_test_info(self, test_info, user_input=True, log_error=True):
+    def __validate_test_info(self, test_info):
         """Validate the test information in order to check that the fields that contains are suitable
         for trying to generate a configuration data.
 
         Args:
             test_info (dict): dict containing all the info of the test. This info is by its containing documentation
             user_input (boolean): boolean that checks if there is going to be an input from the user.
-            This parameter is set to True by default.
-            log_error (boolean): boolean that checks if there is going to be a logging of the errors.
-            This parameter is set to True by default.
 
         Returns:
             boolean : True if the validation has succeed, False otherwise
@@ -342,9 +332,8 @@ class QACTLConfigGenerator:
                     self.config['deployment'][f"host_{manager_host_number}"]['provider']['vagrant']['vm_ip']
 
             # QA framework
-            wazuh_qa_branch = self.__get_qa_branch()
             self.config['provision']['hosts'][instance]['qa_framework'] = {
-                'wazuh_qa_branch': wazuh_qa_branch,
+                'wazuh_qa_branch': self.qa_branch,
                 'qa_workdir': self.LINUX_TMP
             }
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/qa_ctl_configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/qa_ctl_configuration.py
@@ -4,8 +4,7 @@ class QACTLConfiguration:
 
     Args:
         configuration_data (dict) : Dict with all the info needed for this module coming from config file.
-        debug_level (int): Debug level. It is indicated in the qa-ctl script parameters.
-
+        script_parameters (argparse.Namespace): qa-ctl script parameters object.
     Attributes:
         configuration_data (dict) : Dict with all the info needed for this module coming from config file.
         vagrant_output (boolean): Defines if the vagrant's outputs are going to be replaced by customized
@@ -19,22 +18,23 @@ class QACTLConfiguration:
         logging_file (string): This field defines a path for a file where the outputs will be logged as well
     """
 
-    def __init__(self, configuration_data, debug_level=0):
+    def __init__(self, configuration_data, script_parameters):
         self.configuration_data = configuration_data
         self.vagrant_output = False
         self.ansible_output = False
         self.logging_enable = True
         self.logging_level = 'INFO'
         self.logging_file = None
-        self.debug_level = debug_level
+        self.script_parameters = script_parameters
+        self.debug_level = script_parameters.debug
 
         self.__read_configuration_data()
 
         # Check debug level parameter set in qa-ctl script parameters. It has a higher priority than indicated in
         # the configuration file.
-        if debug_level == 1:
+        if self.debug_level == 1:
             self.logging_level = 'DEBUG'
-        if debug_level > 1:
+        if self.debug_level > 1:
             self.vagrant_output = True
             self.ansible_output = True
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/Dockerfile
@@ -1,5 +1,7 @@
 From ubuntu:focal
 
+ARG qa_branch
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNNING_ON_DOCKER_CONTAINER=true
 
@@ -12,7 +14,7 @@ RUN apt-get -q update && \
         python3-pip \
         python3-setuptools
 
-ADD https://raw.githubusercontent.com/wazuh/wazuh-qa/1900-qa-ctl-windows/requirements.txt /tmp/requirements.txt
+ADD https://raw.githubusercontent.com/wazuh/wazuh-qa/$qa_branch/requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /tmp/requirements.txt --ignore-installed
 
 RUN mkdir /qa_ctl

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -181,7 +181,7 @@ class QAProvisioning():
 
         if 'qa_framework' in host_provision_info:
             qa_framework_info = host_provision_info['qa_framework']
-            wazuh_qa_branch = None if 'wazuh_qa_branch' not in qa_framework_info \
+            wazuh_qa_branch = 'master' if 'wazuh_qa_branch' not in qa_framework_info \
                 else qa_framework_info['wazuh_qa_branch']
 
             QAProvisioning.LOGGER.info(f"Provisioning the {current_host} host with the Wazuh QA framework using "
@@ -219,8 +219,8 @@ class QAProvisioning():
             file.write_yaml_file(tmp_config_file, {'provision': self.provision_info})
 
             try:
-                qa_ctl_docker_run(tmp_config_file_name, self.qa_ctl_configuration.debug_level,
-                                  topic='provisioning the instances')
+                qa_ctl_docker_run(tmp_config_file_name, self.qa_ctl_configuration.script_parameters.qa_branch,
+                                  self.qa_ctl_configuration.debug_level, topic='provisioning the instances')
             finally:
                 file.remove_file(tmp_config_file)
         else:

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/qa_test_runner.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/qa_test_runner.py
@@ -161,8 +161,8 @@ class QATestRunner():
             file.write_yaml_file(tmp_config_file, {'tests': self.test_parameters})
 
             try:
-                qa_ctl_docker_run(tmp_config_file_name, self.qa_ctl_configuration.debug_level,
-                                  topic='launching the tests')
+                qa_ctl_docker_run(tmp_config_file_name, self.qa_ctl_configuration.script_parameters.qa_branch,
+                                  self.qa_ctl_configuration.debug_level, topic='launching the tests')
                 # Move all test results to their original paths specified in Windows qa-ctl configuration
                 index = 0
                 for _, host_data in self.test_parameters.items():

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -163,11 +163,13 @@ def validate_parameters(parameters):
     qactl_logger.info('Input parameters validation has passed successfully')
 
 
-def main():
+def get_script_parameters():
+    """Handle the script parameters. It capturates and validates them.
+
+    Returns:
+        argparse.Namespace: Object with the script parameters.
+    """
     parser = argparse.ArgumentParser()
-    configuration_data = {}
-    instance_handler = None
-    configuration_file = None
 
     parser.add_argument('--config', '-c', type=str, action='store', required=False, dest='config',
                         help='Path to the configuration file.')
@@ -194,6 +196,16 @@ def main():
                                        help='Set a custom wazuh-qa branch to use in the run and provisioning. This '
                                             'has higher priority than the specified in the configuration file')
     arguments = parser.parse_args()
+
+    return arguments
+
+
+def main():
+    configuration_data = {}
+    instance_handler = None
+    configuration_file = None
+
+    arguments = get_script_parameters()
 
     set_parameters(arguments)
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -97,6 +97,7 @@ def set_parameters(parameters):
         level = 'DEBUG' if parameters.debug >= 1 else 'INFO'
         qactl_logger.set_level(level)
 
+    parameters.user_version = parameters.version if parameters.version else None
     parameters.version = parameters.version if parameters.version  else get_last_wazuh_version()
     parameters.version = (parameters.version).replace('v', '')
 
@@ -132,7 +133,7 @@ def validate_parameters(parameters):
         raise QAValueError('The --run parameter is incompatible with --config. --run will autogenerate the '
                            'configuration', qactl_logger.error, QACTL_LOGGER)
 
-    if parameters.version and parameters.run_test is None:
+    if parameters.user_version and parameters.run_test is None:
         raise QAValueError('The -v, --version parameter can only be used with -r, --run', qactl_logger.error)
 
     if parameters.dry_run and parameters.run_test is None:

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -97,6 +97,12 @@ def set_parameters(parameters):
         level = 'DEBUG' if parameters.debug >= 1 else 'INFO'
         qactl_logger.set_level(level)
 
+    parameters.version = parameters.version if parameters.version  else get_last_wazuh_version()
+    parameters.version = (parameters.version).replace('v', '')
+
+    short_version =  f"{(parameters.version).split('.')[0]}.{(parameters.version).split('.')[1]}"
+    parameters.qa_branch = parameters.qa_branch if parameters.qa_branch else short_version
+
 
 def validate_parameters(parameters):
     """Validate the input parameters entered by the user of qa-ctl tool.
@@ -122,32 +128,24 @@ def validate_parameters(parameters):
         raise QAValueError('The --dry-run parameter can only be used with -r, --run', qactl_logger.error, QACTL_LOGGER)
 
     # Check version parameter
-    if parameters.version is not None:
-        version = (parameters.version).replace('v', '')
+    if len((parameters.version).split('.')) != 3:
+        raise QAValueError(f"Version parameter has to be in format x.y.z. You entered {parameters.version}",
+                           qactl_logger.error, QACTL_LOGGER)
 
-        if len((parameters.version).split('.')) != 3:
-            raise QAValueError(f"Version parameter has to be in format x.y.z. You entered {version}",
-                               qactl_logger.error, QACTL_LOGGER)
+    # Check if Wazuh has the specified version
+    if not version_is_released(parameters.version):
+        raise QAValueError(f"The wazuh {parameters.version} version has not been released. Enter a right version.",
+                           qactl_logger.error, QACTL_LOGGER)
 
-        if not version_is_released(parameters.version):
-            raise QAValueError(f"The wazuh {parameters.version} version has not been released. Enter a right version.",
-                               qactl_logger.error, QACTL_LOGGER)
+    # Check if QA branch exists
+    if not branch_exist(parameters.qa_branch, WAZUH_QA_REPO):
+        raise QAValueError(f"{parameters.qa_branch} branch does not exist in Wazuh QA repository.",
+                           qactl_logger.error, QACTL_LOGGER)
 
-        short_version = f"{version.split('.')[0]}.{version.split('.')[1]}"
-
-        if not branch_exist(short_version, WAZUH_QA_REPO):
-            raise QAValueError(f"{short_version} branch does not exist in Wazuh QA repository.",
-                               qactl_logger.error, QACTL_LOGGER)
-
-    # Check if tests exist
+    # Check if specified tests exist
     if parameters.run_test:
-        if parameters.version:
-            qa_branch = f"{parameters.version.split('.')[0]}.{parameters.version.split('.')[1]}".replace('v', '')
-        else:
-            version = get_last_wazuh_version()
-            qa_branch = f"{version.split('.')[0]}.{version.split('.')[1]}".replace('v', '')
-
-        local_actions.download_local_wazuh_qa_repository(branch=qa_branch, path=gettempdir())
+        # Download wazuh-qa repository locally to run qa-docs tool and get the tests info
+        local_actions.download_local_wazuh_qa_repository(branch=parameters.qa_branch, path=gettempdir())
 
         for test in parameters.run_test:
             tests_path = os.path.join(WAZUH_QA_FILES, 'tests')
@@ -183,16 +181,21 @@ def main():
                                                                          ' level with more [-d+]')
     parser.add_argument('--no-validation-logging', action='store_true', help='Disable initial logging of parameter '
                                                                              'validations')
+
+    parser.add_argument('--qa-branch', type=str, action='store', required=False, dest='qa_branch',
+                                       help='Set a custom wazuh-qa branch to use in the run and provisioning. This '
+                                            'has higher priority than the specified in the configuration file')
     arguments = parser.parse_args()
 
     set_parameters(arguments)
 
-    validate_parameters(arguments)
+    # validate_parameters(arguments)
 
     # Generate or get the qactl configuration file
     if arguments.run_test:
         qactl_logger.debug('Generating configuration file')
-        config_generator = QACTLConfigGenerator(arguments.run_test, arguments.version, WAZUH_QA_FILES)
+        config_generator = QACTLConfigGenerator(arguments.run_test, arguments.version, arguments.qa_branch,
+                                                WAZUH_QA_FILES)
         config_generator.run()
         launched['config_generator'] = True
         configuration_file = config_generator.config_file_path
@@ -217,7 +220,7 @@ def main():
     validate_configuration_data(configuration_data)
 
     # Set QACTL configuration
-    qactl_configuration = QACTLConfiguration(configuration_data, arguments.debug)
+    qactl_configuration = QACTLConfiguration(configuration_data, arguments)
 
     # Set QACTL logging
     set_qactl_logging(qactl_configuration)

--- a/deps/wazuh_testing/wazuh_testing/tools/github_repository.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/github_repository.py
@@ -56,8 +56,9 @@ def get_wazuh_qa_master_version():
 
 def version_is_released(version):
     releases = get_wazuh_releases()
+    v_version = f"v{version}" if not 'v' in version else version
 
-    return f"v{version}" in releases
+    return v_version in releases
 
 
 def branch_exist(branch_name, repository=WAZUH_REPO):


### PR DESCRIPTION
|Related issue|
|---|
|Close #1964 |

The aim of this PR is to add a new `qa-ctl` script parameter to set a custom wazuh-qa repository branch. This is needed to specify the qa branch of the downloaded repository and the provisioned hosts.

This PR makes the following changes

- Add new `--qa-branch` parameter to `qa-ctl`.
- Updated all qa-ctl classes to use the new `qa-branch` parameter.
- Improve qa-ctl script parameters management.
- Update qa-ctl dockerfile to parameterize the qa-branch.
- Updated the local repository download. Now it is cloned all the repository instead of a single branch. Needed to checkout if needed.
- Add function `set_environment` in `qa-ctl` script to separate the logic of downloading the qa repository locally from the parameters validation.

**Example output**

```
$ qa-ctl -r test_general_settings_enabled --qa-branch 1964-qa-branch-parameter

2021-10-04 14:18:53,687 - INFO - Pulling remote repository changes in C:\Users\jmv74211\AppData\Local\Temp\wazuh-qa local repository
2021-10-04 14:18:55,314 - INFO - Validating input parameters
2021-10-04 14:18:57,098 - INFO - Input parameters validation has passed successfully
2021-10-04 14:18:58,314 - INFO - Starting 1 instances deployment
2021-10-04 14:20:35,342 - INFO - The instances deployment has finished sucessfully
2021-10-04 14:20:35,345 - INFO - Building docker image for provisioning the instances
2021-10-04 14:20:38,247 - INFO - Running the Linux container for provisioning the instances
The Vagrant executable cannot be found. Please check if it is in the system path.
2021-10-04 12:20:48,839 - INFO - Checking hosts SSH connection
2021-10-04 12:21:09,090 - INFO - Hosts connection OK. The instances are accessible via ssh
2021-10-04 12:21:09,091 - INFO - Provisioning 1 instances
2021-10-04 12:22:46,204 - INFO - Performing a Wazuh installation healthcheck in 10.150.50.5 host
2021-10-04 12:23:24,769 - INFO - Provisioning the 10.150.50.5 host with the Wazuh QA framework using 1964-qa-branch-parameter branch.
2021-10-04 12:28:16,205 - INFO - The instances have been provisioned sucessfully
2021-10-04 14:28:16,731 - INFO - Building docker image for launching the tests
2021-10-04 14:28:19,024 - INFO - Running the Linux container for launching the tests
The Vagrant executable cannot be found. Please check if it is in the system path.
2021-10-04 12:28:32,412 - INFO - Launching 1 tests
2021-10-04 12:28:32,412 - INFO - Waiting for tests to finish
2021-10-04 12:28:47,046 - INFO - Running /tmp/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py test on ['10.150.50.5'] hosts
2021-10-04 12:29:06,791 - INFO -

============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /tmp/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-3.1.1
collected 4 items

../../tmp/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py . [ 25%]
ss.                                                                      [100%]

- generated html file: file:///tmp/wazuh-qa/test/integration/reports/test_report_2021_10_04_12_28_47_046269.html -
========================= 2 passed, 2 skipped in 8.15s =========================


2021-10-04 12:29:06,796 - INFO - The test run is finished
2021-10-04 14:29:07,331 - INFO - The results of /tmp/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py tests have been saved in C:\Users\jmv74211\AppData\Local\Temp/test_general_settings_enabled_1633349938.284917/
2021-10-04 14:29:07,331 - INFO - Destroying 1 instances
2021-10-04 14:29:16,444 - INFO - The instances have been destroyed sucessfully
```