### PR TITLE
Migrate `test_registry_ambiguous_confs` of `test_fim/test_registry` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_complex.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_complex.py
@@ -1,8 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using complex paths and ambiguous configurations, such as keys and subkeys with opposite
+       monitoring settings.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_ambiguous_confs
+'''
 import os
 from hashlib import sha1
 
@@ -86,18 +138,54 @@ def get_configuration(request):
 ])
 def test_ambiguous_complex_checks(key, subkey, key_checkers,
                                   get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if the events of every configured key has the proper check attributes.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds, in the generated events, the 'check_' fields
+                 specified in the configuration. These checks are attributes indicating that a monitored key
+                 has been modified. For this purpose, the test will monitor several registry keys, and
+                 configure different 'checks' for them. Then, it will make operations using testing keys/values
+                 to generate events, and finally, the test will verify that the FIM events generated contain only
+                 the 'check_' fields specified for the monitored key/values.
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_key: str
-        Path of the configured key.
-    key_checkers: set
-        Set of checks that are expected.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - key_checkers:
+            type: set
+            brief: Set of 'check_' fields that are expected.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: A test case (complex_checks) is contained in an external YAML file
+                       (wazuh_complex_entries.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the
+                       testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({"complex_checks"}, get_configuration['tags'])
     # Test registry keys.
     registry_key_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout,
@@ -119,20 +207,57 @@ def test_ambiguous_complex_checks(key, subkey, key_checkers,
 ])
 def test_ambiguous_report_changes(key, subkey, value_list, report,
                                   get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if report changes works properly for every configured entry
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates or not the 'content_changes' field for each event
+                 depending on the value set in the 'report_changes' attribute. This attribute allows reporting the
+                 modifications made in a monitored key. For this purpose, the test will monitor a registry key,
+                 and make operations using a testing value. Finally, it will verify that FIM events generated
+                 contain the changes made in the 'content_changes' field when required.
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_key: str
-        Path of the configured key.
-    value_list: list
-        List with the name of the values that will be used in the cud operation.
-    report: boolean
-        True if the key is configured with report changes.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - value_list:
+            type: list
+            brief: List with the name of the values that will be used in the CUD operations.
+        - report:
+            type: bool
+            brief: True if the key is configured to report changes. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated include in its 'content_changes' field the changes made
+          in the monitored value when 'report_changes == yes' and vice versa.
+
+    input_description: A test case (complex_report_changes) is contained in an external YAML file
+                       (wazuh_complex_entries.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the
+                       testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'complex_report_changes'}, get_configuration['tags'])
 
     validator_after_update = None
@@ -165,21 +290,56 @@ def test_ambiguous_report_changes(key, subkey, value_list, report,
 ])
 def test_ambiguous_report_tags(key, subkey, tag,
                                get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if syscheck detects the event property 'tags' for each configured entry.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates or not the 'tags' field for each event
+                 depending on the value(s) set in the 'tags' attribute. This attribute allows adding tags
+                 to the FIM events for monitored keys. For this purpose, the test will monitor a registry
+                 key, and make CUD (create, update, and delete) operations using testing keys/values. Finally,
+                 it will verify that FIM events generated include in its 'tag' field the tags required.
 
-    This test validates both situations, making sure that if tags='no', there won't be a
-    tags event property.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_key: str
-        Path of the configured key.
-    tag: str
-        Tag that is configured for each entry. If None, the entry isn't configured with a tag.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - tag:
+            type: str
+            brief: Tag configured for each entry. If None, the entry is not configured with a tag.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the 'tags' field is not generated in FIM events
+          when the 'tags' attribute not exists or is empty.
+        - Verify that FIM events generated contain the proper content in the 'tags' field
+          when the 'tags' attribute has content.
+
+    input_description: A test case (complex_tags) is contained in an external YAML file
+                       (wazuh_complex_entries.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the
+                       testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'complex_tags'}, get_configuration['tags'])
 
     def no_tag_validator(event):

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_duplicated_entries.py
@@ -1,8 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using complex paths and ambiguous configurations, such as keys and subkeys with opposite
+       monitoring settings. In particular, it will verify that duplicate events are not generated
+       when multiple configurations are used to monitor the same registry key.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_ambiguous_confs
+'''
 import os
 from hashlib import sha1
 
