### PR TITLE
Migrate `test_fim/test_files/test_report_changes` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       'diff' information to generate from the file monitored when the 'diff_size_limit' and
+       the 'report_changes' options are enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -53,21 +124,52 @@ def get_configuration(request):
     {'ossec_conf_diff_size_limit'}
 ])
 def test_diff_size_limit_default(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that the diff_size_limit option is configured properly when the global file_size variable is different.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of 'diff' information to generate from
+                 the value set in the 'diff_size_limit' attribute when the global 'file_size' tag is different.
+                 For this purpose, the test will monitor a directory and, once the FIM is started, it will wait
+                 for the FIM event related to the maximum file size to generate 'diff' information. Finally,
+                 the test will verify that the value gotten from that FIM event corresponds with the one set
+                 in the 'diff_size_limit'.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that an FIM event is generated indicating the size limit of 'diff' information to generate
+          set in the 'diff_size_limit' attribute when the global 'file_size' tag is different.
+
+    input_description: A test case (ossec_conf_diff_size_limit) is contained in external YAML
+                       file (wazuh_conf.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and, these are combined with the
+                       testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Maximum file size limit to generate diff information configured to'
+
+    tags:
+        - diff
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    diff_size_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                              callback=callback_diff_size_limit_value,
-                                              error_message='Did not receive expected '
-                                                            '"Maximum file size limit configured to \'... KB\'..." event'
-                                              ).result()
+    diff_size_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_diff_size_limit_value,
+        error_message='Did not receive expected "Maximum file size limit configured to \'... KB\'..." event').result()
 
     if diff_size_value:
         assert diff_size_value == str(DIFF_LIMIT_VALUE), 'Wrong value for diff_size_limit'

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       'diff' information to generate from the file monitored to the default value of
+       the 'diff_size_limit' attribute when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -48,20 +119,51 @@ def get_configuration(request):
     {'ossec_conf_diff_default'}
 ])
 def test_diff_size_limit_default(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that the diff_size_limit option is configured properly with the default value (50MB).
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of 'diff' information to generate from
+                 the default value of the 'diff_size_limit' attribute. For this purpose, the test will monitor
+                 a directory and, once the FIM is started, it will wait for the FIM event related to the maximum
+                 file size to generate 'diff' information. Finally, the test will verify that the value gotten
+                 from that FIM event corresponds with the default value of the 'diff_size_limit' attribute (50MB).
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that an FIM event is generated indicating the size limit of 'diff' information to generate
+          with the default value of the 'diff_size_limit' attribute (50MB).
+
+    input_description: A test case (ossec_conf_diff_default) is contained in external YAML
+                       file (wazuh_conf.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and, these are combined with the
+                       testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Maximum file size limit to generate diff information configured to'
+
+    tags:
+        - diff
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    diff_size_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                              callback=callback_diff_size_limit_value,
-                                              error_message='Did not receive expected '
-                                                            '"Maximum file size limit configured to \'... KB\'..." event'
+    diff_size_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_diff_size_limit_value,
+        error_message='Did not receive expected "Maximum file size limit configured to \'... KB\'..." event'
                                               ).result()
 
     if diff_size_value:

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_default.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       the 'queue/diff/local' folder, where Wazuh stores the compressed files used to perform
+       the 'diff' operation, to the default value when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#disk-quota
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -48,20 +119,51 @@ def get_configuration(request):
     {'ossec_conf_diff_default'}
 ])
 def test_disk_quota_default(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that the default value for disk_quota (1GB) is configured properly.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the folder where the data used to perform
+                 the 'diff' operations is stored to the default value. For this purpose, the test will monitor
+                 a directory and, once the FIM is started, it will wait for the FIM event related to the maximum
+                 disk quota to store 'diff' information. Finally, the test will verify that the value gotten from
+                 that FIM event corresponds with the default value of the 'disk_quota' tag (1GB).
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that an FIM event is generated indicating the size limit of the folder
+          to store 'diff' information to the default limit of the 'disk_quota' tag (1GB).
+
+    input_description: A test case (ossec_conf_diff_default) is contained in external YAML
+                       file (wazuh_conf.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and, these are combined with the
+                       testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Maximum disk quota size limit configured to'
+
+    tags:
+        - disk_quota
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    disk_quota_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                               callback=callback_disk_quota_default,
-                                               error_message='Did not receive expected '
-                                                             '"Maximum disk quota size limit configured to \'... KB\'." event'
+    disk_quota_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_disk_quota_default,
+        error_message='Did not receive expected "Maximum disk quota size limit configured to \'... KB\'." event'
                                                ).result()
 
     if disk_quota_value:

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_disabled.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_disabled.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM does not limit
+       the size of the 'queue/diff/local' folder where Wazuh stores the compressed files used
+       to perform the 'diff' operation when the 'disk_quota' option is disabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#disk-quota
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -57,23 +128,57 @@ def get_configuration(request):
 ])
 def test_disk_quota_disabled(tags_to_apply, filename, folder, size, get_configuration, configure_environment,
                              restart_syscheckd, wait_for_fim_start):
