### PR TITLE
Replacing old force option by the new force block

### DIFF
--- a/tests/integration/test_authd/data/enroll_messages.yaml
+++ b/tests/integration/test_authd/data/enroll_messages.yaml
@@ -9,7 +9,7 @@
 -
   name: "Single Group - Valid group"
   description: "Check single group enrollment"
-  groups: 
+  groups:
     - 'Group1'
     - 'Group2'
   test_case:
@@ -27,7 +27,7 @@
 -
   name: "Single Group - Name too long"
   description: "Check group does not exist"
-  groups: 
+  groups:
     - 'sltqohmjeltdihvfvolvfeazekpdmgdusyprzwtwhptfnxsgwhoumythxhubnbhtqpmaojadpypupryblaiqdutylohhtjcalblytmbboiunldafzjghpmqlrwmhpwtoxflabdfzpsosfmniwyymhkurgelfzpewmftksbkrmzqoibsgatoqgmsidtailhleghqybdqjikdmcjfktyofscfowszjilwjmfdxwojshpimwkmmafmpiciouybmldkdf'
   test_case:
   -
@@ -36,7 +36,7 @@
 -
   name: "Single Group - Invalid Characters"
   description: "Check group does not exist"
-  groups: 
+  groups:
     - "Group\\"
     - "Group?1"
     - "Group<3"
@@ -57,7 +57,7 @@
 -
   name: "Single Group - Empty Group"
   description: "Check Error message when groups is empty"
-  groups: 
+  groups:
     - "GroupA"
     - "GroupB"
   test_case:
@@ -67,7 +67,7 @@
 -
   name: "Multiple Group - Valid groups"
   description: "Check Multiple groups enrollment"
-  groups: 
+  groups:
     - 'Group1'
     - 'Group2'
   test_case:
@@ -77,7 +77,7 @@
 -
   name: "Multiple Group - One group is invalid"
   description: "Check Multiple groups enrollment"
-  groups: 
+  groups:
     - 'Group1'
     - 'Group2'
   test_case:
@@ -87,7 +87,7 @@
 -
   name: "Multiple Group - Name too long"
   description: "Check group does not exist"
-  groups: 
+  groups:
     - 'Group1'
     - 'sltqohmjeltdihvfvolvfeazekpdmgdusyprzwtwhptfnxsgwhoumythxhubnbhtqpmaojadpypupryblaiqdutylohhtjcalblytmbboiunldafzjghpmqlrwmhpwtoxflabdfzpsosfmniwyymhkurgelfzpewmftksbkrmzqoibsgatoqgmsidtailhleghqybdqjikdmcjfktyofscfowszjilwjmfdxwojshpimwkmmafmpiciouybmldkdf'
   test_case:
@@ -97,7 +97,7 @@
 -
   name: "Multiple Group - Invalid Characters"
   description: "Check groups with invalid characters"
-  groups: 
+  groups:
     - "Group\\"
 
     - "Group?1"
@@ -110,7 +110,7 @@
 -
   name: "Multiple Group - Empty List"
   description: "Check empty group list"
-  groups: 
+  groups:
     - "GroupA"
     - "GroupB"
   test_case:

--- a/tests/integration/test_authd/data/enroll_ssl_options_tests.yaml
+++ b/tests/integration/test_authd/data/enroll_ssl_options_tests.yaml
@@ -88,7 +88,7 @@
       name: "Valid Certificates - Manager verification without host"
       description: "Enables CA Certificate and validates that conneciton is acepted when valid certs are provided"
       test_case:
-      - 
+      -
         ciphers: "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH"
         protocol: "ssl_tlsv1_2"
         expect: "output"

--- a/tests/integration/test_authd/data/wazuh_authd_configuration.yaml
+++ b/tests/integration/test_authd/data/wazuh_authd_configuration.yaml
@@ -14,10 +14,18 @@
             value: 1515
         - use_source_ip:
             value: 'no'
-        - force_insert:
-            value: 'yes'
-        - force_time:
-            value: 0
+        - force:
+            elements:
+            - enabled:
+                value: 'yes'
+            - key_mismatch:
+                value: 'yes'
+            - after_registration_time:
+                value: '0h'
+            - disconnected_time:
+                attributes:
+                - enabled: 'yes'
+                value: '0h'
         - purge:
             value: 'yes'
         - use_password:
@@ -80,10 +88,18 @@
             value: 1515
         - use_source_ip:
             value: 'no'
-        - force_insert:
-            value: 'yes'
-        - force_time:
-            value: 0
+        - force:
+            elements:
+            - enabled:
+                value: 'yes'
+            - key_mismatch:
+                value: 'no'
+            - after_registration_time:
+                value: '0h'
+            - disconnected_time:
+                attributes:
+                - enabled: 'yes'
+                value: '0h'
         - purge:
             value: 'yes'
         - use_password:
@@ -114,10 +130,18 @@
             value: 1515
         - use_source_ip:
             value: 'no'
-        - force_insert:
-            value: 'yes'
-        - force_time:
-            value: 0
+        - force:
+            elements:
+            - enabled:
+                value: 'yes'
+            - key_mismatch:
+                value: 'no'
+            - after_registration_time:
+                value: '0h'
+            - disconnected_time:
+                attributes:
+                - enabled: 'yes'
+                value: '0h'
         - purge:
             value: 'yes'
         - use_password:
@@ -162,10 +186,18 @@
             value: 1515
         - use_source_ip:
             value: 'no'
-        - force_insert:
-            value: 'yes'
-        - force_time:
-            value: 0
+        - force:
+            elements:
+            - enabled:
+                value: 'yes'
+            - key_mismatch:
+                value: 'no'
+            - after_registration_time:
+                value: '0h'
+            - disconnected_time:
+                attributes:
+                - enabled: 'yes'
+                value: '0h'
         - purge:
             value: 'yes'
         - use_password:
@@ -217,10 +249,18 @@
               value: 1515
           - use_source_ip:
               value: USE_SOURCE_IP
-          - force_insert:
-              value: 'yes'
-          - force_time:
-              value: 0
+          - force:
+              elements:
+              - enabled:
+                  value: 'yes'
+              - key_mismatch:
+                  value: 'no'
+              - after_registration_time:
+                  value: '0h'
+              - disconnected_time:
+                  attributes:
+                  - enabled: 'yes'
+                  value: '0h'
           - purge:
               value: 'yes'
           - limit_maxagents:
@@ -246,8 +286,18 @@
               value: 'no'
           - port:
               value: 1515
-          - force_time:
-              value: 0
+          - force:
+              elements:
+              - enabled:
+                  value: 'yes'
+              - key_mismatch:
+                  value: 'no'
+              - after_registration_time:
+                  value: '0h'
+              - disconnected_time:
+                  attributes:
+                  - enabled: 'yes'
+                  value: '0h'
           - purge:
               value: 'yes'
           - use_password:
@@ -277,10 +327,18 @@
             value: 1515
         - use_source_ip:
             value: 'no'
-        - force_insert:
-            value: 'yes'
-        - force_time:
-            value: 0
+        - force:
+            elements:
+            - enabled:
+                value: 'yes'
+            - key_mismatch:
+                value: 'no'
+            - after_registration_time:
+                value: '0h'
+            - disconnected_time:
+                attributes:
+                - enabled: 'yes'
+                value: '0h'
         - purge:
             value: 'yes'
         - use_password:
@@ -310,10 +368,18 @@
             value: 1515
         - use_source_ip:
             value: 'no'
-        - force_insert:
-            value: 'yes'
-        - force_time:
-            value: 0
+        - force:
+            elements:
+            - enabled:
+                value: 'yes'
+            - key_mismatch:
+                value: 'no'
+            - after_registration_time:
+                value: '0h'
+            - disconnected_time:
+                attributes:
+                - enabled: 'yes'
+                value: '0h'
         - purge:
             value: 'yes'
         - use_password:

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -237,7 +237,9 @@ def register_agent_main_server(Name, Group=None, IP=None):
 
 
 def register_agent_local_server(Name, Group=None, IP=None):
-    message = '{{"arguments":{{"force":0,"name":"{}"'.format(Name)
+    message = ('{"arguments":{"force":{"enabled":true,"disconnected_time":{"enabled":true,"value":"0"},'
+              '"key_mismatch":true,"after_registration_time":"0"}')
+    message += ',"name":"{}"'.format(Name)
     if Group:
         message += ',"groups":"{}"'.format(Group)
     if IP:

--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -90,52 +90,11 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope='module')
-def clean_client_keys_file_module():
-    """
-    Stops Wazuh and cleans any previus key in client.keys file at module scope.
-    """
-    # Stop Wazuh
-    control_service('stop')
-
-    # Clean client.keys
-    try:
-        with open(client_keys_path, 'w') as client_file:
-            client_file.close()
-    except IOError as exception:
-        raise
-
-    # Start Wazuh
-    control_service('start')
-
-
-@pytest.fixture(scope='module')
-def tear_down():
-    """
-    Roll back the daemon and client.keys state after the test ends.
-    """
-    yield
-    # Stop Wazuh
-    control_service('stop')
-
-    # Clean client.keys
-    try:
-        with open(client_keys_path, 'w') as client_file:
-            client_file.close()
-    except IOError as exception:
-        raise
-
-    # Start Wazuh
-    control_service('start')
-
-
-# Test
-
 @pytest.mark.parametrize('test_case', [case for case in test_authd_use_source_ip_tests],
                          ids=[test_case['name'] for test_case in test_authd_use_source_ip_tests])
 def test_authd_force_options(get_configuration, configure_environment, configure_sockets_environment,
-                             restart_authd, wait_for_authd_startup_module, connect_to_sockets_configuration,
-                             test_case, tear_down):
+                             clean_client_keys_file_function, restart_authd_function, wait_for_authd_startup_function,
+                             connect_to_sockets_function, test_case, tear_down):
     """
         description:
            "Check that every input message in authd port generates the adequate output"


### PR DESCRIPTION
|Related issue|
|---|
|#2052|

## Description

This PR changes the old force options by the new force configuration block.

## Tests

- [X] Proven that tests **pass** when they have to pass.
- [X] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in wazuh-qa/docs.