### PR TITLE
Disable test_benchmark folder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ jsonschema==3.2.0
 kiwisolver>=1.0.1; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 lockfile==0.12.2
 matplotlib>=3.3.4; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-netifaces==0.10.9
+netifaces==0.10.9; platform_system == "Linux" or platform_system == "MacOS"
 numpydoc==0.9.2
 pandas>=1.1.5
 pillow>=6.2.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
@@ -28,3 +28,4 @@ seaborn>=0.11.1; platform_system == "Linux" or platform_system == "MacOS" or pla
 testinfra==5.0.0
 jq==1.1.2; platform_system == "Linux" or platform_system == "MacOS"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+wmi>=1.5.1; platform_system=='Windows'

--- a/tests/integration/test_fim/test_files/test_benchmark/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_benchmark/data/wazuh_conf.yaml
@@ -5,6 +5,24 @@
   apply_to_modules:
   - MODULE_NAME
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:

--- a/tests/integration/test_fim/test_files/test_benchmark/test_benchmark.py
+++ b/tests/integration/test_fim/test_files/test_benchmark/test_benchmark.py
@@ -50,6 +50,7 @@ def get_configuration(request):
 
 # tests
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 @pytest.mark.benchmark
 @pytest.mark.parametrize('files, folder, tags_to_apply', [
     (file_list[0:10], testdir1, {'ossec_conf'}),

--- a/tests/integration/test_fim/test_files/test_benchmark/test_report_changes_big.py
+++ b/tests/integration/test_fim/test_files/test_benchmark/test_report_changes_big.py
@@ -181,6 +181,7 @@ def write_csv(data):
     df.to_csv(metrics_path, sep='\t', mode='a', index=False, header=(not os.path.exists(metrics_path)))
 
 
+@pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 @pytest.mark.benchmark
 @pytest.mark.parametrize('tags_to_apply', [
     {'ossec_conf'}

--- a/tests/integration/test_fim/test_files/test_windows_audit_interval/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_windows_audit_interval/data/wazuh_conf.yaml
@@ -5,6 +5,24 @@
   apply_to_modules:
   - test_windows_audit_interval
   sections:
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
   - section: syscheck
     elements:
     - disabled:


### PR DESCRIPTION
|Related issue|
|---|
| [#1956](https://github.com/wazuh/wazuh-qa/issues/1956) and [#1602](https://github.com/wazuh/wazuh-qa/issues/1602) |

## Description

During testing, it was found that test_benchmark fails erratically. With Timeouts of even 20 times the timeout it has already configured, it reads up to 8000 lines in one test run, and 400 in another instance. Causing tests to fail. 

## Configuration options

All tests were run with `SCA`, `Rootcheck`, `Active Response `and `Syscollector` modules deactivated.

### Pipeline parameters

|  Jenkins branch  | QA branch   | 
|- |- |
|  v4.2.1-rc1 |   1873-4.2.1-fim-windows-agent |

Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | "gusztavvargadr/windows-10" | Windows | 2 | 2048 |
Vagrant | "centos/8" | Centos/8 | 2 | 2048 |

### pytest_args
`-v --tier 0 --tier 1 --tier 2 --fim_mode="realtime" --fim_mode="whodata"`

## Tests

| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Linux - Manager - `test_fim/test_files/test_benchmark` | 2021/10/05 | @Deblintrake09  | [:red_circle:](https://github.com/wazuh/wazuh-qa/files/7288285/ResultsBenchmark.zip) | Base timeout (30s) |
| R2 | Linux - Manager - `test_fim/test_files/test_benchmark` | 2021/10/05 | @Deblintrake09  | [:red_circle:](https://github.com/wazuh/wazuh-qa/files/7288286/ResultsBenchmark2.zip) | Base timeout (30s) |
| R3 |Linux - Manager - `test_fim/test_files/test_benchmark` | 2021/10/05 | @Deblintrake09  | [:red_circle:](https://github.com/wazuh/wazuh-qa/files/7288288/ResultsBenchmark3.zip) | Base timeout (30s) |
| R1-W |Windows10 - Agent - `test_fim/test_files/test_benchmark` | 2021/10/05 | @Deblintrake09  | [:red_circle:](https://github.com/wazuh/wazuh-qa/files/7288291/ResultsTestBenchmark600.zip)  | Timeout=600 |
| R2-W |Windows10 - Agent - `test_fim/test_files/test_benchmark` | 2021/10/05 | @Deblintrake09  | [:red_circle:](https://github.com/wazuh/wazuh-qa/files/7288293/ResultsTestBenchmark600-2.zip)| Timeout=600 |
| R3-W |Windows10 - Agent - `test_fim/test_files/test_benchmark` | 2021/10/05 | @Deblintrake09  | [:red_circle:](https://github.com/wazuh/wazuh-qa/files/7288307/ResultsBenchmarkWin3.zip) | Base timeout (30s) |

