### PR TITLE
qa-docs docker deployment

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
@@ -1,3 +1,12 @@
+#!/bin/sh
 branch_name=$1
 
-docker build -t qadocs/$branch_name:0.1 --build-arg BRANCH=$branch_name dockerfiles/
+if [ "$#" -ne 1 ];
+then
+  echo "The branch where the tests to parse are located is missing:\n\n$0 BRANCH" >&2
+  exit 1
+fi
+
+docker build -t qa-docs_base:0.1 -f dockerfiles/qa_docs_base.Dockerfile dockerfiles/
+docker build -t qa-docs/$branch_name:0.1 --build-arg BRANCH=$branch_name -f dockerfiles/qa_docs_tool.Dockerfile dockerfiles/
+docker run qa-docs/$branch_name:0.1

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
@@ -1,4 +1,3 @@
 branch_name=$1
 
 docker build -t qadocs/$branch_name:0.1 --build-arg BRANCH=$branch_name dockerfiles/
-docker run qadocs/$branch_name:0.1

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
@@ -1,2 +1,4 @@
-docker build -t qadocs:0.1 dockerfiles/
-docker run qadocs:0.1
+branch_name=$1
+
+docker build -t qadocs/$branch_name:0.1 --build-arg BRANCH=$branch_name dockerfiles/
+docker run qadocs/$branch_name:0.1

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/deploy_qa_docs.sh
@@ -1,0 +1,2 @@
+docker build -t qadocs:0.1 dockerfiles/
+docker run qadocs:0.1

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/Dockerfile
@@ -33,7 +33,9 @@ RUN git clone https://github.com/wazuh/wazuh-qa.git
 
 WORKDIR wazuh-qa
 
-RUN git checkout 1796-migrate-doc-schema-2
+ARG BRANCH
+
+RUN git checkout ${BRANCH}
 
 WORKDIR /
 
@@ -51,5 +53,5 @@ RUN git checkout 1864-qa-docs-fixes && \
 CMD service elasticsearch start && \
     service wazuh-manager start && \
     sleep 8 && \
-    qa-docs -I /tests/wazuh-qa/tests --type integration --modules test_active_response test_agentd test_analysisd test_api test_authd test_cluster && \
+    qa-docs -I /tests/wazuh-qa/tests --types integration && \
     qa-docs -I /tests/wazuh-qa/tests -il qa-docs

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:focal
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    python \
+    python3-pip \
+    curl \
+    npm \
+    apt-transport-https \
+    lsb-release \
+    gnupg
+
+# install ES
+RUN curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
+    echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list && \
+    apt update && \
+    apt install -y elasticsearch
+
+# install wazuh manager
+RUN curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && \
+    echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list && \
+    apt-get update && \
+    apt-get install wazuh-manager
+
+RUN mkdir tests
+
+WORKDIR tests
+
+# cloning parsed tests
+RUN git clone https://github.com/wazuh/wazuh-qa.git
+
+WORKDIR wazuh-qa
+
+RUN git checkout 1796-migrate-doc-schema-2
+
+WORKDIR /
+
+# cloning and installing qa reqs
+RUN git clone https://github.com/wazuh/wazuh-qa.git
+
+WORKDIR wazuh-qa/deps/wazuh_testing/
+
+RUN git checkout 1864-qa-docs-fixes && \
+    pip install -r ../../requirements.txt && \
+    pip install -r wazuh_testing/qa_docs/requirements.txt && \
+    python3  setup.py install
+
+# start services, parse some tests and launch the api
+CMD service elasticsearch start && \
+    service wazuh-manager start && \
+    sleep 8 && \
+    qa-docs -I /tests/wazuh-qa/tests --type integration --modules test_active_response test_agentd test_analysisd test_api test_authd test_cluster && \
+    qa-docs -I /tests/wazuh-qa/tests -il qa-docs

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_base.Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_base.Dockerfile
@@ -38,6 +38,6 @@ RUN git checkout 1864-qa-docs-fixes && \
     python3 setup.py install
 
 # install npm deps
