### PR TITLE
QA-CTL: Add new folder level for qa-ctl temporary files

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -232,7 +232,7 @@ class QACTLConfigGenerator:
         instance_ip = self.__get_host_IP()
         instance = {
             'enabled': True,
-            'vagrantfile_path': gettempdir(),
+            'vagrantfile_path': join(gettempdir(), 'qa_ctl'),
             'vagrant_box': QACTLConfigGenerator.BOX_MAPPING[os_version],
             'vm_memory': vm_memory,
             'vm_cpu': vm_cpu,
@@ -335,7 +335,7 @@ class QACTLConfigGenerator:
             # QA framework
             self.config['provision']['hosts'][instance]['qa_framework'] = {
                 'wazuh_qa_branch': self.qa_branch,
-                'qa_workdir': self.LINUX_TMP
+                'qa_workdir': join(self.LINUX_TMP, 'qa_ctl')
             }
 
     def __process_test_data(self, tests_info):
@@ -355,9 +355,9 @@ class QACTLConfigGenerator:
             self.config['tests'][instance]['test'] = {
                 'type': 'pytest',
                 'path': {
-                    'test_files_path': f"{self.LINUX_TMP}/wazuh-qa/{test['path']}",
-                    'run_tests_dir_path': f"{self.LINUX_TMP}/wazuh-qa/test/integration",
-                    'test_results_path': f"{gettempdir()}/{test['test_name']}_{get_current_timestamp()}/"
+                    'test_files_path': f"{self.LINUX_TMP}/qa_ctl/wazuh-qa/{test['path']}",
+                    'run_tests_dir_path': f"{self.LINUX_TMP}/qa_ctl/wazuh-qa/test/integration",
+                    'test_results_path': f"{gettempdir()}/qa_ctl/{test['test_name']}_{get_current_timestamp()}/"
                 }
             }
             test_host_number += 1

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -66,11 +66,11 @@ class QACTLConfigGenerator:
         }
     }
 
-    def __init__(self, tests, wazuh_version, qa_branch='master', qa_files_path=join(gettempdir(), 'wazuh-qa')):
+    def __init__(self, tests, wazuh_version, qa_branch='master', qa_files_path=join(gettempdir(), 'qa_ctl', 'wazuh-qa')):
         self.tests = tests
         self.wazuh_version = get_last_wazuh_version() if wazuh_version is None else wazuh_version
-        self.qactl_used_ips_file = join(gettempdir(), 'qactl_used_ips.txt')
-        self.config_file_path = join(gettempdir(), f"config_{get_current_timestamp()}.yaml")
+        self.qactl_used_ips_file = join(gettempdir(), 'qa_ctl', 'qactl_used_ips.txt')
+        self.config_file_path = join(gettempdir(), 'qa_ctl', f"config_{get_current_timestamp()}.yaml")
         self.config = {}
         self.hosts = []
         self.qa_branch = qa_branch
@@ -85,8 +85,8 @@ class QACTLConfigGenerator:
         Returns:
             dict : return the info of the named test in dict format.
         """
-        qa_docs_command = f"qa-docs -T {test_name} -o {gettempdir()} -I {join(self.qa_files_path, 'tests')}"
-        test_data_file_path = f"{join(gettempdir(), test_name)}.json"
+        qa_docs_command = f"qa-docs -T {test_name} -o {os.path.join(gettempdir(), 'qa_ctl')} -I {join(self.qa_files_path, 'tests')}"
+        test_data_file_path = f"{join(gettempdir(), 'qa_ctl', test_name)}.json"
 
         run_local_command_with_output(qa_docs_command)
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -85,7 +85,7 @@ class QACTLConfigGenerator:
         Returns:
             dict : return the info of the named test in dict format.
         """