-    """
-    Check that the disk_quota option is disabled correctly.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the folder where the data used
+                 to perform the 'diff' operations is stored when the 'disk_quota' option is disabled.
+                 For this purpose, the test will monitor a directory and, once the FIM is started, it
+                 will create a testing file that, when compressed, is larger than the configured
+                 'disk_quota' limit. Finally, the test will verify that the FIM event related
+                 to the reached disk quota has not been generated.
 
-    Creates a file that, when compressed, is larger than the configured disk_quota limit and checks that the message
-    about reaching the limit does not appear in the log.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    filename : str
-        Name of the file to be created.
-    folder : str
-        Directory where the files are being created.
-    size : int
-        Size of each file in bytes.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - folder:
+            type: str
+            brief: Path to the directory where the testing files are being created.
+        - size:
+            type: int
+            brief: Size of each testing file in bytes.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that no FIM events are generated indicating the disk quota exceeded for monitored files
+          when the 'disk_quota' option is disabled.
+
+    input_description: A test case (ossec_conf_diff) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*The (.*) of the file size .* exceeds the disk_quota.*' (if the test fails)
+
+    tags:
+        - disk_quota
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 

--- a/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_disk_quota_values.py
@@ -1,7 +1,83 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       the 'queue/diff/local' folder where Wazuh stores the compressed files used to perform
+       the 'diff' operation when the 'disk_quota' limit is set.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+    - macos
+    - solaris
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+    - macOS Catalina
+    - Solaris 10
+    - Solaris 11
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#disk-quota
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 import tempfile
 
@@ -66,15 +142,45 @@ def create_specific_size_file(get_configuration, request):
 
 # Tests
 def test_disk_quota_values(get_configuration, configure_environment, create_specific_size_file, restart_syscheckd):
-    """Check that the disk_quota option for report_changes is working correctly.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the folder where the data
+                 used to perform the 'diff' operations is stored when the 'disk_quota' limit is set.
+                 For this purpose, the test will monitor a system directory with lot of files changes
+                 that when compressed, are larger than the configured 'disk_quota' limit. Finally, once
+                 the FIM is started, the test will verify that the FIM event related to the reached
+                 disk quota has been generated.
 