@@ -90,24 +143,64 @@ def get_configuration(request):
 ])
 def test_duplicate_entries(key, subkey, arch, key_list, value_list, checkers, tags_to_apply,
                            get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check that duplicate antries are overwritten by the last entry.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon uses the last entry when setting multiple ones with
+                 the same key path in the configuration. For this purpose, the test will monitor a registry
+                 key that is duplicated using diferent settings in the configuration, and make key/value
+                 operations inside it. Finally, the test will verify that FIM events are only generated from
+                 the last entry detected.
 
-    Parameters
-    ----------
-    key: str
-        Root key (HKEY_*)
-    subkey: str
-        path of the registry where the test will be executed.
-    arch: str
-        Architecture of the registry.
-    key_list: list
-        List with the name of the keys that will be used for cud. If None, registry_key_cud won't be executed.
-    value_list: list
-        List with the name of the values that will be used for cud. If None, registry_value_cud won't be executed.
-    checkers: set
-        Set with the checkers that are expected in the events.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - key_list:
+            type: list
+            brief: List with the name of the keys that will be used to make CUD operations.
+        - value_list:
+            type: list
+            brief: List with the name of the values that will be used to make CUD operations.
+        - checkers:
+            type: set
+            brief: Set of 'check_' fields that are expected.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated from only one entry of the configuration.
+
+    input_description: Diferent test cases are contained in an external YAML file (wazuh_duplicated_entries.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. These are combined
+                       with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # Test registry keys.
@@ -129,20 +222,66 @@ def test_duplicate_entries(key, subkey, arch, key_list, value_list, checkers, ta
 ])
 def test_duplicate_entries_rc(key, subkey, arch, value_list, tags_to_apply, report_changes,
                               get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check registry entries are overwritten when report changes is activated/deactivated.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon uses the last entry when setting multiple ones
+                 using the same key path and the 'report_changes' attribute in the configuration.
+                 For this purpose, the test will monitor a registry key that is duplicated using a different
+                 value for the 'report_changes' attribute in the configuration, and make value operations
+                 inside it. Finally, the test will verify that FIM events generated include the value changes
+                 when this option is enabled in the last entry of the configuration.
 
-    Parameters
-    ----------
-    key: str
-        Root key (HKEY_* constants).
-    subkey: str
-        path of the registry where the test will be executed.
-    arch: str
-        Architecture of the registry.
-    value_list: list
-        List with the name of the values that will be used for cud.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_list:
+            type: list
+            brief: List with the name of the values that will be used to make CUD operations.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - report_changes:
+            type: bool
+            brief: True if the key is configured to report changes. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated include in its 'content_changes' field the changes made
+          in the monitored key when 'report_changes == yes'.
+        - Verify that a 'diff' file is created when 'report_changes == yes' and changes are made
+          on the monitored value.
+
+    input_description: A test case (duplicate_report_entries) is contained in an external YAML file
+                       (wazuh_duplicated_entries.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys
+                       to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     def report_changes_validator(event):

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_ignore_works_over_restrict.py
@@ -1,8 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using complex paths and ambiguous configurations, such as keys and subkeys with opposite
+       monitoring settings. In particular, it will verify that the value of the 'ignore' attribute
+       prevails over the 'restrict' one.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-ignore
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_ambiguous_confs
+'''
 import os
 
 import pytest
@@ -66,18 +119,58 @@ def get_configuration(request):
 ])
 def test_ignore_over_restrict_key(key, subkey, key_name, arch,
                                   get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check registry values are ignored according to configuration.
+    '''
+    description: Check if the 'ignore' tag prevails over the 'restrict' one when using both in the same
+                 registry key. For example, when a registry key is ignored, and at the same time,
+                 monitoring is restricted on other key that is in that key, no FIM events should be generated
+                 when that key is modified. For this purpose, the test will monitor a registry key that
+                 is ignored in the configuration, and make key operations inside it. Finally, it will verify
+                 that no FIM events are generated.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry where the test will be executed.
-    arch : str
-        Architecture of the registry.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - key_name:
+            type: str
+            brief: Name of the testing key that will be used to make CUD operations.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that when a registry key is ignored, the 'restrict' attribute
+          is not taken into account to generate FIM events.
+
+    input_description: A test case (ambiguous_ignore_restrict_key) is contained in an external YAML file
+                       (wazuh_ignore_over_restrict.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys
+                       to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (at end of the initial FIM scan)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({"ambiguous_ignore_restrict_key"}, get_configuration['tags'])
 
     # Test registry keys.
@@ -93,18 +186,58 @@ def test_ignore_over_restrict_key(key, subkey, key_name, arch,
 ])
 def test_ignore_over_restrict_values(key, subkey, value_name, arch,
                                      get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check registry values are ignored according to configuration.
+    '''
+    description: Check if the 'ignore' tag prevails over the 'restrict' one when using both in the same
+                 registry key. For example, when a registry key is ignored, and at the same time,
+                 monitoring is restricted on a value that is in that key, no FIM events should be generated
+                 when that value is modified. For this purpose, the test will monitor a registry key that
+                 is ignored in the configuration, and make value operations inside it. Finally, it will verify
+                 that no FIM events are generated.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry where the test will be executed.
-    arch : str
-        Architecture of the registry.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_key:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - value_name:
+            type: str
+            brief: Value of the testing key that will be used to make CUD operations.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that when a registry key is ignored, the 'restrict' attribute
+          is not taken into account to generate FIM events.
+
+    input_description: A test case (ambiguous_ignore_restrict_values) is contained in an external YAML file
+                       (wazuh_ignore_over_restrict.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry keys
+                       to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' (at end of the initial FIM scan)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({"ambiguous_ignore_restrict_values"}, get_configuration['tags'])
 
     # Test registry keys.

--- a/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_simple.py
+++ b/tests/integration/test_fim/test_registry/test_registry_ambiguous_confs/test_registry_ambiguous_simple.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM watches selected
+       files and triggering alerts when these files are modified. All these tests will be performed
+       using ambiguous configurations, such as keys and subkeys with opposite monitoring settings.
+       In particular, it will verify that the 'restrict_*', 'tags', 'recursion_level', and 'check_'
+       attributes work properly.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_ambiguous_confs
+'''
 import os
 
 import pytest
@@ -90,23 +144,57 @@ def get_configuration(request):
 ])
 def test_ambiguous_restrict(key, sub_keys, is_key, name,
                             get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check restrict configuration events.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects changes (add, modify, delete) of key/values
+                 depending on its 'restrict' attribute. This attribute limit checks to keys/values containing
+                 the entered string in its name. For example, if 'SOFTWARE/testkey1' has a 'restrict' setting
+                 and 'SOFTWARE/testkey1/testkey2' has not, only events from 'SOFTWARE/testkey1/testkey2' should
+                 appear in the 'ossec.log' file. For this purpose, the test will monitor two registry keys
+                 (one of them inside the other) and perform key/value operations within them. Finally, the test
+                 will verify that FIM events are only generated for keys/values that are not inside
+                 the restricted registry entries.
 
-    Check if syscheck detects changes (add, modify, delete) of key/events depending on its restrict configuration.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_keys: tuple
-        Tuple where the first element is the path of a key that won't raise alerts due to the restrict and the
-        second element is a key that will raise alerts.
-    is_key: boolean
-        Variable to distinguish if the restrict is for keys or for values.
-    name: str
-        String with the name of the value/key that will be created.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_keys:
+            type: tuple
+            brief: The first entry does restrict, and the second one does not.
+        - is_key:
+            type: bool
+            brief: True if the restriction is for keys. False for values.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that no FIM events are generated after modifying keys/values in the monitored
+          registry key specified in the 'restrict' attribute and vice versa.
+
+    input_description: A test case (ambiguous_restrict) is contained in an external YAML file
+                       (wazuh_ambiguous_simple.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({"ambiguous_restrict"}, get_configuration['tags'])
 
     if is_key:
@@ -128,22 +216,57 @@ def test_ambiguous_restrict(key, sub_keys, is_key, name,
 ])
 def test_ambiguous_tags(key, sub_keys, arch,
                         get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """Check if syscheck detects the event property 'tags' for each event.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds, in the generated events, the tags specified in
+                 the configuration. The 'tags' attribute allows adding tags to alerts for monitored registry
+                 keys. For this purpose, the test will monitor a registry key using different tags in
+                 key and subkey paths. Then it will make key operations inside that entry, and finally, the
+                 test will verify that FIM events generated include only in its 'tags' field, the tags set
+                 in the configuration for the monitored key paths or subpaths.
 
-    This test validates both situations, making sure that if tags='no', there won't be a
-    tags event property.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_keys: tuple
-        Tuple where the first element is the path of a key that will have the tag attribute
-        and the second won't have the tag attribute.
-    arch: int
-        Architecture of the key.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - sub_keys:
+            type: tuple
+            brief: The first entry does not have the tag attribute, and the second one does.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
+    assertions:
+        - Verify that FIM events generated contain in its 'tags' field the tags specified
+          in the configuration for the monitored registry keys.
+        - Verify that FIM events generated do not contain the 'tags' field
+          when the 'tag' attribute is not used.
+
+    input_description: A test case (ambiguous_tag) is contained in an external YAML file
+                       (wazuh_ambiguous_simple.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     def tag_validator(event):
         """Validate tags event property exists in the event."""
         assert tag == event['data']['tags'], 'Defined_tags are not equal'
@@ -168,25 +291,53 @@ def test_ambiguous_tags(key, sub_keys, arch,
 ])
 def test_ambiguous_recursion(key, subkey, arch,
                              get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if syscheck detects the event property 'tags' for each event.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects events for a registry key level defined
+                 in the 'recursion_level' attribute. The 'recursion_level' attribute limits the maximum
+                 level of recursion allowed. For this purpose, the test will monitor a registry key
+                 with several levels of deep and make key/value operations inside it. Finally, it
+                 will verify that only FIM events are generated up to the deep level specified.
 
-    This test validates both situations, making sure that if tags='no', there won't be a
-    tags event property.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_keys: str
-        Path of the subkey that will be used for the test (must have a higher recursion level than the configured key).
-        Example:
-        <windows_registry recursion_level="2">HKLM//some_key</windows_registry>
-        subkey = HKLM//some_key//1//2//3
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
 
-    arch: int
-        Architecture of the key.
-    """
+    assertions:
+        - Verify that FIM events are generated up to the specified registry key depth.
+
+    input_description: A test case (ambiguous_recursion) is contained in an external YAML file
+                       (wazuh_ambiguous_simple.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     expected_recursion_key = os.path.join(subkey, key_name)
     check_apply_test({"ambiguous_recursion"}, get_configuration['tags'])
 
@@ -206,21 +357,58 @@ def test_ambiguous_recursion(key, subkey, arch,
 ])
 def test_ambiguous_checks(key, subkey, key_checkers, subkey_checkers,
                           get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if syscheck detects the event property 'tags' for each event.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds, in the generated events, the 'check_' fields
+                 specified in the configuration. These checks are attributes indicating that a monitored
+                 key has been modified. For this purpose, the test will monitor a registry key using
+                 different 'check_' attributes in key and subkey paths. Then it will make key/value operations
+                 inside that key, and finally, the test will verify that the FIM events generated include
+                 only the 'check_' fields set in the configuration for the monitored key paths or subpaths.
 
-    This test validates both situations, making sure that if tags='no', there won't be a
-    tags event property.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        Key of the registry (HKEY_* constants).
-    sub_keys: tuple
-        Tuple where ther first element is the configured key and the second is the configured subkey.
-    arch: int
-        Architecture of the key.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - key_checkers:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - subkey_checkers:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events generated contain only the 'check_' fields specified in the configuration
+          for the monitored registry entries.
+
+    input_description: A test case (ambiguous_checks) is contained in an external YAML file
+                       (wazuh_ambiguous_simple.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({"ambiguous_checks"}, get_configuration['tags'])
     # Test registry keys.
     registry_key_cud(key, subkey[0], wazuh_log_monitor, min_timeout=global_parameters.default_timeout,


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2061


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`