### PR TITLE
Migrate `test_registry_basic_usage` of `test_fim/test_registry` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_delete_registry.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_delete_registry.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM generates events
+       of type 'deleted' from the values contained in a registry key that is being deleted.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 0
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_basic_usage
+'''
 import os
 from collections import Counter
 
@@ -60,22 +111,57 @@ def get_configuration(request):
 def test_delete_registry(key, subkey, arch, value_list,
                          get_configuration, configure_environment,
                          restart_syscheckd, wait_for_fim_start):
-    """
-    Check if syscheckd detects 'deleted' events from the values contained
-    in a registry key that is being deleted.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects 'deleted' events from the values contained
+                 in a registry key that is being deleted. For this purpose, the test will monitor a registry
+                 key and create several values inside it. Then, it will remove the registry key, and finally,
+                 the test will verify that FIM 'deleted' events are generated for the values that were inside
+                 the registry key.
 
-    Parameters
-    ----------
-    key : str
-        Root key where the sub key will be created (HKEY_LOCAL_MACHINE, etc)
-    subkey : str
-        Path of the registry subkey
-    arch : int
-        Arch of the registry subkey
-    value_list : list
-        Names of the values.
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_list:
+            type: list
+            brief: List with the name of the values that will be used.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM 'deleted' events are generated from values found
+          in a monitored registry key when removed.
+
+    input_description: A test case (ossec_conf_2) is contained in an external YAML file
+                       (wazuh_conf_registry_both.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     mode = get_configuration['metadata']['fim_mode']
     scheduled = mode == 'scheduled'
 

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_entries_match_key_count.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_entries_match_key_count.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM detects the number
+       of modifications made on monitored registry entries.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 0
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_basic_usage
+'''
 import os
 
 import pytest
@@ -56,10 +107,44 @@ def extra_configuration_before_yield():
 
 
 def test_entries_match_key_count(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if FIM entries match the entries count
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects the correct number of events when adding
+                 registry entries. For this purpose, the test will add and monitor a registry key. Then,
+                 it will create several values inside it, and finally, the test will verify that an FIM
+                 event is generated indicating the number of entries added for the key and values added.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM event is generated with the number of changes
+          made on the monitored registry entries.
+
+    input_description: A test case (ossec_conf_2) is contained in an external YAML file
+                       (wazuh_conf_reg_attr.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       key to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Fim registry entries'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     entries = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                       callback=callback_registry_count_entries,
                                       error_message='Did not receive expected '

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_changes.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_changes.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM detects correctly
+       common operations ('add', 'modify', and 'delete') on monitored registry entries.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 0
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_basic_usage
+'''
 import os
 
 import pytest
@@ -63,9 +114,54 @@ def get_configuration(request):
 ])
 def test_registry_changes(key, subkey, arch, value_type, get_configuration, configure_environment, restart_syscheckd,
                           wait_for_fim_start):
-    """
-    Check if events appear for subkeys/values of a monitored key
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects registry events generated from subkeys/values.
+                 For this purpose, the test will monitor a registry key and make key/value operations inside it.
+                 Finally, it will check that FIM events are generated for the modifications made on the key/values.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_type:
+            type: srt
+            brief: Type of the registry value to be created.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated for the changes detected on the monitored registry entries.
+
+    input_description: A test case (ossec_conf_2) is contained in an external YAML file
+                       (wazuh_conf_registry_both.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     registry_key_cud(key, subkey, wazuh_log_monitor, arch=arch,
                      time_travel=get_configuration['metadata']['fim_mode'] == 'scheduled',
                      min_timeout=global_parameters.default_timeout,

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_new_key.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_new_key.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM detects correctly
+       common operations ('add', 'modify', and 'delete') on monitored registry values after
+       the next scheduled scan.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 0
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_basic_usage
+'''
 import os
 
 import pytest
@@ -46,10 +98,44 @@ def get_configuration(request):
 # tests
 
 def test_new_key(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check that a new monitored key generates events after the next scheduled scan.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates events from a new monitored key after
+                 the next scheduled scan. For this purpose, the test will monitor a registry key and
+                 make value operations inside it. Finally, it will check that FIM events are generated
+                 for the modifications made on the testing value.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated for the changes detected on the monitored values
+          after the next scheduled scan.
+
+    input_description: A test case (ossec_conf_2) is contained in an external YAML file
+                       (wazuh_conf_reg_attr.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       key to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     create_registry(registry_parser[key], sub_key_1, arch)
 
     check_time_travel(True, monitor=wazuh_log_monitor)

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_long_registry_path.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM detects correctly
+       common operations ('add', 'modify', and 'delete') on registry values from monitored
+       registry keys that use long paths.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 0
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_basic_usage
+'''
 import os
 
 import pytest
@@ -47,10 +99,44 @@ def get_configuration(request):
 
 
 def test_long_registry_path(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if long key names generates events
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates events from monitored keys with long paths.
+                 For this purpose, the test will monitor a registry key with a long character length path
+                 and make value operations inside it. Finally, it will check that FIM events are generated
+                 for the modifications made on the testing value.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated for the changes detected on the monitored values
+          in the registry key with a long path.
+
+    input_description: A test case (ossec_conf_2) is contained in an external YAML file
+                       (wazuh_conf_reg_attr.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       key to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     max_value_name = "value_test"
     for i in range(16372):
         max_value_name += "a"


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2072


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`