### PR TITLE
Migrate `test_env_variables` and `test_file_limit` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_dir.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM events are
+       generated when multiple environment variables are used to monitor directories.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_env_variables
+'''
 import os
 import sys
 
@@ -61,9 +131,49 @@ def get_configuration(request):
 ])
 def test_tag_directories(directory, get_configuration, put_env_variables, configure_environment,
                          restart_syscheckd, wait_for_fim_start):
-    """
-    Test alerts are generated when monitor environment variables
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects CUD events ('added', 'modified', and 'deleted')
+                 when environment variables are used to monitor directories. For this purpose, the test
+                 will monitor a directory that is defined in an environment variable. Then, different
+                 operations will be performed on testing files, and finally, the test will verify
+                 that the proper FIM events have been generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - directory:
+            type: str
+            brief: Path to the directory to be monitored.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - put_env_variables:
+            type: fixture
+            brief: Create the environment variables.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated when environment variables are used to monitor directories.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_conf_dir.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, it is combined
+                       with the directories to be monitored defined as environment variables in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     regular_file_cud(directory, wazuh_log_monitor, file_list=["testing_env_variables"],
                      min_timeout=global_parameters.default_timeout,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')

--- a/tests/integration/test_fim/test_files/test_env_variables/test_dir_win32.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_dir_win32.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM events are
+       generated when environment variables are used to monitor directories in Windows systems.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_env_variables
+'''
 import os
 
 import pytest
@@ -43,9 +94,49 @@ def get_configuration(request):
 @pytest.mark.parametrize('directory', [subdir1])
 def test_tag_directories(directory, get_configuration, put_env_variables, configure_environment,
                          restart_syscheckd, wait_for_fim_start):
-    """
-    Test alerts are generated when monitor environment variables
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects CUD events ('added', 'modified', and 'deleted')
+                 when environment variables are used to monitor directories. For this purpose, the test
+                 will monitor a directory that is defined in an environment variable. Then, different
+                 operations will be performed on testing files, and finally, the test will verify
+                 that the proper FIM events have been generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - directory:
+            type: str
+            brief: Path to the directory to be monitored.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - put_env_variables:
+            type: fixture
+            brief: Create the environment variables.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated when environment variables are used to monitor directories.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_conf_dir.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, it is combined
+                       with the directory to be monitored defined as an environment variable in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     regular_file_cud(directory, wazuh_log_monitor, file_list=["testing_env_variables"],
                      min_timeout=global_parameters.default_timeout,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled')

--- a/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_ignore.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if the 'ignore' tag
+       works correctly when environment variables are used to define the directories to ignore.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#ignore
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_env_variables
+'''
 import os
 import sys
 
@@ -64,10 +134,54 @@ def get_configuration(request):
 ])
 def test_tag_ignore(directory, event_generated, get_configuration, configure_environment, put_env_variables,
                     restart_syscheckd, wait_for_fim_start):
-    """
-    Test environment variables are ignored
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon ignores directories when they are defined using
+                 environment variables. For this purpose, the test will monitor a directory that is ignored
+                 in an environment variable set in the 'ignore' tag. Then, a testing file will be added to
+                 that directory, and finally, the test will verify that the 'ignoring' or `added` FIM events
+                 have been generated according to the test case.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - directory:
+            type: str
+            brief: Path to the directory to be monitored.
+        - event_generated:
+            type: bool
+            brief: True if the directory is not ignored. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - put_env_variables:
+            type: fixture
+            brief: Create the environment variables.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that 'ignoring' FIM event is generated when the ignored directories
+          are defined using environment variables.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_conf_ignore.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, it is combined
+                       with the directories to be ignored defined as environment variables in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' event if the testing directory is not ignored)
+        - r'.*Ignoring'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     # Create text files
     filename = "test"
     create_file(REGULAR, directory, filename, content="")