-    Monitor one of the system's folder and wait for the message alerting that the disk_quota limit has been reached.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that FIM events are generated indicating the disk quota exceeded for monitored files
+          when the 'disk_quota' option is enabled.
+
+    input_description: A test case (ossec_conf_diff) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the 'disk_quota' values defined in the module.
+
+    expected_output:
+        - r'.*The (.*) of the file size .* exceeds the disk_quota.*'
+
+    tags:
+        - disk_quota
+        - scheduled
+    '''
     wazuh_log_monitor.start(timeout=extended_timeout, callback=callback_disk_quota_limit_reached,
                             error_message='Did not receive expected '
                                           '"The maximum configured size for the ... folder has been reached, ..." event.')

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_default.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM limits the size of the file
+       monitored to generate 'diff' information to the default value of the 'file_size' tag when
+       the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-size
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -70,22 +141,57 @@ def extra_configuration_after_yield():
 ])
 def test_file_size_default(tags_to_apply, filename, folder, get_configuration, configure_environment, restart_syscheckd,
                            wait_for_fim_start):
-    """
-    Check that the file_size option with a default value for report_changes is working correctly.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the monitored file to generate
+                 'diff' information from the default value of the 'file_size' option. For this purpose,
+                 the test will monitor a directory, create a testing file smaller than the default limit,
+                 and check if the compressed file has been created. Then, it will increase the size of
+                 the testing file. Finally, the test will verify that the FIM event related to the
+                 reached file size limit has been generated, and the compressed file in the 'queue/diff/local'
+                 directory does not exist.
 
-    Create a file smaller than the default limit and check that the compressed file has been created. If the first part
-    is successful, increase the size of the file and expect the message for file_size limit reached and no compressed
-    file in the queue/diff/local folder.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    filename : str
-        Name of the file to be created.
-    folder : str
-        Directory where the files are being created.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - folder:
+            type: str
+            brief: Path to the directory where the testing files are being created.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the 'diff' folder is created when a monitored file does not exceed the size limit.
+        - Verify that FIM events are generated indicating the size limit reached of monitored files
+          to generate 'diff' information with the default limit of the 'file_size' tag (50MB).
+        - Verify that the 'diff' folder is removed when a monitored file exceeds the size limit.
+
+    input_description: A test case (ossec_conf_diff_default) is contained in external YAML
+                       file (wazuh_conf.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and, these are combined with the
+                       testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+        - r'.*File .* is too big for configured maximum size to perform diff operation'
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     size_limit = translate_size('50MB')
@@ -108,9 +214,11 @@ def test_file_size_default(tags_to_apply, filename, folder, get_configuration, c
 
     check_time_travel(scheduled)
 
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_file_size_limit_reached,
-                            error_message='Did not receive expected '
-                                          '"File ... is too big for configured maximum size to perform diff operation" event.')
+    wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_file_size_limit_reached,
+        error_message='Did not receive expected '
+                      '"File ... is too big for configured maximum size to perform diff operation" event.')
 
     if os.path.exists(diff_file_path):
         pytest.raises(FileExistsError(f"{diff_file_path} found. It should not exist after incresing the size."))

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_disabled.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_disabled.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will verify that FIM does not limit the size of
+       the file monitored to generate 'diff' information when disabling the 'file_size' tag and
+       the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-size
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -57,23 +128,57 @@ def get_configuration(request):
 ])
 def test_file_size_disabled(tags_to_apply, filename, folder, size, get_configuration, configure_environment,
                             restart_syscheckd, wait_for_fim_start):
-    """
-    Check that the file_size option is disabled correctly.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the monitored file to generate
+                 'diff' information when the 'file_size' option is disabled. For this purpose, the test
+                 will monitor a directory and create a testing file larger than the limit set in the
+                 'file_size' tag. Finally, the test will verify that the FIM event related to the
+                 reached file size limit has not been generated.
 
-    Creates a file larger than the configured file_size limit and checks that the message about reaching the limit does
-    not appear in the log.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    filename : str
-        Name of the file to be created.
-    folder : str
-        Directory where the files are being created.
-    size : int
-        Size of each file in bytes.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - folder:
+            type: str
+            brief: Path to the directory where the testing files are being created.
+        - size:
+            type: int
+            brief: Size of each testing file in bytes.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that no FIM events are generated indicating the reached file size limit of monitored files
+          when the 'file_size' option is disabled.
+
+    input_description: A test case (ossec_conf_diff) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*The (.*) of the file size .* exceeds the disk_quota.*' (if the test fails)
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
 

--- a/tests/integration/test_fim/test_files/test_report_changes/test_file_size_values.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_file_size_values.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       the file monitored to generate 'diff' information to the limit set in the 'file_size' tag
+       when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-size
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 
 import pytest
@@ -79,22 +150,57 @@ def extra_configuration_after_yield():
 ])
 def test_file_size_values(tags_to_apply, filename, folder, get_configuration, configure_environment, restart_syscheckd,
                           wait_for_fim_start):
-    """
-    Check that the file_size option for report_changes is working correctly.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the monitored file to generate
+                 'diff' information from the limit set in the 'file_size' tag. For this purpose, the test
+                 will monitor a directory, create a testing file smaller than the 'file_limit' value,
+                 and check if the compressed file has been created. Then, it will increase the size of
+                 the testing file. Finally, the test will verify that the FIM event related to the reached
+                 file size limit has been generated, and the compressed file in the 'queue/diff/local'
+                 directory does not exist.
 
-    Create a file smaller than the limit and check that the compressed file has been created. If the first part is
-    successful, increase the size of the file and expect the message for file_size limit reached and no compressed file
-    in the queue/diff/local folder.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    filename : str
-        Name of the file to be created.
-    folder : str
-        Directory where the files are being created.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - folder:
+            type: str
+            brief: Path to the directory where the testing files are being created.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the 'diff' folder is created when a monitored file does not exceed the size limit.
+        - Verify that FIM events are generated indicating the size limit reached of monitored files
+          to generate 'diff' information when a limit is set in the 'file_size' tag.
+        - Verify that the 'diff' folder is removed when a monitored file exceeds the size limit.
+
+    input_description: A test case (ossec_conf_diff) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the 'file_size' values defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+        - r'.*Folder .* has been deleted.*'
+        - r'.*File .* is too big for configured maximum size to perform diff operation'
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     scheduled = get_configuration['metadata']['fim_mode'] == 'scheduled'
     size_limit = translate_size(get_configuration['metadata']['file_size_limit'])
@@ -124,7 +230,8 @@ def test_file_size_values(tags_to_apply, filename, folder, get_configuration, co
     if os.path.exists(diff_file_path):
         raise FileExistsError(f"{diff_file_path} found. It should not exist after incresing the size.")
 
-    wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                            callback=callback_file_size_limit_reached,
-                            error_message='Did not receive expected '
-                                          '"File ... is too big for configured maximum size to perform diff operation" event.')
+    wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_file_size_limit_reached,
+        error_message='Did not receive expected '
+                      '"File ... is too big for configured maximum size to perform diff operation" event.')

--- a/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
@@ -1,7 +1,78 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM events include
+       the 'content_changes' field with the tag 'More changes' when it exceeds the maximum size
+       allowed, and the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import gzip
 import os
 import re
@@ -80,26 +151,68 @@ def extra_configuration_after_yield():
 ])
 def test_large_changes(filename, folder, original_size, modified_size, tags_to_apply, get_configuration,
                        configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check content_changes shows the tag 'More changes' when it exceeds the maximum size.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects the character limit in the file changes is reached
+                 showing the 'More changes' tag in the 'content_changes' field of the generated events. For this
+                 purpose, the test will monitor a directory, add a testing file and modify it, adding more characters
+                 than the allowed limit. Then, it will unzip the 'diff' and get the size of the changes. Finally,
+                 the test will verify that the generated FIM event contains in its 'content_changes' field the proper
+                 value depending on the test case.
 
-    Every change in the content of the file shall produce an alert including
-    the difference. But, if the difference is greater or equal than 59391 bytes, 'More changes'
-    appears instead.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    filename : str
-        Name of the file to be created.
-    folder : str
-        Directory where the files are being created.
-    original_size : int
-        Size of each file in bytes before being modified.
-    modified_size : int
-        Size of each file in bytes after being modified.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - filename:
+            type: str
+            brief: Name of the testing file to be created.
+        - folder:
+            type: str
+            brief: Path to the directory where the testing files will be created.
+        - original_size:
+            type: int
+            brief: Size of the testing file in bytes before being modified.
+        - modified_size:
+            type: int
+            brief: Size of the testing file in bytes after being modified.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
+    assertions:
+        - Verify that FIM events are generated when adding and modifying the testing file.
+        - Verify that FIM events include the 'content_changes' field with the 'More changes' tag when
+          the changes made on the testing file have more characters than the allowed limit.
+        - Verify that FIM events include the 'content_changes' field with the old content
+          of the monitored file.
+        - Verify that FIM events include the 'content_changes' field with the new content
+          of the monitored file when the old content is lower than the allowed limit or
+          the testing platform is Windows.
+
+    input_description: A test case (ossec_conf_report) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory and files to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+        - The length of the testing file content by running the diff/fc command.
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     limit = 59391
     has_more_changes = False
     original_file = os.path.join(folder, filename)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
@@ -1,6 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM reports (or truncates if required)
+       the changes made in monitored files when it matches the 'nodiff' tag and vice versa when
+       the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#nodiff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 import re
 import sys
@@ -62,20 +135,60 @@ def get_configuration(request):
 def test_reports_file_and_nodiff(folder, checkers, tags_to_apply,
                                  get_configuration, configure_environment,
                                  restart_syscheckd, wait_for_fim_start):
-    """
-    Check if report_changes events and diff truncated files are correct
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon reports the file changes (or truncates if required)
+                 in the generated events using the 'nodiff' tag and vice versa. For this purpose, the test
+                 will monitor a directory and make file operations inside it. Then, it will check if a
+                 'diff' file is created for the modified testing file. Finally, if the testing file matches
+                 the 'nodiff' tag, the test will verify that the FIM event generated contains in its
+                 'content_changes' field a message indicating that 'diff' is truncated because
+                 the 'nodiff' option is used.
 
-    The report_changes attribute adds a new event property to the 'modified' sent event: 'content_changes'
-    It has information about what changed from the previous content. To do so, it duplicates the file in the diff
-    directory. We call this duplicated file 'diff_file'.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the files will be created.
-    checkers : dict
-        Syscheck checkers
-    """
+    parameters:
+        - folder:
+            type: str
+            brief: Path to the directory where the testing files will be created.
+        - checkers:
+            type: dict
+            brief: Syscheck 'check_' fields to be generated.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that for each modified file a 'diff' file is generated.
+        - Verify that FIM events include the 'content_changes' field.
+        - Verify that FIM events truncate the modifications made in a monitored file
+          when it matches the 'nodiff' tag.
+        - Verify that FIM events include the modifications made in a monitored file
+          when it does not match the 'nodiff' tag.
+
+    input_description: A test case (ossec_conf_report) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     file_list = ['regular_file']

--- a/tests/integration/test_fim/test_files/test_report_changes/test_report_deleted_diff.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_report_deleted_diff.py
@@ -1,6 +1,79 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM manages properly
+       the 'diff' folder created in the 'queue/diff/local' directory when removing a monitored
+       folder or the 'report_changes' option is disabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_report_changes
+'''
 import os
 import re
 import shutil
