### PR TITLE
Migrate `test_ignore`, `test_inotify`, and `test_invalid` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_max_fd_rt.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM limits the number
+       of file descriptors that can open when using the 'realtime' monitoring mode in Windows
+       systems. That limit is set in the 'max_fd_win_rt' internal option.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+    - https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#syscheck
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_inotify
+'''
 import os
 import shutil
 import pytest
@@ -59,19 +112,51 @@ def get_configuration(request):
 
 @pytest.mark.parametrize('tags_to_apply', [{'test_max_fd_rt'}])
 def test_max_fd_win_rt(tags_to_apply, get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check the correct behavior of the max_fd_win_rt internal option. Then test sets this option to two.
-       The test will remove 2 monitored folders, then it will create those folders and check that events are
-       triggered. After that, it will remove these folders.  Finally will create other 2 folders and will check that
-       events are triggered.
-       Args:
-            tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
-            get_configuration (fixture): Gets the current configuration of the test.
-            configure_environment (fixture): Configure the environment for the execution of the test.
-            restart_syscheckd (fixture): Restarts syscheck.
-            wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
-       Raises:
-            TimeoutError: If an expected event couldn't be captured.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the number of file descriptors that can open when
+                 using the 'realtime' monitoring mode. That limit is set in the 'max_fd_win_rt' internal option.
+                 For this purpose, the test will monitor four folders, two of them are created before FIM starts,
+                 setting the limit to two folders. Once FIM is started, the test will remove the two existing
+                 folders and create them again, verifying that FIM events are triggered. Then, it will remove
+                 those two folders, and finally, the test will create another two folders and verify that
+                 FIM events are generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated when changes are made in monitored folders
+          that are deleted and created again.
+        - Verify that FIM events are generated when making changes in the new monitored folders.
+
+    input_description: A test case (test_max_fd_rt) is contained in external YAML file (wazuh_conf_max_fd.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Realtime watch deleted for'
+        - r'.*Directory added for real time monitoring'
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - realtime
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     for dir in created_dirs:

--- a/tests/integration/test_fim/test_files/test_inotify/test_num_watches.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_num_watches.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will verify that FIM detects
+       the correct 'inotify watches' number when renaming and deleting a monitored directory.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_inotify
+'''
 import os
 import shutil as sh
 import sys
@@ -91,21 +161,53 @@ def extra_configuration_after_yield():
 ])
 def test_num_watches(realtime_enabled, decreases_num_watches, rename_folder, get_configuration, configure_environment,
                      restart_syscheckd_each_time):
-    """
-    Check if the number of inotify watches is correct when renaming and deleting a directory.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects the correct number of 'inotify watches' when
+                 renaming and deleting a monitored directory. For this purpose, the test will create and monitor
+                 a folder with two subdirectories. Once FIM is started, it will verify that three watches have
+                 been detected. If these 'inotify watches' are correct, the test will make file operations on
+                 the monitored folder or do nothing. Finally, it will verify that the 'inotify watches' number
+                 detected in the generated FIM events is correct.
 
-    It creates a folder with two subdirectories and checks that there are three watches. If the number is correct,
-    deletes, renames or does nothing to the folder and checks that the number of watches is correct.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    realtime_enabled : Boolean
-        Tells if realtime is enabled
-    decreases_num_watches : Boolean
-        Tells if the number of watches must decrease
-    rename_folder : Boolean
-        Tells if the folder must be renamed
-    """
+    parameters:
+        - realtime_enabled:
+            type: bool
+            brief: True if 'realtime' monitoring mode is enabled. False otherwise.
+        - decreases_num_watches:
+            type: bool
+            brief: True if the 'inotify watches' number must decrease. False otherwise.
+        - rename_folder:
+            type: bool
+            brief: True if the testing folder must be renamed. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd_each_time:
+            type: fixture
+            brief: Clear the 'ossec.log' file, add a testing directory, and start a new monitor in each test case.
+
+    assertions:
+        - Verify that FIM detects that the 'inotify watches' number is correct
+          before and after modifying the monitored folder.
+        - Verify that FIM adds 'inotify watches' when monitored directories have been removed or renamed, and
+          they are restored.
+
+    input_description: A test case (num_watches_conf) is contained in external YAML file (wazuh_conf_num_watches.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Folders monitored with real-time engine'
+
+    tags:
+        - realtime
+        - scheduled
+    '''
     check_apply_test({'num_watches_conf'}, get_configuration['tags'])
 
     if ((get_configuration['metadata']['fim_mode'] == "scheduled" and realtime_enabled) or

--- a/tests/integration/test_fim/test_files/test_inotify/test_remove_rename_folder.py
+++ b/tests/integration/test_fim/test_files/test_inotify/test_remove_rename_folder.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will verify that FIM manages
+       the 'inotify watches' (adds, deletes) when a monitored directory is modified.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_inotify
+'''
 import os
 import shutil as sh
 import sys
@@ -79,17 +149,49 @@ def get_configuration(request):
     (False, True)
 ])
 def test_readded_watches(removed, renamed, get_configuration, configure_environment, restart_syscheckd_each_time):
