### PR TITLE
Migrate `test_api` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -88,7 +88,6 @@ def restart_api(get_configuration, request):
         control_service('start', daemon=process_name)
 
 
-
 @pytest.fixture(scope='module')
 def wait_for_start(get_configuration, request):
     # Wait for API to start

--- a/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'DOS' (Denial-of-service attack) blocking feature of the API handled
+       by the 'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful' API
+       that allows for interaction with the Wazuh manager from a web browser, command line tool
+       like 'cURL' or any script or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#access
+    - https://en.wikipedia.org/wiki/Denial-of-service_attack
+
+tags:
+    - api
+'''
 import os
 import time
 
@@ -37,15 +91,48 @@ def get_configuration(request):
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                              wait_for_start, get_api_details):
-    """Check the correct functionality of the DOS blocking system.
+    '''
+    description: Check if the API blocking system for IP addresses detected as 'DOS' attack works.
+                 For this purpose, the test causes an IP blocking, makes a request within
+                 the same minute, makes a request after the minute.
 
-    Provoke a block, make a request within the same minute, make a request after the minute.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the IP address is blocked using multiple requests.
+        - Verify that the IP address is still blocked within the one-minute block time.
+        - Verify that the IP address is not blocked when expires the blocking time.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters.
+
+    expected_output:
+        - r'429' ('Too Many Requests' HTTP status code)
+        - r'200' ('OK' HTTP status code)
+
+    tags:
+        - dos_attack
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     max_request_per_minute = get_configuration['configuration']['access']['max_request_per_minute']
     api_details = get_api_details()
