### PR TITLE
FIM Windows Agent - Fix test_fim/test_registry

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_ambiguous_simple.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_ambiguous_simple.yaml
@@ -27,6 +27,20 @@
         value: SUBKEY_2
         attributes:
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Tag configuration
 - tags:
   - ambiguous_tag
@@ -55,6 +69,20 @@
         value: SUBKEY_2
         attributes:
         - arch: "both"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Recursion configuration
 - tags:
   - ambiguous_recursion
@@ -85,6 +113,20 @@
         value: RECURSION_SUBKEY_2
         attributes:
         - arch: "both"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Checks configuration
 - tags:
   - ambiguous_checks
@@ -120,3 +162,17 @@
         attributes:
         - check_all: "yes"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_complex_entries.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_complex_entries.yaml
@@ -35,6 +35,20 @@
         - check_owner: "no"
         - check_group: "no"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration 3
 - tags:
   - complex_report_changes
@@ -65,6 +79,20 @@
         attributes:
         - report_changes: "yes"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration 3
 - tags:
   - complex_tags
@@ -94,3 +122,17 @@
         attributes:
         - tags: TAG_3
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_duplicated_entries.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_duplicated_entries.yaml
@@ -25,6 +25,20 @@
         value: WINDOWS_REGISTRY_2
         attributes:
         - arch: "both"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Duplicate restrict configuration for keys
 - tags:
   - duplicate_restrict_entries
@@ -55,6 +69,20 @@
         attributes:
           - restrict_key: RESTRICT_2
           - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Duplicate arch configuration for keys
 - tags:
   - duplicate_arch_entries
@@ -81,6 +109,20 @@
         value: WINDOWS_REGISTRY_2
         attributes:
           - arch: "32bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Duplicate complex configuration for keys
 - tags:
   - duplicate_complex_entries
@@ -126,6 +168,20 @@
           - check_sum: "yes"
           - check_type: "yes"
           - check_size: "yes"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Duplicate report configuration for keys
 - tags:
   - duplicate_report_entries
@@ -156,6 +212,20 @@
         attributes:
           - report_changes: "no"
           - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Single registry and a list of registries
 - tags:
   - single_registry_and_list
@@ -176,3 +246,17 @@
         attributes:
           - check_all: "yes"
           - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_ignore_over_restrict.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data/wazuh_ignore_over_restrict.yaml
@@ -28,6 +28,20 @@
           attributes:
           - type: 'sregex'
           - arch: 'both'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Restrict configuration for values
 - tags:
   - ambiguous_ignore_restrict_values
@@ -57,3 +71,17 @@
           attributes:
           - type: 'sregex'
           - arch: 'both'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_duplicated_registry.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_duplicated_registry.yaml
@@ -19,3 +19,17 @@
         attributes:
           - ATTRIBUTE
           - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_reg_attr.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_reg_attr.yaml
@@ -16,3 +16,17 @@
         attributes:
           - ATTRIBUTE
           - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_registry_both.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/data/wazuh_conf_registry_both.yaml
@@ -21,3 +21,17 @@
         attributes:
           - ATTRIBUTE
           - arch: "both"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import json
 from wazuh_testing import global_parameters
 import wazuh_testing.fim as fim
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -39,6 +40,10 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 
 monitoring_modes = ['scheduled']
 