--- a/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
+++ b/tests/integration/test_fim/test_files/test_env_variables/test_nodiff.py
@@ -1,7 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if the 'nodiff' tag works correctly
+       when environment variables are used to define the files whose changes will not be tracked.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks  configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+    - macos
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+    - macOS Catalina
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_env_variables
+'''
 import os
 import sys
 
@@ -26,10 +98,12 @@ dir1, dir2, dir3, dir4 = test_directories
 
 # Check big environment variables ending with backslash
 if sys.platform == 'win32':
-    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(10)] + \
+            [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
     test_env = "%TEST_NODIFF_ENV%"
 else:
-    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
+    paths = [os.path.join(PREFIX, 'a' * 50 + '\\') for i in range(100)] + \
+            [os.path.join(dir2, "test.txt"), os.path.join(dir3, "test.txt")]
     test_env = "$TEST_NODIFF_ENV"
 
 multiple_env_var = os.pathsep.join(paths)
@@ -62,17 +136,60 @@ def get_configuration(request):
 ])
 def test_tag_nodiff(directory, filename, hidden_content, get_configuration, put_env_variables, configure_environment,
                     restart_syscheckd, wait_for_fim_start):
-    """
-    Test nodiff option works with environment variables
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon truncates the content in the 'diff' files when testing files
+                 are defined using environment variables via the 'nodiff' tag. For this purpose, the test will monitor
+                 a directory using the 'report_changes=yes' attribute and some testing files will be defined in
+                 the 'nodiff' tag using environment variables. Then, it will perform operations on the testing files
+                 and check if the corresponding diff files have been created. Finally, the test will verify that
+                 the 'diff' files of the testing files set in the 'nodiff' tag have their content truncated.
 
-    Parameters
-    ----------
-    directory : str
-        Directory where the file is being created.
-    hidden_content : bool
-        True if content must be truncated,, False otherwise.
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - directory:
+            type: str
+            brief: Path to the directory to be monitored.
+        - filename:
+            type: str
+            brief: Name of the testing file to be tracked.
+        - hidden_content:
+            type: bool
+            brief: True if the 'diff' file must not be created. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - put_env_variables:
+            type: fixture
+            brief: Create the environment variables.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the 'content_changes' field of FIM events has a message
+          indicating that the 'nodiff' option is being used.
+        - Verify that 'diff' files are its content truncated when files are specified
+          via environment variables using the 'nodiff' tag.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_conf_nodiff.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, it is combined
+                       with the directories and testing files defined as environment variables in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+        - The 'diff' file in the default location.
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     files = {filename: b'Hello word!'}
 
     def report_changes_validator(event):

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_capacity_alerts.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_capacity_alerts.py
@@ -1,7 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if the threshold
+       set in the 'file_limit' tag generates FIM events when the number of monitored files
+       approaches this value.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+    - https://en.wikipedia.org/wiki/Inode
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_file_limit
+'''
 import os
 import sys
 
@@ -58,14 +130,56 @@ def get_configuration(request):
 ])
 def test_file_limit_capacity_alert(percentage, tags_to_apply, get_configuration, configure_environment,
                                    restart_syscheckd, wait_for_fim_start):
