### PR TITLE
FIM Windows Agent - Fix test_ambiguous_confs

### DIFF
--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_complex_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_complex_win32.yaml
@@ -62,6 +62,20 @@
           - check_size: 'yes'
           - check_owner: 'yes'
           - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
  #conf 2
 - tags:
   - complex
@@ -117,6 +131,20 @@
           - check_perm: 'yes'
           - check_sha256sum: 'yes'
           - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 #conf 3
 - tags:
   - complex
@@ -171,3 +199,18 @@
           - restrict: ".txt$"
           - FIM_MODE
           - report_changes: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_dup_entries.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_dup_entries.yaml
@@ -19,6 +19,20 @@
         attributes:
         - check_all: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # conf 2
 - tags:
   - ossec_conf_duplicate_complex
@@ -43,6 +57,20 @@
         - check_size: 'yes'
         - check_perm: 'yes'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # conf 3
 - tags:
   - ossec_conf_duplicate_report
@@ -63,6 +91,20 @@
         attributes:
         - report_changes: 'no'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # conf 4
 - tags:
   - ossec_conf_duplicate_sregex
@@ -83,3 +125,18 @@
         attributes:
         - restrict: '^he.*$'
         - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_ignore_restrict_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_ignore_restrict_win32.yaml
@@ -22,6 +22,20 @@
         - FIM_MODE
     - ignore:
         value: "c:\\testdir1\\testfile"
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 # Conf 2
 - tags:
   - valid_regex
@@ -48,3 +62,18 @@
         value: "testfile2$"
         attributes:
         - type: sregex
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_whodata_prevails_over_realtime.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_whodata_prevails_over_realtime.yaml
@@ -18,3 +18,18 @@
         attributes:
         - whodata: 'yes'
         - realtime: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_whodata_thread.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_whodata_thread.yaml
@@ -17,6 +17,20 @@
         value: TEST_DIRECTORIES
         attributes:
         - whodata: 'no'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
 
 # conf 2
 - tags:
@@ -36,3 +50,17 @@
         value: TEST_DIRECTORIES
         attributes:
         - whodata: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'


### PR DESCRIPTION
|Related issue|
|---|
| #2003 |

## Description
As explained in issue #2003, some tests from `test_fim/test_files/test_ambiguous_confs` fail randomly. After further research, we think the problem is caused by configuration files that do not disable unneeded modules.

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Agent | msi (Windows) | x86_64 | v4.2.1 | 40214| v4.2.1| wazuh-agent-4.2.1-0.1873.msi |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | gusztavvargadr/windows-10 | Windows | 2 | 2048 |

## Local internal options - Windows Agent
```
agent.debug=2
syscheck.debug=2
monitord.rotate_log=0
windows.debug=2
```

## Pytest arguments
`-v --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"`

### Test results
| Round | OS - Manager/Agent - Module | Date | By | Reports | Notes |
|:--:|:--:|:--:|:--:|:--:|:--:|
| R1 | Windows 10 - Agent - `test_fim/test_files/test_ambiguous_confs` | 2021/10/07 | @danisan90  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7307205/ResultsTesAmbiguous.zip) | - |
| R2 | Windows 10 - Agent - `test_fim/test_files/test_ambiguous_confs` | 2021/10/07 | @danisan90  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7307208/ResultsAmbiguous2.zip)
 | - |