### PR TITLE
Migrate `test_max_eps`, `test_max_files_per_second`, and `test_moving_files` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -57,6 +57,9 @@ Ignore paths:
   - "../../tests/integration/test_fim/test_files/test_ignore/data"
   - "../../tests/integration/test_fim/test_files/test_inotify/data"
   - "../../tests/integration/test_fim/test_files/test_invalid/data"
+  - "../../tests/integration/test_fim/test_files/test_max_eps/data"
+  - "../../tests/integration/test_fim/test_files/test_max_files_per_second/data"
+  - "../../tests/integration/test_fim/test_files/test_moving_files/data"
 
 Output fields:
   Module:

--- a/tests/integration/test_fim/test_files/test_max_eps/test_max_eps.py
+++ b/tests/integration/test_fim/test_files/test_max_eps/test_max_eps.py
@@ -1,7 +1,76 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will verify that FIM limits
+       the maximum events per second that it generates, set in the 'max_eps' tag.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_max_eps
+'''
 import os
 from collections import Counter
 
@@ -46,12 +115,45 @@ def get_configuration(request):
 
 
 def test_max_eps(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check that max_eps is respected when a big quantity of syscheck events are generated.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon applies the limit set in the 'max_eps' tag when
+                 a lot of 'syscheck' events are generated. For this purpose, the test will monitor a folder,
+                 and once FIM is started, it will create multiple testing files in it. Then, the test
+                 will collect FIM 'added' events generated and check if the number of events matches
+                 the testing files created. Finally, it will verify the limit of events per second (eps)
+                 is not exceeded by checking the creation time of the testing files.
 
-    During the test, a big quantity of files are created and the max number of event occurrences per second is measured
-    to ensure it never exceeds max_eps
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated for each testing file created.
+        - Verify that the eps limit set in the 'max_eps' tag has not been exceeded at generating FIM events.
+
+    input_description: A test case (max_eps) is contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+
+    tags:
+        - realtime
+        - scheduled
+    '''
     check_apply_test({'max_eps'}, get_configuration['tags'])
 
     max_eps = int(get_configuration['metadata']['max_eps'])

--- a/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
+++ b/tests/integration/test_fim/test_files/test_max_files_per_second/test_max_files_per_second.py
@@ -1,7 +1,74 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will verify that FIM limits
+       the maximum number of files scanned per second, set in the 'max_files_per_second' tag.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - macos
+    - solaris
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - macOS Catalina
+    - Solaris 10
+    - Solaris 11
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#max-files-per-second
+    - https://en.wikipedia.org/wiki/Inode
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_max_files_per_second
+'''
 import os
 import pytest
 import wazuh_testing.fim as fim
@@ -48,17 +115,53 @@ def get_configuration(request):
                          ])
 def test_max_files_per_second(inode_collision, get_configuration, configure_environment, restart_syscheckd,
                               wait_for_fim_start):
-    """ Check that FIM sleeps for one second when the option max_files_per_second is enabled
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon sleeps to limit the file scanning frequency when
+                 the 'max_files_per_second' option is enabled. For this purpose, after the 'baseline' is
+                 generated, the test will create testing files inside a monitored folder. Then, if the
+                 'max_files_per_second' tag is set (its value is != 0), it will verify that FIM 'sleep'
+                 events are generated. Finally, the test will check the inode collision algorithm by
+                 removing the testing files and creating them again, verifying that FIM 'sleep' events
+                 are generated.
 
-    Args:
-        inode_collision (boolean): Signals if the test should check the limit while running inode collisions.
-        get_configuration (fixture): Gets the current configuration of the test.
-        configure_environment (fixture): Configure the environment for the execution of the test.
-        restart_syscheckd (fixture): Restarts syscheck.
-        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
-    Raises:
-        TimeoutError: If an expected event couldn't be captured.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - inode_collision:
+            type: bool
+            brief: True if the limit, while running inode collisions, should be checked. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM sleeps once the maximum number of files scanned per second is reached.
+        - Verify that FIM does not sleep if the 'max_files_per_second' option is disabled.
+        - Verify the file scanning limit is also applied to the inode collision algorithm.
+
+    input_description: A test case (max_files_per_second) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Maximum number of files read per second reached, sleeping'
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+
+    tags:
+        - realtime
+        - scheduled
+        - time_travel
+        - who_data
+    '''
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 
     if inode_collision is True and scheduled is False:

