### PR TITLE
Fix `qa-ctl` configuration path separators

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -186,7 +186,7 @@ class QAProvisioning():
 
             QAProvisioning.LOGGER.info(f"Provisioning the {current_host} host with the Wazuh QA framework using "
                                        f"{wazuh_qa_branch} branch.")
-            qa_instance = QAFramework(qa_branch=wazuh_qa_branch,
+            qa_instance = QAFramework(qa_branch=wazuh_qa_branch, workdir=qa_framework_info['qa_workdir'],
                                       ansible_output=self.qa_ctl_configuration.ansible_output)
             qa_instance.download_qa_repository(inventory_file_path=self.inventory_file_path, hosts=current_host)
             qa_instance.install_dependencies(inventory_file_path=self.inventory_file_path, hosts=current_host)


### PR DESCRIPTION
Now the paths are generated correctly, regardless of the system where they are launched both locally and remotely.

|Related issue|
|---|
|close #2016|

## Description

The objective of this PR is to fix the paths of the qa-ctl configuration file, since depending on the operating system, there could be inconsistencies between the `/` and `/` separators, although they worked correctly.

Also, the paths have been prepared to be calculated dynamically in case you want to provision and test on a Windows system.

This PR makes the following changes:

- Fixes the separators of the dynamically calculated paths according to the operating system.
- Prepares the new paths to add support for Windows tests.


## Checks

- [x] Probado que se generan correctamente los paths del fichero de configuración al ejecutar `qa-ctl` en Windows
- [x] Probado que se generan correctamente los paths del fichero de configuración al ejecutar `qa-ctl` en Linux
- [x] Build on Linux: `qa-ctl -r test_general_settings_enabled --qa-branch 2016-qa-ctl-fix-paths`
- [x] Build on Windows: `qa-ctl -r test_general_settings_enabled --qa-branch 2016-qa-ctl-fix-paths`