@@ -136,13 +209,52 @@ def disable_report_changes(fim_mode):
 @pytest.mark.parametrize('path', [testdir_nodiff])
 def test_report_when_deleted_directories(path, get_configuration, configure_environment, restart_syscheckd,
                                          wait_for_fim_start):
-    """Check if the diff directory is empty when the monitored directory is deleted.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon deletes the 'diff' folder created in the 'queue/diff/local'
+                 directory when removing a monitored folder and the 'report_changes' option is enabled.
+                 For this purpose, the test will monitor a directory and add a testing file inside it. Then,
+                 it will check if a 'diff' file is created for the modified testing file. Finally, the test
+                 will remove the monitored folder, wait for the FIM 'deleted' event, and verify that
+                 the corresponding 'diff' folder is deleted.
 
-    Parameters
-    ----------
-    path : str
-        Path to the file to be deleted
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - path:
+            type: str
+            brief: Path to the testing file to be deleted.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM event is generated when removing the monitored folder.
+        - Verify that FIM adds the 'diff' file in the 'queue/diff/local' directory
+          when monitoring the corresponding testing file.
+        - Verify that FIM deletes the 'diff' folder in the 'queue/diff/local' directory
+          when removing the corresponding monitored folder.
+
+    input_description: Different test cases are contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('deleted' events)
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     fim_mode = get_configuration['metadata']['fim_mode']
     diff_dir = os.path.join(WAZUH_PATH, 'queue', 'diff', 'local')
 
@@ -160,14 +272,51 @@ def test_report_when_deleted_directories(path, get_configuration, configure_envi
 @pytest.mark.parametrize('path', [testdir_reports])
 def test_no_report_changes(path, get_configuration, configure_environment,
                            restart_syscheckd, wait_for_fim_start):
-    """Check if duplicated directories in diff are deleted when changing `report_changes` to 'no' or deleting the
-    monitored directories.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon deletes the 'diff' folder created in the 'queue/diff/local'
+                 directory when disabling the 'report_changes' option. For this purpose, the test will monitor
+                 a directory and add a testing file inside it. Then, it will check if a 'diff' file is created
+                 for the modified testing file. Next, the test will backup the main configuration, disable
+                 the 'report_changes' option, and check if the diff folder has been deleted. Finally, the test
+                 will restore the backed configuration and verify that the initial scan of FIM scan is made.
 