@@ -58,7 +145,8 @@ def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_env
     # Request within the same minute
     get_response = requests.get(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
     assert get_response.status_code == 429, f'Expected status code was 429, ' \
-                                            f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                            f'but {get_response.status_code} was returned. ' \
+                                            f'\nFull response: {get_response.text}'
 
     # Request after the minute.
     time.sleep(60)  # 60 = 1 minute
@@ -66,4 +154,5 @@ def test_DOS_blocking_system(tags_to_apply, get_configuration, configure_api_env
 
     # After blocking time, status code will be 200 again
     assert get_response.status_code == 200, f'Expected status code was 200, ' \
-                                            f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                            f'but {get_response.status_code} was returned. ' \
+                                            f'\nFull response: {get_response.text}'

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the IP blocking feature of the API handled by the 'wazuh-apid' daemon
+       is working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like 'cURL' or any script
+       or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#access
+
+tags:
+    - api
+'''
 import os
 import time
 
@@ -36,16 +89,47 @@ def get_configuration(request):
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_bruteforce_blocking_system(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                                     wait_for_start, get_api_details):
-    """Check that the blocking time for IPs detected as brute-force attack works.
+    '''
+    description: Check if the blocking time for IP addresses detected as brute-force attack works.
+                 For this purpose, the test causes an IP blocking, make a request before
+                 the blocking time finishes and one after the blocking time.
 
-    Provoke a block, make a request before the blocking
-    time finishes and one after the blocking time.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the IP address is blocked using incorrect credentials.
+        - Verify that the IP address is still blocked even when using
+          the correct credentials within the blocking time.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters.
+
+    expected_output:
+        - r"Error obtaining login token"
+
+    tags:
+        - brute_force_attack
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     block_time = get_configuration['configuration']['access']['block_time']
     max_login_attempts = get_configuration['configuration']['access']['max_login_attempts']

--- a/tests/integration/test_api/test_config/test_cache/test_cache.py
+++ b/tests/integration/test_api/test_config/test_cache/test_cache.py
@@ -7,8 +7,10 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the cache feature of the API handled
-       by the `wazuh-apid` daemon is working properly.
+brief: These tests will check if the cache feature of the API handled by the 'wazuh-apid' daemon
+       is working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like 'cURL' or any script
+       or program that can make web requests.
 
 tier: 0
 
@@ -17,8 +19,6 @@ modules:
 
 components:
     - manager
-
-path: tests/integration/test_api/test_config/test_cache/test_cache.py
 
 daemons:
     - wazuh-apid
@@ -114,7 +114,7 @@ def test_cache(tags_to_apply, get_configuration, configure_api_environment, rest
                  a period established in the configuration, even though a new file
                  has been created during the process.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
         - tags_to_apply:
@@ -128,7 +128,7 @@ def test_cache(tags_to_apply, get_configuration, configure_api_environment, rest
             brief: Configure a custom environment for API testing.
         - restart_api:
             type: fixture
-            brief: Reset `api.log` and start a new monitor.
+            brief: Reset 'api.log' and start a new monitor.
         - wait_for_start:
             type: fixture
             brief: Wait until the API starts.
@@ -139,7 +139,7 @@ def test_cache(tags_to_apply, get_configuration, configure_api_environment, rest
     assertions:
         - Verify that the stored response is returned when the cache is enabled.
 
-    input_description: Different test cases are contained in an external `YAML` file (conf.yaml)
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
                        which includes API configuration parameters.
 
     expected_output:

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -7,8 +7,11 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the CORS (Cross-origin resource sharing) feature
-       of the API handled by the `wazuh-apid` daemon is working properly.
+brief:
+    These tests will check if the 'CORS' (Cross-origin resource sharing) feature of the API handled
+    by the 'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful' API
+    that allows for interaction with the Wazuh manager from a web browser, command line tool
+    like 'cURL' or any script or program that can make web requests.
 
 tier: 0
 
@@ -17,8 +20,6 @@ modules:
 
 components:
     - manager
-
-path: tests/integration/test_api/test_config/test_cors/test_cors.py
 
 daemons:
     - wazuh-apid
@@ -92,12 +93,12 @@ def get_configuration(request):
 def test_cors(origin, tags_to_apply, get_configuration, configure_api_environment,
               restart_api, wait_for_start, get_api_details):
     '''
-    description: Check if expected headers are returned when CORS is enabled.
-                 When CORS is enabled, special headers must be returned in case the
-                 request origin matches the one established in the CORS configuration
+    description: Check if expected headers are returned when 'CORS' is enabled.
+                 When 'CORS' is enabled, special headers must be returned in case the
+                 request origin matches the one established in the 'CORS' configuration
                  of the API.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
         - origin:
@@ -114,7 +115,7 @@ def test_cors(origin, tags_to_apply, get_configuration, configure_api_environmen
             brief: Configure a custom environment for API testing.
         - restart_api:
             type: fixture
-            brief: Reset `api.log` and start a new monitor.
+            brief: Reset 'api.log' and start a new monitor.
         - wait_for_start:
             type: fixture
             brief: Wait until the API starts.
@@ -123,12 +124,12 @@ def test_cors(origin, tags_to_apply, get_configuration, configure_api_environmen
             brief: Get API information.
 
     assertions:
-        - Verify that when CORS is enabled, the `Access-Control-Allow-Origin` header is received.
-        - Verify that when CORS is enabled, the `Access-Control-Expose-Headers` header is received.
-        - Verify that when CORS is enabled, the `Access-Control-Allow-Credentials` header is received.
-        - Verify that when CORS is disabled, the `Access-Control-Allow-Origin` header is not received.
+        - Verify that when CORS is enabled, the 'Access-Control-Allow-Origin' header is received.
+        - Verify that when CORS is enabled, the 'Access-Control-Expose-Headers' header is received.
+        - Verify that when CORS is enabled, the 'Access-Control-Allow-Credentials' header is received.
+        - Verify that when CORS is disabled, the 'Access-Control-Allow-Origin' header is not received.
 
-    input_description: A test case is contained in an external `YAML` file (conf.yaml)
+    input_description: A test case is contained in an external YAML file (conf.yaml)
                        which includes API configuration parameters.
 
     expected_output:

--- a/tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.py
+++ b/tests/integration/test_api/test_config/test_drop_privileges/test_drop_privileges.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'drop_privileges' setting of the API is working properly.
+       This setting allows the user who starts the 'wazuh-apid' daemon to be different from
+       the 'root' user. The Wazuh API is an open source 'RESTful' API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like 'cURL' or any script
+       or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#drop-privileges
+
+tags:
+    - api
+'''
 import os
 import pwd
 
@@ -36,17 +90,46 @@ def get_configuration(request):
 ])
 def test_drop_privileges(tags_to_apply, get_configuration, configure_api_environment,
                          restart_api, wait_for_start, get_api_details):
-    """Check if drop_privileges affects the user of the API process.
+    '''
+    description: Check if 'drop_privileges' affects the user of the API process.
+                 In this test, the 'PID' of the API process is obtained. After that,
+                 it gets the user ('root' or 'wazuh') and checks if it matches the
+                 'drop_privileges' setting.
 
-    In this test, the PID of the API process is obtained. After that,
-    it gets the user (root or wazuh) and checks if it matches the
-    drop_privileges setting.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that when 'drop_privileges' is enabled the user who has started the 'wazuh-apid' daemon is 'wazuh'.
+        - Verify that when 'drop_privileges' is disabled the user who has started the 'wazuh-apid' daemon is 'root'.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters.
+
+    expected_output:
+        - PID of the 'wazuh-apid' process.
+        - r'wazuh' (if 'drop_privileges == yes')
+        - r'root' (if 'drop_privileges == no')
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     drop_privileges = get_configuration['configuration']['drop_privileges']
 

--- a/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
+++ b/tests/integration/test_api/test_config/test_experimental_features/test_experimental_features.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'experimental_features' setting of the API is working properly.
+       This setting allows users to access API endpoints containing features that are under development.
+       The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#drop-privileges
+
+tags:
+    - api
+'''
 import os
 
 import pytest
@@ -36,13 +89,46 @@ def get_configuration(request):
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_experimental_features(tags_to_apply, get_configuration, configure_api_environment,
                                restart_api, wait_for_start, get_api_details):
-    """Check if requests to an experimental endpoint are allowed according to the configuration.
+    '''
+    description: Check if requests to an experimental API endpoint are allowed according
+                 to the configuration. For this purpose, it configures the API to use
+                 this functionality and makes requests to it, waiting for a correct response.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that when 'experimental_features' is enabled,
+          it is possible to access experimental API endpoints.
+        - Verify that when 'experimental_features' is disabled,
+          it is not possible to access experimental API endpoints.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code if 'experimental_features == true')
+        - r'404' ('Forbidden' HTTP status code if 'experimental_features == false')
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     experimental = get_configuration['configuration']['experimental_features']
     api_details = get_api_details()
@@ -52,7 +138,9 @@ def test_experimental_features(tags_to_apply, get_configuration, configure_api_e
 
     if experimental:
         assert get_response.status_code == 200, f'Expected status code was 200, ' \
-                                                f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                                f'but {get_response.status_code} was returned. ' \
+                                                f'\nFull response: {get_response.text}'
     else:
         assert get_response.status_code == 404, f'Expected status code was 404, ' \
-                                                f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                                f'but {get_response.status_code} was returned. ' \
+                                                f'\nFull response: {get_response.text}'

--- a/tests/integration/test_api/test_config/test_host_port/test_host_port.py
+++ b/tests/integration/test_api/test_config/test_host_port/test_host_port.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check that the settings related to the API host address and listening port
+       are working correctly. The Wazuh API is an open source 'RESTful' API that allows for interaction
+       with the Wazuh manager from a web browser, command line tool like 'cURL' or any script
+       or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#api-configuration-options
+
+tags:
+    - api
+'''
 import os
 
 import pytest
@@ -43,18 +96,46 @@ def get_configuration(request):
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_host_port(expected_exception, tags_to_apply,
                    get_configuration, configure_api_environment, restart_api, get_api_details):
-    """Try different host and port configurations.
+    '''
+    description: Check different host and port configurations. For this purpose, apply multiple
+                 combinations of host and port, verify that the 'aiohttp' http framework correctly
+                 publishes that value in the 'api.log' and check that the request returns the expected one.
 
-    Apply multiple combinations of host and port, verify that aiohttp correctly publishes
-    that value in the api.log and check that the request returns the expected value.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    expected_exception : bool
-        True if an exception must be raised, false otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        -  expected_exception:
+            type: bool
+            brief: True if an exception must be raised, false otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the API starts listening on the specified IP address and port.
+        - Verify that using a valid configuration, the API requests are performed correctly.
+        - Verify that no unexpected exceptions occur.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters (IP addresses and ports).
+
+    expected_output:
+        - r'.*INFO: Listening on (.+)..'
+        - r'{host}{port}' ('host' and 'port' are obtained from each test_case.)
+        - r'200' ('OK' HTTP status code)
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     host = get_configuration['configuration']['host']
     port = get_configuration['configuration']['port']

--- a/tests/integration/test_api/test_config/test_https/test_https.py
+++ b/tests/integration/test_api/test_config/test_https/test_https.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check that the API works correctly using the 'HTTPS' protocol.
+       The Wazuh API is an open source 'RESTful' API that allows for interaction with
+       the Wazuh manager from a web browser, command line tool like 'cURL' or any script
+       or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#https
+
+tags:
+    - api
+'''
 import os
 
 import pytest
@@ -41,13 +94,47 @@ def get_configuration(request):
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_https(tags_to_apply, get_configuration, configure_api_environment,
                restart_api, wait_for_start, get_api_details):
-    """Check that the API works with http and https protocols.
+    '''
+    description:
+        Check if the API works with 'HTTP' and 'HTTPS' protocols.
+        For this purpose, it configures the API to use both protocols
+        and makes requests to it, waiting for a correct response.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version:
+        4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the API requests are made correctly using both 'HTTP' and 'HTTPS' protocols.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters (HTTPS settings).
+
+    expected_output:
+        - r'200' ('OK' HTTP status code)
+
+    tags:
+        - ssl
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     https = get_configuration['configuration']['https']['enabled']
     api_details = get_api_details(protocol='https' if https else 'http')

--- a/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
+++ b/tests/integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'auth_token_exp_timeout' setting of the API is working properly.
+       This setting allows specifying the expiration time of the 'JWT' token used for authentication.
+       The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#auth-token-exp-timeout
+    - https://en.wikipedia.org/wiki/JSON_Web_Token
+
+tags:
+    - api
+'''
 import os
 import time
 
@@ -37,13 +91,46 @@ def get_configuration(request):
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                                wait_for_start, get_api_details):
-    """Verify that the JWT token expires after defined time.
+    '''
+    description: Check if the API 'JWT' token expires after defined time. For this purpose,
+                 an expiration time is set for the token, and API requests are made before
+                 and after the expiration time, waiting for a valid 'HTTP status code'.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the API requests are successful if the 'JWT' token has not expired and vice versa.
+
+    input_description: Different test cases are contained in an external YAML file (conf_exp_timeout.yaml)
+                       which includes API configuration parameters (timeouts for token expiration).
+
+    expected_output:
+        - r'200' ('OK' HTTP status code if the token has not expired)
+        - r'401' ('Unauthorized' HTTP status code if the token has expired)
+
+    tags:
+        - token
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     short_exp = get_configuration['tags'][0] == 'short_exp_time'
     api_details = get_api_details()
@@ -52,7 +139,8 @@ def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_e
     # Request manager info before token expires.
     get_response = requests.get(api_details['base_url'], headers=api_details['auth_headers'], verify=False)
     assert get_response.status_code == 200, f'Expected status code was 200, ' \
-                                            f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                            f'but {get_response.status_code} was returned. ' \
+                                            f'\nFull response: {get_response.text}'
 
     # Request manager info after token expires.
     time.sleep(min(get_configuration['security_config']['auth_token_exp_timeout'] + 2, 10))
@@ -61,7 +149,9 @@ def test_jwt_token_exp_timeout(tags_to_apply, get_configuration, configure_api_e
     # If token has expired, user can't access that information.
     if short_exp:
         assert get_response.status_code == 401, f'Expected status code was 401, ' \
-                                                f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                                f'but {get_response.status_code} was returned. ' \
+                                                f'\nFull response: {get_response.text}'
     else:
         assert get_response.status_code == 200, f'Expected status code was 200, ' \
-                                                f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                                f'but {get_response.status_code} was returned. ' \
+                                                f'\nFull response: {get_response.text}'

--- a/tests/integration/test_api/test_config/test_logs/test_logs.py
+++ b/tests/integration/test_api/test_config/test_logs/test_logs.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'level' setting of the API is working properly. This setting
+       allows specifying the level of detail (INFO, DEBUG) of the messages written to the 'api.log' file.
+       The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#logs
+
+tags:
+    - api
+'''
 import os
 from grp import getgrnam
 from pwd import getpwnam
@@ -54,17 +107,41 @@ def extra_configuration_before_yield():
     {'logs_debug'}
 ])
 def test_logs(tags_to_apply, get_configuration, configure_api_environment, restart_api):
-    """Check that the logs are saved in the desired path and with desired level.
+    '''
+    description: Check if the logs are saved in the desired path and with desired level.
+                 Logs are usually store in '/var/ossec/logs/api.log' and with level 'info'.
+                 In this test the API log has a different path and 'debug' level configured.
+                 It checks if logs are saved in the new path and with 'debug' level.
 
-    Logs are usually store in /var/ossec/logs/api.log and with level "info".
-    In this test the api log has a different path and "debug" level configured.
-    It checks if logs are saved in the new path and with "debug" level.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+
+    assertions:
+        - Verify that no 'DEBUG' messages are written when the value of the 'level' setting is set to 'info'.
+        - Verify that 'DEBUG' messages are written when the value of the 'level' setting is set to 'debug'.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters (log paths and log levels).
+
+    expected_output:
+        - r'.*DEBUG: (.*)'
+
+    tags:
+        - logs
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # Detect any "DEBUG:" message in the new log path

--- a/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
+++ b/tests/integration/test_api/test_config/test_rbac/test_rbac_mode.py
@@ -1,7 +1,62 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'rbac_mode' (Role-Based Access Control) setting of the API
+       is working properly. This setting allows you to specify the operating mode between
+       'whitelist mode' and 'blacklist mode'. The Wazuh API is an open source 'RESTful' API
+       that allows for interaction with the Wazuh manager from a web browser, command line tool
+       like 'cURL' or any script or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#rbac-mode
+    - https://en.wikipedia.org/wiki/Role-based_access_control
+
+tags:
+    - api
+'''
 import os
 import sqlite3
 
@@ -62,19 +117,53 @@ def extra_configuration_after_yield():
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                    wait_for_start, get_api_details):
-    """Verify that the RBAC mode selected in api.yaml is applied.
+    '''
+    description: Check if the 'RBAC' mode selected in 'api.yaml' is applied. This test creates a user
+                 without any assigned permission. For this reason, when 'RBAC' is in 'white mode',
+                 there is no endpoint that the user can execute, so the 'HTTP status code'
+                 must be 403 ('forbidden'). On the other hand, when it is in 'black mode',
+                 there is no endpoint that has it denied, so the status code must be 200 ('ok').
 
-    This test creates a user without any assigned permission.
-    For this reason, when RBAC is in white mode, there is no
-    endpoint that the user can execute, so the response must be 400.
-    On the other hand, when it is in black mode, there is no endpoint
-    that has it denied, so the answer must be 200.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Check that when the value of the 'rbac_mode' setting is set to 'white',
+          the API forbids requests.
+        - Verify that when the value of the 'rbac_mode' setting is set to 'black',
+          the API requests are performed correctly.
+
+    input_description: Different test cases are contained in an external YAML file (conf_mode.yaml)
+                       which includes API configuration parameters (rbac operation modes).
+                       Two 'SQL' scripts are also used to add (schema_add_user.sql)
+                       and remove (schema_delete_user.sql) the testing user.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code if 'rbac_white == True')
+        - r'403' ('Forbidden' HTTP status code if 'rbac_white == False')
+
+    tags:
+        - rbac
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     rbac_white = get_configuration['security_config']['rbac_mode'] == 'white'
     api_details = get_api_details(user='test_user', password='wazuh')
@@ -86,7 +175,9 @@ def test_rbac_mode(tags_to_apply, get_configuration, configure_api_environment, 
     # If white mode, user can't access that information.
     if rbac_white:
         assert get_response.status_code == 403, f'Expected status code was 403, ' \
-                                                f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                                f'but {get_response.status_code} was returned. ' \
+                                                f'\nFull response: {get_response.text}'
     else:
         assert get_response.status_code == 200, f'Expected status code was 200, ' \
-                                                f'but {get_response.status_code} was returned. \nFull response: {get_response.text}'
+                                                f'but {get_response.status_code} was returned. ' \
+                                                f'\nFull response: {get_response.text}'

--- a/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
+++ b/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'request_timeout' setting of the API is working properly.
+       This setting allows specifying the time limit for the API to process a request.
+       The Wazuh API is an open source 'RESTful' API that allows for interaction with
+       the Wazuh manager from a web browser, command line tool like 'cURL' or any script
+       or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html
+
+tags:
+    - api
+'''
 import os
 from json import loads
 
@@ -37,15 +91,43 @@ def get_configuration(request):
 ])
 def test_request_timeout(tags_to_apply, get_configuration, configure_api_environment, restart_api,
                          wait_for_start, get_api_details):
-    """Check that the maximum request time for an API request works.
+    '''
+    description: Check if the maximum request time for an API request works.
+                 For this purpose, a value of '0' seconds is set for the 'request_timeout'
+                 setting, and a request is made to the API, expecting an error in the response.
 
-    Make a request to check the timeout error.
+    wazuh_min_version: 4.3.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request cannot finish successfully, resulting in a timeout error.
+
+    input_description: A test case is contained in an external YAML file (conf.yaml) which includes
+                       API configuration parameters ('request_timeout' set to '0' seconds).
+
+    expected_output:
+        - r'500' ('Internal server error' HTTP status code)
+        - r'3021' ('timeout error' in the response body)
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     get_response = requests.get(f'{api.API_PROTOCOL}://{api.API_HOST}:{api.API_PORT}{api.API_LOGIN_ENDPOINT}',
                                 headers=api.get_login_headers(api.API_USER, api.API_PASS), verify=False)

--- a/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
+++ b/tests/integration/test_api/test_config/test_use_only_authd/test_use_only_authd.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'use_only_authd' setting of the API is working properly.
+       This setting allows forcing the use of 'wazuh-authd' daemon when registering and removing agents.
+       The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager
+       from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html#use-only-authd
+
+tags:
+    - api
+'''
 import os
 import random
 import time
@@ -52,16 +106,51 @@ def extra_configuration_after_yield():
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
                    restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of wazuh-authd when adding an agent.
+    '''
+    description: Check if 'use_only_authd' forces the use of the 'wazuh-authd' daemon when adding an agent.
+                 Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon
+                 is stopped, the request made is not completed correctly.
 
-    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
-    is not active, an error is returned.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to add the testing agent cannot finish successfully when
+          the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.
+        - Verify that the request to add the testing agent is successfully processed
+          when the 'use_only_authd' setting is disabled.
+        - Verify that the request to remove the testing agent is processed correctly.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters ('use_only_authd').
+
+    expected_output:
+        - r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and 'wazuh-authd' is stopped)
+        - r'200' ('OK' HTTP status code if 'use_only_authd == no')
+        - r'200' ('OK' HTTP status code if the testing agent is removed successfully)
+
+    tags:
+        - authd
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # API variables and random data for the request
@@ -98,16 +187,49 @@ def test_add_agent(tags_to_apply, get_configuration, configure_api_environment,
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_insert_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of wazuh-authd when inserting an agent.
+    '''
+    description: Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when inserting an agent.
+                 Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon
+                 is stopped, the request made is not completed correctly.
 
-    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
-    is not active, an error is returned.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to insert the testing agent cannot finish successfully when
+          the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.
+        - Verify that the request to insert the testing agent is successfully processed
+          when the 'use_only_authd' setting is disabled.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters ('use_only_authd').
+
+    expected_output:
+        - r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and 'wazuh-authd' is stopped)
+        - r'200' ('OK' HTTP status code if 'use_only_authd == no')
+
+    tags:
+        - authd
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # API variables and random data for the request
@@ -144,16 +266,50 @@ def test_insert_agent(tags_to_apply, get_configuration, configure_api_environmen
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_environment,
                             restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of wazuh-authd when quick inserting an agent.
+    '''
+    description: Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when
+                 quickly inserting an agent. Verify that when 'use_only_authd' option
+                 is enabled and the 'wazuh-authd' daemon is stopped,
+                 the request made is not completed correctly.
 
-    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
-    is not active, an error is returned.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to quickly inserting the testing agent cannot finish successfully when
+          the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.
+        - Verify that the request to quickly inserting the testing agent is successfully processed
+          when the 'use_only_authd' setting is disabled.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters ('use_only_authd').
+
+    expected_output:
+        - r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and 'wazuh-authd' is stopped)
+        - r'200' ('OK' HTTP status code if 'use_only_authd == no')
+
+    tags:
+        - authd
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # API variables
@@ -186,17 +342,52 @@ def test_insert_quick_agent(tags_to_apply, get_configuration, configure_api_envi
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_delete_agent(tags_to_apply, get_configuration, configure_api_environment,
                       restart_api, wait_for_start, get_api_details):
-    """Check if use_only_authd forces the use of wazuh-authd when deleting an agent.
+    '''
+    description: Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when deleting an agent.
+                 Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon
+                 is not active, an error is returned. In this test, 'wazuh-authd' daemon is started
+                 in order to create an agent before it can be deleted.
 
-    Verify that when 'use_only_authd' option is enabled, if the wazuh-authd service
-    is not active, an error is returned. In this test, wazuh-authd is activated in order
-    to create an agent before it can be deleted.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_api_environment:
+            type: fixture
+            brief: Configure a custom environment for API testing.
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - wait_for_start:
+            type: fixture
+            brief: Wait until the API starts.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to insert the testing agent is successfully processed.
+        - Verify that the request to delete the testing agent is successfully processed when
+          the 'use_only_authd' setting is disabled and the 'wazuh-authd' daemon is running.
+        - Verify that the request to delete the testing agent cannot finish successfully when
+          the 'use_only_authd' setting is enabled and the 'wazuh-authd' daemon is stopped.
+
+    input_description: Different test cases are contained in an external YAML file (conf.yaml)
+                       which includes API configuration parameters ('use_only_authd').
+
+    expected_output:
+        - r'200' ('OK' HTTP status code at inserting the testing agent)
+        - r '1' (Value of the 'total_affected_items' field in the response body when 'use_only_authd == yes')
+        - r '1726' (Error code in the response body when 'use_only_authd == yes' and 'wazuh-authd' is stopped)
+
+    tags:
+        - authd
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     use_only_authd = get_configuration['configuration']['use_only_authd']
     api_details = get_api_details()
@@ -209,8 +400,8 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
     # Create an agent to delete (we need wazuh-authd daemon running if use_only_authd in the configuration)
     post_url = api_details['base_url'] + f'/insert/quick?agent_name={token_hex(16)}'
     post_response = requests.post(post_url, headers=api_details['auth_headers'], verify=False)
-    assert post_response.status_code == 200, 'Status code expected after quick inserting agent was 200. Full response: ' \
-                                             f'{post_response.text}'
+    assert post_response.status_code == 200, 'Status code expected after quick inserting agent was 200.' \
+                                             f' Full response: {post_response.text}'
 
     if use_only_authd:
         control_service('stop', daemon='wazuh-authd')
@@ -219,7 +410,7 @@ def test_delete_agent(tags_to_apply, get_configuration, configure_api_environmen
     # It is necessary to wait a bit after adding the agent before deleting or querying it.
     time.sleep(1)
     delete_url = api_details['base_url'] + \
-                 f"?agents_list={post_response.json()['data']['id']}&purge=true&status=&older_than=0s&status=all"
+        f"?agents_list={post_response.json()['data']['id']}&purge=true&status=&older_than=0s&status=all"
     delete_response = requests.delete(delete_url, headers=api_details['auth_headers'], verify=False).json()
 
     # Assert if an error code was returned when wazuh-authd is disabled and use_only_authd enabled.

--- a/tests/integration/test_api/test_rbac/test_add_old_resource.py
+++ b/tests/integration/test_api/test_rbac/test_add_old_resource.py
@@ -1,6 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that when resources are added with the same identifier of previously
+       existing ones, the previous relationships are not maintained. The 'RBAC' capability allows users
+       accessing the API to be assigned a role that will define the privileges they have.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
+    - https://en.wikipedia.org/wiki/Role-based_access_control
+
+tags:
+    - api
+'''
 import requests
 import pytest
 from wazuh_testing.api import get_security_resource_information
@@ -12,7 +67,40 @@ user_id, role_id, policy_id, rule_id = None, None, None, None
 # Tests
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_user(set_security_resources, get_api_details):
-    """Remove a user with defined relationships and create it with the same ID to see if said relationships remain."""
+    '''
+    description: Check if the security relationships of a previous user are maintained
+                 in the system after adding a new user with the same ID.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of security relationships along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the testing user information exists.
+        - Verify that the request to remove the testing agent is successfully processed.
+        - Verify that the request to add the testing agent is successfully processed.
+        - Verify that security relationships do not exist between the old and the new user.
+
+    inputs:
+        - The testing 'user_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained to perform
+                       the test, concretely the 'user_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the old user.
+        - r'200' ('OK' HTTP status code at deleting the old user)
+        - r'200' ('OK' HTTP status code at inserting the old user)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     old_user_info = get_security_resource_information(user_ids=user_id)
     assert old_user_info, f'There is not information about this role: {user_id}'
@@ -34,7 +122,40 @@ def test_add_old_user(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_role(set_security_resources, get_api_details):
-    """Remove a role with defined relationships and create it with the same ID to see if said relationships remain."""
+    '''
+    description: Check if the security relationships of a previous role are maintained
+                 in the system after adding a new role with the same ID.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of security relationships along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the testing role information exists.
+        - Verify that the request to remove the testing role is successfully processed.
+        - Verify that the request to add the testing role is successfully processed.
+        - Verify that security relationships do not exist between the old and the new role.
+
+    inputs:
+        - The testing 'role_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'role_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the old role.
+        - r'200' ('OK' HTTP status code at deleting the old role)
+        - r'200' ('OK' HTTP status code at inserting the old role)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     old_role_info = get_security_resource_information(role_ids=role_id)
     assert old_role_info, f'There is not information about this role: {role_id}'
@@ -55,7 +176,40 @@ def test_add_old_role(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_policy(set_security_resources, get_api_details):
-    """Remove a policy with defined relationships and create it with the same ID to see if said relationships remain."""
+    '''
+    description: Check if the security relationships of a previous policy are maintained
+                 in the system after adding a new policy with the same ID.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of security relationships along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the testing policy information exists.
+        - Verify that the request to remove the testing policy is successfully processed.
+        - Verify that the request to add the testing policy is successfully processed.
+        - Verify that security relationships do not exist between the old and the new policy.
+
+    inputs:
+        - The testing 'policy_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained to perform the test,
+                       concretely the 'policy_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the old policy.
+        - r'200' ('OK' HTTP status code at deleting the old policy)
+        - r'200' ('OK' HTTP status code at inserting the old policy)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     old_policy_info = get_security_resource_information(policy_ids=policy_id)
     assert old_policy_info, f'There is not information about this policy: {policy_id}'
@@ -79,7 +233,40 @@ def test_add_old_policy(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_add_old_rule(set_security_resources, get_api_details):
-    """Remove a rule with defined relationships and create it with the same ID to see if said relationships remain."""
+    '''
+    description: Check if the security relationships of a previous rule are maintained
+                 in the system after adding a new rule with the same ID.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of security relationships along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the testing rule information exists.
+        - Verify that the request to remove the testing rule is successfully processed.
+        - Verify that the request to add the testing rule is successfully processed.
+        - Verify that security relationships do not exist between the old and the new rule.
+
+    inputs:
+        - The testing 'rule_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'rule_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the old rule.
+        - r'200' ('OK' HTTP status code at deleting the old rule)
+        - r'200' ('OK' HTTP status code at inserting the old rule)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     old_rule_info = get_security_resource_information(rule_ids=rule_id)
     assert old_rule_info, f'There is not information about this policy: {rule_id}'

--- a/tests/integration/test_api/test_rbac/test_admin_resources.py
+++ b/tests/integration/test_api/test_rbac/test_admin_resources.py
@@ -1,6 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that the different actions that can be performed with admin resources
+       are working correctly. The 'RBAC' capability allows users accessing the API to be assigned a role
+       that will define the privileges they have.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
+    - https://en.wikipedia.org/wiki/Role-based_access_control
+
+tags:
+    - api
+'''
 import pytest
 import requests
 
@@ -78,7 +133,40 @@ def modify_admin_resources(api_details, admin_ids, endpoint, body):
 # Tests
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_users(restart_api, get_api_details):
-    """Test if admin security users can be removed."""
+    '''
+    description: Check if the admin security users can be removed. For this purpose,
+                 it tries to delete these users, expecting an error as a response.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to collect the admin security users information is done correctly.
+        - Verify that the request to delete the admin security users is done correctly.
+        - Verify that admin security users have not been deleted by checking the response of the request.
+
+    inputs:
+        - The data are obtained from within the test.
+
+    input_description: From the 'get_admin_resources' function information is obtained to perform
+                       the test, concretely the 'admin_ids'.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code at collect the admin security users information)
+        - r'200' ('OK' HTTP status code when trying to delete the admin security users)
+        - r'1' (Size of the 'failed_items' array from the response body)
+        - r'5004' (Error code of the 'failed_items[0]' array from the response body)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
 
     endpoint = '/security/users'
@@ -89,7 +177,40 @@ def test_admin_users(restart_api, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_roles(restart_api, get_api_details):
-    """Test if admin security roles can be removed."""
+    '''
+    description: Check if the admin security roles can be removed. For this purpose,
+                 it tries to delete these roles, expecting an error as a response.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to collect the admin security roles information is done correctly.
+        - Verify that the request to delete the admin security roles is done correctly.
+        - Verify that admin security roles have not been deleted by checking the response of the request.
+
+    inputs:
+        - The data are obtained from within the test.
+
+    input_description: From the 'get_admin_resources' function information is obtained
+                       to perform the test, concretely the 'role_ids'.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code at collect the admin security roles information)
+        - r'200' ('OK' HTTP status code when trying to delete the admin security roles)
+        - r'1' (Size of the 'failed_items' array from the response body)
+        - r'4008' (Error code of the 'failed_items[0]' array from the response body)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
 
     endpoint = '/security/roles'
@@ -103,7 +224,40 @@ def test_admin_roles(restart_api, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_policies(restart_api, get_api_details):
-    """Test if admin security policies can be removed."""
+    '''
+    description: Check if the admin security policies can be removed. For this purpose,
+                 it tries to delete these policies, expecting an error as a response.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to collect the admin security policies information is done correctly.
+        - Verify that the request to delete the admin security policies is done correctly.
+        - Verify that admin security policies have not been deleted by checking the response of the request.
+
+    inputs:
+        - The data are obtained from within the test.
+
+    input_description: From the 'get_admin_resources' function information is obtained
+                       to perform the test, concretely the 'policy_ids'.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code at collect the admin security policies information)
+        - r'200' ('OK' HTTP status code when trying to delete the admin security policies)
+        - r'1' (Size of the 'failed_items' array from the response body)
+        - r'4008' (Error code of the 'failed_items[0]' array from the response body)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
 
     endpoint = '/security/policies'
@@ -118,7 +272,40 @@ def test_admin_policies(restart_api, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_admin_rules(restart_api, get_api_details):
-    """Test if admin security rules can be removed."""
+    '''
+    description: Check if the admin security rules can be removed. For this purpose,
+                 it tries to delete these rules, expecting an error as a response.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_api:
+            type: fixture
+            brief: Reset 'api.log' and start a new monitor.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to collect the admin security rules information is done correctly.
+        - Verify that the request to delete the admin security rules is done correctly.
+        - Verify that admin security rules have not been deleted by checking the response of the request.
+
+    inputs:
+        - The data are obtained from within the test.
+
+    input_description: From the 'get_admin_resources' function information is obtained
+                       to perform the test, concretely the 'rule_ids'.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code at collect the admin security rules information)
+        - r'200' ('OK' HTTP status code when trying to delete the admin security rules)
+        - r'1' (Size of the 'failed_items' array from the response body)
+        - r'4008' (Error code of the 'failed_items[0]' array from the response body)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
 
     endpoint = '/security/rules'

--- a/tests/integration/test_api/test_rbac/test_policy_position.py
+++ b/tests/integration/test_api/test_rbac/test_policy_position.py
@@ -1,6 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that that the policies are applied to the roles in the right order.
+       The 'RBAC' capability allows users accessing the API to be assigned a role
+       that will define the privileges they have.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
+    - https://en.wikipedia.org/wiki/Role-based_access_control
+
+tags:
+    - api
+'''
 import pytest
 import requests
 from wazuh_testing.api import get_security_resource_information
@@ -75,8 +130,40 @@ def add_role_policy(api_details, p_id, position):
 # Tests
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_policy_position(set_security_resources, add_new_policies, get_api_details):
-    """Test if the correct order between role-policy relationships remain after removing some of them and adding others
-    using the `position` parameter."""
+    '''
+    description: Check if the correct order between role-policy relationships remain after
+                 removing some of them and adding others using the 'position' parameter.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - add_new_policies:
+            type: fixture
+            brief: Create new policies and relationships between them and the testing role.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the request to add or delete a role-policy is done correctly.
+        - Verify that the role-policy positions are kept in order when deleting or adding a role-policy.
+
+    inputs:
+        - The testing 'policy_ids' array as a module variable.
+
+    input_description: From the 'add_new_policies', 'remove_role_policy' and 'add_role_policy' fixtures
+                       information is obtained to perform the test, concretely the 'policy_ids' array.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code when deleting or adding a role-policy)
+        - An integer array with the role-policy positions.
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
 
     # Remove and add in the same position

--- a/tests/integration/test_api/test_rbac/test_remove_relationship.py
+++ b/tests/integration/test_api/test_rbac/test_remove_relationship.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that the different relationships between users-roles-policies can be
+       correctly removed. The 'RBAC' capability allows users accessing the API to be assigned a role
+       that will define the privileges they have.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
+    - https://en.wikipedia.org/wiki/Role-based_access_control
+
+tags:
+    - api
+'''
 import requests
 import pytest
 from wazuh_testing.api import get_security_resource_information
@@ -45,7 +99,40 @@ def remove_relationship(api_details, endpoint, resource, related_resource, relat
 # Tests
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_user_role_relationship(set_security_resources, get_api_details):
-    """Test if the user and role still exist after removing their relationship."""
+    '''
+    description: Check if the user and role still exist after removing their relationship.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the user-role relationship exists.
+        - Verify that the user-role relationship is removed.
+        - Verify that the user and the role still exist independently.
+
+    inputs:
+        - The testing 'user_id' as a module attribute.
+        - The testing 'role_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'user_id' and 'role_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the user-role relationship.
+        - r'200' ('OK' HTTP status code when deleting the user-role relationship)
+        - A 'JSON' string in the response body with information of the role.
+        - A 'JSON' string in the response body with information of the user.
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     endpoint = api_details['base_url'] + f'/security/users/{user_id}/roles?role_ids={role_id}'
     resource = role_id
@@ -57,7 +144,40 @@ def test_remove_user_role_relationship(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_role_policy_relationship(set_security_resources, get_api_details):
-    """Test if the role and policy still exist after removing their relationship."""
+    '''
+    description: Check if the role and policy still exist after removing their relationship.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the role-policy relationship exists.
+        - Verify that the role-policy relationship is removed.
+        - Verify that the role and the policy still exists independently.
+
+    inputs:
+        - The testing 'role_id' as a module attribute.
+        - The testing 'policy_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'role_id' and 'policy_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the role-policy relationship.
+        - r'200' ('OK' HTTP status code when deleting the role-policy relationship)
+        - A 'JSON' string in the response body with information of the role.
+        - A 'JSON' string in the response body with information of the policy.
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     endpoint = api_details['base_url'] + f'/security/roles/{role_id}/policies?policy_ids={policy_id}'
     resource = role_id
@@ -69,7 +189,40 @@ def test_remove_role_policy_relationship(set_security_resources, get_api_details
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_role_rule_relationship(set_security_resources, get_api_details):
-    """Test if the role and rule still exist after removing their relationship."""
+    '''
+    description: Check if the role and rule still exist after removing their relationship.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the role-rule relationship exists.
+        - Verify that the role-rule relationship is removed.
+        - Verify that the role and the rule still exists independently.
+
+    inputs:
+        - The testing 'role_id' as a module attribute.
+        - The testing 'rule_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'role_id' and 'rule_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the role-rule relationship.
+        - r'200' ('OK' HTTP status code when deleting the role-rule relationship)
+        - A 'JSON' string in the response body with information of the role.
+        - A 'JSON' string in the response body with information of the rule.
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     endpoint = api_details['base_url'] + f'/security/roles/{role_id}/rules?rule_ids={rule_id}'
     resource = role_id

--- a/tests/integration/test_api/test_rbac/test_remove_resource.py
+++ b/tests/integration/test_api/test_rbac/test_remove_resource.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly.
+       Specifically, they will verify that the different security resources (users, roles, policies, and rules)
+       can be correctly removed. The 'RBAC' capability allows users accessing the API to be assigned a role that
+       will define the privileges they have.
+
+tier: 0
+
+modules:
+    - api
+
+components:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-analysisd
+    - wazuh-syscheckd
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
+    - https://en.wikipedia.org/wiki/Role-based_access_control
+
+tags:
+    - api
+'''
 import requests
 import pytest
 from wazuh_testing.api import get_security_resource_information
@@ -54,7 +108,41 @@ def check_resources(deleted_resource, resource_id):
 # Tests
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_rule(set_security_resources, get_api_details):
-    """Test if relationships between security resources stay the same after removing the linked rule."""
+    '''
+    description: Check if relationships between security resources stay the same
+                 after removing the linked rule.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the role-based relationships exist.
+        - Verify that the request to delete the linked rule is done correctly.
+        - Verify that the role-based security relationships still exist.
+        - Verify that the remaining security resources still exist (user, role, and policy).
+        - Verify that the remaining role-based security relationships still exist.
+
+    inputs:
+        - The testing 'role_id' as a module attribute.
+        - The testing 'rule_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'role_id' and the 'rule_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the role-based relationships.
+        - r'200' ('OK' HTTP status code when deleting the linked rule)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
@@ -72,7 +160,41 @@ def test_remove_rule(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_policy(set_security_resources, get_api_details):
-    """Test if relationships between security resources stay the same after removing the linked policy."""
+    '''
+    description: Check if relationships between security resources stay the same
+                 after removing the linked policy.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the role-based relationships exist.
+        - Verify that the request to delete the linked policy is done correctly.
+        - Verify that the role-based security relationships still exist.
+        - Verify that the remaining security resources still exist (user, role, and rule).
+        - Verify that the remaining role-based security relationships still exist.
+
+    inputs:
+        - The testing 'role_id' as a module attribute.
+        - The testing 'policy_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'role_id' and the 'policy_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the role-based relationships.
+        - r'200' ('OK' HTTP status code when deleting the linked policy)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
@@ -90,7 +212,41 @@ def test_remove_policy(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_user(set_security_resources, get_api_details):
-    """Test if relationships between security resources stay the same after removing the linked user."""
+    '''
+    description: Check if relationships between security resources stay the same
+                 after removing the linked user.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the role-based relationships exist.
+        - Verify that the request to delete the linked user is done correctly.
+        - Verify that the role-based security relationships still exist.
+        - Verify that the remaining security resources still exist (policy, role, and rule).
+        - Verify that the remaining role-based security relationships still exist.
+
+    inputs:
+        - The testing 'role_id' as a module attribute.
+        - The testing 'user_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'role_id' and the 'user_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the role-based relationships.
+        - r'200' ('OK' HTTP status code when deleting the linked user)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     relationships = get_security_resource_information(role_ids=role_id)
     assert relationships, 'There are not relationships'
@@ -108,7 +264,41 @@ def test_remove_user(set_security_resources, get_api_details):
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_remove_role(set_security_resources, get_api_details):
-    """Test if relationships between security resources stay the same after removing the linked role."""
+    '''
+    description: Check if relationships between security resources stay the same
+                 after removing the linked role.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_security_resources:
+            type: fixture
+            brief: Creates a set of role-based security resources along with a user for testing.
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the role-based relationships exist.
+        - Verify that the request to delete the linked role is done correctly.
+        - Verify that the role-based security relationships still exist.
+        - Verify that the remaining security resources still exist (policy, user, and rule).
+        - Verify that the remaining role-based security relationships still exist.
+
+    inputs:
+        - The testing 'user_id' as a module attribute.
+        - The testing 'role_id' as a module attribute.
+
+    input_description: From the 'set_security_resources' fixture information is obtained
+                       to perform the test, concretely the 'user_id' and the 'role_id'.
+
+    expected_output:
+        - A 'JSON' string in the response body with information of the role-based relationships.
+        - r'200' ('OK' HTTP status code when deleting the linked role)
+
+    tags:
+        - rbac
+    '''
     api_details = get_api_details()
     relationships = get_security_resource_information(user_ids=user_id)
     assert relationships, 'There are not relationships'


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


## `test_config`


<details><summary>test_bruteforce_blocking_system.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the IP blocking feature of the API handled by the 'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#access"
    ],
    "tags": [
        "api"
    ],
    "name": "test_bruteforce_blocking_system.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the blocking time for IP addresses detected as brute-force attack works. For this purpose, the test causes an IP blocking, make a request before the blocking time finishes and one after the blocking time.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the IP address is blocked using incorrect credentials.",
                "Verify that the IP address is still blocked even when using the correct credentials within the blocking time."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters.",
            "expected_output": [
                "r\"Error obtaining login token\""
            ],
            "tags": [
                "brute_force_attack"
            ],
            "name": "test_bruteforce_blocking_system",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_bruteforce_blocking_system.yaml</summary>
<p>

```yaml
brief: These tests will check if the IP blocking feature of the API handled by the
  'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful'
  API that allows for interaction with the Wazuh manager from a web browser, command
  line tool like 'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 2
modules:
- api
name: test_bruteforce_blocking_system.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#access
tags:
- api
tests:
- assertions:
  - Verify that the IP address is blocked using incorrect credentials.
  - Verify that the IP address is still blocked even when using the correct credentials
    within the blocking time.
  description: Check if the blocking time for IP addresses detected as brute-force
    attack works. For this purpose, the test causes an IP blocking, make a request
    before the blocking time finishes and one after the blocking time.
  expected_output:
  - r"Error obtaining login token"
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_bruteforce_blocking_system
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - brute_force_attack
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_cache.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the cache feature of the API handled by the 'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#cache"
    ],
    "tags": [
        "api"
    ],
    "name": "test_cache.py",
    "id": 3,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the stored response is returned when the cache is enabled. Calls to rules endpoints can be cached. This test verifies if the result of the first call to the rule endpoint is equal to the second call within a period established in the configuration, even though a new file has been created during the process.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the stored response is returned when the cache is enabled."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters.",
            "expected_output": [
                "Number of rule files (if caching is enabled).",
                "Number of rule files + 1 (if caching is disabled)."
            ],
            "tags": [
                "cache"
            ],
            "name": "test_cache",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_cache.yaml</summary>
<p>

```yaml
brief: These tests will check if the cache feature of the API handled by the 'wazuh-apid'
  daemon is working properly. The Wazuh API is an open source 'RESTful' API that allows
  for interaction with the Wazuh manager from a web browser, command line tool like
  'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 3
modules:
- api
name: test_cache.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#cache
tags:
- api
tests:
- assertions:
  - Verify that the stored response is returned when the cache is enabled.
  description: Check if the stored response is returned when the cache is enabled.
    Calls to rules endpoints can be cached. This test verifies if the result of the
    first call to the rule endpoint is equal to the second call within a period established
    in the configuration, even though a new file has been created during the process.
  expected_output:
  - Number of rule files (if caching is enabled).
  - Number of rule files + 1 (if caching is disabled).
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_cache
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - cache
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_cors.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'CORS' (Cross-origin resource sharing) feature of the API handled by the 'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#cors",
        "https://en.wikipedia.org/wiki/Cross-origin_resource_sharing"
    ],
    "tags": [
        "api"
    ],
    "name": "test_cors.py",
    "id": 4,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if expected headers are returned when 'CORS' is enabled. When 'CORS' is enabled, special headers must be returned in case the request origin matches the one established in the 'CORS' configuration of the API.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "origin": {
                        "type": "set",
                        "brief": "Origin path to be appended as a header in the request."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that when CORS is enabled, the 'Access-Control-Allow-Origin' header is received.",
                "Verify that when CORS is enabled, the 'Access-Control-Expose-Headers' header is received.",
                "Verify that when CORS is enabled, the 'Access-Control-Allow-Credentials' header is received.",
                "Verify that when CORS is disabled, the 'Access-Control-Allow-Origin' header is not received."
            ],
            "input_description": "A test case is contained in an external YAML file (conf.yaml) which includes API configuration parameters.",
            "expected_output": [
                "r'Access-Control-Allow-Origin'",
                "r'Access-Control-Expose-Headers'",
                "r'https://test_url.com'",
                "r'true'"
            ],
            "tags": [
                "cors"
            ],
            "name": "test_cors",
            "inputs": [
                "get_configuration0-https://test_url.com-tags_to_apply0",
                "get_configuration0-http://other_url.com-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_cors.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'CORS' (Cross-origin resource sharing) feature
  of the API handled by the 'wazuh-apid' daemon is working properly. The Wazuh API
  is an open source 'RESTful' API that allows for interaction with the Wazuh manager
  from a web browser, command line tool like 'cURL' or any script or program that
  can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 4
modules:
- api
name: test_cors.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#cors
- https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
tags:
- api
tests:
- assertions:
  - Verify that when CORS is enabled, the 'Access-Control-Allow-Origin' header is
    received.
  - Verify that when CORS is enabled, the 'Access-Control-Expose-Headers' header is
    received.
  - Verify that when CORS is enabled, the 'Access-Control-Allow-Credentials' header
    is received.
  - Verify that when CORS is disabled, the 'Access-Control-Allow-Origin' header is
    not received.
  description: Check if expected headers are returned when 'CORS' is enabled. When
    'CORS' is enabled, special headers must be returned in case the request origin
    matches the one established in the 'CORS' configuration of the API.
  expected_output:
  - r'Access-Control-Allow-Origin'
  - r'Access-Control-Expose-Headers'
  - r'https://test_url.com'
  - r'true'
  input_description: A test case is contained in an external YAML file (conf.yaml)
    which includes API configuration parameters.
  inputs:
  - get_configuration0-https://test_url.com-tags_to_apply0
  - get_configuration0-http://other_url.com-tags_to_apply1
  name: test_cors
  parameters:
  - origin:
      brief: Origin path to be appended as a header in the request.
      type: set
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - cors
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_DOS_blocking_system.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'DOS' (Denial-of-service attack) blocking feature of the API handled by the 'wazuh-apid' daemon is working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#access",
        "https://en.wikipedia.org/wiki/Denial-of-service_attack"
    ],
    "tags": [
        "api"
    ],
    "name": "test_DOS_blocking_system.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the API blocking system for IP addresses detected as 'DOS' attack works. For this purpose, the test causes an IP blocking, makes a request within the same minute, makes a request after the minute.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the IP address is blocked using multiple requests.",
                "Verify that the IP address is still blocked within the one-minute block time.",
                "Verify that the IP address is not blocked when expires the blocking time."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters.",
            "expected_output": [
                "r'429' ('Too Many Requests' HTTP status code)",
                "r'200' ('OK' HTTP status code)"
            ],
            "tags": [
                "dos_attack"
            ],
            "name": "test_DOS_blocking_system",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_DOS_blocking_system.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'DOS' (Denial-of-service attack) blocking feature
  of the API handled by the 'wazuh-apid' daemon is working properly. The Wazuh API
  is an open source 'RESTful' API that allows for interaction with the Wazuh manager
  from a web browser, command line tool like 'cURL' or any script or program that
  can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 1
modules:
- api
name: test_DOS_blocking_system.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#access
- https://en.wikipedia.org/wiki/Denial-of-service_attack
tags:
- api
tests:
- assertions:
  - Verify that the IP address is blocked using multiple requests.
  - Verify that the IP address is still blocked within the one-minute block time.
  - Verify that the IP address is not blocked when expires the blocking time.
  description: Check if the API blocking system for IP addresses detected as 'DOS'
    attack works. For this purpose, the test causes an IP blocking, makes a request
    within the same minute, makes a request after the minute.
  expected_output:
  - r'429' ('Too Many Requests' HTTP status code)
  - r'200' ('OK' HTTP status code)
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_DOS_blocking_system
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - dos_attack
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_drop_privileges.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'drop_privileges' setting of the API is working properly. This setting allows the user who starts the 'wazuh-apid' daemon to be different from the 'root' user. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#drop-privileges"
    ],
    "tags": [
        "api"
    ],
    "name": "test_drop_privileges.py",
    "id": 5,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if 'drop_privileges' affects the user of the API process. In this test, the 'PID' of the API process is obtained. After that, it gets the user ('root' or 'wazuh') and checks if it matches the 'drop_privileges' setting.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that when 'drop_privileges' is enabled the user who has started the 'wazuh-apid' daemon is 'wazuh'.",
                "Verify that when 'drop_privileges' is disabled the user who has started the 'wazuh-apid' daemon is 'root'."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters.",
            "expected_output": [
                "PID of the 'wazuh-apid' process.",
                "r'wazuh' (if 'drop_privileges == yes')",
                "r'root' (if 'drop_privileges == no')"
            ],
            "name": "test_drop_privileges",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_drop_privileges.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'drop_privileges' setting of the API is working
  properly. This setting allows the user who starts the 'wazuh-apid' daemon to be
  different from the 'root' user. The Wazuh API is an open source 'RESTful' API that
  allows for interaction with the Wazuh manager from a web browser, command line tool
  like 'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 5
modules:
- api
name: test_drop_privileges.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#drop-privileges
tags:
- api
tests:
- assertions:
  - Verify that when 'drop_privileges' is enabled the user who has started the 'wazuh-apid'
    daemon is 'wazuh'.
  - Verify that when 'drop_privileges' is disabled the user who has started the 'wazuh-apid'
    daemon is 'root'.
  description: Check if 'drop_privileges' affects the user of the API process. In
    this test, the 'PID' of the API process is obtained. After that, it gets the user
    ('root' or 'wazuh') and checks if it matches the 'drop_privileges' setting.
  expected_output:
  - PID of the 'wazuh-apid' process.
  - r'wazuh' (if 'drop_privileges == yes')
  - r'root' (if 'drop_privileges == no')
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_drop_privileges
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_experimental_features.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'experimental_features' setting of the API is working properly. This setting allows users to access API endpoints containing features that are under development. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#drop-privileges"
    ],
    "tags": [
        "api"
    ],
    "name": "test_experimental_features.py",
    "id": 6,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if requests to an experimental API endpoint are allowed according to the configuration. For this purpose, it configures the API to use this functionality and makes requests to it, waiting for a correct response.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that when 'experimental_features' is enabled, it is possible to access experimental API endpoints.",
                "Verify that when 'experimental_features' is disabled, it is not possible to access experimental API endpoints."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters.",
            "expected_output": [
                "r'200' ('OK' HTTP status code if 'experimental_features == true')",
                "r'404' ('Forbidden' HTTP status code if 'experimental_features == false')"
            ],
            "name": "test_experimental_features",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_experimental_features.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'experimental_features' setting of the API is
  working properly. This setting allows users to access API endpoints containing features
  that are under development. The Wazuh API is an open source 'RESTful' API that allows
  for interaction with the Wazuh manager from a web browser, command line tool like
  'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 6
