### PR TITLE
Migrate `test_tags`, `test_timezone_changes`, `test_wildcards_complex`, and `test_windows_audit_interval` of `test_fim/test_files` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_files/test_tags/test_tags.py
+++ b/tests/integration/test_fim/test_files/test_tags/test_tags.py
@@ -1,6 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM events include
+       all tags set in the 'tags' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_tags
+'''
 import os
 
 import pytest
@@ -58,19 +129,53 @@ def get_configuration(request):
 ])
 def test_tags(folder, name, content,
               get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check the tags functionality by applying some tags an ensuring the events raised for the monitored directory has
-    the expected tags.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates the tags required for each event
+                 depending on the values set in the 'tags' attribute. This attribute allows adding
+                 tags to alerts for monitored directories. For this purpose, the test will monitor a
+                 folder and make file operations inside it. Finally, it will verify that FIM events
+                 generated include in the 'tags' field all tags set in the configuration.
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the file is being created.
-    name : str
-        Name of the file to be created.
-    content : str, bytes
-        Content to fill the new file.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - folder:
+            type: str
+            brief: Monitored directory.
+        - name:
+            type: str
+            brief: Name of the testing file to be created.
+        - content:
+            type: str
+            brief: Content to fill the testing file.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events include all tags set in the 'tags' attribute.
+
+    input_description: A test case is contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon and,
+                       it is combined with the testing directory to be monitored defined
+                       in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified' and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     defined_tags = get_configuration['metadata']['fim_tags']
 
     def tag_validator(event):

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM monitors newly added directories
+       that match with complex wildcards used in the configuration.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_wildcards_complex
+'''
 import os
 import sys
 import pytest
@@ -66,18 +136,55 @@ def get_configuration(request):
 def test_wildcards_complex(subfolder, file_name, tags_to_apply,
                            get_configuration, configure_environment,
                            restart_syscheckd, wait_for_fim_start):
