### PR TITLE
Migrate `test_registry_checks`, `test_registry_ignore`, and `test_registry_nodiff` of `test_fim/test_registry` documentation to `qa-docs`

### DIFF
--- a/docs/DocGenerator/config.yaml
+++ b/docs/DocGenerator/config.yaml
@@ -76,6 +76,9 @@ Ignore paths:
   - "../../tests/integration/test_fim/test_files/test_windows_audit_interval/data"
   - "../../tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/data"
   - "../../tests/integration/test_fim/test_registry/test_registry_basic_usage/data"
+  - "../../tests/integration/test_fim/test_registry/test_registry_checks/data"
+  - "../../tests/integration/test_fim/test_registry/test_registry_ignore/data"
+  - "../../tests/integration/test_fim/test_registry/test_registry_nodiff/data"  
 
 Output fields:
   Module:

--- a/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_check_others.py
+++ b/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_check_others.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM events generated
+       contain only the 'check_' fields specified in the configuration when using the 'check_'
+       attributes individually and use the 'check_all=no' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_checks
+'''
 import os
 
 import pytest
@@ -81,27 +132,66 @@ def get_configuration(request):
                          params_list)
 def test_check_others(key, subkey, key_attr, value_attr, triggers_key_modification, triggers_value_modification,
                       get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Test the behavior disabling different check options over the same key with check_all enabled.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the 'check_' specified in
+                 the configuration. These checks are attributes indicating that a monitored registry entry has
+                 been modified. For example, if 'check_all=no' and 'check_sum=yes' are set for the same entry,
+                 'syscheck' must send an event containing only the checksums.
+                 For this purpose, the test will monitor a registry key using the 'check_all=no' attribute
+                 (in order to avoid using the default 'check_all' configuration) in conjunction with several
+                 'check_' on the same key. Then it will make key/value operations inside it, and finally,
+                 the test will verify that FIM events generated contain only the fields of the 'check_' specified
+                 for the monitored keys/values.
 
-    Example:
-        check_all: "yes" check_size: "no" check_sum: "no".
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        key of the directory (HKEY_* constants).
-    subkey: str
-        Path of the subkey.
-    key_attr: set
-        Set of options that are expected for key events.
-    value_attr: set
-        Set of options that are expected for value events.
-    triggers_key_modification: boolean
-        Specify if the given options generate key events.
-    triggers_value_modification: boolean
-        Specify if the given options generate value events.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - key_attr:
+            type: set
+            brief: Set of options that are expected for key events.
+        - value_attr:
+            type: set
+            brief: Set of options that are expected for value events.
+        - triggers_key_modification:
+            type: bool
+            brief: Specify if the given options generate key events.
+        - triggers_value_modification:
+            type: bool
+            brief: Specify if the given options generate value events.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: A test case (test_others) is contained in an external YAML file
+                       (wazuh_check_others.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_others'}, get_configuration['tags'])
     # Test registry keys.
     registry_key_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, options=key_attr,

--- a/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_checkers.py
+++ b/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_checkers.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM events generated contain only
+       the 'check_' fields specified in the configuration when using the 'check_all' attribute along
+       with other 'check_' attributes.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_checks
+'''
 import os
 
 import pytest