modules:
- api
name: test_experimental_features.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#drop-privileges
tags:
- api
tests:
- assertions:
  - Verify that when 'experimental_features' is enabled, it is possible to access
    experimental API endpoints.
  - Verify that when 'experimental_features' is disabled, it is not possible to access
    experimental API endpoints.
  description: Check if requests to an experimental API endpoint are allowed according
    to the configuration. For this purpose, it configures the API to use this functionality
    and makes requests to it, waiting for a correct response.
  expected_output:
  - r'200' ('OK' HTTP status code if 'experimental_features == true')
  - r'404' ('Forbidden' HTTP status code if 'experimental_features == false')
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_experimental_features
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_host_port.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check that the settings related to the API host address and listening port are working correctly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#api-configuration-options"
    ],
    "tags": [
        "api"
    ],
    "name": "test_host_port.py",
    "id": 7,
    "group_id": 0,
    "tests": [
        {
            "description": "Check different host and port configurations. For this purpose, apply multiple combinations of host and port, verify that the 'aiohttp' http framework correctly publishes that value in the 'api.log' and check that the request returns the expected one.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "expected_exception": {
                        "type": "bool",
                        "brief": "True if an exception must be raised, false otherwise."
                    }
                },
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the API starts listening on the specified IP address and port.",
                "Verify that using a valid configuration, the API requests are performed correctly.",
                "Verify that no unexpected exceptions occur."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters (IP addresses and ports).",
            "expected_output": [
                {
                    "r'.*INFO": "Listening on (.+)..'"
                },
                "r'{host}{port}' ('host' and 'port' are obtained from each test_case.)",
                "r'200' ('OK' HTTP status code)"
            ],
            "name": "test_host_port",
            "inputs": [
                "get_configuration0-False-tags_to_apply0",
                "get_configuration0-True-tags_to_apply1",
                "get_configuration1-False-tags_to_apply0",
                "get_configuration1-True-tags_to_apply1",
                "get_configuration2-False-tags_to_apply0",
                "get_configuration2-True-tags_to_apply1",
                "get_configuration3-False-tags_to_apply0",
                "get_configuration3-True-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_host_port.yaml</summary>
<p>

```yaml
brief: These tests will check that the settings related to the API host address and
  listening port are working correctly. The Wazuh API is an open source 'RESTful'
  API that allows for interaction with the Wazuh manager from a web browser, command
  line tool like 'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 7
modules:
- api
name: test_host_port.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#api-configuration-options
tags:
- api
tests:
- assertions:
  - Verify that the API starts listening on the specified IP address and port.
  - Verify that using a valid configuration, the API requests are performed correctly.
  - Verify that no unexpected exceptions occur.
  description: Check different host and port configurations. For this purpose, apply
    multiple combinations of host and port, verify that the 'aiohttp' http framework
    correctly publishes that value in the 'api.log' and check that the request returns
    the expected one.
  expected_output:
  - r'.*INFO: Listening on (.+)..'
  - r'{host}{port}' ('host' and 'port' are obtained from each test_case.)
  - r'200' ('OK' HTTP status code)
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters (IP addresses and ports).
  inputs:
  - get_configuration0-False-tags_to_apply0
  - get_configuration0-True-tags_to_apply1
  - get_configuration1-False-tags_to_apply0
  - get_configuration1-True-tags_to_apply1
  - get_configuration2-False-tags_to_apply0
  - get_configuration2-True-tags_to_apply1
  - get_configuration3-False-tags_to_apply0
  - get_configuration3-True-tags_to_apply1
  name: test_host_port
  parameters:
  - expected_exception:
      brief: True if an exception must be raised, false otherwise.
      type: bool
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_https.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check that the API works correctly using the 'HTTPS' protocol. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#https"
    ],
    "tags": [
        "api"
    ],
    "name": "test_https.py",
    "id": 8,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the API works with 'HTTP' and 'HTTPS' protocols. For this purpose, it configures the API to use both protocols and makes requests to it, waiting for a correct response.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the API requests are made correctly using both 'HTTP' and 'HTTPS' protocols."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters (HTTPS settings).",
            "expected_output": [
                "r'200' ('OK' HTTP status code)"
            ],
            "tags": [
                "ssl"
            ],
            "name": "test_https",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_https.yaml</summary>
<p>

```yaml
brief: These tests will check that the API works correctly using the 'HTTPS' protocol.
  The Wazuh API is an open source 'RESTful' API that allows for interaction with the
  Wazuh manager from a web browser, command line tool like 'cURL' or any script or
  program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 8
modules:
- api
name: test_https.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#https
tags:
- api
tests:
- assertions:
  - Verify that the API requests are made correctly using both 'HTTP' and 'HTTPS'
    protocols.
  description: Check if the API works with 'HTTP' and 'HTTPS' protocols. For this
    purpose, it configures the API to use both protocols and makes requests to it,
    waiting for a correct response.
  expected_output:
  - r'200' ('OK' HTTP status code)
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters (HTTPS settings).
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_https
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - ssl
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_jwt_token_exp_timeout.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'auth_token_exp_timeout' setting of the API is working properly. This setting allows specifying the expiration time of the 'JWT' token used for authentication. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#auth-token-exp-timeout",
        "https://en.wikipedia.org/wiki/JSON_Web_Token"
    ],
    "tags": [
        "api"
    ],
    "name": "test_jwt_token_exp_timeout.py",
    "id": 9,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the API 'JWT' token expires after defined time. For this purpose, an expiration time is set for the token, and API requests are made before and after the expiration time, waiting for a valid 'HTTP status code'.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the API requests are successful if the 'JWT' token has not expired and vice versa."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf_exp_timeout.yaml) which includes API configuration parameters (timeouts for token expiration).",
            "expected_output": [
                "r'200' ('OK' HTTP status code if the token has not expired)",
                "r'401' ('Unauthorized' HTTP status code if the token has expired)"
            ],
            "tags": [
                "token"
            ],
            "name": "test_jwt_token_exp_timeout",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_jwt_token_exp_timeout.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'auth_token_exp_timeout' setting of the API is
  working properly. This setting allows specifying the expiration time of the 'JWT'
  token used for authentication. The Wazuh API is an open source 'RESTful' API that
  allows for interaction with the Wazuh manager from a web browser, command line tool
  like 'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 9