-    """
-    Check if Wazuh delete watches when directory is removed or renamed, and add watches when directory is readded.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon deletes an 'inotify watch' when renaming or deleting
+                 a monitored directory, and add an 'inotify watch' when the directory is restored. For this
+                 purpose, the test will create and monitor a testing directory. Once FIM is started, it will
+                 verify that a watch has been added. Then, the test will make file operations (rename, delete)
+                 on the monitored directory and check if the watch has been removed. Finally, it will restore
+                 the directory and verify that the 'inotify watch' has been added by checking the FIM events.
 
-    Parameters
-    ----------
-    removed : Boolean
-        Tells if the directory must be removed
-    renamed : Boolean
-        Tells if the directory must be renamed
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - removed:
+            type: bool
+            brief: True if the directory must be removed. False otherwise.
+        - renamed:
+            type: bool
+            brief: True if the directory must be renamed. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd_each_time:
+            type: fixture
+            brief: Clear the 'ossec.log' file, add a testing directory, and start a new monitor in each test case.
+
+    assertions:
+        - Verify that FIM removes 'inotify watches' when deleting or renaming a monitored folder.
+        - Verify that FIM adds 'inotify watches' when a deleted monitored folder is restored.
+
+    input_description: A test case is contained in external YAML file (wazuh_conf_num_watches.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Folders monitored with real-time engine'
+        - r'.*Directory added for real time monitoring' (On Windows systems)
+        - r'.*Realtime watch deleted for'
+
+    tags:
+        - realtime
+    '''
     # Check Wazuh add directory to realtime mode
     if sys.platform == 'win32':
         directory = wazuh_log_monitor.start(timeout=40, callback=callback_realtime_added_directory,

--- a/tests/integration/test_fim/test_files/test_invalid/test_invalid.py
+++ b/tests/integration/test_fim/test_files/test_invalid/test_invalid.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM detects
+       invalid configurations and indicates the location of the errors detected.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#ignore
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_invalid
+'''
 import os
 import sys
 
@@ -49,11 +119,40 @@ def get_configuration(request):
     ({'invalid_no_regex', 'invalid_scan', 'invalid_file_limit'})
 ])
 def test_invalid(tags_to_apply, get_configuration, configure_environment):
-    """
-    Checks if an invalid configuration is detected
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects invalid configurations. For this purpose, the test
+                 will configure 'syscheck' using invalid configuration settings with different attributes. Finally,
+                 it will verify that error events are generated indicating the source of the errors.
 
-    Using invalid configurations with different attributes, expect an error message and syscheck unable to restart.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+
+    assertions:
+        - Verify that FIM raises a 'ValueError' when an invalid configuration is used
+          and the testing platform is not Windows.
+        - Verify that an FIM error event is generated when an invalid configuration is detected.
+
+    input_description: Different test cases are contained in external YAML files (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Configuration error at'
+
+    tags:
+        - realtime
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     # Configuration error -> ValueError raised
     try:


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #1978


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`