-    """Test the correct expansion of complex wildcards for monitored directories in syscheck
+    '''
+    description: Check if the number of directories to monitor grows when using complex wildcards to specify them.
+                 For this purpose, the test creates a set of directories that match the wildcard expressions
+                 and ones that do not match the expressions set in the directories to be monitored.
+                 Then, the test will create, modify and delete files inside a folder given as an argument.
+                 Finally, the test will wait for FIM events only if the folder where the changes are made
+                 matches the expression previously set in the `wazuh-syscheckd` daemon configuration.
 
-    Params:
-        subfolder (str): Name of the subfolder under root folder.
-        file_name (str): Name of the file that will be created under subfolder.
-        tags_to_apply (str): Value holding the configuration used in the test.
-        get_configuration (fixture): Gets the current configuration of the test.
-        configure_environment (fixture): Configure the environment for the execution of the test.
-        restart_syscheckd (fixture): Restarts syscheck.
-        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - subfolder:
+            type: str
+            brief: Path to the subdirectory in the monitored folder.
+        - file_name:
+            type: str
+            brief: Name of the testing file that will be created in the subfolder.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated from newly added directories that
+          match a complex wildcard used in the configuration.
+
+    input_description: A test case (ossec_conf_wildcards) is contained in external YAML file
+                       (wazuh_conf_wildcards.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and, it is combined with the testing
+                       directories to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified' and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     mult = 1 if sys.platform == 'win32' else 2
 
     if sys.platform == 'win32':

--- a/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
+++ b/tests/integration/test_fim/test_files/test_wildcards_complex/test_wildcards_complex_runtime.py
@@ -1,7 +1,77 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM monitors newly added directories
+       that match with complex wildcards used in the configuration.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#directories
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_wildcards_complex
+'''
 import os
 import sys
 import pytest
@@ -81,22 +151,63 @@ def get_configuration(request):
 def test_wildcards_complex_runtime(subfolder_name, file_name, tags_to_apply,
                                    get_configuration, configure_environment, restart_syscheckd,
                                    wait_for_initial_scan, create_test_folders, wait_for_wildcards_scan):
-    """Test the correct expansion of complex wildcards in runtime for monitored directories in syscheck.
-        The test will monitor an empty folder and once the baseline scan is completed, it will create folders that may
-        match one of the monitored expressions and will check that the events are triggered (in case that a folder
-        doesn't match the configured expresion, the test will check that no events are triggered in those folders.)
-    Params:
-        subfolder (str): Name of the subfolder under root folder.
-        file_name (str): Name of the file that will be created under subfolder.
-        tags_to_apply (str): Value holding the configuration used in the test.
-        get_configuration (fixture): Gets the current configuration of the test.
-        configure_environment (fixture): Configure the environment for the execution of the test.
-        restart_syscheckd (fixture): Restarts syscheck.
-        wait_for_initial_scan (fixture): Waits until the first FIM scan is completed.
-        create_test_folders (fixture): Creates the folders that will match (or not) the configured glob expresion.
-        wait_for_wildcards_scan (fixture): Waits until the end of wildcards scan event is triggered.
-    """
+    '''
+    description: Check if the number of directories to monitor grows when using complex wildcards to specify them.
+                 For this purpose, the test will configure complex wildcards expressions and create an empty folder.
+                 Once the FIM module has started, and the 'baseline' scan is completed, the test will create
+                 folders that may match a configured expression, and it waits until the wildcards are expanded
+                 again (in the next scan). Once the wildcards are reloaded, the test will create, modify and
+                 delete files inside those folders. Finally, the test will wait for FIM events from a folder
+                 only if it matches a configured expression.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - subfolder_name:
+            type: str
+            brief: Path to the subdirectory in the monitored folder.
+        - file_name:
+            type: str
+            brief: Name of the testing file that will be created in the subfolder.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_initial_scan:
+            type: fixture
+            brief: Wait until the first FIM scan is completed.
+        - create_test_folders:
+            type: fixture
+            brief: Create the testing folders that will match (or not) the configured glob expression.
+        - wait_for_wildcards_scan:
+            type: fixture
+            brief: Wait until the end of wildcards scan event is triggered.
+
+    assertions:
+        - Verify that FIM events are generated from newly added directories that
+          match a complex wildcard used in the configuration.
+
+    input_description: A test case (ossec_conf_wildcards_runtime) is contained in external YAML file
+                       (wazuh_conf_wildcards_runtime.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon and, it is combined with the testing directories
+                       to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified' and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+        - who-data
+    '''
     folder = os.path.join(test_folder, subfolder_name)
     if sys.platform == 'win32':
         if "?" in file_name or "*" in file_name:

--- a/tests/integration/test_fim/test_files/test_windows_audit_interval/test_windows_audit_interval.py
+++ b/tests/integration/test_fim/test_files/test_windows_audit_interval/test_windows_audit_interval.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will verify that FIM checks at the specified frequency
+       in the 'windows_audit_interval' tag, that the SACLs of the directories monitored using the 'whodata'
+       monitoring mode are correct, detecting the changes and restoring the SACL rules when required.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#whodata
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-audit-interval
+    - https://en.wikipedia.org/wiki/Access-control_list
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_windows_audit_interval
+'''
 import os
 import re
 import sys
@@ -81,7 +135,48 @@ def callback_sacl_restored(line):
 ])
 def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                                    wait_for_fim_start):
-    """Check that Wazuh detects a SACL change every 'windows_audit_interval' and sets monitoring to real-time if so."""
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects a SACL change every 'windows_audit_interval'
+                 and sets monitoring to 'realtime' mode if so. For this purpose, the test will monitor a
+                 folder and verify that the SACL rules are applied to it. Then, the test will remove one rule,
+                 and finally, it will verify that an FIM event is generated indicating the rule modification
+                 and change the monitoring mode to 'realtime'.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that an FIM event is generated when a SACL modification is detected.
+
+    input_description: A test case (audit_interval) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it
+                       is combined with the testing directory to be monitored defined in this module.
+                       For managing the SACL rules, a module 'manage_acl.py' is used.
+
+    expected_output:
+        - r'.*The SACL of .* has been modified and it is not valid for the real-time Whodata mode. ' \
+           'Whodata will not be available for this file.'
+
+    tags:
+        - realtime
+        - who_data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     with Privilege('SeSecurityPrivilege'):
@@ -109,7 +204,47 @@ def test_windows_audit_modify_sacl(tags_to_apply, get_configuration, configure_e
 ])
 def test_windows_audit_restore_sacl(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                                     wait_for_fim_start):
-    """Check that Wazuh restores previous SACL rules when the service is stopped."""
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon restores previous SACL rules when the Wazuh service is stopped.
+                 For this purpose, the test will monitor a folder and verify that the Wazuh SACL rules are applied
+                 to it. Then, the test will stop the agent service, and finally, it will verify that an FIM event
+                 is generated, indicating the restoration of the previous SACL rules.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the `ossec.log` file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that an FIM event is generated indicating that previous SACL rules are restored
+          when the Wazuh agent is stopped.
+
+    input_description: A test case (audit_interval) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it
+                       is combined with the testing directory to be monitored defined in this module.
+                       For managing the SACL rules, a module 'manage_acl.py' is used.
+
+    expected_output:
+        - r'.*The SACL of .* has been restored correctly.'
+
+    tags:
+        - realtime
+        - who_data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     with Privilege('SeSecurityPrivilege'):


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2045


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`