### PR TITLE
Fix AccessError false positive in macOS logcollector tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -120,7 +120,7 @@ def control_service(action, daemon=None, debug_mode=False):
 
                     for proc in alive:
                         proc.kill()
-                except psutil.NoSuchProcess:
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
 
                 delete_sockets(WAZUH_SOCKETS[daemon])


### PR DESCRIPTION
|Related issue|
|---|
|#1481|

## Description
This PR closes #1481.

This error is related to [psutil](https://groups.google.com/g/psutil/c/EbdkIGlb4ls), and it seems that even with Administrator permissions the system does not allow to get information about certain processes. However these processes are not used/monitored in any test, so, the better approach is to ignore this exception. For this reason, `psutil.AccessDenied` has been added to the `control_service` exception handling. 
