### PR TITLE
GCloud tests failed by issue on 4.2.2

### DIFF
--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -54,8 +54,8 @@ def get_configuration(request):
 
 
 # tests
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
+@pytest.mark.skip(reason="It will be blocked by #1906 on 4.2, when it will solve on 4.3 we can enable again this test.")
+# @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 @pytest.mark.parametrize('publish_messages', [
     ['- DEBUG - GCP message' for _ in range(30)],
     ['- DEBUG - GCP message' for _ in range(100)],


### PR DESCRIPTION
|Related issue|
|---|
| #1906  |

## Description

Issue found in the analysis of the 4.2.2 release, then a fix was applied by the Core team, but it continues to fail, is considered to be fixed for 4.3, for that reason will be disabled in 4.2 until further notice.

## Configuration options

### local_internal_options.conf

> analysisd.debug=2
wazuh_modules.debug=2
monitord.rotate_log=0

## Logs example
| Tests | Results  | Date  |  By 
|--|--|--|--|
tests_gcloud/  | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/13486/) | 2021/10/18| Seyla| 
tests_gcloud/  | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/13506/) | 2021/10/18| Seyla| 
tests_gcloud/  | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/13527/) | 2021/10/18| Seyla| 


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
