### PR TITLE
Improve `qa-docs` errors checking

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -85,7 +85,7 @@ class QACTLConfigGenerator:
         Returns:
             dict : return the info of the named test in dict format.
         """
-        qa_docs_command = f"qa-docs -T {test_name} -o {join(gettempdir(), 'qa_ctl')} -I {join(self.qa_files_path, 'tests')}"
+        qa_docs_command = f"qa-docs -t {test_name} -o {join(gettempdir(), 'qa_ctl')} -I {join(self.qa_files_path, 'tests')}"
         test_data_file_path = f"{join(gettempdir(), 'qa_ctl', test_name)}.json"
 
         run_local_command_with_output(qa_docs_command)

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -290,7 +290,6 @@ class DocGenerator:
 
         return None
 
-<<<<<<< HEAD
     def check_test_exists(self, path):
         """Check that a test exists within the tests path input.
         
@@ -300,12 +299,6 @@ class DocGenerator:
         for test_name in self.conf.test_names:
             if self.locate_test(test_name):
                 print(f'{test_name} exists in {path}')
-=======
-    def do_exist(self, path):
-        for test_name in self.conf.test_names:
-            if self.locate_test(test_name):
-                print(f'{test_name} does exist in {path}')
->>>>>>> fb0ee7c7d5bf6e536b0348fcba395b06b09b61ce
             else:
                 print(f'{test_name} does not exist in {path}')
 

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -288,13 +288,19 @@ class DocGenerator:
                 if filename == complete_test_name:
                     return os.path.join(root, complete_test_name)
 
-        print(f"{test_name} does not exist")
         return None
 
-    def check_documentation_block(self):
-        self.parse_test_list()
-
-        print("Documentation block ok")
+    def check_test_exists(self, path):
+        """Check that a test exists within the tests path input.
+        
+        Args:
+            path (str): A string with the tests path.
+        """
+        for test_name in self.conf.test_names:
+            if self.locate_test(test_name):
+                print(f'{test_name} exists in {path}')
+            else:
+                print(f'{test_name} does not exist in {path}')
 
     def print_test_info(self, test):
         """Print the test info to standard output.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -218,20 +218,18 @@ class DocGenerator:
             if self.conf.mode == Mode.DEFAULT:
                 doc_path = self.get_test_doc_path(path)
 
-            elif self.conf.mode == Mode.PARSE_TESTS:
-                doc_path = self.conf.documentation_path
+                self.dump_output(test, doc_path)
+                DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' "
+                                          "was created with ID:{self.__id_counter}")
+                return self.__id_counter
 
-                # If the user does not specify an output dir
-                if not doc_path:
-                    self.print_test_info(test)
-                    return
-                # If the user specifies an output dir
-                else:
+            elif self.conf.mode == Mode.PARSE_TESTS:
+                if self.conf.documentation_path:
+                    doc_path = self.conf.documentation_path
                     doc_path = os.path.join(doc_path, test_name)
 
-            self.dump_output(test, doc_path)
-            DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' was created with ID:{self.__id_counter}")
-            return self.__id_counter
+                    self.dump_output(test, doc_path)
+                    DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' was created.")
         else:
             DocGenerator.LOGGER.error(f"Content for {path} is empty, ignoring it")
             raise QAValueError(f"Content for {path} is empty, ignoring it", DocGenerator.LOGGER.error)
@@ -292,6 +290,11 @@ class DocGenerator:
 
         print(f"{test_name} does not exist")
         return None
+
+    def check_documentation_block(self):
+        self.parse_test_list()
+
+        print("Documentation block ok")
 
     def print_test_info(self, test):
         """Print the test info to standard output.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -271,8 +271,8 @@ class DocGenerator:
             if self.test_path:
                 self.create_test(self.test_path, 0, test_name)
             else:
-                DocGenerator.LOGGER.error(f"'{self.conf.test_name}' could not be found")
-                raise QAValueError(f"'{self.conf.test_name}' could not be found", DocGenerator.LOGGER.error)
+                DocGenerator.LOGGER.error(f"'{test_name}' could not be found")
+                raise QAValueError(f"'{test_name}' could not be found", DocGenerator.LOGGER.error)
 
     def locate_test(self, test_name):
         """Get the test path when a test is specified by the user.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -188,8 +188,8 @@ class DocGenerator:
             DocGenerator.LOGGER.debug(f"New group file '{doc_path}' was created with ID:{self.__id_counter}")
             return self.__id_counter
         else:
-            DocGenerator.LOGGER.warning(f"Content for {path} is empty, ignoring it")
-            return None
+            DocGenerator.LOGGER.error(f"Content for {path} is empty, ignoring it")
+            raise QAValueError(f"Content for {path} is empty, ignoring it", DocGenerator.LOGGER.error)
 
     def create_test(self, path, group_id, test_name=None):
         """Parse the content of a test file and dumps the content into a file.
@@ -233,8 +233,8 @@ class DocGenerator:
             DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' was created with ID:{self.__id_counter}")
             return self.__id_counter
         else:
-            DocGenerator.LOGGER.warning(f"Content for {path} is empty, ignoring it")
-            return None
+            DocGenerator.LOGGER.error(f"Content for {path} is empty, ignoring it")
+            raise QAValueError(f"Content for {path} is empty, ignoring it", DocGenerator.LOGGER.error)
 
     def parse_folder(self, path, group_id):
         """Search in a specific folder to parse possible group files and each test file.
@@ -244,8 +244,8 @@ class DocGenerator:
             group_id (str): A string with the id of the group where the new elements belong.
         """
         if not os.path.exists(path):
-            DocGenerator.LOGGER.warning(f"Include path '{path}' doesn´t exist")
-            return
+            DocGenerator.LOGGER.error(f"Include path '{path}' doesn´t exist")
+            raise QAValueError(f"Include path '{path}' doesn´t exist", DocGenerator.LOGGER.error)
 
         if not self.is_valid_folder(path):
             return
@@ -274,6 +274,7 @@ class DocGenerator:
                 self.create_test(self.test_path, 0, test_name)
             else:
                 DocGenerator.LOGGER.error(f"'{self.conf.test_name}' could not be found")
+                raise QAValueError(f"'{self.conf.test_name}' could not be found", DocGenerator.LOGGER.error)
 
     def locate_test(self, test_name):
         """Get the test path when a test is specified by the user.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -290,6 +290,7 @@ class DocGenerator:
 
         return None
 
+<<<<<<< HEAD
     def check_test_exists(self, path):
         """Check that a test exists within the tests path input.
         
@@ -299,6 +300,12 @@ class DocGenerator:
         for test_name in self.conf.test_names:
             if self.locate_test(test_name):
                 print(f'{test_name} exists in {path}')
+=======
+    def do_exist(self, path):
+        for test_name in self.conf.test_names:
+            if self.locate_test(test_name):
+                print(f'{test_name} does exist in {path}')
+>>>>>>> fb0ee7c7d5bf6e536b0348fcba395b06b09b61ce
             else:
                 print(f'{test_name} does not exist in {path}')
 

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
@@ -71,6 +71,15 @@ class CodeParser:
                 remove_inexistent(test, allowed_fields, STOP_FIELDS)
 
     def check_fields(self, doc, doc_type, path):
+        """Check if the fields that a documentation block has, are valids.
+        
+        You can check them in the `schema.yaml` file.
+
+        Args:
+            doc (dict): A dict with the documentation block parsed.
+            doc_type (str): A string that specifies which type of documentation block is.
+            path (str): A string with the file path.
+        """
         if doc_type == 'module':
             expected_fields = self.conf.module_fields
         elif doc_type == 'test':

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
@@ -95,21 +95,22 @@ class CodeParser:
             if isinstance(doc_field, list):
                 for value in doc_field:
                     if value not in self.conf.predefined_values[field]:
-                        error = f"{field} field in {path} {doc_type} documentation block has an invalid value: {value}."
-                        f"Follow the predefined values: {self.conf.predefined_values[field]}. "
-                        "If you want more info, visit https://github.com/wazuh/wazuh-qa/wiki/"
-                        " Documenting-tests-using-the-qadocs-schema#pre-defined-values."
-                        CodeParser.LOGGER.error(error)
-                        raise QAValueError(error, CodeParser.LOGGER.error)
+                        CodeParser.LOGGER.error(f"{field} field in {path} {doc_type} documentation block has "
+                                                f"an invalid value: {value}."
+                                                f"Follow the predefined values: {self.conf.predefined_values[field]}. "
+                                                "If you want more info, visit https://github.com/wazuh/wazuh-qa/wiki/"
+                                                "Documenting-tests-using-the-qadocs-schema#pre-defined-values.")
+                        raise QAValueError(f"{field} field in {path} {doc_type} documentation block has "
+                                           f"an invalid value: {value}.", CodeParser.LOGGER.error)
             else:
                 if doc_field not in self.conf.predefined_values[field] and doc_field is not None:
-                    error = f"{field} field in {path} {doc_type} documentation block "
-                    f"has an invalid value: {doc_type}. "
-                    f"Follow the predefined values: {self.conf.predefined_values[field]} "
-                    "If you want more info, visit https://github.com/wazuh/wazuh-qa/wiki/"
-                    " Documenting-tests-using-the-qadocs-schema#pre-defined-values."
-                    CodeParser.LOGGER.error(error)
-                    raise QAValueError(error, CodeParser.LOGGER.error)
+                    CodeParser.LOGGER.error(f"{field} field in {path} {doc_type} documentation block "
+                                            f"has an invalid value: {doc_field}. "
+                                            f"Follow the predefined values: {self.conf.predefined_values[field]} "
+                                            "If you want more info, visit https://github.com/wazuh/wazuh-qa/wiki/"
+                                            "Documenting-tests-using-the-qadocs-schema#pre-defined-values.")
+                    raise QAValueError(f"{field} field in {path} {doc_type} documentation block "
+                                       f"has an invalid value: {doc_field}.", CodeParser.LOGGER.error)
 
     def parse_comment(self, function, doc_type, path):
         """Parse one self-contained documentation block.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/schema.yaml
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/schema.yaml
@@ -8,7 +8,6 @@ output_fields:
       - modules
       - daemons
       - components
-      - path
       - os_platform
       - os_version
     optional:

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -169,7 +169,8 @@ def validate_parameters(parameters):
     if parameters.run_test:
         for test in parameters.run_test:
             tests_path = os.path.join(WAZUH_QA_FILES, 'tests')
-            if 'test exists' not in local_actions.run_local_command_with_output(f"qa-docs -e {test} -I {tests_path}"):
+            if 'Documentation block ok' not in \
+               local_actions.run_local_command_with_output(f"qa-docs -e {test} -I {tests_path}"):
                 raise QAValueError(f"{test} does not exist in {tests_path}", qactl_logger.error, QACTL_LOGGER)
 
     qactl_logger.info('Input parameters validation has passed successfully')

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -169,8 +169,7 @@ def validate_parameters(parameters):
     if parameters.run_test:
         for test in parameters.run_test:
             tests_path = os.path.join(WAZUH_QA_FILES, 'tests')
-            if 'Documentation block ok' not in \
-               local_actions.run_local_command_with_output(f"qa-docs -e {test} -I {tests_path}"):
+            if 'test exists' not in local_actions.run_local_command_with_output(f"qa-docs -e {test} -I {tests_path}"):
                 raise QAValueError(f"{test} does not exist in {tests_path}", qactl_logger.error, QACTL_LOGGER)
 
     qactl_logger.info('Input parameters validation has passed successfully')

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -155,7 +155,7 @@ def validate_parameters(parameters, parser):
 
         for test_name in parameters.test_names:
             if doc_check.locate_test(test_name) is None:
-                raise QAValueError(f"{test_name} not found.", qadocs_logger.error)
+                raise QAValueError(f"{test_name} has not been not found in {parameters.tests_path}.", qadocs_logger.error)
 
     # Check that the index exists
     if parameters.app_index_name:
@@ -194,7 +194,7 @@ def parse_data(args):
     if args.test_exist:
         doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_names=args.test_exist))
 
-        doc_check.check_documentation_block()
+        doc_check.check_test_exists(args.tests_path)
 
     # Parse a list of tests
     elif args.test_names:
@@ -259,11 +259,6 @@ def main():
     # Set the qa-docs logger level
     if args.debug_level:
         set_qadocs_logger_level('DEBUG')
-
-    if args.test_exist:
-        doc_check = DocGenerator(Config(CONFIG_PATH, args.test_dir, '', args.test_exist))
-        if doc_check.locate_test() is not None:
-            print("test exists")
 
     if args.version:
         with open(VERSION_PATH, 'r') as version_file:

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -194,11 +194,7 @@ def parse_data(args):
     if args.test_exist:
         doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_names=args.test_exist))
 
-<<<<<<< HEAD
         doc_check.check_test_exists(args.tests_path)
-=======
-        doc_check.do_exist(args.tests_path)
->>>>>>> fb0ee7c7d5bf6e536b0348fcba395b06b09b61ce
 
     # Parse a list of tests
     elif args.test_names:

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -194,7 +194,11 @@ def parse_data(args):
     if args.test_exist:
         doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_names=args.test_exist))
 
+<<<<<<< HEAD
         doc_check.check_test_exists(args.tests_path)
+=======
+        doc_check.do_exist(args.tests_path)
+>>>>>>> fb0ee7c7d5bf6e536b0348fcba395b06b09b61ce
 
     # Parse a list of tests
     elif args.test_names:

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -192,11 +192,9 @@ def run_searchui(index):
 def parse_data(args):
     """Parse the tests and collect the data."""
     if args.test_exist:
-        doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, test_names=args.test_exist))
+        doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_names=args.test_exist))
 
-        for test_name in args.test_exist:
-            if doc_check.locate_test(test_name) is not None:
-                print(f"{test_name} exists")
+        doc_check.check_documentation_block()
 
     # Parse a list of tests
     elif args.test_names:
@@ -207,7 +205,7 @@ def parse_data(args):
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, args.output_path, test_names=args.test_names))
         # When no output is specified, it is printed
         else:
-            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, test_names=args.test_names))
+            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, test_names=args.test_names))
 
     # Parse a list of test types
     elif args.test_types:
@@ -216,7 +214,7 @@ def parse_data(args):
         # Parse a list of test modules
         if args.test_modules:
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types,
-                                        args.test_modules))
+                                args.test_modules))
         else:
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types))
 
@@ -251,6 +249,7 @@ def index_and_visualize_data(args):
         index_data.run()
         # When SearchUI index is not hardcoded, it will be use args.launching_index_name
         run_searchui(args.launching_index_name)
+
 
 def main():
     args, parser = get_parameters()

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -20,8 +20,6 @@ modules:
 components:
     - agent
 
-path: tests/integration/test_active_response/test_execd/test_execd_restart.py
-
 daemons:
     - wazuh-analysisd
     - wazuh-authd
@@ -153,7 +151,7 @@ def start_agent(request, get_configuration):
 
 @pytest.fixture(scope="function")
 def remove_ip_from_iptables(request, get_configuration):
-    """Remove the test IP from iptables if it exist.
+    """Remove the testing IP address from `iptables` if it exists.
 
     Args:
         get_configuration (fixture): Get configurations from the module.
@@ -246,7 +244,7 @@ def test_execd_firewall_drop(set_debug_mode, get_configuration, test_version, co
                  is sent to it. This response includes an IP address that must be added
                  and removed from iptables, the Linux firewall.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
         - set_debug_mode:

--- a/tests/integration/test_active_response/test_execd/test_execd_restart.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_restart.py
@@ -20,8 +20,6 @@ modules:
 components:
     - agent
 
-path: tests/integration/test_active_response/test_execd/test_execd_restart.py
-
 daemons:
     - wazuh-analysisd
     - wazuh-authd
@@ -201,7 +199,7 @@ def test_execd_restart(set_debug_mode, get_configuration, test_version,
                  This response includes the order to restart the Wazuh agent,
                  which must restart after receiving this response.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
         - set_debug_mode:

--- a/tests/integration/test_api/test_config/test_cache/test_cache.py
+++ b/tests/integration/test_api/test_config/test_cache/test_cache.py
@@ -7,8 +7,10 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the cache feature of the API handled
-       by the `wazuh-apid` daemon is working properly.
+brief: These tests will check if the cache feature of the API handled by the `wazuh-apid` daemon
+       is working properly. The Wazuh API is an open source `RESTful` API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like `cURL` or any script
+       or program that can make web requests.
 
 tier: 0
 
@@ -17,8 +19,6 @@ modules:
 
 components:
     - manager
-
-path: tests/integration/test_api/test_config/test_cache/test_cache.py
 
 daemons:
     - wazuh-apid
@@ -114,7 +114,7 @@ def test_cache(tags_to_apply, get_configuration, configure_api_environment, rest
                  a period established in the configuration, even though a new file
                  has been created during the process.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
         - tags_to_apply:

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -7,8 +7,11 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the CORS (Cross-origin resource sharing) feature
-       of the API handled by the `wazuh-apid` daemon is working properly.
+brief:
+    These tests will check if the `CORS` (Cross-origin resource sharing) feature of the API handled
+    by the `wazuh-apid` daemon is working properly. The Wazuh API is an open source `RESTful` API
+    that allows for interaction with the Wazuh manager from a web browser, command line tool
+    like `cURL` or any script or program that can make web requests.
 
 tier: 0
 
@@ -17,8 +20,6 @@ modules:
 
 components:
     - manager
-
-path: tests/integration/test_api/test_config/test_cors/test_cors.py
 
 daemons:
     - wazuh-apid
@@ -92,12 +93,12 @@ def get_configuration(request):
 def test_cors(origin, tags_to_apply, get_configuration, configure_api_environment,
               restart_api, wait_for_start, get_api_details):
     '''
-    description: Check if expected headers are returned when CORS is enabled.
-                 When CORS is enabled, special headers must be returned in case the
-                 request origin matches the one established in the CORS configuration
+    description: Check if expected headers are returned when `CORS` is enabled.
+                 When `CORS` is enabled, special headers must be returned in case the
+                 request origin matches the one established in the `CORS` configuration
                  of the API.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
         - origin:

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -1,32 +1,20 @@
 '''
 copyright: Copyright (C) 2015-2021, Wazuh Inc.
-
            Created by Wazuh, Inc. <info@wazuh.com>.
-
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
 type: integration
-
-brief: These tests will check if the `enabled` option of the vulnerability detector module
+brief: These tests will check if the 'enabled' option of the vulnerability detector module
        is working correctly. This option is located in its corresponding section of
-       the `ossec.conf` file and allows enabling or disabling this module.
-
+       the 'ossec.conf' file and allows enabling or disabling this module.
 tier: 0
-
 modules:
     - vulnerability_detector
-
 components:
     - manager
-
-path: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
-
 daemons:
     - wazuh-modulesd
-
 os_platform:
     - linux
-
 os_version:
     - Arch Linux
     - Amazon Linux 2
@@ -45,16 +33,13 @@ os_version:
     - Red Hat 8
     - Red Hat 7
     - Red Hat 6
-
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#enabled
-
 tags:
     - settings
 '''
 import os
-
 import pytest
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
@@ -65,27 +50,19 @@ from wazuh_testing.vulnerability_detector import callback_detect_vulnerability_d
 
 # Marks
 pytestmark = pytest.mark.tier(level=0)
-
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_enabled.yaml')
-
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-
 parameters = [{'ENABLED': 'yes', 'TAG': 'enabled'}, {'ENABLED': 'no', 'TAG': 'disabled'}]
 metadata = [{'enabled': 'yes'}, {'enabled': 'no'}]
-
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
-
-
 # fixtures
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
-
-
 @pytest.mark.parametrize('tags_to_apply, custom_callback, custom_error_message', [
     ({'enabled'}, callback_detect_vulnerability_detector_enabled, 'Vulnerability detector is disabled'),
     ({'disabled'}, callback_detect_vulnerability_detector_disabled, 'Vulnerability detector is enabled')
@@ -93,12 +70,10 @@ def get_configuration(request):
 def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_configuration, configure_environment,
                  restart_modulesd):
     '''
-    description: Check if the `enabled ` option is working correctly. To do this,
-                 it checks the `ossec.log` file for the message indicating that the
+    description: Check if the 'enabled' option is working correctly. To do this,
+                 it checks the 'ossec.log' file for the message indicating that the
                  vulnerability detector is enabled or disabled.
-
-    wazuh_min_version: 4.2
-
+    wazuh_min_version: 4.2.0
     parameters:
         - configure_environment:
             type: fixture
@@ -108,21 +83,18 @@ def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_confi
             brief: Get configurations from the module.
         - restart_modulesd:
             type: callable
-            brief: Restart the `wazuh-modulesd` daemon.
+            brief: Restart the 'wazuh-modulesd' daemon.
         - tags_to_apply:
             type: string
             brief: Tags used for use cases.
         - custom_callback_vulnerability:
             type: string
             brief: Custom callback for the use case.
-
     assertions:
-        - Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.
-        - Verify that when the `enabled` option is set to `no`, the vulnerability detector module is stopped.
-
+        - Verify that when the 'enabled' option is set to 'yes', the vulnerability detector module is running.
+        - Verify that when the 'enabled' option is set to 'no', the vulnerability detector module is stopped.
     input_description: Two use cases are found in the test module and include
-                       parameters for `enabled` option (`yes` and `no`).
-
+                       parameters for 'enabled' option ('yes' and 'no').
     expected_output:
         - r'(.*)wazuh-modulesd:vulnerability-detector(.*)'
         - r'DEBUG: Module disabled. Exiting...'


### PR DESCRIPTION
|Related issue|
|---|
|#2017|

## Description
This PR has changed the `qa-docs` logging because it was not traceable. Some errors were logged as `Warning` instead of `Error`, this has been changed so invalid runs can be easily detected.

For example, when a test is not documented:
```
(qactl) luisgr@luisgr-pc:~/2017/wazuh-qa/deps/wazuh_testing$ qa-docs -I ~/wazuh-qa/tests/ -t test_day_wday
2021-10-19 10:47:11,527 - INFO - Looking for test_day_wday.py
2021-10-19 10:47:11,529 - INFO - Parsing the following test(s) ['test_day_wday']
2021-10-19 10:47:11,538 - INFO - Running QADOCS
2021-10-19 10:47:11,539 - INFO - Starting test documentation parsing
2021-10-19 10:47:11,539 - INFO - Looking for test_day_wday.py
2021-10-19 10:47:11,556 - ERROR - Documentation block not found in /home/luisgr/wazuh-qa/tests/integration/test_gcloud/test_functioning/test_day_wday.py
2021-10-19 10:47:11,556 - ERROR - Documentation block not found in /home/luisgr/wazuh-qa/tests/integration/test_gcloud/test_functioning/test_day_wday.py
wazuh_testing.tools.exceptions.QAValueError: Documentation block not found in /home/luisgr/wazuh-qa/tests/integration/test_gcloud/test_functioning/test_day_wday.py
```

Also, errors like invalid fields name or content, test not found, etc. raise an error now.

This has been tested merging the current `qa-docs` version with `qa-ctl` v0.1, so we could test the `qa-docs` errors when launching it with `qa-ctl` to get tests metadata.

## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.