### PR TITLE
Fix Authd tests in 4.3: inconsistencies in conftest.py

### DIFF
--- a/tests/integration/test_authd/test_authd_ssl_options.py
+++ b/tests/integration/test_authd/test_authd_ssl_options.py
@@ -77,7 +77,7 @@ def override_wazuh_conf(configuration):
     """
     # Stop Wazuh
     control_service('stop', daemon='wazuh-authd')
-    time.sleep(4)
+    time.sleep(1)
     check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     truncate_file(LOG_FILE_PATH)
 


### PR DESCRIPTION
|Related issue|
|---|
| #2090 |



## Description

As part of #2040 and the issue #2090  inconsistencies were found in the file `conftest.py` inside the function `configure_sockets_environment_function` related to authd. Fixes and modifications for these inconsistencies can be found in the PR.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Manager | rpm | x86_64 | 4.3.0 | 4.3.2040 | - | wazuh-manager-4.3.0-4.3.2040.x86_64.rpm |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | centos/8 | CentOS 8 | 2 | 1024 |

### Test results
| Status | Type| OS| Date | By |
|:--:|:--:|:--:|:--:|:--:|
|[ 🟢 ](https://github.com/wazuh/wazuh-qa/files/7411209/ResultsAuthd1.zip) |Local |Manager - Linux| 2021/10/25 | @danisan90 
|[ 🟢 ](https://github.com/wazuh/wazuh-qa/files/7411212/ResultsAuthd2.zip) |Local |Manager - Linux|  2021/10/25 | @danisan90 
| [ 🟢 ](https://github.com/wazuh/wazuh-qa/files/7411215/ResultsAuthd3.zip) |Local | Manager - Linux| 2021/10/25 | @danisan90 
| [ 🟢 ](https://ci.wazuh.info/view/Tests/job/Test_integration/14093/consoleFull)|Jenkins| Manager - Linux| 2021/10/25 | @danisan90 
| [ 🟢 ](https://ci.wazuh.info/view/Tests/job/Test_integration/14095/consoleFull)|Jenkins| Manager - Linux| 2021/10/25 | @danisan90 
| [ 🟢 ](https://ci.wazuh.info/view/Tests/job/Test_integration/14096/consoleFull)|Jenkins| Manager - Linux| 2021/10/25 | @danisan90 
  