modules:
- api
name: test_jwt_token_exp_timeout.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#auth-token-exp-timeout
- https://en.wikipedia.org/wiki/JSON_Web_Token
tags:
- api
tests:
- assertions:
  - Verify that the API requests are successful if the 'JWT' token has not expired
    and vice versa.
  description: Check if the API 'JWT' token expires after defined time. For this purpose,
    an expiration time is set for the token, and API requests are made before and
    after the expiration time, waiting for a valid 'HTTP status code'.
  expected_output:
  - r'200' ('OK' HTTP status code if the token has not expired)
  - r'401' ('Unauthorized' HTTP status code if the token has expired)
  input_description: Different test cases are contained in an external YAML file (conf_exp_timeout.yaml)
    which includes API configuration parameters (timeouts for token expiration).
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_jwt_token_exp_timeout
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - token
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_logs.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'level' setting of the API is working properly. This setting allows specifying the level of detail (INFO, DEBUG) of the messages written to the 'api.log' file. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#logs"
    ],
    "tags": [
        "api"
    ],
    "name": "test_logs.py",
    "id": 10,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the logs are saved in the desired path and with desired level. Logs are usually store in '/var/ossec/logs/api.log' and with level 'info'. In this test the API log has a different path and 'debug' level configured. It checks if logs are saved in the new path and with 'debug' level.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that no 'DEBUG' messages are written when the value of the 'level' setting is set to 'info'.",
                "Verify that 'DEBUG' messages are written when the value of the 'level' setting is set to 'debug'."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters (log paths and log levels).",
            "expected_output": [
                {
                    "r'.*DEBUG": "(.*)'"
                }
            ],
            "tags": [
                "logs"
            ],
            "name": "test_logs",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_logs.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'level' setting of the API is working properly.
  This setting allows specifying the level of detail (INFO, DEBUG) of the messages
  written to the 'api.log' file. The Wazuh API is an open source 'RESTful' API that
  allows for interaction with the Wazuh manager from a web browser, command line tool
  like 'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 10
