### PR TITLE
Migrate `test_benchmark` and `test_checks` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_files/test_benchmark/test_report_changes_big.py
+++ b/tests/integration/test_fim/test_files/test_benchmark/test_report_changes_big.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files
+       are modified. Specifically, these tests will check if the 'wazuh-syscheckd' daemon generates the 'diff'
+       files on large amounts of files and files with a large size using the 'report_changes' feature.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 3
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_benchmark
+'''
 import os
 import sys
 from datetime import datetime
@@ -161,7 +231,7 @@ def calculate_metrics(folder, event_list, fim_mode):
         elapsed_time_list = [event['data']['timestamp'] - event['data']['attributes']['mtime'] for event in event_list]
 
     return size_original_folder, used_rss_memory, used_vms_memory, total_creation_time, mean(elapsed_time_list), \
-           median(elapsed_time_list), min(elapsed_time_list), max(elapsed_time_list)
+        median(elapsed_time_list), min(elapsed_time_list), max(elapsed_time_list)
 
 
 def write_csv(data):
@@ -193,25 +263,57 @@ def write_csv(data):
 ])
 def test_report_changes_big(file_size, n_files, tags_to_apply, get_configuration, configure_environment,
                             restart_syscheckd, wait_for_fim_start):
-    """Verify syscheck when using the report_changes option with large amount of files.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates the 'diff' files on large amounts of files and
+                 files with a large size using the 'report_changes' feature. For this purpose, the test creates
+                 in a monitored directory (with the 'report_changes' attribute) large amounts of files and files
+                 with large size. Then it checks if the expected number of FIM events is obtained, if they are
+                 of the correct type and if a copy of each file has been created in the corresponding directory.
+                 In addition, the test generates a CSV file with metrics about the time used to create
+                 the files, generate the logs, and the size of the directory.
 
-    This test creates, in a monitored directory with the report_changes option,
-    large amounts of files and files with a large size. Then it checks if the
-    expected number of events is obtained, if they are of the correct type and if a
-    copy of each file has been created in the corresponding directory.
+    wazuh_min_version: 4.2.0
 
-    In addition, the test generates a CSV file with metrics about the time used
-    to create the files, to generate the logs and the size of the directory.
+    parameters:
+        - file_size:
+            type: int
+            brief: Size of each testing file in bytes.
+        - n_files:
+            type: int
+            brief: Number of testing files to create.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    Parameters
-    ----------
-    n_files : int
-        Number of files to create
-    file_size : int
-        Size of each file in bytes
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise
-    """
+    assertions:
+        - Verify that FIM events are generated for each modified file.
+        - Verify that for each modified file a 'diff' file is generated.
+        - Verify that 'diff' files are updated when files are modified.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it
+                       is combined with the testing files to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+        - A CSV file with the metrics collected.
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     fim_mode = get_configuration['metadata']['fim_mode']
     data = []

--- a/tests/integration/test_fim/test_files/test_checks/test_check_all.py
+++ b/tests/integration/test_fim/test_files/test_checks/test_check_all.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM events generated contain only
+       the 'check_' fields specified in the configuration when using the 'check_all' attribute along
+       with other' check_' attributes.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_checks
+'''
 import os
 import sys
 
@@ -72,22 +143,53 @@ else:
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_all_single(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                           wait_for_fim_start):
-    """
-    Test the functionality of `check_all` option when used in conjunction with another check on the same directory,
-    having "check_all" to "yes" and the other check to "no".
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the checks specified in
+                 the configuration. These checks are attributes indicating that a monitored file has been modified.
+                 For example, if 'check_all=yes' and 'check_sum=no' are set for the same directory, 'syscheck' must
+                 send an event containing every possible 'check_' except the checksums. For this purpose, the test
+                 will monitor a testing folder using the 'check_all' attribute in conjunction with one 'check_'
+                 on the same directory, having 'check_all' to 'yes' and the other one to 'no'.
+                 Finally, the test will verify that the FIM events generated contain only the fields
+                 of the 'checks' specified for the monitored folder.
 
-    Example:
-        check_all="yes" check_sum="no"
-        check_all="yes" check_mtime="no"
-        ...
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created and monitored.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_check_all.yaml or wazuh_check_all_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_check_all_single'}, get_configuration['tags'])
     regular_file_cud(path, wazuh_log_monitor, min_timeout=15, options=checkers,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')
@@ -117,22 +219,53 @@ else:
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_all(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                    wait_for_fim_start):
-    """
-    Test the functionality of `check_all` option when used in conjunction with more than one check on the same directory,
-    having "check_all" to "yes" and the other ones to "no".
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the checks specified in
+                 the configuration. These checks are attributes indicating that a monitored file has been modified.
+                 For example, if 'check_all=yes', 'check_sum=no', and 'check_md5sum=no' are set for the same directory,
+                 'syscheck' must send an event containing every possible 'check_' except the 'md5' checksum.
+                 For this purpose, the test will monitor a testing folder using the 'check_all' attribute in
+                 conjunction with more than one 'check_' on the same directory, having 'check_all' to 'yes' and
+                 the other ones to 'no'. Finally, the test will verify that the FIM events generated contain
+                 only the fields of the 'checks' specified for the monitored folder.
 
