### PR TITLE
Migrate `test_multiple_dirs`, `test_nodiff`, and `test_prefilter_cmd` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_files/test_multiple_dirs/test_multiple_dirs.py
+++ b/tests/integration/test_fim/test_files/test_multiple_dirs/test_multiple_dirs.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM detects
+       all file modification events when monitoring the maximum number of directories (64)
+       set in the 'directories' tag.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_multiple_dirs
+'''
 import os
 
 import pytest
@@ -62,20 +133,50 @@ def wait_for_event():
     (test_directories, {'multiple_dirs'})
 ])
 def test_multiple_dirs(dir_list, tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check if syscheck can detect every event when adding, modifying and deleting a file within multiple monitored
-    directories.
-    Check that the maximum number of monitored directories are processed correctly, generating a warning,
-    and discarding the excess.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects every event when adding, modifying, and deleting
+                 a testing file within each one of the monitored directories. Also, it verifies that it limits
+                 the monitoring to the maximum allowed number of directories (64) set in the 'directories' tag.
+                 For this purpose, the test will try to monitor an upper number of folders allowed and make
+                 file operations inside them. Then, it will check if all FIM events are generated for
+                 each file operation made. Finally, the test will verify that the number of FIM events
+                 generated corresponds with the limit of monitored directories.
 
-    These directories will be added in one single entry like so:
-        <directories>testdir0, testdir1, ..., testdirn</directories>
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    dir_list : list
-        List with all the directories to be monitored.
-    """
+    parameters:
+        - dir_list:
+            type: list
+            brief: List with the directories to be monitored.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that FIM events are generated for all monitored folders set
+          in the 'directories' tag to a limit of 64.
+
+    input_description: A test case (multiple_dirs) is contained in external YAML file (multiple_dirs.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are
+                       combined with the testing directories to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - realtime
+        - scheduled
+        - who_data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     discarded = wait_for_event()

--- a/tests/integration/test_fim/test_files/test_multiple_dirs/test_multiple_entries.py
+++ b/tests/integration/test_fim/test_files/test_multiple_dirs/test_multiple_entries.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM detects
+       all file modification events when monitoring the maximum number of directories (64)
+       set using multiple 'directories' tags.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_multiple_dirs
+'''
 import os
 
 import pytest
@@ -81,20 +152,48 @@ def get_configuration(request):
 ])
 def test_cud_multiple_dir_entries(dir_list, tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                                   wait_for_fim_start):