-        qa_docs_command = f"qa-docs -T {test_name} -o {os.path.join(gettempdir(), 'qa_ctl')} -I {join(self.qa_files_path, 'tests')}"
+        qa_docs_command = f"qa-docs -T {test_name} -o {join(gettempdir(), 'qa_ctl')} -I {join(self.qa_files_path, 'tests')}"
         test_data_file_path = f"{join(gettempdir(), 'qa_ctl', test_name)}.json"
 
         run_local_command_with_output(qa_docs_command)

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
 import vagrant
+import sys
 
 from shutil import rmtree
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
@@ -3,7 +3,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
 import vagrant
-import sys
 
 from shutil import rmtree
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrantfile_template.txt
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrantfile_template.txt
@@ -12,6 +12,11 @@ Vagrant.configure("2") do |config|
       node.vm.box = "#{vm_parameters['box_image']}"
       config.ssh.insert_key = false
       node.vm.synced_folder ".", "/vagrant", disabled: true
+
+      if Vagrant.has_plugin?("vagrant-vbguest")
+        config.vbguest.auto_update = false
+      end
+      
       config.vm.box_url = "#{vm_parameters['box_url']}"
       node.vm.network :private_network, ip: "#{vm_parameters['private_ip']}"
       node.vm.hostname = "#{vm_name}"

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_inventory.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_inventory.py
@@ -25,7 +25,7 @@ class AnsibleInventory():
         self.ansible_instances = ansible_instances
 
         self.inventory_file_path = inventory_file_path if inventory_file_path else \
-            f"{gettempdir()}/{get_current_timestamp()}.yaml"
+            f"{gettempdir()}/qa_ctl/{get_current_timestamp()}.yaml"
         self.ansible_groups = ansible_groups
         self.data = {}
         self.__setup_data__()

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_playbook.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_playbook.py
@@ -43,7 +43,7 @@ class AnsiblePlaybook():
         self.become = become
         self.playbook_vars = playbook_vars
         self.playbook_file_path = playbook_file_path if playbook_file_path else \
-            f"{gettempdir()}/{get_current_timestamp()}.yaml"
+            f"{gettempdir()}/qa_ctl/{get_current_timestamp()}.yaml"
         if generate_file:
             self.write_playbook_to_file()
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_runner.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_runner.py
@@ -1,6 +1,9 @@
+
 import sys
 import shutil
 from tempfile import gettempdir
+from os.path import join
+
 
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_output import AnsibleOutput
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_playbook import AnsiblePlaybook
@@ -28,7 +31,7 @@ class AnsibleRunner:
     """
     LOGGER = Logging.get_logger(QACTL_LOGGER)
 
-    def __init__(self, ansible_inventory_path, ansible_playbook_path, private_data_dir=gettempdir(), output=False):
+    def __init__(self, ansible_inventory_path, ansible_playbook_path, private_data_dir=join(gettempdir(), 'qa_ctl'), output=False):
         self.ansible_inventory_path = ansible_inventory_path
         self.ansible_playbook_path = ansible_playbook_path
         self.private_data_dir = private_data_dir

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/local_actions.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/local_actions.py
@@ -93,4 +93,4 @@ def qa_ctl_docker_run(config_file, qa_branch, debug_level, topic):
     run_local_command_with_output(f"cd {docker_image_path} && docker build -q -t {docker_image_name} .")
 
     LOGGER.info(f"Running the Linux container for {topic}")
-    run_local_command(f"docker run --rm -v {gettempdir()}:/qa_ctl {docker_image_name} {docker_args}")
+    run_local_command(f"docker run --rm -v {os.path.join(gettempdir(), 'qa_ctl')}:/qa_ctl {docker_image_name} {docker_args}")

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_framework/qa_framework.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_framework/qa_framework.py
@@ -1,3 +1,4 @@
+from os.path import join
 from tempfile import gettempdir
 
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_task import AnsibleTask
@@ -23,7 +24,7 @@ class QAFramework():
     """
     LOGGER = Logging.get_logger(QACTL_LOGGER)
 
