### PR TITLE
Replace `git clone` usage for direct downloads in `qa-ctl`

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -106,19 +106,6 @@ class QACTLConfigGenerator:
 
         return info
 
-    def __join_path(self, path, system):
-        """Create the path using the separator indicated for the operating system. Used for remote hosts configuration.
-
-        Parameters:
-            path (list(str)): Path list (one item for level).
-            system (str): host system.
-
-        Returns:
-            str: Joined path.
-        """
-        return '\\'.join(path) if system == 'windows' else '/'.join(path)
-
-
     def __get_all_tests_info(self):
         """Get the info of the documentation of all the test that are going to be run.
 
@@ -350,7 +337,7 @@ class QACTLConfigGenerator:
             system = QACTLConfigGenerator.BOX_INFO[vm_box]['system']
             self.config['provision']['hosts'][instance]['qa_framework'] = {
                 'wazuh_qa_branch': self.qa_branch,
-                'qa_workdir': self.__join_path([installation_files_path, 'wazuh_qa_ctl'], system)
+                'qa_workdir': file.join_path([installation_files_path, 'wazuh_qa_ctl'], system)
             }
 
     def __process_test_data(self, tests_info):
@@ -375,10 +362,10 @@ class QACTLConfigGenerator:
             self.config['tests'][instance]['test'] = {
                 'type': 'pytest',
                 'path': {
-                    'test_files_path': self.__join_path([installation_files_path, 'wazuh_qa_ctl', 'wazuh-qa',
-                                                         test['path']], system),
-                    'run_tests_dir_path': self.__join_path([installation_files_path, 'wazuh_qa_ctl', 'wazuh-qa',
-                                                            'tests', 'integration'], system),
+                    'test_files_path': file.join_path([installation_files_path, 'wazuh_qa_ctl', 'wazuh-qa',
+                                                       test['path']], system),
+                    'run_tests_dir_path': file.join_path([installation_files_path, 'wazuh_qa_ctl', 'wazuh-qa',
+                                                          'tests', 'integration'], system),
                     'test_results_path': join(gettempdir(), 'wazuh_qa_ctl',
                                               f"{test['test_name']}_{get_current_timestamp()}")
                 }

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/Dockerfile
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/Dockerfile
@@ -5,7 +5,7 @@ ENV RUNNING_ON_DOCKER_CONTAINER=true
 
 RUN apt-get -q update && \
     apt-get install -y \
-        git \
+        curl \
         python \
         python3 \
         sshpass \

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/entrypoint.sh
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/dockerfiles/qa_ctl/entrypoint.sh
@@ -4,8 +4,8 @@ BRANCH="$1"
 CONFIG_FILE_PATH="$2"
 EXTRA_ARGS="${@:3}"
 
-# Clone custom wazuh-qa repository branch
-git clone https://github.com/wazuh/wazuh-qa --depth=1 -b ${BRANCH} &> /dev/null
+# Download the custom branch of wazuh-qa repository
+curl -Ls https://github.com/wazuh/wazuh-qa/archive/${BRANCH}.tar.gz | tar zx &> /dev/null && mv wazuh-* wazuh-qa
 
 # Install python dependencies not installed from
 python3 -m pip install -r wazuh-qa/requirements.txt &> /dev/null

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -331,3 +331,16 @@ def move_everything_from_one_directory_to_another(source_directory, destination_
 
     for file_name in file_names:
         shutil.move(os.path.join(source_directory, file_name), destination_directory)
+
+
+def join_path(path, system):
+    """Create the path using the separator indicated for the operating system. Used for remote hosts configuration.
+
+    Parameters:
+        path (list(str)): Path list (one item for level).
+        system (str): host system.
+
+    Returns:
+        str: Joined path.
+    """
+    return '\\'.join(path) if system == 'windows' else '/'.join(path)


### PR DESCRIPTION
|Related issue|
|---|
|close #2018|

## Description

The goal of this PR is to change all uses of `git clone` to direct downloads of the compressed branch in a file. This change improves the download speed, in addition to not depending on the system having the `git` dependency installed.

Below is a comparison of the branch download size, using `git clone` and `curl` of the compromised file.

| Repository     | `git clone <branch>` | `curl <branch_tarball>` |
|----------------|----------------------|-------------------------|
| wazuh/wazuh    |  55 MB               |  6 MB                   |
| wazuh/wazuh-qa |  70 MB               |  2.9 MB                 |


This PR makes the following changes:

- Replace `git` usage with the direct download for all repository file download use cases in `qa-ctl`.
- Move the `join_path` function from module `config_generator.py` to `file.py` to make it generic and use it in several modules.

## Checks

- [x] `qa-ctl` works properly on Linux: `qa-ctl -r test_general_settings_enabled --qa-branch 2018-qa-ctl-git-replacement`
- [x] `qa-ctl` works correctly on Windows: `qa-ctl -r test_general_settings_enabled --qa-branch 2018-qa-ctl-git-replacement`.
- [x] Local downloads from the repository are working correctly on Linux: `/tmp/wazuh_qa_ctl/wazuh-qa/`
- [x] Local downloads from the repository are successful on Windows: `C:\Users\user\AppData\Local\Temp\wazuh_qa_ctl\wazuh-qa`