--- a/tests/integration/test_fim/test_files/test_moving_files/test_moving_files.py
+++ b/tests/integration/test_fim/test_files/test_moving_files/test_moving_files.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM detects
+       moving files from one directory using the 'whodata' monitoring mode to another using
+       the 'realtime' monitoring mode and vice versa.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows server 2012
+    - Windows server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_moving_files
+'''
 import os
 
 import pytest
@@ -93,24 +163,62 @@ def get_configuration(request):
 ])
 def test_moving_file_to_whodata(dirsrc, dirdst, filename, mod_del_event, mod_add_event, get_configuration,
                                 configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Test Syscheck's behaviors when moving files from a directory monitored by whodata to another
-    monitored by realtime and vice versa.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects events when moving files from a directory
+                 monitored by 'whodata' to another monitored by 'realtime' and vice versa. For this purpose,
+                 the test will monitor two folders using both FIM monitoring modes and create a testing file
+                 inside each one. Then, it will rename the testing file of the target folder using the name
+                 of the one inside the source folder. Finally, the test will verify that the FIM events
+                 generated to match the monitoring mode used in the folders.
 
-    Parameters
-    ----------
-    dirsrc : str
-        Source directory.
-    dirdst : str
-        Target directory.
-    filename : str
-        File name.
-    mod_del_event : str
-        Mode of deleted event.
-    mod_add_event : str
-        Mode of added event.
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - dirsrc:
+            type: str
+            brief: Path to the source directory where the testing file will be deleted.
+        - dirdst:
+            type: str
+            brief: Path to the target directory where the testing file will be added.
+        - filename:
+            type: str
+            brief: Name of the testing file.
+        - mod_del_event:
+            type: str
+            brief: Monitoring mode of FIM 'deleted' event.
+        - mod_add_event:
+            type: str
+            brief: Monitoring mode of FIM 'added' event.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the 'mode' field in FIM 'deleted' events match with one used
+          in the source folder of moved files.
+        - Verify that the 'mode' field in FIM 'added' events match with one used
+          in the target folder of moved files.
+
+    input_description: A test case (monitoring_realtime) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' and 'deleted' events)
+
+    tags:
+        - realtime
+        - who_data
+    '''
     os.rename(os.path.join(dirsrc, filename), os.path.join(dirdst, filename))
 
     check_event(dirsrc, dirdst, filename, mod_del_event, mod_add_event)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1980|

# Description
As part of issue #1810 and epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


## `test_max_eps`