-    """
-    Check if syscheck can detect every event when adding, modifying and deleting a file within multiple monitored
-    directories.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects every event when adding, modifying, and deleting
+                 a testing file within each one of the monitored directories. Also, it verifies that it can monitor
+                 the maximum allowed number of folders using multiple 'directories' tags (64). For this purpose,
+                 the test will monitor multiple folders and make file operations inside them. Then, it will check
+                 if all FIM events are generated for each file operation made. Finally, the test will verify that
+                 the number of FIM events generated corresponds with the monitored directories.
 
-    These directories will be added using a new entry for every one of them:
-        <directories>testdir0</directories>
-        ...
-        <directories>testdirn</directories>
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    dir_list : list
-        List with all the directories to be monitored.
-    """
+    parameters:
+        - dir_list:
+            type: list
+            brief: List with the directories to be monitored.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that FIM events are generated for all monitored folders set
+          in multiple 'directories' (up to a limit of 64).
+
+    input_description: A test case (multiple_dir_entries) is contained in external YAML file
+                       (multiple_entries.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and testing directories to be monitored.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - who_data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     file = 'regular'

--- a/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
+++ b/tests/integration/test_fim/test_files/test_nodiff/test_no_diff_valid.py
@@ -1,7 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM ignores the modifications made
+       in a monitored file when it matches the 'nodiff' tag and vice versa.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+    - macos
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+    - macOS Catalina
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#nodiff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_nodiff
+'''
 import os
 import sys
 
@@ -75,25 +147,67 @@ def test_no_diff_subdirectory(folder, filename, content, hidden_content,
                               tags_to_apply, get_configuration,
                               configure_environment, restart_syscheckd,
                               wait_for_fim_start):
-    """
-    Check files are ignored in the subdirectory according to configuration
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon truncates the file changes in the generated events using
+                 the 'nodiff' tag and vice versa. For this purpose, the test will monitor a directory or subdirectory
+                 and make file operations inside it. Then, it will check if the 'diff' file is created for each
+                 testing file modified. Finally, if the testing files match the 'nodiff' tag, the test will verify
+                 that the FIM events generated contain in their 'content_changes' field a message indicating that
+                 'diff' is truncated because the 'nodiff' option is used.
 
-    When using the nodiff option for a file in syscheck configuration, every time we get an event from this file,
-    we won't be able to see its content. We'll see 'Diff truncated because nodiff option' instead.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the file is being created.
-    filename : str
-        Name of the file to be created.
-    content : str, bytes
-        Content to fill the new file.
-    hidden_content : bool
-        True if content must be truncated,, False otherwise.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - folder:
+            type: str
+            brief: Path to the directory where the testing file will be created.
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - content:
+            type: str
+            brief: Content to fill the testing file.
+        - hidden_content:
+            type: bool
+            brief: True if the content of the testing file must be truncated. False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM ignores the modifications made in a monitored file
+          when it matches the 'nodiff' tag.
+        - Verify that FIM includes the modifications made in a monitored file
+          when it does not match the 'nodiff' tag.
+
+    input_description: Diferent test cases are contained in external YAML files
+                       (wazuh_conf.yaml or wazuh_conf_win32.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon and,
+                       these are combined with the testing directories
+                       to be monitored defined in the module.
+
+    inputs:
+        - 567 test cases including multiple regular expressions and names for testing files and directories.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     files = {filename: content}

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
@@ -1,7 +1,66 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check the 'prelink' program is installed on
+       the system to prevent prelinking from creating false positives running it before FIM scanning.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+
+os_version:
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#prefilter-cmd
+    - https://linux.die.net/man/8/prelink
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_prefilter_cmd
+'''
 import os
 import subprocess
 
@@ -61,12 +120,50 @@ def install_prelink():
 
 # Tests
 def test_prefilter_cmd_conf(get_configuration, configure_environment, install_prelink, restart_syscheckd):
-    """Check if prelink is installed and syscheck works. If prelink is not installed, checks if an error log is received.
+    '''
+    description: Check if the 'wazuh-syscheckd' detects the 'prelink' program installed on the system and runs it
+                 using the command defined in the 'prefilter_cmd' tag. For this purpose, the test will monitor
+                 a testing directory and run a bash script to check if the 'prelink' program is installed and
+                 install it if necessary. Finally, it will verify that the command to run the 'prelink' program
+                 is defined in the configuration.
 
-    This test was implemented when prefilter_cmd could only be set with 'prelink'.
+    wazuh_min_version: 4.2.0
 
-    This test will have to updated if prefilter_cmd is updated as well.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - check_prelink:
+            type: fixture
+            brief: Call script to install 'prelink' if it is not installed.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the 'prelink' program is installed on the system.
+
+    input_description: A test case (prefilter_cmd) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+                       Also, a bash script (install_prelink.sh) is included to check if
+                       the 'prelink' program is installed and install it if necessary.
+
+    expected_output:
+        - The path of the 'prelink' program.
+
+    tags:
+        - prelink
+    '''
     if os.path.exists(prefilter.split()[0]):
         check_fim_start(wazuh_log_monitor)
     else:

--- a/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
+++ b/tests/integration/test_fim/test_files/test_prefilter_cmd/test_prefilter_cmd_conf.py
@@ -130,33 +130,27 @@ def test_prefilter_cmd_conf(get_configuration, configure_environment, install_pr
     wazuh_min_version: 4.2.0
 
     parameters:
-        - tags_to_apply:
-            type: set
-            brief: Run test if matches with a configuration identifier, skip otherwise.
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-        - check_prelink:
+        - install_prelink:
             type: fixture
             brief: Call script to install 'prelink' if it is not installed.
         - restart_syscheckd:
             type: fixture
             brief: Clear the 'ossec.log' file and start a new monitor.
-        - wait_for_fim_start:
-            type: fixture
-            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
     assertions:
         - Verify that the 'prelink' program is installed on the system.
 
-    input_description: A test case (prefilter_cmd) is contained in external YAML file (wazuh_conf.yaml)
-                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
-                       are combined with the testing directory to be monitored defined in the module.
-                       Also, a bash script (install_prelink.sh) is included to check if
-                       the 'prelink' program is installed and install it if necessary.
+    input_description: A test case (prefilter_cmd) is contained in external YAML file (wazuh_prefilter_cmd_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these are combined
+                       with the testing directory to be monitored defined in the module. Also, a bash script
+                       (install_prelink.sh) is included to check if the 'prelink' program is installed and install it
+                       if necessary.
 
     expected_output:
         - The path of the 'prelink' program.


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #1994


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`