### PR TITLE
Migrate `test_registry_checks`, `test_registry_ignore`, and `test_registry_nodiff` of `test_fim/test_registry` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_check_others.py
+++ b/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_check_others.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM events generated
+       contain only the 'check_' fields specified in the configuration when using the 'check_'
+       attributes individually and use the 'check_all=no' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_checks
+'''
 import os
 
 import pytest
@@ -81,27 +133,66 @@ def get_configuration(request):
                          params_list)
 def test_check_others(key, subkey, key_attr, value_attr, triggers_key_modification, triggers_value_modification,
                       get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Test the behavior disabling different check options over the same key with check_all enabled.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the 'check_' specified in
+                 the configuration. These checks are attributes indicating that a monitored registry entry has
+                 been modified. For example, if 'check_all=no' and 'check_sum=yes' are set for the same entry,
+                 'syscheck' must send an event containing only the checksums.
+                 For this purpose, the test will monitor a registry key using the 'check_all=no' attribute
+                 (in order to avoid using the default 'check_all' configuration) in conjunction with several
+                 'check_' on the same key. Then it will make key/value operations inside it, and finally,
+                 the test will verify that FIM events generated contain only the fields of the 'check_' specified
+                 for the monitored keys/values.
 
-    Example:
-        check_all: "yes" check_size: "no" check_sum: "no".
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key: str
-        key of the directory (HKEY_* constants).
-    subkey: str
-        Path of the subkey.
-    key_attr: set
-        Set of options that are expected for key events.
-    value_attr: set
-        Set of options that are expected for value events.
-    triggers_key_modification: boolean
-        Specify if the given options generate key events.
-    triggers_value_modification: boolean
-        Specify if the given options generate value events.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - key_attr:
+            type: set
+            brief: Set of options that are expected for key events.
+        - value_attr:
+            type: set
+            brief: Set of options that are expected for value events.
+        - triggers_key_modification:
+            type: bool
+            brief: Specify if the given options generate key events.
+        - triggers_value_modification:
+            type: bool
+            brief: Specify if the given options generate value events.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: A test case (test_others) is contained in an external YAML file
+                       (wazuh_check_others.yaml) which includes configuration settings for
+                       the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_others'}, get_configuration['tags'])
     # Test registry keys.
     registry_key_cud(key, subkey, wazuh_log_monitor, min_timeout=global_parameters.default_timeout, options=key_attr,

--- a/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_checkers.py
+++ b/tests/integration/test_fim/test_registry/test_registry_checks/test_registry_checkers.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM events generated contain only
+       the 'check_' fields specified in the configuration when using the 'check_all' attribute along
+       with other 'check_' attributes.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_checks
+'''
 import os
 
 import pytest
@@ -112,30 +164,68 @@ def get_configuration(request):
 ])
 def test_checkers(key, subkey, arch, key_attrs, value_attrs, tags_to_apply, triggers_modification,
                   get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Test the functionality of `check_all` option is activated/desactivated alone and together with other
-    `check_*` options.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon adds in the generated events the 'check_' specified in
+                 the configuration. These checks are attributes indicating that a monitored registry entry has
+                 been modified. For example, if 'check_all=yes' and 'check_sum=no' are set for the same entry,
+                 'syscheck' must send an event containing every possible 'check_' except the checksums.
+                 For this purpose, the test will monitor a registry key using the 'check_all' attribute in
+                 conjunction with one or more 'check_' on the same key, having 'check_all' to 'yes' and the other
+                 one to 'no'. Then it will make key/value operations inside it, and finally, finally, the test
+                 will verify that the FIM events generated contain only the fields of the 'checks' specified for
+                 the monitored keys/values.
 
-    Example:
-        <windows_registry check_all="yes">HKEY_SOME_KEY</windows_registry>.
-    Parameters
-    ----------
-    key: str
-        Root key (HKEY_* constants).
-    subkey: str
-        Path of the key.
-    arch: int
-        Architecture of the key.
-    key_attrs: set
-        Attributes for the key events.
-    value_attrs: set
-        Attributes for the value events.
-    tags_to_apply: set
-        Configuration that will be applied for every case.
-    triggers_modification: boolean
-        True if the given attributes trigger modification events.
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the key that will be created under the root key.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - key_attr:
+            type: set
+            brief: Set of options that are expected for key events.
+        - value_attr:
+            type: set
+            brief: Set of options that are expected for value events.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - triggers_modification:
+            type: bool
+            brief: Specify if the given options generate registry events.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that the FIM events generated contain only the 'check_' fields specified in the configuration.
+
+    input_description: Different test cases are contained in an external YAML file (wazuh_check_all.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. Those are
+                       combined with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     # Test registry keys.

--- a/tests/integration/test_fim/test_registry/test_registry_nodiff/test_registry_no_diff.py
+++ b/tests/integration/test_fim/test_registry/test_registry_nodiff/test_registry_no_diff.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM ignores the modifications made
+       in a monitored value when it matches the 'registry_nodiff' tag and vice versa.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#registry-nodiff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_nodiff
+'''
 import os
 from hashlib import sha1
 from time import sleep
@@ -68,24 +119,65 @@ def get_configuration(request):
 def test_no_diff_str(key, subkey, arch, value_name, truncated, tags_to_apply,
                      get_configuration, configure_environment, restart_syscheckd,
                      wait_for_fim_start):
-    """
-    Check the only values detected are those matching the restrict using the value path.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon truncates the value changes in the generated events using
+                 the value path in the 'registry_nodiff' tag and vice versa. For this purpose, the test will monitor
+                 a key and make value operations inside it. Then, it will check if the 'diff' file is created for
+                 each testing value modified. Finally, if the testing values match the 'registry_nodiff' tag,
+                 the test will verify that the FIM events generated contain in their 'content_changes' field
+                 a message indicating that 'diff' is truncated because the 'nodiff' option is used.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    truncated : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the registry entry where the test will be executed.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the value that will be created.
+        - truncated:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM ignores the modifications made in a monitored value
+          when it matches the 'registry_nodiff' tag.
+        - Verify that FIM includes the modifications made in a monitored value
+          when it does not match the 'registry_nodiff' tag.
+
+    input_description: A test case (no_diff_str) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     values = {value_name: "some content"}
 
@@ -127,24 +219,65 @@ def test_no_diff_str(key, subkey, arch, value_name, truncated, tags_to_apply,
 def test_no_diff_regex(key, subkey, arch, value_name, truncated, tags_to_apply,
                        get_configuration, configure_environment, restart_syscheckd,
                        wait_for_fim_start):
-    """
-    Check the only files detected are those matching the restrict regex.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon truncates the value changes in the generated events using
+                 regex in the 'registry_nodiff' tag and vice versa. For this purpose, the test will monitor
+                 a key and make value operations inside it. Then, it will check if the 'diff' file is created for
+                 each testing value modified. Finally, if the testing values match the 'registry_nodiff' tag,
+                 the test will verify that the FIM events generated contain in their 'content_changes' field
+                 a message indicating that 'diff' is truncated because the 'nodiff' option is used.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    truncated : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: Path of the registry entry where the test will be executed.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the value that will be created.
+        - truncated:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM ignores the modifications made in a monitored value
+          when it matches the 'registry_nodiff' tag.
+        - Verify that FIM includes the modifications made in a monitored value
+          when it does not match the 'registry_nodiff' tag.
+
+    input_description: A test case (no_diff_regex) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined in the module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     values = {value_name: "some content"}
 


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2076


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`