### PR TITLE
Migrate `test_process_priority`, `test_recursion_level`, and `test_restrict` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -63,6 +63,9 @@ Ignore paths:
   - "../../tests/integration/test_fim/test_files/test_multiple_dirs/data"
   - "../../tests/integration/test_fim/test_files/test_nodiff/data"
   - "../../tests/integration/test_fim/test_files/test_prefilter_cmd/data"
+  - "../../tests/integration/test_fim/test_files/test_process_priority/data"
+  - "../../tests/integration/test_fim/test_files/test_recursion_level/data"
+  - "../../tests/integration/test_fim/test_files/test_restrict/data"
   - "../../tests/integration/test_fim/test_files/test_report_changes/data"
 
 Output fields:

--- a/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
+++ b/tests/integration/test_fim/test_files/test_process_priority/test_process_priority.py
@@ -53,8 +53,8 @@ os_version:
     - Windows 8
     - Windows 7
     - Windows Server 2016
-    - Windows server 2012
-    - Windows server 2003
+    - Windows Server 2012
+    - Windows Server 2003
     - Windows XP
     - macOS Catalina
     - Solaris 10

--- a/tests/integration/test_fim/test_files/test_recursion_level/test_recursion_level.py
+++ b/tests/integration/test_fim/test_files/test_recursion_level/test_recursion_level.py
@@ -1,6 +1,82 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM generates events
+       for file operations in a monitored directory hierarchy using multiple deep levels set in
+       the 'recursion_level' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+    - macos
+    - solaris
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+    - macOS Catalina
+    - Solaris 10
+    - Solaris 11
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_recursion_level
+'''
 import os
 import sys
 
@@ -158,18 +234,57 @@ def get_configuration(request):
 ])
 def test_recursion_level(dirname, subdirname, recursion_level, get_configuration, configure_environment,
                          restart_syscheckd, wait_for_fim_start):
-    """
-    Check if files are correctly detected by syscheck with recursion level using scheduled, realtime and whodata
-    monitoring.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects events in a monitored directories hierarchy with
+                 deep limited by the 'recursion_level' attribute using 'scheduled', 'realtime', and 'whodata'
+                 monitoring modes. For this purpose, the test will monitor a testing folder and create a directory
+                 hierarchy inside it. Once FIM starts, it will make file operations in each level of that hierarchy.
+                 Finally, the test will verify that the FIM events are generated up to the deep level limit, and no
+                 FIM events are generated in the ignored levels.
 
-    Parameters
-    ----------
-    dirname : str
-        The path being monitored by syscheck (indicated in the .conf file).
-    subdirname : str
-        The name of the subdirectories that will be created during the execution for testing purposes.
-    recursion_level : int
-        Recursion level. Also used as the number of subdirectories to be created and checked for the current test.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - dirname:
+            type: str
+            brief: Path to the monitored directory (set in the 'ossec.conf' file).
+        - subdirname:
+            type: str
+            brief: Name of the subdirectory to be created.
+        - recursion_level:
+            type: int
+            brief: Number of subdirectories to be created and checked for the current test case.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated for the file operations in a monitored directory hierarchy up to
+          the level set in the 'recursion_level' attribute.
+        - Verify that no FIM events are generated in the ignored directories within a monitored directory hierarchy.
+
+    input_description: A test case (test_recursion_level) is contained in external YAML files
+                       (wazuh_recursion.yaml or wazuh_recursion_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and the directories
+                       to be monitored. These are combined with the recursion levels defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+        - r'Caching Audit message: event too long' (if the test case fails)
+
+    tags:
+        - realtime
+        - scheduled
+        - who_data
+    '''
     recursion_test(dirname, subdirname, recursion_level, timeout=global_parameters.default_timeout,
                    is_scheduled=get_configuration['metadata']['fim_mode'] == 'scheduled')

