### PR TITLE
Migrate `test_registry_file_limit`, `test_registry_multiple_registries`, and `test_registry_recursion_level` of `test_fim/test_registry` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_capacity_alerts.py
+++ b/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_capacity_alerts.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if the threshold
+       set in the 'file_limit' tag generates FIM events when the number of monitored entries
+       approaches this value.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_file_limit
+'''
 import os
 
 import pytest
@@ -61,16 +113,55 @@ def get_configuration(request):
 ])
 def test_file_limit_capacity_alert(percentage, tags_to_apply, get_configuration, configure_environment,
                                    restart_syscheckd, wait_for_fim_start):
-    """
-    Checks that the corresponding alerts appear in schedule mode for different capacity thresholds.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates events for different capacity thresholds limits when
+                 using the 'schedule' monitoring mode. For this purpose, the test will monitor a key in which
+                 several testing values will be created, corresponding to different percentages of the total limit.
+                 Then, it will check if FIM events are generated when the number of values created exceeds 80% of
+                 the total and when the number is less than that percentage. Finally, the test will verify that, in
+                 the FIM 'entries' event, the entries number is one unit more than the number of monitored values.
 
-    Parameters
-    ----------
-    percentage : int
-        Percentage of full database.
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - percentage:
+            type: int
+            brief: Percentage of testing values to be created.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM 'DB alert' events are generated when the number of values to be monitored
+          exceeds the established threshold and vice versa.
+        - Verify that FIM 'entries' events contain one unit more than the number of monitored values.
+
+    input_description: A test case (file_limit_registry_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined
+                       with the percentages and the testing registry key to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' events)
+        - r'.*Sending DB .* full alert.'
+        - r'.*Sending DB back to normal alert.'
+        - r'.*Fim registry entries'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     # This import must be here in order to avoid problems in Linux.
     import pywintypes
 

--- a/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_full.py
+++ b/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_full.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM events are
+       generated while the database is in 'full database alert' mode for reaching the limit
+       of entries to monitor set in the 'file_limit' tag.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks
+       configured files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_file_limit
+'''
 import os
 
 import pytest
@@ -73,14 +125,49 @@ def extra_configuration_before_yield():
     {'file_limit_registry_conf'}
 ])
 def test_file_limit_full(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that the full database alerts are being sent.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates proper events while the FIM database is in
+                 'full database alert' mode for reaching the limit of entries to monitor set in the 'file_limit' tag.
+                 For this purpose, the test will monitor a key in which several testing values will be created
+                 until the entry monitoring limit is reached. Then, it will check if the FIM event 'full' is generated
+                 when a new testing value is added to the monitored key. Finally, the test will verify that,
+                 in the FIM 'entries' event, the number of entries and monitored values match.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the FIM database is in 'full database alert' mode
+          when the maximum number of values to monitor has been reached.
+        - Verify that proper FIM events are generated while the database
+          is in 'full database alert' mode.
+
+    input_description: A test case (file_limit_registry_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined
+                       with the testing registry key to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending DB .* full alert.'
+        - r'.*The DB is full.*'
+        - r'.*Fim registry entries'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     database_state = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
@@ -99,9 +186,11 @@ def test_file_limit_full(tags_to_apply, get_configuration, configure_environment
 
     RegCloseKey(reg1_handle)
 
-    wazuh_log_monitor.start(timeout=40, callback=callback_file_limit_full_database,
-                            error_message='Did not receive expected '
-                                          '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
+    wazuh_log_monitor.start(
+        timeout=40,
+        callback=callback_file_limit_full_database,
+        error_message='Did not receive expected '
+                      '"DEBUG: ...: Couldn\'t insert \'...\' entry into DB. The DB is full, ..." event')
 
     entries = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
                                       callback=callback_registry_count_entries,

--- a/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_values.py
+++ b/tests/integration/test_fim/test_registry/test_registry_file_limit/test_registry_limit_values.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if the FIM event
+       'maximum number of entries' has the correct value for the monitored entries limit of
+       the 'file_limit' option.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-limit
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_file_limit
+'''
 import os
 
 import pytest
@@ -71,21 +123,53 @@ def extra_configuration_before_yield():
     {'file_limit_registry_conf'}
 ])
 def test_file_limit_values(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """
-    Check that a list of different values gets configured correctly in file_limit.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects the value of the 'entries' tag, which corresponds to
+                 the maximum number of entries to monitor from the 'file_limit' option of FIM. For this purpose,
+                 the test will monitor a key in which multiple testing values will be added. Then, it will check if
+                 the FIM event 'maximum number of entries' is generated and has the correct value. Finally, the test
+                 will verify that, in the FIM 'entries' event, the number of entries and monitored values match.
 
-    Parameters
-    ----------
-    tags_to_apply : set
-        Run test if matches with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the FIM event 'maximum number of entries' has the correct value
+          for the monitored entries limit of the 'file_limit' option.
+
+    input_description: A test case (file_limit_registry_conf) is contained in external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined
+                       with the limits and the testing registry key to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Maximum number of entries to be monitored'
+        - r'.*Fim registry entries'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
-    file_limit_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                               callback=callback_value_file_limit,
-                                               error_message='Did not receive expected '
-                                                             '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
-                                               ).result()
+    file_limit_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_value_file_limit,
+        error_message='Did not receive expected '
+                      '"DEBUG: ...: Maximum number of entries to be monitored: ..." event'
+        ).result()
 
     if file_limit_value:
         assert file_limit_value == get_configuration['metadata']['file_limit'], 'Wrong value for file_limit.'

--- a/tests/integration/test_fim/test_registry/test_registry_multiple_registries/test_multiple_registry_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_multiple_registries/test_multiple_registry_entries.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM detects
+       all registry modification events when monitoring the maximum number of keys (64)
+       set using multiple 'windows_registry' tags.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_multiple_registries
+'''
 import os
 import time
 
@@ -58,15 +110,48 @@ def get_configuration(request):
 ])
 def test_multiple_entries(tags_to_apply, get_configuration, configure_environment, restart_syscheckd,
                           wait_for_fim_start):
-    """
-    Check if syscheck can detect every event when adding, modifying and deleting a subkey/value within multiple
-    monitored registry keys.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects every event when adding, modifying, and deleting
+                 a subkey/value within each one of the monitored keys. Also, it verifies that it can monitor
+                 the maximum allowed number of keys using multiple 'windows_registry' tags (64). For this purpose,
+                 the test will monitor multiple keys and make key/value operations inside them. Finally, it
+                 will check if all FIM events are generated for each operation made.
 
-    These registry keys will be added using a new entry for every one of them:
-        &lt;windows_registry&gt;testkey0&lt;/windows_registry&gt;
-        ...
-        &lt;windows_registry&gt;testkeyn&lt;/windows_registry&gt;
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - - Verify that FIM events are generated for all monitored keys set
+            in multiple 'windows_registry' tags (up to a limit of 64).
+
+    input_description: A test case (multiple_reg_entries) is contained in external YAML file
+                       (wazuh_conf_multiple_entries.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing
+                       registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     multiple_keys_and_entries_keys(n_regs, subkeys, wazuh_log_monitor, KEY, timeout=global_parameters.default_timeout)


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2082


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`