### PR TITLE
Add WMI requirement for test_windows_audit_interval

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ jsonschema==3.2.0
 kiwisolver>=1.0.1; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 lockfile==0.12.2
 matplotlib>=3.3.4; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-netifaces==0.10.9
+netifaces==0.10.9; platform_system == "Linux" or platform_system == "MacOS"
 numpydoc==0.9.2
 pandas>=1.1.5
 pillow>=6.2.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
@@ -28,3 +28,4 @@ seaborn>=0.11.1; platform_system == "Linux" or platform_system == "MacOS" or pla
 testinfra==5.0.0
 jq==1.1.2; platform_system == "Linux" or platform_system == "MacOS"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+wmi>=1.5.1; platform_system=='Windows'

--- a/tests/integration/test_fim/test_files/test_windows_audit_interval/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_windows_audit_interval/data/wazuh_conf.yaml
@@ -5,6 +5,24 @@
   apply_to_modules:
   - test_windows_audit_interval
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:


### PR DESCRIPTION
|Related issue|
|---|
|[#1973](https://github.com/wazuh/wazuh-qa/issues/1973) |


## Description

During testing it was found that the WMI package is not installed as part of the requirements, which causes the tests to fail.

This fix, adds the WMI requirement to the `requirements.txt` file. Also it flags the netifaces package to be installed only on `Linux` and `MacOs` systems, since trying to install it causes installation attempts to fail and has to be manually removed.


### Test file 
`test_fim/test_files/test_windows_audit_interval` for Windows. 

### Configuration options
|  Jenkins branch  | QA branch   | 
|- |- |
|  v4.2.1-rc1 |   1873-4.2.1-fim-windows-agent |

###  Local Internal Options
#### Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
windows.debug=2
```

### Environment 

Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | "gusztavvargadr/windows-10" | Windows | 2 | 2048 |

### pytest_args
`-v --tier 0 --tier 1 --tier 2 --fim_mode="realtime" --fim_mode="whodata"`