--- a/tests/integration/test_fim/test_files/test_restrict/test_restrict_valid.py
+++ b/tests/integration/test_fim/test_files/test_restrict/test_restrict_valid.py
@@ -1,7 +1,76 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM generates events
+       only for file operations in monitored directories that do not match the 'restrict' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_restrict
+'''
 import os
 import sys
 
@@ -71,24 +140,66 @@ def get_configuration(request):
 def test_restrict(folder, filename, mode, content, triggers_event, tags_to_apply,
                   get_configuration, configure_environment, restart_syscheckd,
                   wait_for_fim_start):
-    """
-    Check the only files detected are those matching the restrict regex
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects or ignores events in monitored files depending
+                 on the value set in the 'restrict' attribute. This attribute limit checks to files that match
+                 the entered string or regex and its file name. For this purpose, the test will monitor a folder
+                 and create a testing file inside it. Finally, the test will verify that FIM 'added' events are
+                 generated only for the testing files that not are restricted.
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the file is being created.
-    filename : str
-        Name of the file to be created.
-    mode : str
-        Same as mode in open built-in function.
-    content : str or bytes
-        Content to fill the new file.
-    triggers_event : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - folder:
+            type: str
+            brief: Path to the directory where the testing file will be created.
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - mode:
+            type: str
+            brief: Same as mode in 'open' built-in function.
+        - content:
+            type: str
+            brief: Content to fill the testing file.
+        - triggers_event:
+            type: bool
+            brief: True if an FIM event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are only generated for file operations in monitored directories
+          that do not match the 'restrict' attribute.
+        - Verify that FIM 'ignoring' events are generated for monitored files that are restricted.
+
+    input_description: Different test cases are contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directories to be monitored defined in the module.
+    
+    inputs: 864 test cases including multiple regular expressions and names for testing files and directories.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+        - r'.*Ignoring entry .* due to restriction .*'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # Create text files


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2007|

# Description
As part of issue #1810 and epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


## `test_process_priority`


<details><summary>test_process_priority.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will check if the process priority of the 'wazuh-syscheckd' daemon set in the 'process_priority' tag is applied successfully. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows",
        "macos",
        "solaris"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP",
        "macOS Catalina",
        "Solaris 10",
        "Solaris 11"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#process-priority"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_process_priority"
    ],
    "name": "test_process_priority.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the process priority of the 'wazuh-syscheckd' daemon set in the 'process_priority' tag is updated correctly. For this purpose, the test will monitor a testing folder and, once FIM starts, it will get the priority value from the 'process_priority' tag and the system information of the 'wazuh-syscheckd' process. Finally, the test will compare the current process priority with the target priority to verify that they match.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'wazuh-syscheckd' daemon is running.",
                "Verify that the process priority of the 'wazuh-syscheckd' daemon matches the 'process_priority' tag."
            ],
            "input_description": "A test case (ossec_conf) is contained in external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined with the testing directory to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' events)"
                },
                "r'.*Ignoring .* due to'"
            ],
            "tags": [
                "realtime",
                "scheduled"
            ],
            "name": "test_process_priority",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_process_priority.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will check if the
  process priority of the 'wazuh-syscheckd' daemon set in the 'process_priority' tag
  is applied successfully. The FIM capability is managed by the 'wazuh-syscheckd'
  daemon, which checks configured files for changes to the checksums, permissions,
  and ownership.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 1
modules:
- fim
name: test_process_priority.py
os_platform:
- linux
- windows
- macos
- solaris
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
- macOS Catalina
- Solaris 10
- Solaris 11
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#process-priority
tags:
- fim_process_priority
tests:
- assertions:
  - Verify that the 'wazuh-syscheckd' daemon is running.
  - Verify that the process priority of the 'wazuh-syscheckd' daemon matches the 'process_priority'
    tag.
  description: Check if the process priority of the 'wazuh-syscheckd' daemon set in
    the 'process_priority' tag is updated correctly. For this purpose, the test will
    monitor a testing folder and, once FIM starts, it will get the priority value
    from the 'process_priority' tag and the system information of the 'wazuh-syscheckd'
    process. Finally, the test will compare the current process priority with the
    target priority to verify that they match.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added' events)
  - r'.*Ignoring .* due to'
  input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_conf.yaml)
    which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
    are combined with the testing directory to be monitored defined in the module.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  name: test_process_priority
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - realtime
  - scheduled
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## `test_recursion_level`


<details><summary>test_recursion_level.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will verify that FIM generates events for file operations in a monitored directory hierarchy using multiple deep levels set in the 'recursion_level' attribute. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows",
        "macos",
        "solaris"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP",
        "macOS Catalina",
        "Solaris 10",
        "Solaris 11"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_recursion_level"
    ],
    "name": "test_recursion_level.py",
    "id": 2,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon detects events in a monitored directories hierarchy with deep limited by the 'recursion_level' attribute using 'scheduled', 'realtime', and 'whodata' monitoring modes. For this purpose, the test will monitor a testing folder and create a directory hierarchy inside it. Once FIM starts, it will make file operations in each level of that hierarchy. Finally, the test will verify that the FIM events are generated up to the deep level limit, and no FIM events are generated in the ignored levels.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "dirname": {
                        "type": "str",
                        "brief": "Path to the monitored directory (set in the 'ossec.conf' file)."
                    }
                },
                {
                    "subdirname": {
                        "type": "str",
                        "brief": "Name of the subdirectory to be created."
                    }
                },
                {
                    "recursion_level": {
                        "type": "int",
                        "brief": "Number of subdirectories to be created and checked for the current test case."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM events are generated for the file operations in a monitored directory hierarchy up to the level set in the 'recursion_level' attribute.",
                "Verify that no FIM events are generated in the ignored directories within a monitored directory hierarchy."
            ],
            "input_description": "A test case (test_recursion_level) is contained in external YAML files (wazuh_recursion.yaml or wazuh_recursion_windows.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and the directories to be monitored. These are combined with the recursion levels defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added', 'modified', and 'deleted' events)"
                },
                {
                    "r'Caching Audit message": "event too long' (if the test case fails)"
                }
            ],
            "tags": [
                "realtime",
                "scheduled",
                "who_data"
            ],
            "name": "test_recursion_level",
            "inputs": [
                "get_configuration0-/test_no_recursion-dir-0",
                "get_configuration0-/test no recursion-dir -0",
                "get_configuration0-/test_recursion_1-dir-1",
                "get_configuration0-/test recursion 1-dir -1",
                "get_configuration0-/test_recursion_5-dir-5",
                "get_configuration0-/test recursion 5-dir -5",
                "get_configuration0-/test_recursion_320-dir-320",
                "get_configuration0-/test recursion 320-dir -320",
                "get_configuration1-/test_no_recursion-dir-0",
                "get_configuration1-/test no recursion-dir -0",
                "get_configuration1-/test_recursion_1-dir-1",
                "get_configuration1-/test recursion 1-dir -1",
                "get_configuration1-/test_recursion_5-dir-5",
                "get_configuration1-/test recursion 5-dir -5",
                "get_configuration1-/test_recursion_320-dir-320",
                "get_configuration1-/test recursion 320-dir -320",
                "get_configuration2-/test_no_recursion-dir-0",
                "get_configuration2-/test no recursion-dir -0",
                "get_configuration2-/test_recursion_1-dir-1",
                "get_configuration2-/test recursion 1-dir -1",
                "get_configuration2-/test_recursion_5-dir-5",
                "get_configuration2-/test recursion 5-dir -5",
                "get_configuration2-/test_recursion_320-dir-320",
                "get_configuration2-/test recursion 320-dir -320",
                "get_configuration3-/test_no_recursion-dir-0",
                "get_configuration3-/test no recursion-dir -0",
                "get_configuration3-/test_recursion_1-dir-1",
                "get_configuration3-/test recursion 1-dir -1",
                "get_configuration3-/test_recursion_5-dir-5",
                "get_configuration3-/test recursion 5-dir -5",
                "get_configuration3-/test_recursion_320-dir-320",
                "get_configuration3-/test recursion 320-dir -320",
                "get_configuration4-/test_no_recursion-dir-0",
                "get_configuration4-/test no recursion-dir -0",
                "get_configuration4-/test_recursion_1-dir-1",
                "get_configuration4-/test recursion 1-dir -1",
                "get_configuration4-/test_recursion_5-dir-5",
                "get_configuration4-/test recursion 5-dir -5",
                "get_configuration4-/test_recursion_320-dir-320",
                "get_configuration4-/test recursion 320-dir -320",
                "get_configuration5-/test_no_recursion-dir-0",
                "get_configuration5-/test no recursion-dir -0",
                "get_configuration5-/test_recursion_1-dir-1",
                "get_configuration5-/test recursion 1-dir -1",
                "get_configuration5-/test_recursion_5-dir-5",
                "get_configuration5-/test recursion 5-dir -5",
                "get_configuration5-/test_recursion_320-dir-320",
                "get_configuration5-/test recursion 320-dir -320"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_recursion_level.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will verify that
  FIM generates events for file operations in a monitored directory hierarchy using
  multiple deep levels set in the 'recursion_level' attribute. The FIM capability
  is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes
  to the checksums, permissions, and ownership.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 1
id: 2
modules:
- fim
name: test_recursion_level.py
os_platform:
- linux
- windows
- macos
- solaris
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
- macOS Catalina
- Solaris 10
- Solaris 11
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
tags:
- fim_recursion_level
tests:
- assertions:
  - Verify that FIM events are generated for the file operations in a monitored directory
    hierarchy up to the level set in the 'recursion_level' attribute.
  - Verify that no FIM events are generated in the ignored directories within a monitored
    directory hierarchy.
  description: Check if the 'wazuh-syscheckd' daemon detects events in a monitored
    directories hierarchy with deep limited by the 'recursion_level' attribute using
    'scheduled', 'realtime', and 'whodata' monitoring modes. For this purpose, the
    test will monitor a testing folder and create a directory hierarchy inside it.
    Once FIM starts, it will make file operations in each level of that hierarchy.
    Finally, the test will verify that the FIM events are generated up to the deep
    level limit, and no FIM events are generated in the ignored levels.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
  - r'Caching Audit message: event too long' (if the test case fails)
  input_description: A test case (test_recursion_level) is contained in external YAML
    files (wazuh_recursion.yaml or wazuh_recursion_windows.yaml) which includes configuration
    settings for the 'wazuh-syscheckd' daemon and the directories to be monitored.
    These are combined with the recursion levels defined in the module.
  inputs:
  - get_configuration0-/test_no_recursion-dir-0
  - get_configuration0-/test no recursion-dir -0
  - get_configuration0-/test_recursion_1-dir-1
  - get_configuration0-/test recursion 1-dir -1
  - get_configuration0-/test_recursion_5-dir-5
  - get_configuration0-/test recursion 5-dir -5
  - get_configuration0-/test_recursion_320-dir-320
  - get_configuration0-/test recursion 320-dir -320
  - get_configuration1-/test_no_recursion-dir-0
  - get_configuration1-/test no recursion-dir -0
  - get_configuration1-/test_recursion_1-dir-1
  - get_configuration1-/test recursion 1-dir -1
  - get_configuration1-/test_recursion_5-dir-5
  - get_configuration1-/test recursion 5-dir -5
  - get_configuration1-/test_recursion_320-dir-320
  - get_configuration1-/test recursion 320-dir -320
  - get_configuration2-/test_no_recursion-dir-0
  - get_configuration2-/test no recursion-dir -0
  - get_configuration2-/test_recursion_1-dir-1
  - get_configuration2-/test recursion 1-dir -1
  - get_configuration2-/test_recursion_5-dir-5
  - get_configuration2-/test recursion 5-dir -5
  - get_configuration2-/test_recursion_320-dir-320
  - get_configuration2-/test recursion 320-dir -320
  - get_configuration3-/test_no_recursion-dir-0
  - get_configuration3-/test no recursion-dir -0
  - get_configuration3-/test_recursion_1-dir-1
  - get_configuration3-/test recursion 1-dir -1
  - get_configuration3-/test_recursion_5-dir-5
  - get_configuration3-/test recursion 5-dir -5
  - get_configuration3-/test_recursion_320-dir-320
  - get_configuration3-/test recursion 320-dir -320
  - get_configuration4-/test_no_recursion-dir-0
  - get_configuration4-/test no recursion-dir -0
  - get_configuration4-/test_recursion_1-dir-1
  - get_configuration4-/test recursion 1-dir -1
  - get_configuration4-/test_recursion_5-dir-5
  - get_configuration4-/test recursion 5-dir -5
  - get_configuration4-/test_recursion_320-dir-320
  - get_configuration4-/test recursion 320-dir -320
  - get_configuration5-/test_no_recursion-dir-0
  - get_configuration5-/test no recursion-dir -0
  - get_configuration5-/test_recursion_1-dir-1
  - get_configuration5-/test recursion 1-dir -1
  - get_configuration5-/test_recursion_5-dir-5
  - get_configuration5-/test recursion 5-dir -5
  - get_configuration5-/test_recursion_320-dir-320
  - get_configuration5-/test recursion 320-dir -320
  name: test_recursion_level
  parameters:
  - dirname:
      brief: Path to the monitored directory (set in the 'ossec.conf' file).
      type: str
  - subdirname:
      brief: Name of the subdirectory to be created.
      type: str
  - recursion_level:
      brief: Number of subdirectories to be created and checked for the current test
        case.
      type: int
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - realtime
  - scheduled
  - who_data
  wazuh_min_version: 4.2.0
tier: 2
type: integration
```
</p>
</details>


## `test_restrict`


<details><summary>test_restrict_valid.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will verify that FIM generates events only for file operations in monitored directories that do not match the 'restrict' attribute. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "linux",
        "windows"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6",
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_restrict"
    ],
    "name": "test_restrict_valid.py",
    "id": 3,
    "group_id": 2,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon detects or ignores events in monitored files depending on the value set in the 'restrict' attribute. This attribute limit checks to files that match the entered string or regex and its file name. For this purpose, the test will monitor a folder and create a testing file inside it. Finally, the test will verify that FIM 'added' events are generated only for the testing files that not are restricted.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "folder": {
                        "type": "str",
                        "brief": "Path to the directory where the testing file will be created."
                    }
                },
                {
                    "filename": {
                        "type": "str",
                        "brief": "Name of the testing file to be created."
                    }
                },
                {
                    "mode": {
                        "type": "str",
                        "brief": "Same as mode in 'open' built-in function."
                    }
                },
                {
                    "content": {
                        "type": "str",
                        "brief": "Content to fill the testing file."
                    }
                },
                {
                    "triggers_event": {
                        "type": "bool",
                        "brief": "True if an FIM event must be generated, False otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM events are only generated for file operations in monitored directories that do not match the 'restrict' attribute.",
                "Verify that FIM 'ignoring' events are generated for monitored files that are restricted."
            ],
            "input_description": "Different test cases are contained in external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined with the testing directories to be monitored defined in the module.",
            "inputs": "864 test cases including multiple regular expressions and names for testing files and directories.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' events)"
                },
                "r'.*Ignoring entry .* due to restriction .*'"
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_restrict"
        }
    ]
}
```
</p>
</details>


<details><summary>test_restrict_valid.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will verify that
  FIM generates events only for file operations in monitored directories that do not
  match the 'restrict' attribute. The FIM capability is managed by the 'wazuh-syscheckd'
  daemon, which checks configured files for changes to the checksums, permissions,
  and ownership.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 2
id: 3
modules:
- fim
name: test_restrict_valid.py
os_platform:
- linux
- windows
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
tags:
- fim_restrict
tests:
- assertions:
  - Verify that FIM events are only generated for file operations in monitored directories
    that do not match the 'restrict' attribute.
  - Verify that FIM 'ignoring' events are generated for monitored files that are restricted.
  description: Check if the 'wazuh-syscheckd' daemon detects or ignores events in
    monitored files depending on the value set in the 'restrict' attribute. This attribute
    limit checks to files that match the entered string or regex and its file name.
    For this purpose, the test will monitor a folder and create a testing file inside
    it. Finally, the test will verify that FIM 'added' events are generated only for
    the testing files that not are restricted.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added' events)
  - r'.*Ignoring entry .* due to restriction .*'
  input_description: Different test cases are contained in external YAML file (wazuh_conf.yaml)
    which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
    are combined with the testing directories to be monitored defined in the module.
  inputs: 864 test cases including multiple regular expressions and names for testing
    files and directories.
  name: test_restrict
  parameters:
  - folder:
      brief: Path to the directory where the testing file will be created.
      type: str
  - filename:
      brief: Name of the testing file to be created.
      type: str
  - mode:
      brief: Same as mode in 'open' built-in function.
      type: str
  - content:
      brief: Content to fill the testing file.
      type: str
  - triggers_event:
      brief: True if an FIM event must be generated, False otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`