-WORKDIR /home/wazuh-qa/deps/wazuh_testing/wazuh_testing/qa_docs/search_ui
+WORKDIR /home/wazuh-qa/deps/wazuh_testing/build/lib/wazuh_testing/qa_docs/search_ui
 
 RUN npm install

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_base.Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_base.Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 
+# install packages
 RUN apt-get update && \
     apt-get install -y \
     git \
@@ -24,34 +25,19 @@ RUN curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && \
     apt-get update && \
     apt-get install wazuh-manager
 
-RUN mkdir tests
-
-WORKDIR tests
-
-# cloning parsed tests
-RUN git clone https://github.com/wazuh/wazuh-qa.git
-
-WORKDIR wazuh-qa
-
-ARG BRANCH
-
-RUN git checkout ${BRANCH}
-
-WORKDIR /
-
 # cloning and installing qa reqs
+WORKDIR /home
+
 RUN git clone https://github.com/wazuh/wazuh-qa.git
 
-WORKDIR wazuh-qa/deps/wazuh_testing/
+WORKDIR /home/wazuh-qa/deps/wazuh_testing/
 
 RUN git checkout 1864-qa-docs-fixes && \
     pip install -r ../../requirements.txt && \
     pip install -r wazuh_testing/qa_docs/requirements.txt && \
-    python3  setup.py install
+    python3 setup.py install
 
-# start services, parse some tests and launch the api
-CMD service elasticsearch start && \
-    service wazuh-manager start && \
-    sleep 8 && \
-    qa-docs -I /tests/wazuh-qa/tests --types integration && \
-    qa-docs -I /tests/wazuh-qa/tests -il qa-docs
+# install npm deps
+WORKDIR /home/wazuh-qa/deps/wazuh_testing/wazuh_testing/qa_docs/search_ui
+
+RUN npm install

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_tool.Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_tool.Dockerfile
@@ -1,0 +1,23 @@
+FROM qa-docs_base:0.1
+
+RUN mkdir tests
+
+WORKDIR /home/tests
+
+# cloning parsed tests
+RUN git clone https://github.com/wazuh/wazuh-qa.git
+
+WORKDIR /home/tests/wazuh-qa
+
+ARG BRANCH
+
+RUN git checkout ${BRANCH}
+
+WORKDIR /home/wazuh-qa/deps/wazuh_testing
+
+# start services, parse some tests and launch the api
+CMD service elasticsearch start && \
+    service wazuh-manager start && \
+    sleep 8 && \
+    qa-docs -I /home/tests/wazuh-qa/tests --types integration && \
+    qa-docs -I /home/tests/wazuh-qa/tests -il qa-docs

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_tool.Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/dockerfiles/qa_docs_tool.Dockerfile
@@ -18,6 +18,5 @@ WORKDIR /home/wazuh-qa/deps/wazuh_testing
 # start services, parse some tests and launch the api
 CMD service elasticsearch start && \
     service wazuh-manager start && \
-    sleep 8 && \
     qa-docs -I /home/tests/wazuh-qa/tests --types integration && \
     qa-docs -I /home/tests/wazuh-qa/tests -il qa-docs


### PR DESCRIPTION
|Related issue|
|---|
|#1797|

## Description
As a task from #1864, two images building has been created to `qa-docs` deployment.

Related info can be checked within the related issue #1797.

You can build these images by running `qa_docs/deploy_qa_docs.sh`

```
(docgen) luisgr@luisgr-pc:~/work/wazuh-qa/deps/wazuh_testing/wazuh_testing/qa_docs$ docker image list
REPOSITORY                          TAG       IMAGE ID       CREATED          SIZE
qa-docs/1796-migrate-doc-schema-2   0.1       8a62b2b554d2   10 minutes ago   2.8GB
qa-docs_base                        0.1       dd8369b5d244   11 minutes ago   2.66GB
```