### PR TITLE
Fix requirements in master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
 configobj==5.0.6
 certifi==2020.12.5
-cffi>=1.14.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-cycler>=0.10; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-bcrypt==3.2.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+cffi>=1.14.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
+cycler>=0.10; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
+bcrypt==3.2.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 distro==1.3.0
 filetype==1.0.7
 freezegun==0.3.15
-grpcio>=1.27.2; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+grpcio>=1.27.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 google-cloud-pubsub==2.3.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
 jsonschema==3.2.0
-kiwisolver>=1.0.1; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+kiwisolver>=1.0.1; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 lockfile==0.12.2
-matplotlib>=3.3.4; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+matplotlib>=3.3.4; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 netifaces==0.10.9
 numpy>=1.19.5
 pandas>=1.1.5
-pillow>=6.2.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+pillow>=6.2.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 psutil>=5.6.6
 py~=1.10.0
 pycryptodome>=3.9.8
@@ -24,13 +24,13 @@ pytest-html==2.0.1
 pytest==6.2.2
 pyyaml==5.4
 requests==2.23.0
-scipy>=1.0; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-seaborn>=0.11.1; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
+scipy>=1.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
+seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 setuptools~=56.0.0
 testinfra==5.0.0
-jq==1.1.2; platform_system == "Linux" or platform_system == "MacOS"
-cryptography==3.3.2; platform_system == "Linux" or platform_system == "MacOS" or platform_system=='Windows'
-urllib3>=1.26.5
+jq==1.1.2; platform_system == "Linux" or platform_system == "Darwin"
+cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
+urllib3
 numpydoc>=1.1.0
 ansible-runner>=2.0.1 ; platform_system == "Linux"
 docker>=5.0.0 ; platform_system == "Linux" or platform_system=='Windows'


### PR DESCRIPTION
## Description

This PR fix provision error in python requirements installation in `master` branch.

```
  The conflict is caused by:
      The user requested urllib3>=1.26.5
      requests 2.23.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
      The user requested urllib3>=1.26.5
      requests 2.23.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
```
`urllib3` module version has been removed and MacOS platform has been replaced by Darwin in order to properly install python dependencies in macOS environment