@@ -112,30 +163,68 @@ def get_configuration(request):
 ])
 def test_checkers(key, subkey, arch, key_attrs, value_attrs, tags_to_apply, triggers_modification,
                   get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Test the functionality of `check_all` option is activated/desactivated alone and together with other
-    `check_*` options.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the 'check_' specified in
+                 the configuration. These checks are attributes indicating that a monitored registry entry has
+                 been modified. For example, if 'check_all=yes' and 'check_sum=no' are set for the same entry,
+                 'syscheck' must send an event containing every possible 'check_' except the checksums.
+                 For this purpose, the test will monitor a registry key using the 'check_all' attribute in
+                 conjunction with one or more 'check_' on the same key, having 'check_all' to 'yes' and the other
+                 one to 'no'. Then it will make key/value operations inside it, and finally, finally, the test
+                 will verify that the FIM events generated contain only the fields of the 'checks' specified for
+                 the monitored keys/values.
 
-    Example:
-        <windows_registry check_all="yes">HKEY_SOME_KEY</windows_registry>.
-    Parameters
-    ----------
-    key: str
-        Root key (HKEY_* constants).
-    subkey: str
-        Path of the key.
-    arch: int
-        Architecture of the key.
-    key_attrs: set
-        Attributes for the key events.
-    value_attrs: set
-        Attributes for the value events.
-    tags_to_apply: set
-        Configuration that will be applied for every case.
-    triggers_modification: boolean
-        True if the given attributes trigger modification events.
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - key_attr:
+            type: set
+            brief: Set of options that are expected for key events.
+        - value_attr:
+            type: set
+            brief: Set of options that are expected for value events.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - triggers_modification:
+            type: bool
+            brief: Specify if the given options generate registry events.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in an external YAML file (wazuh_check_all.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. Those are
+                       combined with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # Test registry keys.

--- a/tests/integration/test_fim/test_registry/test_registry_ignore/test_ignore_registry.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ignore/test_ignore_registry.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will verify that FIM ignores the registry entries
+       set in the 'registry_ignore' option using both regex and regular names for specifying them.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-ignore
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_ignore
+'''
 import os
 
 import pytest
@@ -68,24 +118,67 @@ def get_configuration(request):
 ])
 def test_ignore_registry_key(root_key, registry, arch, subkey, triggers_event, tags_to_apply,
                              get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check registry keys are ignored according to configuration.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon ignores the events from keys that are in a monitored subkey
+                 when using the 'registry_ignore' option. It also ensures that events for keys that are not being
+                 ignored are still detected. For this purpose, the test will monitor a subkey containing keys to be
+                 ignored using names or regular expressions. Then it will create these keys and check if FIM events
+                 should be generated. Finally, the test will verify that the FIM events generated are consistent
+                 with the ignored keys and monitored subkey.
 
-    Parameters
-    ----------
-    root_key : str
-        Root key (HKEY_*)
-    registry : str
-        path of the registry where the test will be executed.
-    arch : str
-        Architecture of the registry.
-    subkey : str
-        Name of the key that will be created.
-    triggers_event : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - root_key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - registry:
+            type: str
+            brief: Path of the registry entry where the test will be executed.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - triggers_event:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM 'ignore' events are generated when an ignored key is modified.
+        - Verify that FIM 'added' events are generated when a not ignored key is added.
+        - Verify that 'modified' FIM events are generated from a parent key when
+          a key is added. Whether it is ignored or not.
+
+    input_description: A test case (ignore_registry_key) is contained in an external YAML file
+                       (wazuh_registry_ignore_conf.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing
+                       registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+        - r'.*Ignoring .*? (.*?) due to( sregex)? .*?'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     # Create registry
@@ -140,24 +233,67 @@ def test_ignore_registry_key(root_key, registry, arch, subkey, triggers_event, t
 ])
 def test_ignore_registry_value(root_key, registry, arch, value, triggers_event, tags_to_apply,
                                get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check registry values are ignored according to configuration.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon ignores the events from values that are in a monitored subkey
+                 when using the 'registry_ignore' option. It also ensures that events for values that are not being
+                 ignored are still detected. For this purpose, the test will monitor a subkey containing values to be
+                 ignored using names or regular expressions. Then it will create these values and check if FIM events
+                 should be generated. Finally, the test will verify that the FIM events generated are consistent
+                 with the ignored values and monitored subkey.
 
-    Parameters
-    ----------
-    root_key : str
-        Root key (HKEY_*)
-    registry : str
-        path of the registry where the test will be executed.
-    arch : str
-        Architecture of the registry.
-    value : str
-        Name of the value that will be created.
-    triggers_event : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - root_key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - registry:
+            type: str
+            brief: Path of the registry entry where the test will be executed.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value:
+            type: str
+            brief: Name of the value that will be created.
+        - triggers_event:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM 'ignore' events are generated when an ignored value is modified.
+        - Verify that FIM 'added' events are generated when a not ignored value is added.
+        - Verify that 'modified' FIM events are generated from a parent key when
+          a value is added. Whether it is ignored or not.
+
+    input_description: A test case (ignore_registry_value) is contained in an external YAML file
+                       (wazuh_registry_ignore_conf.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing
+                       registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+        - r'.*Ignoring .*? (.*?) due to( sregex)? .*?'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     # Open the key (this shouldn't create an alert)

--- a/tests/integration/test_fim/test_registry/test_registry_nodiff/test_registry_no_diff.py
+++ b/tests/integration/test_fim/test_registry/test_registry_nodiff/test_registry_no_diff.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM ignores the modifications made
+       in a monitored value when it matches the 'registry_nodiff' tag and vice versa.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-nodiff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_nodiff
+'''
 import os
 from hashlib import sha1
 from time import sleep
@@ -68,24 +118,65 @@ def get_configuration(request):
 def test_no_diff_str(key, subkey, arch, value_name, truncated, tags_to_apply,
                      get_configuration, configure_environment, restart_syscheckd,
                      wait_for_fim_start):
-    """
-    Check the only values detected are those matching the restrict using the value path.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon truncates the value changes in the generated events using
+                 the value path in the 'registry_nodiff' tag and vice versa. For this purpose, the test will monitor
+                 a key and make value operations inside it. Then, it will check if the 'diff' file is created for
+                 each testing value modified. Finally, if the testing values match the 'registry_nodiff' tag,
+                 the test will verify that the FIM events generated contain in their 'content_changes' field
+                 a message indicating that 'diff' is truncated because the 'nodiff' option is used.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    truncated : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the registry entry where the test will be executed.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the value that will be created.
+        - truncated:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM ignores the modifications made in a monitored value
+          when it matches the 'registry_nodiff' tag.
+        - Verify that FIM includes the modifications made in a monitored value
+          when it does not match the 'registry_nodiff' tag.
+
+    input_description: A test case (no_diff_str) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     values = {value_name: "some content"}
 
@@ -127,24 +218,65 @@ def test_no_diff_str(key, subkey, arch, value_name, truncated, tags_to_apply,
 def test_no_diff_regex(key, subkey, arch, value_name, truncated, tags_to_apply,
                        get_configuration, configure_environment, restart_syscheckd,
                        wait_for_fim_start):
-    """
-    Check the only files detected are those matching the restrict regex.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon truncates the value changes in the generated events using
+                 regex in the 'registry_nodiff' tag and vice versa. For this purpose, the test will monitor
+                 a key and make value operations inside it. Then, it will check if the 'diff' file is created for
+                 each testing value modified. Finally, if the testing values match the 'registry_nodiff' tag,
+                 the test will verify that the FIM events generated contain in their 'content_changes' field
+                 a message indicating that 'diff' is truncated because the 'nodiff' option is used.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    truncated : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the registry entry where the test will be executed.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the value that will be created.
+        - truncated:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM ignores the modifications made in a monitored value
+          when it matches the 'registry_nodiff' tag.
+        - Verify that FIM includes the modifications made in a monitored value
+          when it does not match the 'registry_nodiff' tag.
+
+    input_description: A test case (no_diff_regex) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     values = {value_name: "some content"}
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2073|

# Description
As part of issue #1810 and epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694

## New tags
The following tags are added to the wiki: `fim_registry_checks`, `fim_registry_ignore`, and `fim_registry_nodiff`

# Generated documentation


## `test_registry_checks`


<details><summary>test_registry_check_others.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will check if FIM events generated contain only the 'check_' fields specified in the configuration when using the 'check_' attributes individually and use the 'check_all=no' attribute. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "windows"
    ],
    "os_version": [
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_registry_checks"
    ],
    "name": "test_registry_check_others.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon adds in the generated events the 'check_' specified in the configuration. These checks are attributes indicating that a monitored registry entry has been modified. For example, if 'check_all=no' and 'check_sum=yes' are set for the same entry, 'syscheck' must send an event containing only the checksums. For this purpose, the test will monitor a registry key using the 'check_all=no' attribute (in order to avoid using the default 'check_all' configuration) in conjunction with several 'check_' on the same key. Then it will make key/value operations inside it, and finally, the test will verify that FIM events generated contain only the fields of the 'check_' specified for the monitored keys/values.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "key": {
                        "type": "str",
                        "brief": "Path of the registry root key (HKEY_* constants)."
                    }
                },
                {
                    "subkey": {
                        "type": "str",
                        "brief": "Path of the key that will be created under the root key."
                    }
                },
                {
                    "key_attr": {
                        "type": "set",
                        "brief": "Set of options that are expected for key events."
                    }
                },
                {
                    "value_attr": {
                        "type": "set",
                        "brief": "Set of options that are expected for value events."
                    }
                },
                {
                    "triggers_key_modification": {
                        "type": "bool",
                        "brief": "Specify if the given options generate key events."
                    }
                },
                {
                    "triggers_value_modification": {
                        "type": "bool",
                        "brief": "Specify if the given options generate value events."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the FIM events generated contain only the 'check_' fields specified in the configuration."
            ],
            "input_description": "A test case (test_others) is contained in an external YAML file (wazuh_check_others.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added', 'modified', and 'deleted' events)"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_check_others",
            "inputs": [
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\testkey1-key_attr0-value_attr0-True-True",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\testkey2-key_attr1-value_attr1-True-True",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\testkey3-key_attr2-value_attr2-True-False",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\testkey4-key_attr3-value_attr3-False-True",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\testkey5-key_attr4-value_attr4-True-True",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\testkey6-key_attr5-value_attr5-True-True"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_registry_check_others.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will check if FIM
  events generated contain only the 'check_' fields specified in the configuration
  when using the 'check_' attributes individually and use the 'check_all=no' attribute.
  The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
  files for changes to the checksums, permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 1
modules:
- fim
name: test_registry_check_others.py
os_platform:
- windows
os_version:
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
tags:
- fim_registry_checks
tests:
- assertions:
  - Verify that the FIM events generated contain only the 'check_' fields specified
    in the configuration.
  description: Check if the 'wazuh-syscheckd' daemon adds in the generated events
    the 'check_' specified in the configuration. These checks are attributes indicating
    that a monitored registry entry has been modified. For example, if 'check_all=no'
    and 'check_sum=yes' are set for the same entry, 'syscheck' must send an event
    containing only the checksums. For this purpose, the test will monitor a registry
    key using the 'check_all=no' attribute (in order to avoid using the default 'check_all'
    configuration) in conjunction with several 'check_' on the same key. Then it will
    make key/value operations inside it, and finally, the test will verify that FIM
    events generated contain only the fields of the 'check_' specified for the monitored
    keys/values.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
  input_description: A test case (test_others) is contained in an external YAML file
    (wazuh_check_others.yaml) which includes configuration settings for the 'wazuh-syscheckd'
    daemon. That is combined with the testing registry keys to be monitored defined
    in the module.
  inputs:
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\testkey1-key_attr0-value_attr0-True-True
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\testkey2-key_attr1-value_attr1-True-True
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\testkey3-key_attr2-value_attr2-True-False
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\testkey4-key_attr3-value_attr3-False-True
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\testkey5-key_attr4-value_attr4-True-True
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\testkey6-key_attr5-value_attr5-True-True
  name: test_check_others
  parameters:
  - key:
      brief: Path of the registry root key (HKEY_* constants).
      type: str
  - subkey:
      brief: Path of the key that will be created under the root key.
      type: str
  - key_attr:
      brief: Set of options that are expected for key events.
      type: set
  - value_attr:
      brief: Set of options that are expected for value events.
      type: set
  - triggers_key_modification:
      brief: Specify if the given options generate key events.
      type: bool
  - triggers_value_modification:
      brief: Specify if the given options generate value events.
      type: bool
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_registry_checkers.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will check if FIM events generated contain only the 'check_' fields specified in the configuration when using the 'check_all' attribute along with other 'check_' attributes. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "windows"
    ],
    "os_version": [
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_registry_checks"
    ],
    "name": "test_registry_checkers.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon adds in the generated events the 'check_' specified in the configuration. These checks are attributes indicating that a monitored registry entry has been modified. For example, if 'check_all=yes' and 'check_sum=no' are set for the same entry, 'syscheck' must send an event containing every possible 'check_' except the checksums. For this purpose, the test will monitor a registry key using the 'check_all' attribute in conjunction with one or more 'check_' on the same key, having 'check_all' to 'yes' and the other one to 'no'. Then it will make key/value operations inside it, and finally, finally, the test will verify that the FIM events generated contain only the fields of the 'checks' specified for the monitored keys/values.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "key": {
                        "type": "str",
                        "brief": "Path of the registry root key (HKEY_* constants)."
                    }
                },
                {
                    "subkey": {
                        "type": "str",
                        "brief": "Path of the key that will be created under the root key."
                    }
                },
                {
                    "arch": {
                        "type": "str",
                        "brief": "Architecture of the registry."
                    }
                },
                {
                    "key_attr": {
                        "type": "set",
                        "brief": "Set of options that are expected for key events."
                    }
                },
                {
                    "value_attr": {
                        "type": "set",
                        "brief": "Set of options that are expected for value events."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "triggers_modification": {
                        "type": "bool",
                        "brief": "Specify if the given options generate registry events."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that the FIM events generated contain only the 'check_' fields specified in the configuration."
            ],
            "input_description": "Different test cases are contained in an external YAML file (wazuh_check_all.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon. Those are combined with the testing registry keys to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added', 'modified', and 'deleted' events)"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_checkers",
            "inputs": [
                "get_configuration0-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE",
                "get_configuration0-SOFTWARE\\\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE",
                "get_configuration1-SOFTWARE\\\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE",
                "get_configuration2-SOFTWARE\\\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE",
                "get_configuration3-SOFTWARE\\\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\Classes\\\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE",
                "get_configuration4-SOFTWARE\\\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_registry_checkers.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will check if FIM
  events generated contain only the 'check_' fields specified in the configuration
  when using the 'check_all' attribute along with other 'check_' attributes. The FIM
  capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
  for changes to the checksums, permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 0
id: 2
modules:
- fim
name: test_registry_checkers.py
os_platform:
- windows
os_version:
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
tags:
- fim_registry_checks
tests:
- assertions:
  - Verify that the FIM events generated contain only the 'check_' fields specified
    in the configuration.
  description: Check if the 'wazuh-syscheckd' daemon adds in the generated events
    the 'check_' specified in the configuration. These checks are attributes indicating
    that a monitored registry entry has been modified. For example, if 'check_all=yes'
    and 'check_sum=no' are set for the same entry, 'syscheck' must send an event containing
    every possible 'check_' except the checksums. For this purpose, the test will
    monitor a registry key using the 'check_all' attribute in conjunction with one
    or more 'check_' on the same key, having 'check_all' to 'yes' and the other one
    to 'no'. Then it will make key/value operations inside it, and finally, finally,
    the test will verify that the FIM events generated contain only the fields of
    the 'checks' specified for the monitored keys/values.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
  input_description: Different test cases are contained in an external YAML file (wazuh_check_all.yaml)
    which includes configuration settings for the 'wazuh-syscheckd' daemon. Those
    are combined with the testing registry keys to be monitored defined in the module.
  inputs:
  - get_configuration0-SOFTWARE\\Classes\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\Classes\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\Classes\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\Classes\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\Classes\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE
  - get_configuration0-SOFTWARE\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\Classes\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\Classes\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\Classes\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\Classes\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\Classes\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE
  - get_configuration1-SOFTWARE\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\Classes\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\Classes\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\Classes\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\Classes\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\Classes\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE
  - get_configuration2-SOFTWARE\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\Classes\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\Classes\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\Classes\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\Classes\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\Classes\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE
  - get_configuration3-SOFTWARE\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\Classes\\testkey-0-key_attrs0-value_attrs0-tags_to_apply0-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs1-value_attrs1-tags_to_apply1-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs2-value_attrs2-tags_to_apply2-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\Classes\\testkey-0-key_attrs3-value_attrs3-tags_to_apply3-False-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs4-value_attrs4-tags_to_apply4-False-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs5-value_attrs5-tags_to_apply5-False-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\Classes\\testkey-0-key_attrs6-value_attrs6-tags_to_apply6-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs7-value_attrs7-tags_to_apply7-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey3-0-key_attrs8-value_attrs8-tags_to_apply8-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey4-0-key_attrs9-value_attrs9-tags_to_apply9-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey5-0-key_attrs10-value_attrs10-tags_to_apply10-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey6-0-key_attrs11-value_attrs11-tags_to_apply11-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\Classes\\testkey-0-key_attrs12-value_attrs12-tags_to_apply12-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs13-value_attrs13-tags_to_apply13-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey3-0-key_attrs14-value_attrs14-tags_to_apply14-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey4-0-key_attrs15-value_attrs15-tags_to_apply15-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\Classes\\testkey-0-key_attrs16-value_attrs16-tags_to_apply16-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey-0-key_attrs17-value_attrs17-tags_to_apply17-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey3-0-key_attrs18-value_attrs18-tags_to_apply18-True-HKEY_LOCAL_MACHINE
  - get_configuration4-SOFTWARE\\testkey4-0-key_attrs19-value_attrs19-tags_to_apply19-True-HKEY_LOCAL_MACHINE
  name: test_checkers
  parameters:
  - key:
      brief: Path of the registry root key (HKEY_* constants).
      type: str
  - subkey:
      brief: Path of the key that will be created under the root key.
      type: str
  - arch:
      brief: Architecture of the registry.
      type: str
  - key_attr:
      brief: Set of options that are expected for key events.
      type: set
  - value_attr:
      brief: Set of options that are expected for value events.
      type: set
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - triggers_modification:
      brief: Specify if the given options generate registry events.
      type: bool
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## `test_registry_ignore`


<details><summary>test_ignore_registry.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will verify that FIM ignores the registry entries set in the 'registry_ignore' option using both regex and regular names for specifying them. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 1,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "windows"
    ],
    "os_version": [
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-ignore"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_registry_ignore"
    ],
    "name": "test_ignore_registry.py",
    "id": 3,
    "group_id": 2,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon ignores the events from keys that are in a monitored subkey when using the 'registry_ignore' option. It also ensures that events for keys that are not being ignored are still detected. For this purpose, the test will monitor a subkey containing keys to be ignored using names or regular expressions. Then it will create these keys and check if FIM events should be generated. Finally, the test will verify that the FIM events generated are consistent with the ignored keys and monitored subkey.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "root_key": {
                        "type": "str",
                        "brief": "Path of the registry root key (HKEY_* constants)."
                    }
                },
                {
                    "registry": {
                        "type": "str",
                        "brief": "Path of the registry entry where the test will be executed."
                    }
                },
                {
                    "arch": {
                        "type": "str",
                        "brief": "Architecture of the registry."
                    }
                },
                {
                    "subkey": {
                        "type": "str",
                        "brief": "Path of the key that will be created under the root key."
                    }
                },
                {
                    "triggers_event": {
                        "type": "bool",
                        "brief": "True if an event must be generated, False otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM 'ignore' events are generated when an ignored key is modified.",
                "Verify that FIM 'added' events are generated when a not ignored key is added.",
                "Verify that 'modified' FIM events are generated from a parent key when a key is added. Whether it is ignored or not."
            ],
            "input_description": "A test case (ignore_registry_key) is contained in an external YAML file (wazuh_registry_ignore_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' and 'modified' events)"
                },
                "r'.*Ignoring .*? (.*?) due to( sregex)? .*?'"
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ignore_registry_key",
            "inputs": [
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_key-True-tags_to_apply0",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_key-True-tags_to_apply1",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-key_ignore-False-tags_to_apply2",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-key_ignore-False-tags_to_apply3",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_key-False-tags_to_apply4",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_key-False-tags_to_apply5",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_key-True-tags_to_apply6",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-key_ignore-False-tags_to_apply7",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-regex_ignored_key-False-tags_to_apply8",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_key-True-tags_to_apply0",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_key-True-tags_to_apply1",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-key_ignore-False-tags_to_apply2",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-key_ignore-False-tags_to_apply3",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_key-False-tags_to_apply4",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_key-False-tags_to_apply5",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_key-True-tags_to_apply6",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-key_ignore-False-tags_to_apply7",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-regex_ignored_key-False-tags_to_apply8"
            ]
        },
        {
            "description": "Check if the 'wazuh-syscheckd' daemon ignores the events from values that are in a monitored subkey when using the 'registry_ignore' option. It also ensures that events for values that are not being ignored are still detected. For this purpose, the test will monitor a subkey containing values to be ignored using names or regular expressions. Then it will create these values and check if FIM events should be generated. Finally, the test will verify that the FIM events generated are consistent with the ignored values and monitored subkey.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "root_key": {
                        "type": "str",
                        "brief": "Path of the registry root key (HKEY_* constants)."
                    }
                },
                {
                    "registry": {
                        "type": "str",
                        "brief": "Path of the registry entry where the test will be executed."
                    }
                },
                {
                    "arch": {
                        "type": "str",
                        "brief": "Architecture of the registry."
                    }
                },
                {
                    "value": {
                        "type": "str",
                        "brief": "Name of the value that will be created."
                    }
                },
                {
                    "triggers_event": {
                        "type": "bool",
                        "brief": "True if an event must be generated, False otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM 'ignore' events are generated when an ignored value is modified.",
                "Verify that FIM 'added' events are generated when a not ignored value is added.",
                "Verify that 'modified' FIM events are generated from a parent key when a value is added. Whether it is ignored or not."
            ],
            "input_description": "A test case (ignore_registry_value) is contained in an external YAML file (wazuh_registry_ignore_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added' and 'modified' events)"
                },
                "r'.*Ignoring .*? (.*?) due to( sregex)? .*?'"
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_ignore_registry_value",
            "inputs": [
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-True-tags_to_apply0",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-True-tags_to_apply1",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_value-False-tags_to_apply2",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_value-False-tags_to_apply3",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-regex_ignored_value-False-tags_to_apply4",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_value-True-tags_to_apply5",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-value_ignored-False-tags_to_apply6",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-value_ignored-False-tags_to_apply7",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-value_ignored-False-tags_to_apply8",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-True-tags_to_apply0",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-True-tags_to_apply1",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_value-False-tags_to_apply2",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-regex_ignored_value-False-tags_to_apply3",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-regex_ignored_value-False-tags_to_apply4",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_value-True-tags_to_apply5",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-value_ignored-False-tags_to_apply6",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-value_ignored-False-tags_to_apply7",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-value_ignored-False-tags_to_apply8"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_ignore_registry.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will verify that
  FIM ignores the registry entries set in the 'registry_ignore' option using both
  regex and regular names for specifying them. The FIM capability is managed by the
  'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums,
  permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 2
id: 3
modules:
- fim
name: test_ignore_registry.py
os_platform:
- windows
os_version:
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-ignore
tags:
- fim_registry_ignore
tests:
- assertions:
  - Verify that FIM 'ignore' events are generated when an ignored key is modified.
  - Verify that FIM 'added' events are generated when a not ignored key is added.
  - Verify that 'modified' FIM events are generated from a parent key when a key is
    added. Whether it is ignored or not.
  description: Check if the 'wazuh-syscheckd' daemon ignores the events from keys
    that are in a monitored subkey when using the 'registry_ignore' option. It also
    ensures that events for keys that are not being ignored are still detected. For
    this purpose, the test will monitor a subkey containing keys to be ignored using
    names or regular expressions. Then it will create these keys and check if FIM
    events should be generated. Finally, the test will verify that the FIM events
    generated are consistent with the ignored keys and monitored subkey.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
  - r'.*Ignoring .*? (.*?) due to( sregex)? .*?'
  input_description: A test case (ignore_registry_key) is contained in an external
    YAML file (wazuh_registry_ignore_conf.yaml) which includes configuration settings
    for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys
    to be monitored defined in the module.
  inputs:
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_key-True-tags_to_apply0
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_key-True-tags_to_apply1
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-key_ignore-False-tags_to_apply2
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-key_ignore-False-tags_to_apply3
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_key-False-tags_to_apply4
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_key-False-tags_to_apply5
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_key-True-tags_to_apply6
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-key_ignore-False-tags_to_apply7
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-regex_ignored_key-False-tags_to_apply8
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_key-True-tags_to_apply0
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_key-True-tags_to_apply1
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-key_ignore-False-tags_to_apply2
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-key_ignore-False-tags_to_apply3
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_key-False-tags_to_apply4
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_key-False-tags_to_apply5
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_key-True-tags_to_apply6
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-key_ignore-False-tags_to_apply7
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-regex_ignored_key-False-tags_to_apply8
  name: test_ignore_registry_key
  parameters:
  - root_key:
      brief: Path of the registry root key (HKEY_* constants).
      type: str
  - registry:
      brief: Path of the registry entry where the test will be executed.
      type: str
  - arch:
      brief: Architecture of the registry.
      type: str
  - subkey:
      brief: Path of the key that will be created under the root key.
      type: str
  - triggers_event:
      brief: True if an event must be generated, False otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that FIM 'ignore' events are generated when an ignored value is modified.
  - Verify that FIM 'added' events are generated when a not ignored value is added.
  - Verify that 'modified' FIM events are generated from a parent key when a value
    is added. Whether it is ignored or not.
  description: Check if the 'wazuh-syscheckd' daemon ignores the events from values
    that are in a monitored subkey when using the 'registry_ignore' option. It also
    ensures that events for values that are not being ignored are still detected.
    For this purpose, the test will monitor a subkey containing values to be ignored
    using names or regular expressions. Then it will create these values and check
    if FIM events should be generated. Finally, the test will verify that the FIM
    events generated are consistent with the ignored values and monitored subkey.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
  - r'.*Ignoring .*? (.*?) due to( sregex)? .*?'
  input_description: A test case (ignore_registry_value) is contained in an external
    YAML file (wazuh_registry_ignore_conf.yaml) which includes configuration settings
    for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys
    to be monitored defined in the module.
  inputs:
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-True-tags_to_apply0
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-True-tags_to_apply1
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_value-False-tags_to_apply2
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_value-False-tags_to_apply3
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-regex_ignored_value-False-tags_to_apply4
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_value-True-tags_to_apply5
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-value_ignored-False-tags_to_apply6
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-value_ignored-False-tags_to_apply7
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-value_ignored-False-tags_to_apply8
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-True-tags_to_apply0
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-True-tags_to_apply1
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_value-False-tags_to_apply2
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-regex_ignored_value-False-tags_to_apply3
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-regex_ignored_value-False-tags_to_apply4
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_value-True-tags_to_apply5
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-value_ignored-False-tags_to_apply6
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-value_ignored-False-tags_to_apply7
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-value_ignored-False-tags_to_apply8
  name: test_ignore_registry_value
  parameters:
  - root_key:
      brief: Path of the registry root key (HKEY_* constants).
      type: str
  - registry:
      brief: Path of the registry entry where the test will be executed.
      type: str
  - arch:
      brief: Architecture of the registry.
      type: str
  - value:
      brief: Name of the value that will be created.
      type: str
  - triggers_event:
      brief: True if an event must be generated, False otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## `test_registry_nodiff`


<details><summary>test_registry_no_diff.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files are modified. Specifically, these tests will check if FIM ignores the modifications made in a monitored value when it matches the 'registry_nodiff' tag and vice versa. The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files for changes to the checksums, permissions, and ownership.",
    "tier": 2,
    "modules": [
        "fim"
    ],
    "components": [
        "agent"
    ],
    "daemons": [
        "wazuh-syscheckd"
    ],
    "os_platform": [
        "windows"
    ],
    "os_version": [
        "Windows 10",
        "Windows 8",
        "Windows 7",
        "Windows Server 2016",
        "Windows Server 2012",
        "Windows Server 2003",
        "Windows XP"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-nodiff"
    ],
    "pytest_args": [
        {
            "fim_mode": {
                "realtime": "Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.",
                "whodata": "Implies real-time monitoring but adding the 'who-data' information."
            }
        },
        {
            "tier": {
                "0": "Only level 0 tests are performed, they check basic functionalities and are quick to perform.",
                "1": "Only level 1 tests are performed, they check functionalities of medium complexity.",
                "2": "Only level 2 tests are performed, they check advanced functionalities and are slow to perform."
            }
        }
    ],
    "tags": [
        "fim_registry_nodiff"
    ],
    "name": "test_registry_no_diff.py",
    "id": 4,
    "group_id": 3,
    "tests": [
        {
            "description": "Check if the 'wazuh-syscheckd' daemon truncates the value changes in the generated events using the value path in the 'registry_nodiff' tag and vice versa. For this purpose, the test will monitor a key and make value operations inside it. Then, it will check if the 'diff' file is created for each testing value modified. Finally, if the testing values match the 'registry_nodiff' tag, the test will verify that the FIM events generated contain in their 'content_changes' field a message indicating that 'diff' is truncated because the 'nodiff' option is used.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "key": {
                        "type": "str",
                        "brief": "Path of the registry root key (HKEY_* constants)."
                    }
                },
                {
                    "subkey": {
                        "type": "str",
                        "brief": "Path of the registry entry where the test will be executed."
                    }
                },
                {
                    "arch": {
                        "type": "str",
                        "brief": "Architecture of the registry."
                    }
                },
                {
                    "value_name": {
                        "type": "str",
                        "brief": "Name of the value that will be created."
                    }
                },
                {
                    "truncated": {
                        "type": "bool",
                        "brief": "True if an event must be generated, False otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM ignores the modifications made in a monitored value when it matches the 'registry_nodiff' tag.",
                "Verify that FIM includes the modifications made in a monitored value when it does not match the 'registry_nodiff' tag."
            ],
            "input_description": "A test case (no_diff_str) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added', 'modified', and 'deleted' events)"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_no_diff_str",
            "inputs": [
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply0",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply1",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply2",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply3",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-nodiff_value-True-tags_to_apply4",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_value-False-tags_to_apply5",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply0",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply1",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply2",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply3",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-nodiff_value-True-tags_to_apply4",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_value-False-tags_to_apply5"
            ]
        },
        {
            "description": "Check if the 'wazuh-syscheckd' daemon truncates the value changes in the generated events using regex in the 'registry_nodiff' tag and vice versa. For this purpose, the test will monitor a key and make value operations inside it. Then, it will check if the 'diff' file is created for each testing value modified. Finally, if the testing values match the 'registry_nodiff' tag, the test will verify that the FIM events generated contain in their 'content_changes' field a message indicating that 'diff' is truncated because the 'nodiff' option is used.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "key": {
                        "type": "str",
                        "brief": "Path of the registry root key (HKEY_* constants)."
                    }
                },
                {
                    "subkey": {
                        "type": "str",
                        "brief": "Path of the registry entry where the test will be executed."
                    }
                },
                {
                    "arch": {
                        "type": "str",
                        "brief": "Architecture of the registry."
                    }
                },
                {
                    "value_name": {
                        "type": "str",
                        "brief": "Name of the value that will be created."
                    }
                },
                {
                    "truncated": {
                        "type": "bool",
                        "brief": "True if an event must be generated, False otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_syscheckd": {
                        "type": "fixture",
                        "brief": "Clear the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_fim_start": {
                        "type": "fixture",
                        "brief": "Wait for realtime start, whodata start, or end of initial FIM scan."
                    }
                }
            ],
            "assertions": [
                "Verify that FIM ignores the modifications made in a monitored value when it matches the 'registry_nodiff' tag.",
                "Verify that FIM includes the modifications made in a monitored value when it does not match the 'registry_nodiff' tag."
            ],
            "input_description": "A test case (no_diff_regex) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys to be monitored defined in the module.",
            "expected_output": [
                {
                    "r'.*Sending FIM event": "(.+)$' ('added', 'modified', and 'deleted' events)"
                }
            ],
            "tags": [
                "scheduled",
                "time_travel"
            ],
            "name": "test_no_diff_regex",
            "inputs": [
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply0",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply1",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply2",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply3",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-nodiff_value-True-tags_to_apply4",
                "get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_value-False-tags_to_apply5",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply0",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply1",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-nodiff_value-True-tags_to_apply2",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\test_key-0-some_value-False-tags_to_apply3",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-nodiff_value-True-tags_to_apply4",
                "get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\\\Classes\\\\test_key-0-some_value-False-tags_to_apply5"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_registry_no_diff.yaml</summary>
<p>

```yaml
brief: File Integrity Monitoring (FIM) system watches selected files and triggering
  alerts when these files are modified. Specifically, these tests will check if FIM
  ignores the modifications made in a monitored value when it matches the 'registry_nodiff'
  tag and vice versa. The FIM capability is managed by the 'wazuh-syscheckd' daemon,
  which checks configured files for changes to the checksums, permissions, and ownership.
components:
- agent
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-syscheckd
group_id: 3
id: 4
modules:
- fim
name: test_registry_no_diff.py
os_platform:
- windows
os_version:
- Windows 10
- Windows 8
- Windows 7
- Windows Server 2016
- Windows Server 2012
- Windows Server 2003
- Windows XP
pytest_args:
- fim_mode:
    realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls)
      and Windows systems.
    whodata: Implies real-time monitoring but adding the 'who-data' information.
- tier:
    0: Only level 0 tests are performed, they check basic functionalities and are
      quick to perform.
    1: Only level 1 tests are performed, they check functionalities of medium complexity.
    2: Only level 2 tests are performed, they check advanced functionalities and are
      slow to perform.
references:
- https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-nodiff
tags:
- fim_registry_nodiff
tests:
- assertions:
  - Verify that FIM ignores the modifications made in a monitored value when it matches
    the 'registry_nodiff' tag.
  - Verify that FIM includes the modifications made in a monitored value when it does
    not match the 'registry_nodiff' tag.
  description: Check if the 'wazuh-syscheckd' daemon truncates the value changes in
    the generated events using the value path in the 'registry_nodiff' tag and vice
    versa. For this purpose, the test will monitor a key and make value operations
    inside it. Then, it will check if the 'diff' file is created for each testing
    value modified. Finally, if the testing values match the 'registry_nodiff' tag,
    the test will verify that the FIM events generated contain in their 'content_changes'
    field a message indicating that 'diff' is truncated because the 'nodiff' option
    is used.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
  input_description: A test case (no_diff_str) is contained in an external YAML file
    (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd'
    daemon. That is combined with the testing registry keys to be monitored defined
    in the module.
  inputs:
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply0
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply1
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply2
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply3
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-nodiff_value-True-tags_to_apply4
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_value-False-tags_to_apply5
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply0
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply1
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply2
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply3
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-nodiff_value-True-tags_to_apply4
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_value-False-tags_to_apply5
  name: test_no_diff_str
  parameters:
  - key:
      brief: Path of the registry root key (HKEY_* constants).
      type: str
  - subkey:
      brief: Path of the registry entry where the test will be executed.
      type: str
  - arch:
      brief: Architecture of the registry.
      type: str
  - value_name:
      brief: Name of the value that will be created.
      type: str
  - truncated:
      brief: True if an event must be generated, False otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that FIM ignores the modifications made in a monitored value when it matches
    the 'registry_nodiff' tag.
  - Verify that FIM includes the modifications made in a monitored value when it does
    not match the 'registry_nodiff' tag.
  description: Check if the 'wazuh-syscheckd' daemon truncates the value changes in
    the generated events using regex in the 'registry_nodiff' tag and vice versa.
    For this purpose, the test will monitor a key and make value operations inside
    it. Then, it will check if the 'diff' file is created for each testing value modified.
    Finally, if the testing values match the 'registry_nodiff' tag, the test will
    verify that the FIM events generated contain in their 'content_changes' field
    a message indicating that 'diff' is truncated because the 'nodiff' option is used.
  expected_output:
  - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
  input_description: A test case (no_diff_regex) is contained in an external YAML
    file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-syscheckd'
    daemon. That is combined with the testing registry keys to be monitored defined
    in the module.
  inputs:
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply0
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply1
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply2
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply3
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-nodiff_value-True-tags_to_apply4
  - get_configuration0-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_value-False-tags_to_apply5
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply0
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply1
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-nodiff_value-True-tags_to_apply2
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\test_key-0-some_value-False-tags_to_apply3
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-nodiff_value-True-tags_to_apply4
  - get_configuration1-HKEY_LOCAL_MACHINE-SOFTWARE\\Classes\\test_key-0-some_value-False-tags_to_apply5
  name: test_no_diff_regex
  parameters:
  - key:
      brief: Path of the registry root key (HKEY_* constants).
      type: str
  - subkey:
      brief: Path of the registry entry where the test will be executed.
      type: str
  - arch:
      brief: Architecture of the registry.
      type: str
  - value_name:
      brief: Name of the value that will be created.
      type: str
  - truncated:
      brief: True if an event must be generated, False otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_syscheckd:
      brief: Clear the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_fim_start:
      brief: Wait for realtime start, whodata start, or end of initial FIM scan.
      type: fixture
  tags:
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
tier: 2
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`