### PR TITLE
Add skip parameters to the qa-ctl tool

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/Dockerfile
@@ -1,7 +1,5 @@
 From ubuntu:focal
 
-ARG qa_branch
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNNING_ON_DOCKER_CONTAINER=true
 
@@ -14,7 +12,7 @@ RUN apt-get -q update && \
         python3-pip \
         python3-setuptools
 
-ADD https://raw.githubusercontent.com/wazuh/wazuh-qa/$qa_branch/requirements.txt /tmp/requirements.txt
+ADD https://raw.githubusercontent.com/wazuh/wazuh-qa/master/requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --upgrade pip && python3 -m pip install -r /tmp/requirements.txt --ignore-installed
 
 RUN mkdir /qa_ctl

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/local_actions.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/local_actions.py
@@ -90,7 +90,7 @@ def qa_ctl_docker_run(config_file, qa_branch, debug_level, topic):
                                      'dockerfiles', 'qa_ctl')
 
     LOGGER.info(f"Building docker image for {topic}")
-    run_local_command_with_output(f"cd {docker_image_path} && docker build -q -t {docker_image_name} "
-                                  f"--build-arg qa_branch={qa_branch} .")
+    run_local_command_with_output(f"cd {docker_image_path} && docker build -q -t {docker_image_name} .")
+
     LOGGER.info(f"Running the Linux container for {topic}")
     run_local_command(f"docker run --rm -v {gettempdir()}:/qa_ctl {docker_image_name} {docker_args}")

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -138,8 +138,9 @@ def validate_parameters(parameters):
 
     if parameters.dry_run and parameters.run_test is None:
         raise QAValueError('The --dry-run parameter can only be used with -r, --run', qactl_logger.error, QACTL_LOGGER)
-
-    if parameters.skip_deployment or parameters.skip_provisioning or parameters.skip_testing and not parameters.config:
+    print(parameters)
+    if (parameters.skip_deployment or parameters.skip_provisioning or parameters.skip_testing) \
+        and not parameters.config:
         raise QAValueError('The --skip parameter can only be used when a custom configuration file has been '
                            'specified with the option -c or --config', qactl_logger.error, QACTL_LOGGER)
 
@@ -294,6 +295,9 @@ def main():
 
             if arguments.run_test and launched['config_generator']:
                 config_generator.destroy()
+        else:
+            if 'RUNNING_ON_DOCKER_CONTAINER' not in os.environ:
+                qactl_logger.info(f"Configuration file saved in {config_generator.config_file_path}")
 
 if __name__ == '__main__':
     main()

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -138,7 +138,7 @@ def validate_parameters(parameters):
 
     if parameters.dry_run and parameters.run_test is None:
         raise QAValueError('The --dry-run parameter can only be used with -r, --run', qactl_logger.error, QACTL_LOGGER)
-    print(parameters)
+
     if (parameters.skip_deployment or parameters.skip_provisioning or parameters.skip_testing) \
         and not parameters.config:
         raise QAValueError('The --skip parameter can only be used when a custom configuration file has been '

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -139,6 +139,10 @@ def validate_parameters(parameters):
     if parameters.dry_run and parameters.run_test is None:
         raise QAValueError('The --dry-run parameter can only be used with -r, --run', qactl_logger.error, QACTL_LOGGER)
 
+    if parameters.skip_deployment or parameters.skip_provisioning or parameters.skip_testing and not parameters.config:
+        raise QAValueError('The --skip parameter can only be used when a custom configuration file has been '
+                           'specified with the option -c or --config', qactl_logger.error, QACTL_LOGGER)
+
     # Check version parameter
     if len((parameters.version).split('.')) != 3:
         raise QAValueError(f"Version parameter has to be in format x.y.z. You entered {parameters.version}",
@@ -183,19 +187,29 @@ def get_script_parameters():
                              'generated without running anything.')
 
     parser.add_argument('--run', '-r', type=str, action='store', required=False, nargs='+', dest='run_test',
-                        help='Independent run method. Specify a test or a list of tests to be run')
+                        help='Independent run method. Specify a test or a list of tests to be run.')
 
     parser.add_argument('--version', '-v', type=str, action='store', required=False, dest='version',
-                        help='Wazuh installation and tests version')
+                        help='Wazuh installation and tests version.')
 
     parser.add_argument('-d', '--debug', action='count', default=0, help='Run in debug mode. You can increase the debug'
                                                                          ' level with more [-d+]')
     parser.add_argument('--no-validation-logging', action='store_true', help='Disable initial logging of parameter '
-                                                                             'validations')
+                                                                             'validations.')
 
     parser.add_argument('--qa-branch', type=str, action='store', required=False, dest='qa_branch',
                                        help='Set a custom wazuh-qa branch to use in the run and provisioning. This '
-                                            'has higher priority than the specified in the configuration file')
+                                            'has higher priority than the specified in the configuration file.')
+
+    parser.add_argument('--skip-deployment', action='store_true',
+                        help='Flag to skip the deployment phase. Set it only if -c or --config was specified.')
+
+    parser.add_argument('--skip-provisioning', action='store_true',
+                        help='Flag to skip the provisioning phase. Set it only if -c or --config was specified.')
+
+    parser.add_argument('--skip-testing', action='store_true',
+                        help='Flag to skip the testing phase. Set it only if -c or --config was specified.')
+
     arguments = parser.parse_args()
 
     return arguments
@@ -250,19 +264,19 @@ def main():
 
     # Run QACTL modules
     try:
-        if DEPLOY_KEY in configuration_data:
+        if DEPLOY_KEY in configuration_data and not arguments.skip_deployment:
             deploy_dict = configuration_data[DEPLOY_KEY]
             instance_handler = QAInfraestructure(deploy_dict, qactl_configuration)
             instance_handler.run()
             launched['instance_handler'] = True
 
-        if PROVISION_KEY in configuration_data:
+        if PROVISION_KEY in configuration_data and not arguments.skip_provisioning:
             provision_dict = configuration_data[PROVISION_KEY]
             qa_provisioning = QAProvisioning(provision_dict, qactl_configuration)
             qa_provisioning.run()
             launched['qa_provisioning'] = True
 
-        if TEST_KEY in configuration_data:
+        if TEST_KEY in configuration_data and not arguments.skip_testing:
             test_dict = configuration_data[TEST_KEY]
             tests_runner = QATestRunner(test_dict, qactl_configuration)
             tests_runner.run()


### PR DESCRIPTION
|Related issue|
|---|
|close #1975|

Hello team,

The aim of this PR is to add a set of parameters to skip a specified qa-ctl phases. This is useful when the user wants to re-run a build and skip some phases (usually the user will only want to launch testing phase).

This PR makes the following changes:

- Added `--skip-deployment`, `--skip-provisioning` and `--skip-testing` parameters.
- Updated `qa-ctl` tool to filter the execution phases according to the new parameters.
- Removed `qa-ctl` dockerfile `qa-branch` argument. It was not necessary, since a new docker image was built if the `qa-branch` was different.

