### PR TITLE
Add no-validation flag to the qa-ctl docker run for Windows

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/local_actions.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/local_actions.py
@@ -84,7 +84,8 @@ def qa_ctl_docker_run(config_file, qa_branch, debug_level, topic):
         topic (str): Reason for running the qa-ctl docker.
     """
     debug_args = '' if debug_level == 0 else ('-d' if debug_level == 1 else '-dd')
-    docker_args = f"{qa_branch} {config_file} --no-validation-logging {debug_args}"
+    docker_args = f"{qa_branch} {config_file} --no-validation {debug_args}"
+
     docker_image_name = 'wazuh/qa-ctl'
     docker_image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'deployment',
                                      'dockerfiles', 'qa_ctl')
@@ -93,4 +94,5 @@ def qa_ctl_docker_run(config_file, qa_branch, debug_level, topic):
     run_local_command_with_output(f"cd {docker_image_path} && docker build -q -t {docker_image_name} .")
 
     LOGGER.info(f"Running the Linux container for {topic}")
-    run_local_command(f"docker run --rm -v {os.path.join(gettempdir(), 'qa_ctl')}:/qa_ctl {docker_image_name} {docker_args}")
+    run_local_command(f"docker run --rm -v {os.path.join(gettempdir(), 'qa_ctl')}:/qa_ctl {docker_image_name} "
+                      f"{docker_args}")


### PR DESCRIPTION
|Related issue|
|---|
|close #2011 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
## Description

The goal of this PR is to propagate the `qa-ctl` script parameters to the `qa-ctl` call inside a container for the Windows case.

Working on this issue, I have realized that it is not really necessary, since whenever `qa-ctl` is executed inside the docker container, it is executed by passing it a configuration file that already contains the user input parameters information.

The change that has been made is to add the `--no-validation` flag because the parameters have already been previously validated, so it is not necessary to perform the validation again inside the docker. The `---no-validation-logging` flag has also been removed since there is no longer any sense in using it.

This PR makes the following changes:

- Adds flag `--no-validation` on `qa-ctl` execution inside the container, to avoid re-doing parameter validations.
- Removes flag `--no-validation-logging` flag since it no longer makes sense to use it since it does not perform validations.

## Tests

- [x] qa-ctl runs correctly on Windows. 

  <details>
  <summary>Test result</summary>

  ```
  qa-ctl -r test_general_settings_enabled --qa-branch 2011-qa-ctl-propagate-parameters
  
  2021-10-13 10:35:47,903 - INFO - Pulling remote repository changes in C:\Users\jmv74211\AppData\Local\Temp\qa_ctl\wazuh-qa local repository
  2021-10-13 10:35:48,758 - INFO - Validating input parameters
  2021-10-13 10:35:50,549 - INFO - Input parameters validation has passed successfully
  2021-10-13 10:35:51,665 - INFO - Starting 1 instances deployment
  2021-10-13 10:37:27,064 - INFO - The instances deployment has finished sucessfully
  2021-10-13 10:37:27,068 - INFO - Building docker image for provisioning the instances
  2021-10-13 10:40:56,279 - INFO - Running the Linux container for provisioning the instances
  2021-10-13 08:41:10,605 - INFO - Checking hosts SSH connection
  2021-10-13 08:41:18,268 - INFO - Hosts connection OK. The instances are accessible via ssh
  2021-10-13 08:41:18,269 - INFO - Provisioning 1 instances
  2021-10-13 08:43:03,204 - INFO - Performing a Wazuh installation healthcheck in 10.150.50.12 host
  2021-10-13 08:43:40,016 - INFO - Provisioning the 10.150.50.12 host with the Wazuh QA framework using 2011-qa-ctl-propagate-parameters branch.
  2021-10-13 08:44:13,711 - INFO - The instances have been provisioned sucessfully
  2021-10-13 10:44:11,988 - INFO - Building docker image for launching the tests
  2021-10-13 10:44:15,866 - INFO - Running the Linux container for launching the tests
  2021-10-13 08:44:26,408 - INFO - Launching 1 tests
  2021-10-13 08:44:26,410 - INFO - Waiting for tests to finish
  2021-10-13 08:44:28,940 - INFO - Running /tmp/qa_ctl/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py test   on ['10.150.50.12'] hosts
  2021-10-13 08:44:41,899 - INFO -
  ============================= test session starts ==============================
  platform linux -- Python 3.9.7, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
  rootdir: /tmp/qa_ctl/wazuh-qa/tests/integration, configfile: pytest.ini
  plugins: metadata-1.11.0, html-3.1.1, testinfra-5.0.0
  collected 4 items
  ../../tmp/qa_ctl/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py . [ 25%]
  ss.                                                                      [100%]
  - generated html file: file:///tmp/qa_ctl/wazuh-qa/test/integration/reports/test_report_2021_10_13_08_44_28_940127.html -
  ========================= 2 passed, 2 skipped in 3.76s =========================
  2021-10-13 08:44:41,908 - INFO - The test run is finished
  2021-10-13 10:44:40,148 - INFO - The results of /tmp/qa_ctl/wazuh-qa/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.  py tests have been saved in C:\Users\jmv74211\AppData\Local\Temp/qa_ctl/test_general_settings_enabled_1634114151.638435/
  2021-10-13 10:44:40,149 - INFO - Destroying 1 instances
  2021-10-13 10:44:49,950 - INFO - The instances have been destroyed sucessfully
  ```

  </details>