-    Parameters
-    ----------
-    path : str
-        Path to the file
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - path:
+            type: str
+            brief: Path to the testing file to be created.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM adds the 'diff' file in the 'queue/diff/local' directory
+          when monitoring the corresponding testing file.
+        - Verify that FIM deletes the 'diff' folder in the 'queue/diff/local' directory
+          when disabling the 'report_changes' option.
+
+    input_description: Different test cases are contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     fim_mode = get_configuration['metadata']['fim_mode']
     diff_file = create_and_check_diff(FILE_NAME, path, fim_mode)
     backup_conf = get_wazuh_conf()
@@ -183,12 +332,51 @@ def test_no_report_changes(path, get_configuration, configure_environment,
 
 def test_report_changes_after_restart(get_configuration, configure_environment, restart_syscheckd,
                                       wait_for_fim_start):
-    """Check if duplicated directories in diff are deleted when restarting syscheck.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon deletes the 'diff' folder created in the 'queue/diff/local'
+                 directory when restarting that daemon, and the 'report_changes' option is disabled. For this
+                 purpose, the test will monitor a directory and add a testing file inside it. Then, it will check
+                 if a 'diff' file is created for the modified testing file. The folders in the 'queue/diff/local'
+                 directory will be deleted after the 'wazuh-syscheckd' daemon restart but will be created again if
+                 the 'report_changes' option is still active. To avoid this, the test will disable the 'report_changes'
+                 option (backing the main configuration) before restarting the 'wazuh-syscheckd' daemon to ensure that
+                 the directories will not be created again. Finally, the test will restore the backed configuration and
+                 verify that the initial scan of FIM is made.
 
-    The duplicated directories in diff will be removed after Syscheck restarts but will be created again if the report
-    changes is still active. To avoid this we disable turn off report_changes option before restarting Syscheck to
-    ensure directories won't be created again.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM adds the 'diff' file in the 'queue/diff/local' directory
+          when monitoring the corresponding testing file.
+        - Verify that FIM deletes the 'diff' folder in the 'queue/diff/local' directory
+          when restarting the disabling the 'report_changes' option is disabled.
+
+    input_description: Different test cases are contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and, these
+                       are combined with the testing directory to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+
+    tags:
+        - diff
+        - scheduled
+        - time_travel
+    '''
     fim_mode = get_configuration['metadata']['fim_mode']
 
     # Create a file in the monitored path to force the creation of a report in diff


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2005


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`