### PR TITLE
Improving output validation method for authd tests

### DIFF
--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -176,7 +176,7 @@ def test_authd_force_options(get_configuration, configure_environment, configure
 
     metadata = get_configuration['metadata']
 
-    for stage in test_case['test_case']:
+    for index, stage in enumerate(test_case['test_case']):
         # Reopen socket (socket is closed by manager after sending message with client key)
         receiver_sockets[0].open()
         message = stage['input']
@@ -193,4 +193,5 @@ def test_authd_force_options(get_configuration, configure_environment, configure
         else:
             expected = stage['output']
 
-        validate_authd_response(response, expected)
+        result, err_msg = validate_authd_response(response, expected)
+        assert result == 'success', f"Failed stage '{index+1}': {err_msg} Complete response: '{response}'"

--- a/tests/integration/test_authd/test_authd_valid_name_ip.py
+++ b/tests/integration/test_authd/test_authd_valid_name_ip.py
@@ -126,7 +126,7 @@ def test_authd_force_options(get_configuration, configure_environment, configure
             - Registration request responses on Authd socket
     """
 
-    for stage in test_case['test_case']:
+    for index, stage in enumerate(test_case['test_case']):
         # Reopen socket (socket is closed by manager after sending message with client key)
         receiver_sockets[0].open()
         # Checking 'hostname' test case
@@ -150,6 +150,8 @@ def test_authd_force_options(get_configuration, configure_environment, configure
 
         if stage.get('expected_fail') == 'yes':
             with pytest.raises(Exception):
-                validate_authd_response(response, stage['output'])
+                result, err_msg = validate_authd_response(response, stage['output'])
+                assert result == 'success', f"Failed stage '{index+1}': {err_msg} Complete response: '{response}'"
         else:
-            validate_authd_response(response, stage['output'])
+            result, err_msg = validate_authd_response(response, stage['output'])
+            assert result == 'success', f"Failed stage '{index+1}': {err_msg} Complete response: '{response}'"


### PR DESCRIPTION
|Related issue|
|---|
|#2056|

## Description

This PR changes the way the `validate_authd_response()` method validates received messages.
Now the **assert** is done in the test case and not inside the function to provide more information when the test case fails.


## Logs example

When a test fails, now the stage and other information is provided

![err_msg](https://user-images.githubusercontent.com/65046601/138296228-19e0d59d-16f2-464b-8b81-17b17e6ab42c.png)


## Tests

<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