-    def __init__(self, ansible_output=False, workdir=gettempdir(), qa_branch='master',
+    def __init__(self, ansible_output=False, workdir=join(gettempdir(), 'qa_ctl'), qa_branch='master',
                  qa_repository='https://github.com/wazuh/wazuh-qa.git'):
         self.qa_repository = qa_repository
         self.qa_branch = qa_branch

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -213,7 +213,7 @@ class QAProvisioning():
         # If Windows, then run a Linux docker container to run provisioning stage with qa-ctl provision
         if sys.platform == 'win32':
             tmp_config_file_name = f"config_{get_current_timestamp()}.yaml"
-            tmp_config_file = os.path.join(gettempdir(), tmp_config_file_name)
+            tmp_config_file = os.path.join(gettempdir(), 'qa_ctl', tmp_config_file_name)
 
              # Write a custom configuration file with only provision section
             file.write_yaml_file(tmp_config_file, {'provision': self.provision_info})

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_deployment.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/wazuh_deployment/wazuh_deployment.py
@@ -75,7 +75,7 @@ class WazuhDeployment(ABC):
 
             tasks_list.append(AnsibleTask({
                 'name': 'Executing "install.sh" script to build and install Wazuh',
-                'shell': f"./install.sh > {gettempdir()}/wazuh_install_log.txt",
+                'shell': f"./install.sh > {gettempdir()}/qa_ctl/wazuh_install_log.txt",
                 'args': {'chdir': f'{self.installation_files_path}'},
                 'when': 'ansible_system == "Linux"'}))
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/pytest.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/pytest.py
@@ -68,7 +68,7 @@ class Pytest(Test):
         self.log_level = log_level
         self.markers = markers
         self.hosts = hosts
-        self.tests_result_path = gettempdir() if tests_result_path is None else tests_result_path
+        self.tests_result_path = os.path.join(gettempdir(), 'qa_ctl') if tests_result_path is None else tests_result_path
 
         if not os.path.exists(self.tests_result_path):
             os.makedirs(self.tests_result_path)
@@ -88,7 +88,7 @@ class Pytest(Test):
         assets_zip = f"assets_{date_time}.zip"
         html_report_file_name = f"test_report_{date_time}.html"
         plain_report_file_name = f"test_report_{date_time}.txt"
-        playbook_file_path = os.path.join(gettempdir(), f"{get_current_timestamp()}.yaml")
+        playbook_file_path = os.path.join(gettempdir(), 'qa_ctl', f"{get_current_timestamp()}.yaml")
         reports_directory = os.path.join(self.tests_run_dir, reports_folder)
         plain_report_file_path = os.path.join(reports_directory, plain_report_file_name)
         html_report_file_path = os.path.join(reports_directory, html_report_file_name)

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/qa_test_runner.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/qa_test_runner.py
@@ -140,7 +140,7 @@ class QATestRunner():
         # If Windows, then run a Linux docker container to run testing stage with qa-ctl testing
         if sys.platform == 'win32':
             tmp_config_file_name = f"config_{get_current_timestamp()}.yaml"
-            tmp_config_file = os.path.join(gettempdir(), tmp_config_file_name)
+            tmp_config_file = os.path.join(gettempdir(), 'qa_ctl', tmp_config_file_name)
 
             # Save original directory where to store the results in Windows host
             original_result_paths = [ self.test_parameters[host_key]['test']['path']['test_results_path'] \
@@ -166,7 +166,7 @@ class QATestRunner():
                 # Move all test results to their original paths specified in Windows qa-ctl configuration
                 index = 0
                 for _, host_data in self.test_parameters.items():
-                    source_directory = os.path.join(gettempdir(), f"{test_results_folder}_{index}")
+                    source_directory = os.path.join(gettempdir(), 'qa_ctl', f"{test_results_folder}_{index}")
                     file.move_everything_from_one_directory_to_another(source_directory,  original_result_paths[index])
                     file.delete_path_recursively(source_directory)
                     QATestRunner.LOGGER.info(f"The results of {host_data['test']['path']['test_files_path']} tests "

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/test_launcher.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tests/test_launcher.py
@@ -32,7 +32,7 @@ class TestLauncher:
 
     def __init__(self, tests, ansible_inventory_path, qa_ctl_configuration, qa_framework_path=None):
         self.qa_framework_path = qa_framework_path if qa_framework_path is not None else \
-                                                     os.path.join(gettempdir(), 'wazuh-qa/')
+                                                     os.path.join(gettempdir(), 'qa_ctl', 'wazuh-qa')
         self.ansible_inventory_path = ansible_inventory_path
         self.qa_ctl_configuration = qa_ctl_configuration
         self.tests = tests
@@ -45,7 +45,7 @@ class TestLauncher:
                                   wazuh installation path
         """
         local_internal_options = '\n'.join(self.DEBUG_OPTIONS)
-        playbook_file_path = os.path.join(gettempdir(), f"{get_current_timestamp()}.yaml")
+        playbook_file_path = os.path.join(gettempdir(), 'qa_ctl' f"{get_current_timestamp()}.yaml")
 
         local_internal_path = '/var/ossec/etc/local_internal_options.conf'
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -26,7 +26,7 @@ from wazuh_testing.tools.file import recursive_directory_creation
 DEPLOY_KEY = 'deployment'
 PROVISION_KEY = 'provision'
 TEST_KEY = 'tests'
-WAZUH_QA_FILES = os.path.join(gettempdir(), 'wazuh-qa')
+WAZUH_QA_FILES = os.path.join(gettempdir(), 'qa_ctl', 'wazuh-qa')
 
 qactl_logger = Logging(QACTL_LOGGER)
 _data_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'data')
@@ -115,7 +115,7 @@ def set_environment(parameters):
     if parameters.run_test:
         # Download wazuh-qa repository locally to run qa-docs tool and get the tests info
         recursive_directory_creation(os.path.join(gettempdir(), 'qa_ctl'))
-        local_actions.download_local_wazuh_qa_repository(branch=parameters.qa_branch, path=gettempdir())
+        local_actions.download_local_wazuh_qa_repository(branch=parameters.qa_branch, path=os.path.join(gettempdir(), 'qa_ctl'))
 
 
 def validate_parameters(parameters):

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -20,6 +20,7 @@ from wazuh_testing.qa_ctl.configuration.config_generator import QACTLConfigGener
 from wazuh_testing.tools.github_repository import version_is_released, branch_exist, WAZUH_QA_REPO
 from wazuh_testing.qa_ctl.provisioning import local_actions
 from wazuh_testing.tools.github_repository import get_last_wazuh_version
+from wazuh_testing.tools.file import recursive_directory_creation
 
 
 DEPLOY_KEY = 'deployment'
@@ -113,6 +114,7 @@ def set_environment(parameters):
     """
     if parameters.run_test:
         # Download wazuh-qa repository locally to run qa-docs tool and get the tests info
+        recursive_directory_creation(os.path.join(gettempdir(), 'qa_ctl'))
         local_actions.download_local_wazuh_qa_repository(branch=parameters.qa_branch, path=gettempdir())
 
 


### PR DESCRIPTION
|Related issue|
|---|
|issue #1943  |

## Description
The current `qa-ctl` implementation generates all its temporary files in the correspondent system temp folder. However, it is needed a better organization of these files so they can be tracked in an easier way. In order to achieve this purpose, we are going to modify the current implementation and add a new folder level called `qa_ctl`. 
This PR makes the following changes:
- Add a new folder level for temporary files called `qa_ctl`
- Modifies the file `vagrantfile_template.txt` to avoid updating the `VirtualBox guest additions`


## Checks
All the `qa-ctl` generated files are now stored in a folder called qa_ctl located in the temporary system folder. Plus, If the `vbguest` plugin is present in the system, the `VirtualBox guest additions` won't be updated during the `qa-ctl` execution.