-    Example:
-        check_all="yes" check_sum="no" check_md5sum="no"
-        check_all="yes" check_perm="yes" check_mtime="no"
-        ...
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created and monitored.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_check_all.yaml or wazuh_check_all_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_check_all'}, get_configuration['tags'])
 
     regular_file_cud(path, wazuh_log_monitor, min_timeout=15, options=checkers,
@@ -142,19 +275,57 @@ def test_check_all(path, checkers, get_configuration, configure_environment, res
 @pytest.mark.parametrize('path, checkers', [(testdir1, {})])
 def test_check_all_no(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                       wait_for_fim_start):
-    """
-    Test the functionality of `check_all` option when set to no.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the checks specified in
+                 the configuration. These checks are attributes indicating that a monitored file has been modified.
+                 For example, when setting 'check_all' to 'no', only the 'type' and 'checksum' attributes should
+                 appear in every FIM event. This will avoid any modification event. For this purpose, the test
+                 will monitor a testing folder using the 'check_all=no' attribute, create a testing file inside it,
+                 and verify that only the 'type' and 'checksum' attributes are in the 'added' event. Then, it
+                 will modify the testing file and verify that no FIM events of type 'modified' are generated.
+                 Finally, the test will delete the testing file and verify that only the 'type' and
+                 'checksum' attributes are in the 'deleted' event.
 
-    When setting `check_all` to no, only 'type' and 'checksum' attributes should appear in every event. This will
-    avoid any modification event.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created and monitored.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated are only of type 'added' and 'deleted' when
+          the 'check_all=no' attribute is used.
+        - Verify that FIM events generated only contain the 'type' and 'checksum' attributes
+          when the 'check_all=no' attribute is used.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_check_all.yaml or wazuh_check_all_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', and 'deleted' event)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_check_all_no'}, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 

--- a/tests/integration/test_fim/test_files/test_checks/test_check_others.py
+++ b/tests/integration/test_fim/test_files/test_checks/test_check_others.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM events generated contain only
+       the 'check_' fields specified in the configuration when using the 'check_' attributes individually
+       without using the 'check_all=yes' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_checks
+'''
 import os
 import sys
 
@@ -71,22 +142,52 @@ else:
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_others_individually(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                                    wait_for_fim_start):
-    """
-    Test the behavior of every Check option individually without using the Check_all option. Check_all option will
-    be set to "no" in order to avoid using the default check_all configuration.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generate events the checks specified in
+                 the configuration. These checks are attributes indicating that a monitored file has been modified.
+                 For example, if 'check_all=no' and 'check_sum=yes' are set for the same directory, 'syscheck' must
+                 send an event containing only the checksums. For this purpose, the test will monitor a testing folder
+                 using the 'check_all=no' attribute (in order to avoid using the default 'check_all' configuration)
+                 in conjunction with one 'check_' on the same directory. Finally, the test will verify that
+                 the FIM events generated contain only the fields of the 'checks' specified for the monitored folder.
 
-    Example:
-        check_all="no" check_sum="yes"
-        check_all="no" check_mtime="yes"
-        ...
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created and monitored.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_check_others.yaml or wazuh_check_others_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_check_others_individually'}, get_configuration['tags'])
 
     regular_file_cud(path, wazuh_log_monitor, min_timeout=15, options=checkers,
@@ -117,24 +218,55 @@ else:
 @pytest.mark.parametrize('path, checkers', parametrize_list)
 def test_check_others(path, checkers, get_configuration, configure_environment,
                       restart_syscheckd, wait_for_fim_start):
-    """
-    Test the behavior of several combinations of Check options over the same directory with Check_all disabled to
-    avoid using the default check_all configuration. The order of the checks (including check_all="no") will be
-    different on each case to test the behavior of check_all="no".
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generate events the checks specified in
+                 the configuration. These checks are attributes indicating that a monitored file has been modified.
+                 For example, if 'check_md5sum=yes', 'check_all=no' and 'check_mtime=yes' are set for
+                 the same directory, 'syscheck' must send an event containing only the file modification time.
+                 For this purpose, the test will monitor a testing folder using the 'check_all=no' attribute
+                 (in order to avoid using the default 'check_all' configuration) in conjunction with more than
+                 one 'check_' on the same directory. Finally, the test will verify that the FIM events generated
+                 contain only the fields of the 'checks' specified for the monitored folder.
+                 In adittion, the order of the 'checks' (including 'check_all=no') will be different on each
+                 test case to check the behavior of the 'check_all=no' attribute.
 
-    Example:
-        check_all: "no" check_size: "yes" check_sum: "yes"
-        check_all: "no" check_md5sum: "yes" check_mtime: "yes" check_group: "yes"
-        check_md5sum: "yes" check_all: "no" check_mtime: "yes" check_group: "yes"
-        ...
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created and monitored.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_check_others.yaml or wazuh_check_others_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_check_others'}, get_configuration['tags'])
 
     regular_file_cud(path, wazuh_log_monitor, min_timeout=15, options=checkers,

--- a/tests/integration/test_fim/test_files/test_checks/test_checksums.py
+++ b/tests/integration/test_fim/test_files/test_checks/test_checksums.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files
+       are modified. Specifically, these tests will check if FIM events generated contain only the 'check_' fields
+       specified in the configuration when using the 'check_' attributes related to file checksum.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_checks
+'''
 import os
 import sys
 
@@ -67,22 +137,53 @@ def get_configuration(request):
 ])
 def test_checksums_checkall(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                             wait_for_fim_start):
-    """
-    Test the behavior of check_all="yes" when using it with one or more check_sum options (checksum, sha1sum,
-    sha256sum and md5sum) set to "no".
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the checks related to
+                 file checksum specified in the configuration. These checks are attributes indicating that
+                 a monitored file has been modified. For example, if 'check_all=yes' and 'check_sum=no' are
+                 set for the same directory, 'syscheck' must send an event containing every possible 'check_'
+                 except the checksums. For this purpose, the test will monitor a testing folder using
+                 the 'check_all' attribute in conjunction with checksum-related 'checks' on the same directory,
+                 having 'check_all' to 'yes' and the other ones to 'no'. Finally, the test will verify that
+                 the FIM events generated contain only the fields of the 'checks' specified for the monitored folder.
 
-    Example:
-        check_all="yes" check_sum="no"
-        check_all="yes" check_sum="no" check_md5sum="no"
-        ...
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created and monitored.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_checksums.yaml or wazuh_checksums_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_checksums_checkall'}, get_configuration['tags'])
 
     regular_file_cud(path, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, options=checkers,
@@ -105,23 +206,55 @@ def test_checksums_checkall(path, checkers, get_configuration, configure_environ
 ])
 def test_checksums(path, checkers, get_configuration, configure_environment, restart_syscheckd,
                    wait_for_fim_start):
-    """
-    Test the checksum options (checksum, sha1sum, sha256sum and md5sum)
-    behavior when is used alone or in conjunction.
-    Check_all option will be set to "no" in order to avoid using the default check_all configuration.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the checks related to
+                 file checksum (checksum, sha1sum, sha256sum and md5sum) specified in the configuration.
+                 These checks are attributes indicating that a monitored file has been modified. For example,
+                 if 'check_all=no' and 'check_sum=yes' are set for the same directory, 'syscheck' must send
+                 an event only containing the file checksums.
+                 For this purpose, the test will monitor a testing folder using the 'check_all=no' attribute
+                 (in order to avoid using the default 'check_all' configuration) in conjunction with
+                 checksum-related 'checks' on the same directory. Finally, the test will verify that
+                 the FIM events generated contain only the fields of the checksum-related 'checks'
+                 specified for the monitored folder.
 
-    Example:
-        check_all: "no" check_sum: "yes"
-        check_all: "no" check_sum: "yes" check_md5sum: "no"
-        ...
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    path : str
-        Directory where the file is being created.
-    checkers : dict
-        Check options to be used.
-    """
+    parameters:
+        - path:
+            type: str
+            brief: Directory where the file is being created and monitored.
+        - checkers:
+            type: set
+            brief: Checks to be compared to the actual event check list.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in external YAML files
+                       (wazuh_checksums.yaml or wazuh_checksums_windows.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and testing
+                       directories to monitor.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_checksums'}, get_configuration['tags'])
 
     regular_file_cud(path, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, options=checkers,


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #1944


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`