<details><summary>test_max_eps_synchronization.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will verify that FIM limits the maximum synchronization message throughput, set in the 'max_eps' tag. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_max_eps"
    ],
    "name": "test_max_eps_synchronization.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon applies the limit set in the 'max_eps' tag when a lot of synchronization events are generated. For this purpose, the test will monitor a folder and create multiple testing files in it. Once FIM is started, it will wait for the agent to connect to the manager and generate an integrity message. Then, the test will collect FIM 'integrity' events generated and check if the number of events matches the testing files created. Finally, it will verify the limit of events per second (eps) is not exceeded by checking the creation time of the testing files.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "create_files": {
                        "type": "fixture",
                        "brief": "Create the testing files to be monitored."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "delete_files": {
                        "type": "fixture",
                        "brief": "Delete the testing files when the test ends."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM 'integrity' events are generated for each testing file created.",
                "Verify that the eps limit set in the 'max_eps' tag has not been exceeded at generating FIM events."
            ],
            "input_description": "A test case (max_eps_synchronization) is contained in external YAML file (wazuh_conf_synchro.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined with the testing directories to be monitored defined in the module.",
            "expected_output": [
                "r'.* Connected to the server .*'",
                "r'.*Sending integrity control message'"
            ],
            "tags": [
                "realtime",
                "scheduled"
            ],
            "name": "test_max_eps_on_start",
            "inputs": [
                "get_configuration0",
                "get_configuration1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_max_eps_synchronization.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will verify that
  FIM limits the maximum synchronization message throughput, set in the 'max_eps'
  tag. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
  configured files for changes to the checksums, permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 2
modules:
- fim
name: test_max_eps_synchronization.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
tags:
- fim_max_eps
tests:
- assertions:
  - Verify that FIM 'integrity' events are generated for each testing file created.
  - Verify that the eps limit set in the 'max_eps' tag has not been exceeded at generating
    FIM events.
  description: Check if the 'wazuh-syscheckd' daemon applies the limit set in the
    'max_eps' tag when a lot of synchronization events are generated. For this purpose,
    the test will monitor a folder and create multiple testing files in it. Once FIM
    is started, it will wait for the agent to connect to the manager and generate
    an integrity message. Then, the test will collect FIM 'integrity' events generated
    and check if the number of events matches the testing files created. Finally,
    it will verify the limit of events per second (eps) is not exceeded by checking
    the creation time of the testing files.
  expected_output:
  - r'.* Connected to the server .*'
  - r'.*Sending integrity control message'
  input_description: A test case (max_eps_synchronization) is contained in external
    YAML file (wazuh_conf_synchro.yaml) which includes configuration settings for
    the 'wazuh-syscheckd' daemon and, these are combined with the testing directories
    to be monitored defined in the module.
  inputs:
  - get_configuration0
  - get_configuration1
  name: test_max_eps_on_start
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - create_files:
      brief: Create the testing files to be monitored.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - delete_files:
      brief: Delete the testing files when the test ends.
      type: fixture
  tags:
  - realtime
  - scheduled
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_max_eps.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will verify that FIM limits the maximum events per second that it generates, set in the 'max_eps' tag. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_max_eps"
    ],
    "name": "test_max_eps.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon applies the limit set in the 'max_eps' tag when a lot of 'syscheck' events are generated. For this purpose, the test will monitor a folder, and once FIM is started, it will create multiple testing files in it. Then, the test will collect FIM 'added' events generated and check if the number of events matches the testing files created. Finally, it will verify the limit of events per second (eps) is not exceeded by checking the creation time of the testing files.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM events are generated for each testing file created.",
                "Verify that the eps limit set in the 'max_eps' tag has not been exceeded at generating FIM events."
            ],
            "input_description": "A test case (max_eps) is contained in external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined with the testing directory to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' events)"
                }
            ],
            "tags": [
                "realtime",
                "scheduled"
            ],
            "name": "test_max_eps",
            "inputs": [
                "get_configuration0",
                "get_configuration1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_max_eps.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will verify that
  FIM limits the maximum events per second that it generates, set in the 'max_eps'
  tag. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
  configured files for changes to the checksums, permissions, and ownership.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 1
modules:
- fim
name: test_max_eps.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
tags:
- fim_max_eps
tests:
- assertions:
  - Verify that FIM events are generated for each testing file created.
  - Verify that the eps limit set in the 'max_eps' tag has not been exceeded at generating
    FIM events.
  description: Check if the 'wazuh-syscheckd' daemon applies the limit set in the
    'max_eps' tag when a lot of 'syscheck' events are generated. For this purpose,
    the test will monitor a folder, and once FIM is started, it will create multiple
    testing files in it. Then, the test will collect FIM 'added' events generated
    and check if the number of events matches the testing files created. Finally,
    it will verify the limit of events per second (eps) is not exceeded by checking
    the creation time of the testing files.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added' events)
  input_description: A test case (max_eps) is contained in external YAML file (wazuh_conf.yaml)
    which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
    are combined with the testing directory to be monitored defined in the module.
  inputs:
  - get_configuration0
  - get_configuration1
  name: test_max_eps
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - realtime
  - scheduled
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## `test_max_files_per_second`


<details><summary>test_max_files_per_second.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will verify that FIM limits the maximum number of files scanned per second, set in the 'max_files_per_second' tag. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "macos",
        "solaris"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "macOS Catalina",
        "Solaris 10",
        "Solaris 11"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#max-files-per-second",
        "https://en.wikipedia.org/wiki/Inode"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_max_files_per_second"
    ],
    "name": "test_max_files_per_second.py",
    "id": 3,
    "group_id": 2,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon sleeps to limit the file scanning frequency when the 'max_files_per_second' option is enabled. For this purpose, after the 'baseline' is generated, the test will create testing files inside a monitored folder. Then, if the 'max_files_per_second' tag is set (its value is != 0), it will verify that FIM 'sleep' events are generated. Finally, the test will check the inode collision algorithm by removing the testing files and creating them again, verifying that FIM 'sleep' events are generated.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "inode_collision": {
                        "type": "bool",
                        "brief": "True if the limit, while running inode collisions, should be checked. False otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM sleeps once the maximum number of files scanned per second is reached.",
                "Verify that FIM does not sleep if the 'max_files_per_second' option is disabled.",
                "Verify the file scanning limit is also applied to the inode collision algorithm."
            ],
            "input_description": "A test case (max_files_per_second) is contained in external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined with the testing directories to be monitored defined in the module.",
            "expected_output": [
                "r'.*Maximum number of files read per second reached, sleeping'",
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' events)"
                }
            ],
            "tags": [
                "realtime",
                "scheduled",
                "time_travel",
                "who_data"
            ],
            "name": "test_max_files_per_second",
            "inputs": [
                "get_configuration0-False",
                "get_configuration0-True",
                "get_configuration1-False",
                "get_configuration1-True",
                "get_configuration2-False",
                "get_configuration2-True",
                "get_configuration3-False",
                "get_configuration3-True",
                "get_configuration4-False",
                "get_configuration4-True",
                "get_configuration5-False",
                "get_configuration5-True"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_max_files_per_second.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will verify that
  FIM limits the maximum number of files scanned per second, set in the 'max_files_per_second'
  tag. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
  configured files for changes to the checksums, permissions, and ownership.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 2
id: 3
modules:
- fim
name: test_max_files_per_second.py
os_platform:
- linux
- macos
- solaris
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- macOS Catalina
- Solaris 10
- Solaris 11
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#max-files-per-second
- https://en.wikipedia.org/wiki/Inode
tags:
- fim_max_files_per_second
tests:
- assertions:
  - Verify that FIM sleeps once the maximum number of files scanned per second is
    reached.
  - Verify that FIM does not sleep if the 'max_files_per_second' option is disabled.
  - Verify the file scanning limit is also applied to the inode collision algorithm.
  description: Check if the 'wazuh-syscheckd' daemon sleeps to limit the file scanning
    frequency when the 'max_files_per_second' option is enabled. For this purpose,
    after the 'baseline' is generated, the test will create testing files inside a
    monitored folder. Then, if the 'max_files_per_second' tag is set (its value is
    != 0), it will verify that FIM 'sleep' events are generated. Finally, the test
    will check the inode collision algorithm by removing the testing files and creating
    them again, verifying that FIM 'sleep' events are generated.
  expected_output:
  - r'.*Maximum number of files read per second reached, sleeping'
  - r'.*Sending FIM event: (.+)$' ('added' events)
  input_description: A test case (max_files_per_second) is contained in external YAML
    file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd'
    daemon and, these are combined with the testing directories to be monitored defined
    in the module.
  inputs:
  - get_configuration0-False
  - get_configuration0-True
  - get_configuration1-False
  - get_configuration1-True
  - get_configuration2-False
  - get_configuration2-True
  - get_configuration3-False
  - get_configuration3-True
  - get_configuration4-False
  - get_configuration4-True
  - get_configuration5-False
  - get_configuration5-True
  name: test_max_files_per_second
  parameters:
  - inode_collision:
      brief: True if the limit, while running inode collisions, should be checked.
        False otherwise.
      type: bool
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - realtime
  - scheduled
  - time_travel
  - who_data
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## `test_moving_files`


<details><summary>test_moving_files.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will check if FIM detects moving files from one directory using the 'whodata' monitoring mode to another using the 'realtime' monitoring mode and vice versa. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows server 2012",
        "Windows server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_moving_files"
    ],
    "name": "test_moving_files.py",
    "id": 4,
    "group_id": 3,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon detects events when moving files from a directory monitored by 'whodata' to another monitored by 'realtime' and vice versa. For this purpose, the test will monitor two folders using both FIM monitoring modes and create a testing file inside each one. Then, it will rename the testing file of the target folder using the name of the one inside the source folder. Finally, the test will verify that the FIM events generated to match the monitoring mode used in the folders.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "dirsrc": {
                        "type": "str",
                        "brief": "Path to the source directory where the testing file will be deleted."
                    }
                },
                {
                    "dirdst": {
                        "type": "str",
                        "brief": "Path to the target directory where the testing file will be added."
                    }
                },
                {
                    "filename": {
                        "type": "str",
                        "brief": "Name of the testing file."
                    }
                },
                {
                    "mod_del_event": {
                        "type": "str",
                        "brief": "Monitoring mode of FIM 'deleted' event."
                    }
                },
                {
                    "mod_add_event": {
                        "type": "str",
                        "brief": "Monitoring mode of FIM 'added' event."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'mode' field in FIM 'deleted' events match with one used in the source folder of moved files.",
                "Verify that the 'mode' field in FIM 'added' events match with one used in the target folder of moved files."
            ],
            "input_description": "A test case (monitoring_realtime) is contained in external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined with the testing directories to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' and 'deleted' events)"
                }
            ],
            "tags": [
                "realtime",
                "who_data"
            ],
            "name": "test_moving_file_to_whodata",
            "inputs": [
                "get_configuration0-/testdir1-/testdir2-file1-whodata-realtime",
                "get_configuration0-/testdir2-/testdir1-file2-realtime-whodata"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_moving_files.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will check if FIM
  detects moving files from one directory using the 'whodata' monitoring mode to another
  using the 'realtime' monitoring mode and vice versa. The FIM capability is managed
  by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the
  checksums, permissions, and ownership.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 3
id: 4
modules:
- fim
name: test_moving_files.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows server 2012
- Windows server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
tags:
- fim_moving_files
tests:
- assertions:
  - Verify that the 'mode' field in FIM 'deleted' events match with one used in the
    source folder of moved files.
  - Verify that the 'mode' field in FIM 'added' events match with one used in the
    target folder of moved files.
  description: Check if the 'wazuh-syscheckd' daemon detects events when moving files
    from a directory monitored by 'whodata' to another monitored by 'realtime' and
    vice versa. For this purpose, the test will monitor two folders using both FIM
    monitoring modes and create a testing file inside each one. Then, it will rename
    the testing file of the target folder using the name of the one inside the source
    folder. Finally, the test will verify that the FIM events generated to match the
    monitoring mode used in the folders.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added' and 'deleted' events)
  input_description: A test case (monitoring_realtime) is contained in external YAML
    file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd'
    daemon and, these are combined with the testing directories to be monitored defined
    in the module.
  inputs:
  - get_configuration0-/testdir1-/testdir2-file1-whodata-realtime
  - get_configuration0-/testdir2-/testdir1-file2-realtime-whodata
  name: test_moving_file_to_whodata
  parameters:
  - dirsrc:
      brief: Path to the source directory where the testing file will be deleted.
      type: str
  - dirdst:
      brief: Path to the target directory where the testing file will be added.
      type: str
  - filename:
      brief: Name of the testing file.
      type: str
  - mod_del_event:
      brief: Monitoring mode of FIM 'deleted' event.
      type: str
  - mod_add_event:
      brief: Monitoring mode of FIM 'added' event.
      type: str
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - realtime
  - who_data
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`