modules:
- api
name: test_logs.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#logs
tags:
- api
tests:
- assertions:
  - Verify that no 'DEBUG' messages are written when the value of the 'level' setting
    is set to 'info'.
  - Verify that 'DEBUG' messages are written when the value of the 'level' setting
    is set to 'debug'.
  description: Check if the logs are saved in the desired path and with desired level.
    Logs are usually store in '/var/ossec/logs/api.log' and with level 'info'. In
    this test the API log has a different path and 'debug' level configured. It checks
    if logs are saved in the new path and with 'debug' level.
  expected_output:
  - r'.*DEBUG: (.*)'
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters (log paths and log levels).
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_logs
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  tags:
  - logs
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_max_upload_size.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'max_upload_size' setting of the API is working properly. This setting allows specifying the size limit of the request body for the API to process. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 2,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html"
    ],
    "tags": [
        "api"
    ],
    "name": "test_max_upload_size.py",
    "id": 11,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if a '413' HTTP status code ('Payload Too Large') is returned if the response body is bigger than the value of the 'max_upload_size' tag. For this purpose, the test will call to a PUT and a POST endpoint specifying a body. If the 'max_upload_size' is 0 (limitless), a '200' HTTP status code ('OK') should be returned. If 'max_upload_size' is not limitless, both PUT and POST endpoints should fail when trying to send a bigger body.",
            "wazuh_min_version": "4.3.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_required_api_wazuh": {
                        "type": "fixture",
                        "brief": "Restart API-required services and stop them all at the end of the test."
                    }
                },
                {
                    "file_monitoring": {
                        "type": "fixture",
                        "brief": "Handle the monitoring of a specified file."
                    }
                },
                {
                    "daemons_handler": {
                        "type": "fixture",
                        "brief": "Handler of Wazuh daemons."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'wazuh-apid' daemon returns a proper HTTP status code depending on the value of the 'max_upload_size' tag and the size of the response body received."
            ],
            "input_description": "A test case is (test_upload_size) contained in an external YAML file (wazuh_max_upload_size.yaml) which includes API configuration parameters ('max_upload_size' option).",
            "expected_output": [
                "r'413' ('Payload Too Large' HTTP status code)",
                "r'200' ('OK' HTTP status code)"
            ],
            "name": "test_max_upload_size",
            "inputs": [
                "max_upload_size_0-content_size_100-tags_to_apply0",
                "max_upload_size_5-content_size_20-tags_to_apply0",
                "max_upload_size_40-content_size_10-tags_to_apply0",
                "max_upload_size_40-content_size_500-tags_to_apply0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_max_upload_size.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'max_upload_size' setting of the API is working
  properly. This setting allows specifying the size limit of the request body for
  the API to process. The Wazuh API is an open source 'RESTful' API that allows for
  interaction with the Wazuh manager from a web browser, command line tool like 'cURL'
  or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 11
modules:
- api
name: test_max_upload_size.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html
tags:
- api
tests:
- assertions:
  - Verify that the 'wazuh-apid' daemon returns a proper HTTP status code depending
    on the value of the 'max_upload_size' tag and the size of the response body received.
  description: Check if a '413' HTTP status code ('Payload Too Large') is returned
    if the response body is bigger than the value of the 'max_upload_size' tag. For
    this purpose, the test will call to a PUT and a POST endpoint specifying a body.
    If the 'max_upload_size' is 0 (limitless), a '200' HTTP status code ('OK') should
    be returned. If 'max_upload_size' is not limitless, both PUT and POST endpoints
    should fail when trying to send a bigger body.
  expected_output:
  - r'413' ('Payload Too Large' HTTP status code)
  - r'200' ('OK' HTTP status code)
  input_description: A test case is (test_upload_size) contained in an external YAML
    file (wazuh_max_upload_size.yaml) which includes API configuration parameters
    ('max_upload_size' option).
  inputs:
  - max_upload_size_0-content_size_100-tags_to_apply0
  - max_upload_size_5-content_size_20-tags_to_apply0
  - max_upload_size_40-content_size_10-tags_to_apply0
  - max_upload_size_40-content_size_500-tags_to_apply0
  name: test_max_upload_size
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_required_api_wazuh:
      brief: Restart API-required services and stop them all at the end of the test.
      type: fixture
  - file_monitoring:
      brief: Handle the monitoring of a specified file.
      type: fixture
  - daemons_handler:
      brief: Handler of Wazuh daemons.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  wazuh_min_version: 4.3.0
tier: 2
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_rbac_mode.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'rbac_mode' (Role-Based Access Control) setting of the API is working properly. This setting allows you to specify the operating mode between 'whitelist mode' and 'blacklist mode'. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#rbac-mode",
        "https://en.wikipedia.org/wiki/Role-based_access_control"
    ],
    "tags": [
        "api"
    ],
    "name": "test_rbac_mode.py",
    "id": 12,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'RBAC' mode selected in 'api.yaml' is applied. This test creates a user without any assigned permission. For this reason, when 'RBAC' is in 'white mode', there is no endpoint that the user can execute, so the 'HTTP status code' must be 403 ('forbidden'). On the other hand, when it is in 'black mode', there is no endpoint that has it denied, so the status code must be 200 ('ok').",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Check that when the value of the 'rbac_mode' setting is set to 'white', the API forbids requests.",
                "Verify that when the value of the 'rbac_mode' setting is set to 'black', the API requests are performed correctly."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf_mode.yaml) which includes API configuration parameters (rbac operation modes). Two 'SQL' scripts are also used to add (schema_add_user.sql) and remove (schema_delete_user.sql) the testing user.",
            "expected_output": [
                "r'200' ('OK' HTTP status code if 'rbac_white == True')",
                "r'403' ('Forbidden' HTTP status code if 'rbac_white == False')"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_rbac_mode",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_rbac_mode.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'rbac_mode' (Role-Based Access Control) setting
  of the API is working properly. This setting allows you to specify the operating
  mode between 'whitelist mode' and 'blacklist mode'. The Wazuh API is an open source
  'RESTful' API that allows for interaction with the Wazuh manager from a web browser,
  command line tool like 'cURL' or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 12
modules:
- api
name: test_rbac_mode.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#rbac-mode
- https://en.wikipedia.org/wiki/Role-based_access_control
tags:
- api
tests:
- assertions:
  - Check that when the value of the 'rbac_mode' setting is set to 'white', the API
    forbids requests.
  - Verify that when the value of the 'rbac_mode' setting is set to 'black', the API
    requests are performed correctly.
  description: Check if the 'RBAC' mode selected in 'api.yaml' is applied. This test
    creates a user without any assigned permission. For this reason, when 'RBAC' is
    in 'white mode', there is no endpoint that the user can execute, so the 'HTTP
    status code' must be 403 ('forbidden'). On the other hand, when it is in 'black
    mode', there is no endpoint that has it denied, so the status code must be 200
    ('ok').
  expected_output:
  - r'200' ('OK' HTTP status code if 'rbac_white == True')
  - r'403' ('Forbidden' HTTP status code if 'rbac_white == False')
  input_description: Different test cases are contained in an external YAML file (conf_mode.yaml)
    which includes API configuration parameters (rbac operation modes). Two 'SQL'
    scripts are also used to add (schema_add_user.sql) and remove (schema_delete_user.sql)
    the testing user.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_rbac_mode
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_request_timeout.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'request_timeout' setting of the API is working properly. This setting allows specifying the time limit for the API to process a request. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html"
    ],
    "tags": [
        "api"
    ],
    "name": "test_request_timeout.py",
    "id": 13,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the maximum request time for an API request works. For this purpose, a value of '0' seconds is set for the 'request_timeout' setting, and a request is made to the API, expecting an error in the response.",
            "wazuh_min_version": "4.3.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request cannot finish successfully, resulting in a timeout error."
            ],
            "input_description": "A test case is contained in an external YAML file (conf.yaml) which includes API configuration parameters ('request_timeout' set to '0' seconds).",
            "expected_output": [
                "r'500' ('Internal server error' HTTP status code)",
                "r'3021' ('timeout error' in the response body)"
            ],
            "name": "test_request_timeout",
            "inputs": [
                "get_configuration0-tags_to_apply0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_request_timeout.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'request_timeout' setting of the API is working
  properly. This setting allows specifying the time limit for the API to process a
  request. The Wazuh API is an open source 'RESTful' API that allows for interaction
  with the Wazuh manager from a web browser, command line tool like 'cURL' or any
  script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 13
modules:
- api
name: test_request_timeout.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html
tags:
- api
tests:
- assertions:
  - Verify that the request cannot finish successfully, resulting in a timeout error.
  description: Check if the maximum request time for an API request works. For this
    purpose, a value of '0' seconds is set for the 'request_timeout' setting, and
    a request is made to the API, expecting an error in the response.
  expected_output:
  - r'500' ('Internal server error' HTTP status code)
  - r'3021' ('timeout error' in the response body)
  input_description: A test case is contained in an external YAML file (conf.yaml)
    which includes API configuration parameters ('request_timeout' set to '0' seconds).
  inputs:
  - get_configuration0-tags_to_apply0
  name: test_request_timeout
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  wazuh_min_version: 4.3.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_use_only_authd.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'use_only_authd' setting of the API is working properly. This setting allows forcing the use of 'wazuh-authd' daemon when registering and removing agents. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/configuration.html#use-only-authd"
    ],
    "tags": [
        "api"
    ],
    "name": "test_use_only_authd.py",
    "id": 14,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if 'use_only_authd' forces the use of the 'wazuh-authd' daemon when adding an agent. Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon is stopped, the request made is not completed correctly.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to add the testing agent cannot finish successfully when the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.",
                "Verify that the request to add the testing agent is successfully processed when the 'use_only_authd' setting is disabled.",
                "Verify that the request to remove the testing agent is processed correctly."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters ('use_only_authd').",
            "expected_output": [
                "r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and 'wazuh-authd' is stopped)",
                "r'200' ('OK' HTTP status code if 'use_only_authd == no')",
                "r'200' ('OK' HTTP status code if the testing agent is removed successfully)"
            ],
            "tags": [
                "authd"
            ],
            "name": "test_add_agent",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        },
        {
            "description": "Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when inserting an agent. Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon is stopped, the request made is not completed correctly.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to insert the testing agent cannot finish successfully when the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.",
                "Verify that the request to insert the testing agent is successfully processed when the 'use_only_authd' setting is disabled."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters ('use_only_authd').",
            "expected_output": [
                "r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and 'wazuh-authd' is stopped)",
                "r'200' ('OK' HTTP status code if 'use_only_authd == no')"
            ],
            "tags": [
                "authd"
            ],
            "name": "test_insert_agent",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        },
        {
            "description": "Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when quickly inserting an agent. Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon is stopped, the request made is not completed correctly.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to quickly inserting the testing agent cannot finish successfully when the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.",
                "Verify that the request to quickly inserting the testing agent is successfully processed when the 'use_only_authd' setting is disabled."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters ('use_only_authd').",
            "expected_output": [
                "r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and 'wazuh-authd' is stopped)",
                "r'200' ('OK' HTTP status code if 'use_only_authd == no')"
            ],
            "tags": [
                "authd"
            ],
            "name": "test_insert_quick_agent",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        },
        {
            "description": "Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when deleting an agent. Verify that when 'use_only_authd' option is enabled and the 'wazuh-authd' daemon is not active, an error is returned. In this test, 'wazuh-authd' daemon is started in order to create an agent before it can be deleted.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if match with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_api_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for API testing."
                    }
                },
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "wait_for_start": {
                        "type": "fixture",
                        "brief": "Wait until the API starts."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to insert the testing agent is successfully processed.",
                "Verify that the request to delete the testing agent is successfully processed when the 'use_only_authd' setting is disabled and the 'wazuh-authd' daemon is running.",
                "Verify that the request to delete the testing agent cannot finish successfully when the 'use_only_authd' setting is enabled and the 'wazuh-authd' daemon is stopped."
            ],
            "input_description": "Different test cases are contained in an external YAML file (conf.yaml) which includes API configuration parameters ('use_only_authd').",
            "expected_output": [
                "r'200' ('OK' HTTP status code at inserting the testing agent)",
                "r '1' (Value of the 'total_affected_items' field in the response body when 'use_only_authd == yes')",
                "r '1726' (Error code in the response body when 'use_only_authd == yes' and 'wazuh-authd' is stopped)"
            ],
            "tags": [
                "authd"
            ],
            "name": "test_delete_agent",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_use_only_authd.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'use_only_authd' setting of the API is working
  properly. This setting allows forcing the use of 'wazuh-authd' daemon when registering
  and removing agents. The Wazuh API is an open source 'RESTful' API that allows for
  interaction with the Wazuh manager from a web browser, command line tool like 'cURL'
  or any script or program that can make web requests.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 14
