### PR TITLE
Update qa-ctl configuration files path to use the python function os.path.join()

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
 import vagrant
+import sys
 
 from shutil import rmtree
 
@@ -54,7 +55,8 @@ class VagrantWrapper(Instance):
         """Write the vagrantfile and starts the VM specified in the vagrantfile."""
         VagrantWrapper.LOGGER.debug(f"Running {self.vm_name} vagrant up")
 
-        if len(run_local_command_with_output(f"vagrant box list | grep {self.vm_box}")) == 0:
+        filter_command = 'findstr' if sys.platform == 'win32' else 'grep'
+        if len(run_local_command_with_output(f"vagrant box list | {filter_command} {self.vm_box}")) == 0:
             VagrantWrapper.LOGGER.info(f"{self.vm_box} vagrant box not found in local repository. Downloading and "
                                        'running')
         self.vagrant.up()

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_s3_package.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_s3_package.py
@@ -103,7 +103,7 @@ class WazuhS3Package(WazuhPackage):
             str: String with the complete path of the downloaded installation package
         """
         package_name = Path(self.s3_package_url).name
-        WazuhS3Package.LOGGER.debug(f"Downloading Wazuh S3 package from <url> in {hosts} hosts")
+        WazuhS3Package.LOGGER.debug(f"Downloading Wazuh S3 package from {self.s3_package_url} in {hosts} hosts")
 
         download_s3_package = AnsibleTask({'name': 'Download S3 package',
                                            'get_url': {'url': self.s3_package_url,

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -138,7 +138,7 @@ def validate_parameters(parameters):
 
     if parameters.dry_run and parameters.run_test is None:
         raise QAValueError('The --dry-run parameter can only be used with -r, --run', qactl_logger.error, QACTL_LOGGER)
-    print(parameters)
+
     if (parameters.skip_deployment or parameters.skip_provisioning or parameters.skip_testing) \
         and not parameters.config:
         raise QAValueError('The --skip parameter can only be used when a custom configuration file has been '


### PR DESCRIPTION
|Related issue|
|---|
|close #1977|

Hi,

The aim of this PR is to fix the qa-ctl configuration paths, since they was built with `/` character. Now it is done dynamically by the `os.path.join` python function.

This PR makes the following changes:

- Updated paths in `qa-ctl` config generator to use `os.path.join` python function.
- Changed Ubuntu OS as a default test system.
- Fixed URL log when downloading S3 packages.
- Fixed the vagrant box check for the Windows system.

