### PR TITLE
FIM Windows Agent - Fix test_nodiff

### DIFF
--- a/tests/integration/test_fim/test_files/test_nodiff/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_nodiff/data/wazuh_conf.yaml
@@ -20,6 +20,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 2
 - tags:
   - valid_no_regex
@@ -39,6 +58,25 @@
         - report_changes: 'yes'
     - nodiff:
         value: "/testdir1/nodiff_this"
+    - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 3
 - tags:
   - valid_no_regex
@@ -58,6 +96,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 4
 - tags:
   - valid_no_regex
@@ -79,6 +136,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 5
 - tags:
   - valid_regex
@@ -100,6 +176,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+    - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 6
 - tags:
   - valid_regex
@@ -121,6 +216,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 7
 - tags:
   - valid_regex
@@ -146,6 +260,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 8
 - tags:
   - valid_regex
@@ -167,6 +300,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 9
 - tags:
   - valid_regex
@@ -188,3 +340,22 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+

--- a/tests/integration/test_fim/test_files/test_nodiff/data/wazuh_conf_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_nodiff/data/wazuh_conf_win32.yaml
@@ -20,6 +20,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 2
 - tags:
   - valid_no_regex
@@ -39,6 +58,25 @@
         - report_changes: 'yes'
     - nodiff:
         value: "c:\\testdir1\\nodiff_this"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 3
 - tags:
   - valid_no_regex
@@ -58,6 +96,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 4
 - tags:
   - valid_no_regex
@@ -79,6 +136,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 5
 - tags:
   - valid_regex
@@ -100,6 +176,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 6
 - tags:
   - valid_regex
@@ -121,6 +216,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 7
 - tags:
   - valid_regex
@@ -146,6 +260,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 8
 - tags:
   - valid_regex
@@ -167,6 +300,25 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'
+
 # conf 9
 - tags:
   - valid_regex
@@ -188,3 +340,21 @@
         - check_all: 'yes'
         - FIM_MODE
         - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: active-response
+    elements:
+    - disabled:
+        value: 'yes'


### PR DESCRIPTION
|Related issue|
|---|
| #1971 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As explained in issue #1971 , some tests from test_fim/test_files/test_nodiff fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
windows.debug=2
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

## Tests
### Test results
| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_nodiff` | 2021/10/05 | @danisan90  | 🟢 [ResultsTestsNodiff](https://github.com/wazuh/wazuh-qa/files/7288763/ResultsTestsNodiff.zip) | - |