modules:
- api
name: test_use_only_authd.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/configuration.html#use-only-authd
tags:
- api
tests:
- assertions:
  - Verify that the request to add the testing agent cannot finish successfully when
    the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not active.
  - Verify that the request to add the testing agent is successfully processed when
    the 'use_only_authd' setting is disabled.
  - Verify that the request to remove the testing agent is processed correctly.
  description: Check if 'use_only_authd' forces the use of the 'wazuh-authd' daemon
    when adding an agent. Verify that when 'use_only_authd' option is enabled and
    the 'wazuh-authd' daemon is stopped, the request made is not completed correctly.
  expected_output:
  - r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and
    'wazuh-authd' is stopped)
  - r'200' ('OK' HTTP status code if 'use_only_authd == no')
  - r'200' ('OK' HTTP status code if the testing agent is removed successfully)
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters ('use_only_authd').
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_add_agent
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - authd
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the request to insert the testing agent cannot finish successfully
    when the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not
    active.
  - Verify that the request to insert the testing agent is successfully processed
    when the 'use_only_authd' setting is disabled.
  description: Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when
    inserting an agent. Verify that when 'use_only_authd' option is enabled and the
    'wazuh-authd' daemon is stopped, the request made is not completed correctly.
  expected_output:
  - r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and
    'wazuh-authd' is stopped)
  - r'200' ('OK' HTTP status code if 'use_only_authd == no')
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters ('use_only_authd').
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_insert_agent
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - authd
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the request to quickly inserting the testing agent cannot finish successfully
    when the 'use_only_authd' setting is enabled but the 'wazuh-authd' daemon is not
    active.
  - Verify that the request to quickly inserting the testing agent is successfully
    processed when the 'use_only_authd' setting is disabled.
  description: Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when
    quickly inserting an agent. Verify that when 'use_only_authd' option is enabled
    and the 'wazuh-authd' daemon is stopped, the request made is not completed correctly.
  expected_output:
  - r'400' ('Internal server error' HTTP status code if 'use_only_authd == yes' and
    'wazuh-authd' is stopped)
  - r'200' ('OK' HTTP status code if 'use_only_authd == no')
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters ('use_only_authd').
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_insert_quick_agent
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - authd
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the request to insert the testing agent is successfully processed.
  - Verify that the request to delete the testing agent is successfully processed
    when the 'use_only_authd' setting is disabled and the 'wazuh-authd' daemon is
    running.
  - Verify that the request to delete the testing agent cannot finish successfully
    when the 'use_only_authd' setting is enabled and the 'wazuh-authd' daemon is stopped.
  description: Check if 'use_only_authd' forces the use of 'wazuh-authd' daemon when
    deleting an agent. Verify that when 'use_only_authd' option is enabled and the
    'wazuh-authd' daemon is not active, an error is returned. In this test, 'wazuh-authd'
    daemon is started in order to create an agent before it can be deleted.
  expected_output:
  - r'200' ('OK' HTTP status code at inserting the testing agent)
  - r '1' (Value of the 'total_affected_items' field in the response body when 'use_only_authd
    == yes')
  - r '1726' (Error code in the response body when 'use_only_authd == yes' and 'wazuh-authd'
    is stopped)
  input_description: Different test cases are contained in an external YAML file (conf.yaml)
    which includes API configuration parameters ('use_only_authd').
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  name: test_delete_agent
  parameters:
  - tags_to_apply:
      brief: Run test if match with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_api_environment:
      brief: Configure a custom environment for API testing.
      type: fixture
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - wait_for_start:
      brief: Wait until the API starts.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - authd
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


## `test_rbac`


<details><summary>test_add_old_resource.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly. Specifically, they will verify that when resources are added with the same identifier of previously existing ones, the previous relationships are not maintained. The 'RBAC' capability allows users accessing the API to be assigned a role that will define the privileges they have.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security",
        "https://en.wikipedia.org/wiki/Role-based_access_control"
    ],
    "tags": [
        "api"
    ],
    "name": "test_add_old_resource.py",
    "id": 15,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the security relationships of a previous user are maintained in the system after adding a new user with the same ID.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of security relationships along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the testing user information exists.",
                "Verify that the request to remove the testing agent is successfully processed.",
                "Verify that the request to add the testing agent is successfully processed.",
                "Verify that security relationships do not exist between the old and the new user."
            ],
            "inputs": [
                "The testing 'user_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'user_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the old user.",
                "r'200' ('OK' HTTP status code at deleting the old user)",
                "r'200' ('OK' HTTP status code at inserting the old user)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_add_old_user"
        },
        {
            "description": "Check if the security relationships of a previous role are maintained in the system after adding a new role with the same ID.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of security relationships along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the testing role information exists.",
                "Verify that the request to remove the testing role is successfully processed.",
                "Verify that the request to add the testing role is successfully processed.",
                "Verify that security relationships do not exist between the old and the new role."
            ],
            "inputs": [
                "The testing 'role_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'role_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the old role.",
                "r'200' ('OK' HTTP status code at deleting the old role)",
                "r'200' ('OK' HTTP status code at inserting the old role)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_add_old_role"
        },
        {
            "description": "Check if the security relationships of a previous policy are maintained in the system after adding a new policy with the same ID.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of security relationships along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the testing policy information exists.",
                "Verify that the request to remove the testing policy is successfully processed.",
                "Verify that the request to add the testing policy is successfully processed.",
                "Verify that security relationships do not exist between the old and the new policy."
            ],
            "inputs": [
                "The testing 'policy_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'policy_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the old policy.",
                "r'200' ('OK' HTTP status code at deleting the old policy)",
                "r'200' ('OK' HTTP status code at inserting the old policy)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_add_old_policy"
        },
        {
            "description": "Check if the security relationships of a previous rule are maintained in the system after adding a new rule with the same ID.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of security relationships along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the testing rule information exists.",
                "Verify that the request to remove the testing rule is successfully processed.",
                "Verify that the request to add the testing rule is successfully processed.",
                "Verify that security relationships do not exist between the old and the new rule."
            ],
            "inputs": [
                "The testing 'rule_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'rule_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the old rule.",
                "r'200' ('OK' HTTP status code at deleting the old rule)",
                "r'200' ('OK' HTTP status code at inserting the old rule)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_add_old_rule"
        }
    ]
}
```
</p>
</details>


<details><summary>test_add_old_resource.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of
  the API is working properly. Specifically, they will verify that when resources
  are added with the same identifier of previously existing ones, the previous relationships
  are not maintained. The 'RBAC' capability allows users accessing the API to be assigned
  a role that will define the privileges they have.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 15
modules:
- api
name: test_add_old_resource.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
- https://en.wikipedia.org/wiki/Role-based_access_control
tags:
- api
tests:
- assertions:
  - Verify that the testing user information exists.
  - Verify that the request to remove the testing agent is successfully processed.
  - Verify that the request to add the testing agent is successfully processed.
  - Verify that security relationships do not exist between the old and the new user.
  description: Check if the security relationships of a previous user are maintained
    in the system after adding a new user with the same ID.
  expected_output:
  - A 'JSON' string in the response body with information of the old user.
  - r'200' ('OK' HTTP status code at deleting the old user)
  - r'200' ('OK' HTTP status code at inserting the old user)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'user_id'.
  inputs:
  - The testing 'user_id' as a module attribute.
  name: test_add_old_user
  parameters:
  - set_security_resources:
      brief: Creates a set of security relationships along with a user for testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the testing role information exists.
  - Verify that the request to remove the testing role is successfully processed.
  - Verify that the request to add the testing role is successfully processed.
  - Verify that security relationships do not exist between the old and the new role.
  description: Check if the security relationships of a previous role are maintained
    in the system after adding a new role with the same ID.
  expected_output:
  - A 'JSON' string in the response body with information of the old role.
  - r'200' ('OK' HTTP status code at deleting the old role)
  - r'200' ('OK' HTTP status code at inserting the old role)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'role_id'.
  inputs:
  - The testing 'role_id' as a module attribute.
  name: test_add_old_role
  parameters:
  - set_security_resources:
      brief: Creates a set of security relationships along with a user for testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the testing policy information exists.
  - Verify that the request to remove the testing policy is successfully processed.
  - Verify that the request to add the testing policy is successfully processed.
  - Verify that security relationships do not exist between the old and the new policy.
  description: Check if the security relationships of a previous policy are maintained
    in the system after adding a new policy with the same ID.
  expected_output:
  - A 'JSON' string in the response body with information of the old policy.
  - r'200' ('OK' HTTP status code at deleting the old policy)
  - r'200' ('OK' HTTP status code at inserting the old policy)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'policy_id'.
  inputs:
  - The testing 'policy_id' as a module attribute.
  name: test_add_old_policy
  parameters:
  - set_security_resources:
      brief: Creates a set of security relationships along with a user for testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the testing rule information exists.
  - Verify that the request to remove the testing rule is successfully processed.
  - Verify that the request to add the testing rule is successfully processed.
  - Verify that security relationships do not exist between the old and the new rule.
  description: Check if the security relationships of a previous rule are maintained
    in the system after adding a new rule with the same ID.
  expected_output:
  - A 'JSON' string in the response body with information of the old rule.
  - r'200' ('OK' HTTP status code at deleting the old rule)
  - r'200' ('OK' HTTP status code at inserting the old rule)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'rule_id'.
  inputs:
  - The testing 'rule_id' as a module attribute.
  name: test_add_old_rule
  parameters:
  - set_security_resources:
      brief: Creates a set of security relationships along with a user for testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_admin_resources.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly. Specifically, they will verify that the different actions that can be performed with admin resources are working correctly. The 'RBAC' capability allows users accessing the API to be assigned a role that will define the privileges they have.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security",
        "https://en.wikipedia.org/wiki/Role-based_access_control"
    ],
    "tags": [
        "api"
    ],
    "name": "test_admin_resources.py",
    "id": 16,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the admin security users can be removed. For this purpose, it tries to delete these users, expecting an error as a response.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to collect the admin security users information is done correctly.",
                "Verify that the request to delete the admin security users is done correctly.",
                "Verify that admin security users have not been deleted by checking the response of the request."
            ],
            "inputs": [
                "The data are obtained from within the test."
            ],
            "input_description": "From the 'get_admin_resources' function information is obtained to perform the test, concretely the 'admin_ids'.",
            "expected_output": [
                "r'200' ('OK' HTTP status code at collect the admin security users information)",
                "r'200' ('OK' HTTP status code when trying to delete the admin security users)",
                "r'1' (Size of the 'failed_items' array from the response body)",
                "r'5004' (Error code of the 'failed_items[0]' array from the response body)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_admin_users"
        },
        {
            "description": "Check if the admin security roles can be removed. For this purpose, it tries to delete these roles, expecting an error as a response.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to collect the admin security roles information is done correctly.",
                "Verify that the request to delete the admin security roles is done correctly.",
                "Verify that admin security roles have not been deleted by checking the response of the request."
            ],
            "inputs": [
                "The data are obtained from within the test."
            ],
            "input_description": "From the 'get_admin_resources' function information is obtained to perform the test, concretely the 'role_ids'.",
            "expected_output": [
                "r'200' ('OK' HTTP status code at collect the admin security roles information)",
                "r'200' ('OK' HTTP status code when trying to delete the admin security roles)",
                "r'1' (Size of the 'failed_items' array from the response body)",
                "r'4008' (Error code of the 'failed_items[0]' array from the response body)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_admin_roles"
        },
        {
            "description": "Check if the admin security policies can be removed. For this purpose, it tries to delete these policies, expecting an error as a response.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to collect the admin security policies information is done correctly.",
                "Verify that the request to delete the admin security policies is done correctly.",
                "Verify that admin security policies have not been deleted by checking the response of the request."
            ],
            "inputs": [
                "The data are obtained from within the test."
            ],
            "input_description": "From the 'get_admin_resources' function information is obtained to perform the test, concretely the 'policy_ids'.",
            "expected_output": [
                "r'200' ('OK' HTTP status code at collect the admin security policies information)",
                "r'200' ('OK' HTTP status code when trying to delete the admin security policies)",
                "r'1' (Size of the 'failed_items' array from the response body)",
                "r'4008' (Error code of the 'failed_items[0]' array from the response body)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_admin_policies"
        },
        {
            "description": "Check if the admin security rules can be removed. For this purpose, it tries to delete these rules, expecting an error as a response.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_api": {
                        "type": "fixture",
                        "brief": "Reset 'api.log' and start a new monitor."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to collect the admin security rules information is done correctly.",
                "Verify that the request to delete the admin security rules is done correctly.",
                "Verify that admin security rules have not been deleted by checking the response of the request."
            ],
            "inputs": [
                "The data are obtained from within the test."
            ],
            "input_description": "From the 'get_admin_resources' function information is obtained to perform the test, concretely the 'rule_ids'.",
            "expected_output": [
                "r'200' ('OK' HTTP status code at collect the admin security rules information)",
                "r'200' ('OK' HTTP status code when trying to delete the admin security rules)",
                "r'1' (Size of the 'failed_items' array from the response body)",
                "r'4008' (Error code of the 'failed_items[0]' array from the response body)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_admin_rules"
        }
    ]
}
```
</p>
</details>