-    """
-    Checks that the corresponding alerts appear in schedule mode for different capacity thresholds.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates events for different capacity thresholds limits when
+                 using the 'schedule' monitoring mode. For this purpose, the test will monitor a directory in which
+                 several testing files will be created, corresponding to different percentages of the total file limit.
+                 Then, it will check if FIM events are generated when the number of files created exceeds 80% of
+                 the total and when the number is less than that percentage. Finally, the test will verify that
+                 on the FIM event, inodes and monitored files number match.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - percentage:
+            type: int
+            brief: Percentage of testing files to be created.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated when the number of files to be monitored
+          exceeds the established threshold and vice versa.
+        - Verify that the FIM events contain the same number of inodes and files in the monitored directory.
+
+    input_description: A test case (file_limit_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it is
+                       combined with the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' event if the testing directory is not ignored)
+        - r'.*Sending DB * full alert.'
+        - r'.*Sending DB back to normal alert.'
+        - r'.*Fim inode entries*, path count'
+        - r'.*Fim entries' (on Windows systems)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     NUM_FILES = percentage + 1

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_default.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_default.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if the maximum
+       number of files monitored by the 'wazuh-syscheckd' daemon is set to default when
+       the 'file_limit' tag is missing in the configuration.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_file_limit
+'''
 import os
 
 import pytest
@@ -48,21 +119,50 @@ def get_configuration(request):
     {'file_limit_default'}
 ])
 def test_file_limit_default(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that if the file_limit option is missing, the maximum number of files monitored is set to default.
+    '''
+    description: Check if the maximum number of files monitored by the 'wazuh-syscheckd' daemon is set to default
+                 when the 'file_limit' tag is missing in the configuration. For this purpose, the test will monitor
+                 a directory and wait for FIM to start and generate an event indicating the maximum number of files
+                 to monitor. Finally, the test will verify that this number matches the default value (100000).
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that an FIM event is generated indicating the maximum number of files
+          to monitor is the default value (100000).
+
+    input_description: A test case (file_limit_default) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it is
+                       combined with the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Maximum number of entries to be monitored'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                               callback=callback_value_file_limit,
-                                               error_message='Did not receive expected '
-                                                             '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
-                                               ).result()
+    file_limit_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_value_file_limit,
+        error_message='Did not receive expected '
+                      '"DEBUG: ...: Maximum number of entries to be monitored: ..." event').result()
 
     if file_limit_value:
         assert file_limit_value == str(NUM_FILES), 'Wrong value for file_limit'

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_delete_full.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_delete_full.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if, after manipulating files while
+       the FIM database is in 'full database alert' mode, files that are deleted in 'normal' mode
+       generate events consistent with deleted files.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_file_limit
+'''
 import os
 from time import sleep
 
@@ -69,20 +140,58 @@ def extra_configuration_before_yield():
 ])
 def test_file_limit_delete_full(folder, file_name, tags_to_apply,
                                 get_configuration, configure_environment, restart_syscheckd):
-    """
-    This test checks a specific case:
-    If in a file (for example test_1) is not inserted in the database and a file ended in 0 (for example test_10) is
-    inserted in the DB, after deleting test_1, the delete alert was raised for test_10.
+    '''
+    description: Check a specific case. If a testing file ('test_file1') is not inserted in the FIM database
+                 (because the maximum number of files to be monitored has already been reached), and another
+                 testing file ended in 0 ('test_file10') is in the database, after deleting 'test_file1',
+                 the FIM event 'delete' was raised for the 'test_file10' file. For this purpose, the test
+                 will monitor a directory and create several test files until the maximum limit of monitored
+                 files is reached. Then, it will create and delete the file 'test_file1' and wait for
+                 no FIM events to be generated (file limit reached). Finally, it will delete 'test_file10'
+                 and verify that the 'deleted' FIM event matches that file.
 
-    Parameters
-    ----------
-    folder: path
-        Path to the folder where the test is going to be executed.
-    file_name:
-        base name of the file (in the example above it will be test_)
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - folder:
+            type: str
+            brief: Path to the directory to be monitored.
+        - file_name:
+            type: str
+            brief: Name of the testing file to be created.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the FIM database is in 'full database alert' mode
+          when the maximum number of files to monitor has been reached.
+        - Verify that no FIM events are generated when operations are performed on new files
+          and the limit of files to monitor has been reached.
+        - Verify that after manipulating files in 'full database alert' mode, files that are deleted
+          while the FIM database is in 'normal' mode generate events consistent with deleted files.
+
+    input_description: A test case (tags_delete_full) is contained in external YAML file (wazuh_conf_delete_full.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it is combined with
+                       the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending DB * full alert.'
+        - r'.*Sending FIM event: (.+)$' ('deleted' event)
+
+    tags:
+        - realtime
+        - who-data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     database_state = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_full.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_full.py
@@ -1,7 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM events are
+       generated while the database is in 'full database alert' mode for reaching the limit
+       of files to monitor set in the 'file_limit' tag.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+    - https://en.wikipedia.org/wiki/Inode
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_file_limit
+'''
 import os
 import sys
 