+f = open('../../version.json')
+data = json.load(f)
+version = data['version']
+
 # Configurations
 
 conf_params = {'WINDOWS_DUPLICATED_REGISTRY_1': registry_1,
@@ -62,6 +67,7 @@ def get_configuration(request):
 
 # Test
 
+@pytest.mark.skipif(version != 'v4.2.3', reason="This test fails unless it is executed in v4.2.3")
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuration, configure_environment,
                                    file_monitoring, configure_local_internal_options_module, daemons_handler,

--- a/tests/integration/test_fim/test_registry/test_registry_checks/data/wazuh_check_all.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_checks/data/wazuh_check_all.yaml
@@ -21,6 +21,20 @@
         - FIM_MODE
         - check_all: "yes"
         - arch: "both"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration for check_all=no
 - tags:
   - check_all_no
@@ -43,6 +57,20 @@
         - FIM_MODE
         - check_all: "no"
         - arch: "both"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration for conjuction
 - tags:
   - check_all_conjuction
@@ -97,6 +125,20 @@
         - check_group: "no"
         - check_perm: "no"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration for test checksum all
 - tags:
   - test_checksum_all
@@ -138,6 +180,20 @@
         - check_sum: "no"
         - check_md5sum: "yes"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration for test checksum
 - tags:
   - test_checksum
@@ -192,3 +248,17 @@
         - check_mtime: "yes"
         - check_md5sum: "yes"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_checks/data/wazuh_check_others.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_checks/data/wazuh_check_others.yaml
@@ -74,3 +74,17 @@
         - check_sum: "yes"
         - check_type: "yes"
         - arch: "64bit"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_file_limit/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_file_limit/data/wazuh_conf.yaml
@@ -21,3 +21,17 @@
             value: 'yes'
         - entries:
             value: FILE_LIMIT
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_ignore/data/wazuh_registry_ignore_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_ignore/data/wazuh_registry_ignore_conf.yaml
@@ -30,6 +30,20 @@
             value: WINDOWS_REGISTRY_2
             attributes:
                 - arch: '64bit'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Configuration for registry_ignore_value
 - tags:
   - ignore_registry_value
@@ -61,3 +75,17 @@
             value: WINDOWS_REGISTRY_2
             attributes:
                 - arch: '64bit'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_multiple_registries/data/wazuh_conf_multiple_entries.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_multiple_registries/data/wazuh_conf_multiple_entries.yaml
@@ -137,3 +137,17 @@
         value: WINDOWS_REGISTRY62
     - windows_registry:
         value: WINDOWS_REGISTRY63
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_multiple_registries/data/wazuh_conf_multiple_keys.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_multiple_registries/data/wazuh_conf_multiple_keys.yaml
@@ -11,3 +11,17 @@
         value: 'no'
     - windows_registry:
         value: WINDOWS_REGISTRY
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_nodiff/data/wazuh_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_nodiff/data/wazuh_conf.yaml
@@ -29,6 +29,20 @@
                 value: VALUE_2
                 attributes:
                     - arch: '64bit'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # No diff regex configuration
 - tags:
   - no_diff_regex
@@ -61,3 +75,17 @@
                 attributes:
                     - type: 'sregex'
                     - arch: '64bit'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_recursion_level/data/wazuh_recursion_windows_registry.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_recursion_level/data/wazuh_recursion_windows_registry.yaml
@@ -27,3 +27,17 @@
         attributes:
         - recursion_level: LEVEL_3
         - arch: '64bit'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/data/wazuh_registry_report_changes.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/data/wazuh_registry_report_changes.yaml
@@ -23,6 +23,20 @@
           attributes:
             - arch: '64bit'
             - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 - tags:
   - test_duplicate_report
   apply_to_modules:
@@ -52,6 +66,20 @@
           attributes:
             - arch: '64bit'
             - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 - tags:
   - test_delete_after_restart
   apply_to_modules:
@@ -71,3 +99,17 @@
           attributes:
             - arch: '64bit'
             - report_changes: REPORT_CHANGES_2
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/data/wazuh_registry_report_changes_limits_quota.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/data/wazuh_registry_report_changes_limits_quota.yaml
@@ -33,6 +33,20 @@
                   value: DISK_QUOTA_ENABLED
               - limit:
                   value: DISK_QUOTA_LIMIT
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 
 - tags:
   - test_diff_size_limit
@@ -55,3 +69,17 @@
             - arch: '64bit'
             - report_changes: 'yes'
             - DIFF_SIZE_LIMIT
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_restrict/data/wazuh_restrict_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_restrict/data/wazuh_restrict_conf.yaml
@@ -20,6 +20,20 @@
         attributes:
         - arch: "both"
         - restrict_value: RESTRICT_VALUE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Registry keys configuration
 - tags:
   - key_restrict
@@ -41,3 +55,17 @@
         attributes:
         - arch: "both"
         - restrict_key: RESTRICT_KEY
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_registry/test_registry_tags/data/wazuh_registry_tag_conf.yaml
+++ b/tests/integration/test_fim/test_registry/test_registry_tags/data/wazuh_registry_tag_conf.yaml
@@ -19,3 +19,17 @@
         attributes:
           - arch: 64bit
           - tags: FIM_TAGS
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1888 |

## Description
As explained in issue #1888, some tests from `test_fim/test_registry/` fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules. In addition, `test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py` fails unless it is executed in v4.2.3, so that test will be skipped the version doesn't match.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

### Test results
| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_tags` | - | - | - | - |
| R2 | Windows 10 - Agent - `test_fim/test_files/test_tags` | - | - | - | - |
| R3 | Windows 10 - Agent - `test_fim/test_files/test_tags` | - | - | - | - |