<details><summary>test_admin_resources.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of
  the API is working properly. Specifically, they will verify that the different actions
  that can be performed with admin resources are working correctly. The 'RBAC' capability
  allows users accessing the API to be assigned a role that will define the privileges
  they have.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 16
modules:
- api
name: test_admin_resources.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
- https://en.wikipedia.org/wiki/Role-based_access_control
tags:
- api
tests:
- assertions:
  - Verify that the request to collect the admin security users information is done
    correctly.
  - Verify that the request to delete the admin security users is done correctly.
  - Verify that admin security users have not been deleted by checking the response
    of the request.
  description: Check if the admin security users can be removed. For this purpose,
    it tries to delete these users, expecting an error as a response.
  expected_output:
  - r'200' ('OK' HTTP status code at collect the admin security users information)
  - r'200' ('OK' HTTP status code when trying to delete the admin security users)
  - r'1' (Size of the 'failed_items' array from the response body)
  - r'5004' (Error code of the 'failed_items[0]' array from the response body)
  input_description: From the 'get_admin_resources' function information is obtained
    to perform the test, concretely the 'admin_ids'.
  inputs:
  - The data are obtained from within the test.
  name: test_admin_users
  parameters:
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the request to collect the admin security roles information is done
    correctly.
  - Verify that the request to delete the admin security roles is done correctly.
  - Verify that admin security roles have not been deleted by checking the response
    of the request.
  description: Check if the admin security roles can be removed. For this purpose,
    it tries to delete these roles, expecting an error as a response.
  expected_output:
  - r'200' ('OK' HTTP status code at collect the admin security roles information)
  - r'200' ('OK' HTTP status code when trying to delete the admin security roles)
  - r'1' (Size of the 'failed_items' array from the response body)
  - r'4008' (Error code of the 'failed_items[0]' array from the response body)
  input_description: From the 'get_admin_resources' function information is obtained
    to perform the test, concretely the 'role_ids'.
  inputs:
  - The data are obtained from within the test.
  name: test_admin_roles
  parameters:
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the request to collect the admin security policies information is
    done correctly.
  - Verify that the request to delete the admin security policies is done correctly.
  - Verify that admin security policies have not been deleted by checking the response
    of the request.
  description: Check if the admin security policies can be removed. For this purpose,
    it tries to delete these policies, expecting an error as a response.
  expected_output:
  - r'200' ('OK' HTTP status code at collect the admin security policies information)
  - r'200' ('OK' HTTP status code when trying to delete the admin security policies)
  - r'1' (Size of the 'failed_items' array from the response body)
  - r'4008' (Error code of the 'failed_items[0]' array from the response body)
  input_description: From the 'get_admin_resources' function information is obtained
    to perform the test, concretely the 'policy_ids'.
  inputs:
  - The data are obtained from within the test.
  name: test_admin_policies
  parameters:
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the request to collect the admin security rules information is done
    correctly.
  - Verify that the request to delete the admin security rules is done correctly.
  - Verify that admin security rules have not been deleted by checking the response
    of the request.
  description: Check if the admin security rules can be removed. For this purpose,
    it tries to delete these rules, expecting an error as a response.
  expected_output:
  - r'200' ('OK' HTTP status code at collect the admin security rules information)
  - r'200' ('OK' HTTP status code when trying to delete the admin security rules)
  - r'1' (Size of the 'failed_items' array from the response body)
  - r'4008' (Error code of the 'failed_items[0]' array from the response body)
  input_description: From the 'get_admin_resources' function information is obtained
    to perform the test, concretely the 'rule_ids'.
  inputs:
  - The data are obtained from within the test.
  name: test_admin_rules
  parameters:
  - restart_api:
      brief: Reset 'api.log' and start a new monitor.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_policy_position.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly. Specifically, they will verify that that the policies are applied to the roles in the right order. The 'RBAC' capability allows users accessing the API to be assigned a role that will define the privileges they have.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security",
        "https://en.wikipedia.org/wiki/Role-based_access_control"
    ],
    "tags": [
        "api"
    ],
    "name": "test_policy_position.py",
    "id": 17,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the correct order between role-policy relationships remain after removing some of them and adding others using the 'position' parameter.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "add_new_policies": {
                        "type": "fixture",
                        "brief": "Create new policies and relationships between them and the testing role."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the request to add or delete a role-policy is done correctly.",
                "Verify that the role-policy positions are kept in order when deleting or adding a role-policy."
            ],
            "inputs": [
                "The testing 'policy_ids' array as a module variable."
            ],
            "input_description": "From the 'add_new_policies', 'remove_role_policy' and 'add_role_policy' fixtures information is obtained to perform the test, concretely the 'policy_ids' array.",
            "expected_output": [
                "r'200' ('OK' HTTP status code when deleting or adding a role-policy)",
                "An integer array with the role-policy positions."
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_policy_position"
        }
    ]
}
```
</p>
</details>


<details><summary>test_policy_position.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of
  the API is working properly. Specifically, they will verify that that the policies
  are applied to the roles in the right order. The 'RBAC' capability allows users
  accessing the API to be assigned a role that will define the privileges they have.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 17
modules:
- api
name: test_policy_position.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
- https://en.wikipedia.org/wiki/Role-based_access_control
tags:
- api
tests:
- assertions:
  - Verify that the request to add or delete a role-policy is done correctly.
  - Verify that the role-policy positions are kept in order when deleting or adding
    a role-policy.
  description: Check if the correct order between role-policy relationships remain
    after removing some of them and adding others using the 'position' parameter.
  expected_output:
  - r'200' ('OK' HTTP status code when deleting or adding a role-policy)
  - An integer array with the role-policy positions.
  input_description: From the 'add_new_policies', 'remove_role_policy' and 'add_role_policy'
    fixtures information is obtained to perform the test, concretely the 'policy_ids'
    array.
  inputs:
  - The testing 'policy_ids' array as a module variable.
  name: test_policy_position
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - add_new_policies:
      brief: Create new policies and relationships between them and the testing role.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_remove_relationship.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly. Specifically, they will verify that the different relationships between users-roles-policies can be correctly removed. The 'RBAC' capability allows users accessing the API to be assigned a role that will define the privileges they have.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security",
        "https://en.wikipedia.org/wiki/Role-based_access_control"
    ],
    "tags": [
        "api"
    ],
    "name": "test_remove_relationship.py",
    "id": 18,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the user and role still exist after removing their relationship.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the user-role relationship exists.",
                "Verify that the user-role relationship is removed.",
                "Verify that the user and the role still exist independently."
            ],
            "inputs": [
                "The testing 'user_id' as a module attribute.",
                "The testing 'role_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'user_id' and 'role_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the user-role relationship.",
                "r'200' ('OK' HTTP status code when deleting the user-role relationship)",
                "A 'JSON' string in the response body with information of the role.",
                "A 'JSON' string in the response body with information of the user."
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_user_role_relationship"
        },
        {
            "description": "Check if the role and policy still exist after removing their relationship.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the role-policy relationship exists.",
                "Verify that the role-policy relationship is removed.",
                "Verify that the role and the policy still exists independently."
            ],
            "inputs": [
                "The testing 'role_id' as a module attribute.",
                "The testing 'policy_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'role_id' and 'policy_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the role-policy relationship.",
                "r'200' ('OK' HTTP status code when deleting the role-policy relationship)",
                "A 'JSON' string in the response body with information of the role.",
                "A 'JSON' string in the response body with information of the policy."
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_role_policy_relationship"
        },
        {
            "description": "Check if the role and rule still exist after removing their relationship.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the role-rule relationship exists.",
                "Verify that the role-rule relationship is removed.",
                "Verify that the role and the rule still exists independently."
            ],
            "inputs": [
                "The testing 'role_id' as a module attribute.",
                "The testing 'rule_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'role_id' and 'rule_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the role-rule relationship.",
                "r'200' ('OK' HTTP status code when deleting the role-rule relationship)",
                "A 'JSON' string in the response body with information of the role.",
                "A 'JSON' string in the response body with information of the rule."
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_role_rule_relationship"
        }
    ]
}
```
</p>
</details>