@@ -63,14 +135,49 @@ def extra_configuration_before_yield():
     {'file_limit_conf'}
 ])
 def test_file_limit_full(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that the full database alerts are being sent.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates proper events while the FIM database is in
+                 'full database alert' mode for reaching the limit of files to monitor set in the 'file_limit' tag.
+                 For this purpose, the test will monitor a directory in which several testing files will be created
+                 until the file monitoring limit is reached. Then, it will check if the FIM event 'full' is generated
+                 when a new testing file is added to the monitored directory. Finally, the test will verify that
+                 on the FIM event, inodes and monitored files number match.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the FIM database is in 'full database alert' mode
+          when the maximum number of files to monitor has been reached.
+        - Verify that proper FIM events are generated while the database is in 'full database alert' mode.
+
+    input_description: A test case (file_limit_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it is
+                       combined with the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending DB * full alert.'
+        - r'.*The DB is full.*'
+        - r'.*Fim inode entries*, path count'
+        - r'.*Fim entries' (on Windows systems)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     database_state = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
@@ -83,9 +190,10 @@ def test_file_limit_full(tags_to_apply, get_configuration, configure_environment
 
     create_file(REGULAR, testdir1, 'file_full', content='content')
 
-    wazuh_log_monitor.start(timeout=40, callback=callback_file_limit_full_database,
-                            error_message='Did not receive expected '
-                                          '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
+    wazuh_log_monitor.start(
+        timeout=40, callback=callback_file_limit_full_database,
+        error_message='Did not receive expected '
+        '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
 
     entries, path_count = wazuh_log_monitor.start(timeout=40, callback=callback_entries_path_count,
                                                   error_message='Did not receive expected '

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_no_limit.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_no_limit.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if the FIM event 'no limit'
+       is generated when the 'file_limit' feature is disabled in the configuration.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_file_limit
+'''
 import os
 
 import pytest
@@ -47,14 +117,41 @@ def get_configuration(request):
     {'no_file_limit'}
 ])
 def test_file_limit_no_limit(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that a 0 in file_limit disables the limit.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects that the 'file_limit' feature of FIM is disabled.
+                 For this purpose, the test will monitor a testing directory, and finally, it will verify
+                 that the FIM event 'no limit' is generated.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the FIM event 'no limit' is generated when the 'file_limit' feature is disabled.
+
+    input_description: A test case (no_file_limit) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it is
+                       combined with the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*No limit set to maximum number of entries to be monitored'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_file_limit_zero,

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_values.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_values.py
@@ -1,7 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if the FIM event
+       'maximum number of entries' has the correct value for the monitored files limit of
+       the 'file_limit' feature.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+    - https://en.wikipedia.org/wiki/Inode
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_file_limit
+'''
 import os
 import sys
 
@@ -62,21 +134,51 @@ def extra_configuration_before_yield():
     {'file_limit_conf'}
 ])
 def test_file_limit_values(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that a list of different values gets configured correctly in file_limit.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects that the value of the 'entries' tag, which corresponds
+                 to the maximum number of files to monitor from the 'file_limit' feature of FIM. For this purpose,
+                 the test will monitor a directory. Then, it will check if the FIM event 'maximum number of entries'
+                 is generated and has the correct value. Finally, the test will verify that on the FIM event,
+                 inodes and monitored files number match.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the FIM event 'maximum number of entries' has the correct value
+          for the monitored files limit of the 'file_limit' feature.
+
+    input_description: A test case (file_limit_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it is
+                       combined with the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Maximum number of entries to be monitored'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                               callback=callback_value_file_limit,
-                                               error_message='Did not receive expected '
-                                                             '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
-                                               ).result()
+    file_limit_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_value_file_limit,
+        error_message='Did not receive expected '
+        '"DEBUG: ...: Maximum number of entries to be monitored: ..." event').result()
 
     if file_limit_value:
         assert file_limit_value == get_configuration['metadata']['file_limit'], 'Wrong value for file_limit'


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #1947


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`