### PR TITLE
Skip test_windows_audit_interval on windows 10 systems

### DIFF
--- a/tests/integration/test_fim/test_files/test_windows_audit_interval/test_windows_audit_interval.py
+++ b/tests/integration/test_fim/test_files/test_windows_audit_interval/test_windows_audit_interval.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import platform
 import re
 import sys
 
@@ -18,6 +19,7 @@ if sys.platform == 'win32':
         modify_sacl, \
         get_sacl
 
+skiptest_win10 = True if platform.system()=='Windows' and platform.release()=='10' else False
 # Marks
 
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
@@ -76,6 +78,7 @@ def callback_sacl_restored(line):
 
 
 # tests
+@pytest.mark.skipif(skiptest_win10, reason='refactor required to obtain ACLs on windows 10')
 @pytest.mark.parametrize('tags_to_apply', [
     {'audit_interval'}
 ])
@@ -103,7 +106,7 @@ def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_e
                                                   'of \'...\' has been restored correctly" event').result()
     assert testdir_modify in event, f'{testdir_modify} not detected in SACL modification event'
 
-
+@pytest.mark.skipif(skiptest_win10, reason='refactor required to obtain ACLs on windows 10')
 @pytest.mark.parametrize('tags_to_apply', [
     {'audit_interval'}
 ])


### PR DESCRIPTION
|Related issue|
|---|
|[ #1973 ](https://github.com/wazuh/wazuh-qa/issues/1973) |

## Description
During testing and debugging it was found that tests failed on `Windows 10` systems, because the SACL was not properly retrieved from the file. On `Windows 7` and `Windows Server 2016`, for example, the tests passed. It is thought that there might have occurred a change in the way Windows 10 retrieves that information, so the test needs to be refactored to work properly. 

In the meantime, the test will be skipped, only on `Windows 10` systems.

## Configuration options

### Pipeline parameters
|  Jenkins branch  | QA branch   | 
|- |- |
|  v4.2.1-rc1 |   1873-4.2.1-fim-windows-agent |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | "gusztavvargadr/windows-10" | Windows | 2 | 2048 |
Vagrant | "jacqinthebox/windowsserver2016" | Windows | 2 | 2048 |

## Tests

| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_windows_audit_interval` | 2021/10/06 | @Deblintrake09  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7295755/ResultsAuditskip.zip)| - |
| R2 | Windows 10 - Agent - `test_fim/test_files/test_windows_audit_interval` | 2021/10/06 | @Deblintrake09  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7295756/ResultsAuditskip2.zip)| - |
| R3 | Windows 10 - Agent - `test_fim/test_files/test_windows_audit_interval` | 2021/10/06 | @Deblintrake09  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7295757/ResultsAuditSkip3.zip)| - |

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.