### PR TITLE
Update `agent files deletion` system test

### DIFF
--- a/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.py
+++ b/tests/system/test_cluster/test_agent_files_deletion/test_agent_files_deletion.py
@@ -21,7 +21,6 @@ time_to_sync = 60
 # Each file should exist in all hosts specified in 'hosts'.
 files = [{'path': join(WAZUH_PATH, 'queue', 'rids', '{id}'), 'hosts': managers_hosts},
          {'path': join(WAZUH_PATH, 'queue', 'agent-groups', '{id}'), 'hosts': managers_hosts},
-         {'path': join(WAZUH_PATH, 'var', 'db', 'agents', '{id}-{name}.db'), 'hosts': managers_hosts},
          {'path': join(WAZUH_PATH, 'queue', 'diff', '{name}'), 'hosts': [worker_host]},
          {'path': join(WAZUH_PATH, 'queue', 'db', '{id}.db'), 'hosts': [worker_host]}]
 db_queries = ["select * from agent where id={id}",


### PR DESCRIPTION
|Related issue|
|---|
| Closes #2035 |

# Description

The `test_agent_files_deletion.py` was failing after the change performed at [Remove all legacy agents database](https://github.com/wazuh/wazuh/pull/9158/commits/dc2d45b32982492d8033e4a309b009b48d2974ed). The test had to check if the /var/ossec/var/db/agents/{id}-{name}.db file exists, but it no longer exists after the mentioned commit, so this error was shown:
```
E               AssertionError: This file should exist in wazuh-master but could not be found: /var/ossec/var/db/agents/003-wazuh-agent3.db
```

The test is updated in this PR so it does not check the existence of said file. In addition, it has been checked if the test was working fine when files inside `/var/ossec/queue/db/xxx.db` were not deleted. To do it, I run it in two different branches: 
- [4.2](https://github.com/wazuh/wazuh/tree/4.2): `xxx.db` files were not being deleted in this branch. The test failed as expected, with this error:
```
selu@selu-pc:~/Git/wazuh-qa/tests/system/test_cluster$ pytest test_agent_files_deletion/ -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-5.0.0, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-88-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.0.0', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'pep8': '1.0.6', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                       

test_agent_files_deletion/test_agent_files_deletion.py::test_agent_files_deletion FAILED

```
- [8605-delete-agent-files](https://github.com/wazuh/wazuh/pull/9158): A bug was fixed so now `xxx.db` files are deleted. In addition, the cluster is not in charge of deleting agent files anymore. The test passed correctly:
```
selu@selu-pc:~/Git/wazuh-qa/tests/system/test_cluster$ pytest test_agent_files_deletion/ -vv
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-5.0.0, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-88-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.0.0', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'pep8': '1.0.6', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh-qa/tests/system/test_cluster
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                                                                                                                                                                                            

test_agent_files_deletion/test_agent_files_deletion.py::test_agent_files_deletion PASSED                                                                                                              [100%]

======================================================================================== 1 passed in 102.30 seconds =========================================================================================
```

---
**PS:** Notice it can be necessary to apply the changes from this PR https://github.com/wazuh/wazuh-qa/pull/1732, in order to correctly build the system test environment.