### PR TITLE
FIM Windows Agent - Fix test_files

### DIFF
--- a/tests/integration/test_fim/test_files/test_file_limit/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_file_limit/data/wazuh_conf.yaml
@@ -19,6 +19,18 @@
             value: 'no'
         - entries:
             value: '10'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
 
 # conf 2
 - tags:
@@ -34,6 +46,18 @@
         value: TEST_DIRECTORIES
         attributes:
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
 
 # conf 3
 - tags:
@@ -57,3 +81,16 @@
             value: 'yes'
         - entries:
             value: FILE_LIMIT
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+

--- a/tests/integration/test_fim/test_files/test_file_limit/data/wazuh_conf_delete_full.yaml
+++ b/tests/integration/test_fim/test_files/test_file_limit/data/wazuh_conf_delete_full.yaml
@@ -19,3 +19,16 @@
             value: 'yes'
         - entries:
             value: LIMIT
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+


### PR DESCRIPTION
|Related issue|
|---|
| #1972 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As explained in issue #1972 , some tests from test_fim/test_files/test_file_limit fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
windows.debug=2
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`
## Tests Results

| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_file_limit` | 2021/10/05 | @danisan90 | :green_circle:  [ResultsFilelimitTest1](https://github.com/wazuh/wazuh-qa/files/7286657/ResultsFilelimitTest1.zip)| - |
| R2 | Windows 10 - Agent - `test_fim/test_files/test_file_limit` | 2021/10/05 | @danisan90 | :green_circle: [ResultsFilelimitTest2](https://github.com/wazuh/wazuh-qa/files/7286674/ResultsFilelimitTest2.zip) | - |
| R3 | Windows 10 - Agent - `test_fim/test_files/test_file_limit` | 2021/10/05 | @danisan90 | :green_circle:  [ResultsFilelimitTest3](https://github.com/wazuh/wazuh-qa/files/7286776/ResultsFilelimitTest3.zip)| - |