<details><summary>test_remove_relationship.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of
  the API is working properly. Specifically, they will verify that the different relationships
  between users-roles-policies can be correctly removed. The 'RBAC' capability allows
  users accessing the API to be assigned a role that will define the privileges they
  have.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 18
modules:
- api
name: test_remove_relationship.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
- https://en.wikipedia.org/wiki/Role-based_access_control
tags:
- api
tests:
- assertions:
  - Verify that the user-role relationship exists.
  - Verify that the user-role relationship is removed.
  - Verify that the user and the role still exist independently.
  description: Check if the user and role still exist after removing their relationship.
  expected_output:
  - A 'JSON' string in the response body with information of the user-role relationship.
  - r'200' ('OK' HTTP status code when deleting the user-role relationship)
  - A 'JSON' string in the response body with information of the role.
  - A 'JSON' string in the response body with information of the user.
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'user_id' and 'role_id'.
  inputs:
  - The testing 'user_id' as a module attribute.
  - The testing 'role_id' as a module attribute.
  name: test_remove_user_role_relationship
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the role-policy relationship exists.
  - Verify that the role-policy relationship is removed.
  - Verify that the role and the policy still exists independently.
  description: Check if the role and policy still exist after removing their relationship.
  expected_output:
  - A 'JSON' string in the response body with information of the role-policy relationship.
  - r'200' ('OK' HTTP status code when deleting the role-policy relationship)
  - A 'JSON' string in the response body with information of the role.
  - A 'JSON' string in the response body with information of the policy.
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'role_id' and 'policy_id'.
  inputs:
  - The testing 'role_id' as a module attribute.
  - The testing 'policy_id' as a module attribute.
  name: test_remove_role_policy_relationship
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the role-rule relationship exists.
  - Verify that the role-rule relationship is removed.
  - Verify that the role and the rule still exists independently.
  description: Check if the role and rule still exist after removing their relationship.
  expected_output:
  - A 'JSON' string in the response body with information of the role-rule relationship.
  - r'200' ('OK' HTTP status code when deleting the role-rule relationship)
  - A 'JSON' string in the response body with information of the role.
  - A 'JSON' string in the response body with information of the rule.
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'role_id' and 'rule_id'.
  inputs:
  - The testing 'role_id' as a module attribute.
  - The testing 'rule_id' as a module attribute.
  name: test_remove_role_rule_relationship
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_remove_resource.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'RBAC' (Role-Based Access Control) feature of the API is working properly. Specifically, they will verify that the different security resources (users, roles, policies, and rules) can be correctly removed. The 'RBAC' capability allows users accessing the API to be assigned a role that will define the privileges they have.",
    "tier": 0,
    "modules": [
        "api"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-apid",
        "wazuh-analysisd",
        "wazuh-syscheckd",
        "wazuh-db"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/api/getting-started.html",
        "https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security",
        "https://en.wikipedia.org/wiki/Role-based_access_control"
    ],
    "tags": [
        "api"
    ],
    "name": "test_remove_resource.py",
    "id": 19,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if relationships between security resources stay the same after removing the linked rule.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the role-based relationships exist.",
                "Verify that the request to delete the linked rule is done correctly.",
                "Verify that the role-based security relationships still exist.",
                "Verify that the remaining security resources still exist (user, role, and policy).",
                "Verify that the remaining role-based security relationships still exist."
            ],
            "inputs": [
                "The testing 'role_id' as a module attribute.",
                "The testing 'rule_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'role_id' and the 'rule_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the role-based relationships.",
                "r'200' ('OK' HTTP status code when deleting the linked rule)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_rule"
        },
        {
            "description": "Check if relationships between security resources stay the same after removing the linked policy.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the role-based relationships exist.",
                "Verify that the request to delete the linked policy is done correctly.",
                "Verify that the role-based security relationships still exist.",
                "Verify that the remaining security resources still exist (user, role, and rule).",
                "Verify that the remaining role-based security relationships still exist."
            ],
            "inputs": [
                "The testing 'role_id' as a module attribute.",
                "The testing 'policy_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'role_id' and the 'policy_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the role-based relationships.",
                "r'200' ('OK' HTTP status code when deleting the linked policy)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_policy"
        },
        {
            "description": "Check if relationships between security resources stay the same after removing the linked user.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the role-based relationships exist.",
                "Verify that the request to delete the linked user is done correctly.",
                "Verify that the role-based security relationships still exist.",
                "Verify that the remaining security resources still exist (policy, role, and rule).",
                "Verify that the remaining role-based security relationships still exist."
            ],
            "inputs": [
                "The testing 'role_id' as a module attribute.",
                "The testing 'user_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'role_id' and the 'user_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the role-based relationships.",
                "r'200' ('OK' HTTP status code when deleting the linked user)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_user"
        },
        {
            "description": "Check if relationships between security resources stay the same after removing the linked role.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_security_resources": {
                        "type": "fixture",
                        "brief": "Creates a set of role-based security resources along with a user for testing."
                    }
                },
                {
                    "get_api_details": {
                        "type": "fixture",
                        "brief": "Get API information."
                    }
                }
            ],
            "assertions": [
                "Verify that the role-based relationships exist.",
                "Verify that the request to delete the linked role is done correctly.",
                "Verify that the role-based security relationships still exist.",
                "Verify that the remaining security resources still exist (policy, user, and rule).",
                "Verify that the remaining role-based security relationships still exist."
            ],
            "inputs": [
                "The testing 'user_id' as a module attribute.",
                "The testing 'role_id' as a module attribute."
            ],
            "input_description": "From the 'set_security_resources' fixture information is obtained to perform the test, concretely the 'user_id' and the 'role_id'.",
            "expected_output": [
                "A 'JSON' string in the response body with information of the role-based relationships.",
                "r'200' ('OK' HTTP status code when deleting the linked role)"
            ],
            "tags": [
                "rbac"
            ],
            "name": "test_remove_role"
        }
    ]
}
```
</p>
</details>


<details><summary>test_remove_resource.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'RBAC' (Role-Based Access Control) feature of
  the API is working properly. Specifically, they will verify that the different security
  resources (users, roles, policies, and rules) can be correctly removed. The 'RBAC'
  capability allows users accessing the API to be assigned a role that will define
  the privileges they have.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-apid
- wazuh-analysisd
- wazuh-syscheckd
- wazuh-db
group_id: 0
id: 19
modules:
- api
name: test_remove_resource.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/api/getting-started.html
- https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Security
- https://en.wikipedia.org/wiki/Role-based_access_control
tags:
- api
tests:
- assertions:
  - Verify that the role-based relationships exist.
  - Verify that the request to delete the linked rule is done correctly.
  - Verify that the role-based security relationships still exist.
  - Verify that the remaining security resources still exist (user, role, and policy).
  - Verify that the remaining role-based security relationships still exist.
  description: Check if relationships between security resources stay the same after
    removing the linked rule.
  expected_output:
  - A 'JSON' string in the response body with information of the role-based relationships.
  - r'200' ('OK' HTTP status code when deleting the linked rule)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'role_id' and the 'rule_id'.
  inputs:
  - The testing 'role_id' as a module attribute.
  - The testing 'rule_id' as a module attribute.
  name: test_remove_rule
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the role-based relationships exist.
  - Verify that the request to delete the linked policy is done correctly.
  - Verify that the role-based security relationships still exist.
  - Verify that the remaining security resources still exist (user, role, and rule).
  - Verify that the remaining role-based security relationships still exist.
  description: Check if relationships between security resources stay the same after
    removing the linked policy.
  expected_output:
  - A 'JSON' string in the response body with information of the role-based relationships.
  - r'200' ('OK' HTTP status code when deleting the linked policy)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'role_id' and the 'policy_id'.
  inputs:
  - The testing 'role_id' as a module attribute.
  - The testing 'policy_id' as a module attribute.
  name: test_remove_policy
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the role-based relationships exist.
  - Verify that the request to delete the linked user is done correctly.
  - Verify that the role-based security relationships still exist.
  - Verify that the remaining security resources still exist (policy, role, and rule).
  - Verify that the remaining role-based security relationships still exist.
  description: Check if relationships between security resources stay the same after
    removing the linked user.
  expected_output:
  - A 'JSON' string in the response body with information of the role-based relationships.
  - r'200' ('OK' HTTP status code when deleting the linked user)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'role_id' and the 'user_id'.
  inputs:
  - The testing 'role_id' as a module attribute.
  - The testing 'user_id' as a module attribute.
  name: test_remove_user
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the role-based relationships exist.
  - Verify that the request to delete the linked role is done correctly.
  - Verify that the role-based security relationships still exist.
  - Verify that the remaining security resources still exist (policy, user, and rule).
  - Verify that the remaining role-based security relationships still exist.
  description: Check if relationships between security resources stay the same after
    removing the linked role.
  expected_output:
  - A 'JSON' string in the response body with information of the role-based relationships.
  - r'200' ('OK' HTTP status code when deleting the linked role)
  input_description: From the 'set_security_resources' fixture information is obtained
    to perform the test, concretely the 'user_id' and the 'role_id'.
  inputs:
  - The testing 'user_id' as a module attribute.
  - The testing 'role_id' as a module attribute.
  name: test_remove_role
  parameters:
  - set_security_resources:
      brief: Creates a set of role-based security resources along with a user for
        testing.
      type: fixture
  - get_api_details:
      brief: Get API information.
      type: fixture
  tags:
  - rbac
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`