### PR TITLE
Migrate `test_registry_report_changes` of `test_fim/test_registry` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_all_limits_disabled.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_all_limits_disabled.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these files
+       are modified. Specifically, these tests will verify that FIM does not limit the size of the key
+       monitored to generate 'diff' information or the 'queue/diff/local' folder where Wazuh stores the
+       compressed files used to perform the 'diff' operation. Having the 'file_size' and 'disk_quota'
+       options disabled, and the 'report_changes' option enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -61,22 +114,62 @@ def get_configuration(request):
 def test_all_limits_disabled(key, subkey, arch, value_name, tags_to_apply,
                              get_configuration, configure_environment, restart_syscheckd,
                              wait_for_fim_start):
-    """
-    Check that no events are sent when the file_size exceeded
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates all FIM events when the 'file_size' and
+                 the 'disk_quota' tags have set a small limit but they are disabled. For this purpose,
+                 the test will monitor a key and create multiple values with a content of big size inside it.
+                 That values exceed both, 'file_size' and 'disk_quota' limits. Finally, the test will verify
+                 that all FIM events have been generated, since that those limits are disabled.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that all FIM events are generated for the modifications made on the testing values.
+        - Verify that a 'diff' file is created for each monitored value.
+        - Verify that FIM events include the 'content_changes' field.
+
+    input_description: A test case (test_limits) is contained in external YAML file
+                       (wazuh_registry_report_changes_limits_quota.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined
+                       in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     value_content = generate_string(4 * 1024 * 1024, '0')
     values = {value_name: value_content}

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_diff_size_limit_values.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_diff_size_limit_values.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       'diff' information to generate from the monitored value when the 'diff_size_limit' and
+       the 'report_changes' options are enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -62,24 +114,64 @@ def get_configuration(request):
 def test_diff_size_limit_values(key, subkey, arch, value_name, tags_to_apply, size,
                                 get_configuration, configure_environment, restart_syscheckd,
                                 wait_for_fim_start):
-    """
-    Check that no events are sent when the diff_size_limit exceeded
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the monitored value to generate
+                 'diff' information from the limit set in the 'diff_size_limit' tag. For this purpose,
+                 the test will monitor a key, create a testing value smaller than the 'diff_size_limit' and
+                 increase its size on each test case. Finally, the test will verify that the compressed file
+                 has been created, and the related FIM event includes the 'content_changes' field if the
+                 value size does not exceed the specified limit and vice versa.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    size : int
-        Size of the content to write in value
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that a 'diff' file is created when a monitored value does not exceed the size limit.
+        - Verify that no 'diff' file is created when a monitored value exceeds the size limit.
+        - Verify that FIM events include the 'content_changes' field when the monitored value
+          does not exceed the size limit.
+
+    input_description: A test case (test_diff_size_limit) is contained in external YAML file
+                       (wazuh_registry_report_changes_limits_quota.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined
+                       in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     value_content = generate_string(size, '0')
     values = {value_name: value_content}

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_disk_quota_default.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       the 'queue/diff/local' folder, where Wazuh stores the compressed files used to perform
+       the 'diff' operation, to the default value when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#disk-quota
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -66,31 +118,69 @@ def get_configuration(request):
 ])
 def test_disk_quota_default(key, subkey, arch, value_name, tags_to_apply,
                             get_configuration, configure_environment, restart_syscheckd_each_time):
-    """
-    Check that no events are sent when the disk_quota exceeded
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the folder where the data used to perform
+                 the 'diff' operations is stored to the default value. For this purpose, the test will monitor a key
+                 and, once the FIM is started, it will wait for the FIM event related to the maximum disk quota to
+                 store 'diff' information, and create and modify a testing value. Finally, the test will verify that
+                 the value gotten from that FIM event corresponds with the default value of the 'disk_quota' tag (1GB),
+                 and the FIM 'added' y 'modified' events from the testing value have been generated properly.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    size : int
-        Size of the content to write in value
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd_each_time:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor on each test case.
+
+    assertions:
+        - Verify that an FIM event is generated indicating the size limit of the folder
+          to store 'diff' information to the default limit of the 'disk_quota' tag (1GB).
+        - Verify that FIM events are generated when adding and modifying a testing value.
+
+
+    input_description: A test case (test_report_changes) is contained in external YAML file
+                       (wazuh_registry_report_changes.yaml) which includes configuration
+                       settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Maximum disk quota size limit configured to .*'
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     mode = get_configuration['metadata']['fim_mode']
 
-    disk_quota_value = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                               callback=callback_disk_quota_default,
-                                               error_message='Did not receive expected '
-                                                             '"Maximum disk quota size limit configured to \'... KB\'." event'
+    disk_quota_value = wazuh_log_monitor.start(
+        timeout=global_parameters.default_timeout,
+        callback=callback_disk_quota_default,
+        error_message='Did not receive expected '
+                      '"Maximum disk quota size limit configured to \'... KB\'." event'
                                                ).result()
     if disk_quota_value:
         assert disk_quota_value == str(DEFAULT_SIZE), 'Wrong value for disk_quota'

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts
+       when these files are modified. Specifically, these tests will check if FIM limits
+       the size of the monitored value to generate 'diff' information to the default limit
+       of the 'file_size' tag when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-size
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -66,24 +118,61 @@ def get_configuration(request):
 ])
 def test_file_size_default(key, subkey, arch, value_name, tags_to_apply,
                            get_configuration, configure_environment, restart_syscheckd_each_time):
-    """
-    Check that no events are sent when the disk_quota exceeded
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the monitored value to generate
+                 'diff' information from the default limit of the 'file_size' option. For this purpose,
+                 the test will monitor a key and, once the FIM is started, it will wait for the FIM event
+                 related to the maximum file size limit to generate 'diff' information and create and
+                 modify a testing value. Finally, the test will verify that the value gotten from the
+                 FIM event corresponds with the default value of the 'file_size' tag (50MB), and the FIM
+                 'added' y 'modified' events from the testing value have been generated properly.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    size : int
-        Size of the content to write in value
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd_each_time:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor on each test case.
+
+    assertions:
+        - Verify that an FIM event is generated indicating tthe maximum file size limit
+          to generate 'diff' information to the default limit of the 'file_size' tag (50MB).
+        - Verify that FIM events are generated when adding and modifying a testing value.
+
+    input_description: A test case (test_report_changes) is contained in external YAML file
+                       (wazuh_registry_report_changes.yaml) which includes configuration
+                       settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Maximum file size limit to generate diff information configured to .*'
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     mode = get_configuration['metadata']['fim_mode']
 

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_values.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_values.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM limits the size of
+       the monitored value to generate 'diff' information to the limit set in the 'file_size' tag
+       when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#file-size
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -65,24 +117,67 @@ def get_configuration(request):
 def test_file_size_values(key, subkey, arch, value_name, tags_to_apply, size,
                           get_configuration, configure_environment, restart_syscheckd,
                           wait_for_fim_start):
-    """
-    Check that no events are sent when the file_size exceeded
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon limits the size of the monitored value to generate
+                 'diff' information from the limit set in the 'file_size' tag. For this purpose, the test
+                 will monitor a key, create a testing value smaller than the 'file_size' and increase
+                 its size on each test case. Finally, the test will verify that the compressed 'diff' file
+                 has been created, and the related FIM event includes the 'content_changes' field if the
+                 value size does not exceed the specified limit and vice versa.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    size : int
-        Size of the content to write in value
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - size:
+            type: int
+            brief: Size of the content to write in the testing value.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that a 'diff' file is created when a monitored value does not exceed the 'file_size' limit.
+        - Verify that no 'diff' file is created when a monitored value exceeds the 'file_size' limit.
+        - Verify that FIM events include the 'content_changes' field when the monitored value
+          does not exceed the 'file_size' limit.
+
+    input_description: A test case (test_limits) is contained in external YAML file
+                       (wazuh_registry_report_changes_limits_quota.yaml) which includes
+                       configuration settings for the 'wazuh-syscheckd' daemon. That is
+                       combined with the testing registry keys to be monitored defined
+                       in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     value_content = generate_string(size, '0')
     values = {value_name: value_content}

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM reports the changes
+       made in monitored keys when the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -56,23 +108,60 @@ def get_configuration(request):
 def test_report_changes(key, subkey, arch, value_name, tags_to_apply,
                         get_configuration, configure_environment, restart_syscheckd,
                         wait_for_fim_start):
-    """
-    Checks that events of keys configured using report changes are correct.
-    It also checks that the diff file is created for each value.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects events and creates 'diff' files from monitored
+                 keys when the 'report_changes' option is enabled. For this purpose, the test will monitor a key,
+                 add a testing value and modify it. Finally, the test will verify that the 'diff' file has been
+                 created, and the FIM event generated includes the 'content_changes' field.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are generated for the changes made on the testing values.
+        - Verify that a 'diff' file is created for each monitored value.
+        - Verify that FIM events include the 'content_changes' field.
+
+    input_description: A test case (test_report_changes) is contained in external YAML file
+                       (wazuh_registry_report_changes.yaml) which includes configuration
+                       settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     values = {value_name: "some content"}
 

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes_deleted.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes_deleted.py
@@ -1,6 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM manages properly 'diff' folders
+       and files when removing a monitored key/value or the 'report_changes' option is disabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -93,27 +146,66 @@ def get_configuration(request):
 def test_report_when_deleted_key(key, subkey, arch, value_name, enabled, tags_to_apply,
                                  get_configuration, configure_environment, restart_syscheckd,
                                  wait_for_fim_start):
-    """
-    Check that the diff files are generated when there is a modification in a value and these files are deleted when
-    the value is deleted.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon creates a 'diff' file when a modification is made on
+                 a monitored value and deletes that 'diff' file when it is deleted. This test also checks
+                 that a 'diff' folder of a monitored key is removed when that key is deleted. For this purpose,
+                 the test will monitor a key and make value operations inside it. Then, it will check if the
+                 'diff' file has been created/deleted if the 'report_changes' option is enabled, and vice versa.
+                 Finally, the test will remove the monitored key and verify that the 'diff' folder has been deleted.
 
-    It also checks that the diff folder of the key is deleted when the key is deleted.
+    wazuh_min_version: 4.2.0
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    enabled: boolean
-        True if report_changes is enabled
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - enabled:
+            type: bool
+            brief: True if the 'report_changes' option is enabled. False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM adds/removes a 'diff' file when modifying/deleting the corresponding value,
+          and the 'report_changes' option is enabled.
+        - Verify that FIM removes the 'diff' file of a related value when disabling the 'report_changes' option.
+        - Verify that FIM removes the 'diff' folder when removing the related key.
+
+    input_description: A test case (test_report_changes) is contained in external YAML file
+                       (wazuh_registry_report_changes.yaml) which includes configuration
+                       settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     vals_after_update = None
@@ -152,9 +244,47 @@ def test_report_when_deleted_key(key, subkey, arch, value_name, enabled, tags_to
 
 
 def test_report_changes_after_restart(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check if diff directories are removed after disabling report_changes and Wazuh is restarted.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon removes the 'diff' directories when disabling
+                 the 'report_changes' option and Wazuh is restarted. For this purpose, the test
+                 will monitor two keys and make value operations inside them. Then, it will check if
+                 the related 'diff' folders have been created. After this, it will apply a new main
+                 configuration with the 'report_changes' disabled and restart Wazuh. Finally, the test
+                 will verify that the 'diff' folders have been deleted.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM adds the 'diff' folders when the testing keys are created.
+        - Verify that FIM deletes the 'diff' folders when disabling the 'report_changes' option
+          and Wazuh is restarted.
+
+    input_description: A test case (test_delete_after_restart) is contained in external YAML file
+                       (wazuh_registry_report_changes.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing registry
+                       keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'test_delete_after_restart'}, get_configuration['tags'])
     value_name = 'random_value'
 

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes_more_changes.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_report_changes_more_changes.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM events include
+       the 'content_changes' field with the tag 'More changes' when it exceeds the maximum size
+       allowed, and the 'report_changes' option is enabled.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#diff
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_report_changes
+'''
 import os
 
 import pytest
@@ -59,22 +111,62 @@ def get_configuration(request):
 def test_report_changes_more_changes(key, subkey, arch, value_name, tags_to_apply,
                                      get_configuration, configure_environment, restart_syscheckd,
                                      wait_for_fim_start):
-    """
-    Checks that "More changes..." diff string is MAX_STR_MORE_CHANGES
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects when the character limit is reached in
+                 the value changes, showing the 'More changes' tag in the 'content_changes' field of
+                 the generated FIM events. For this purpose, the test will monitor a key, add a testing
+                 value and modify it, adding more characters than the allowed limit. Finally, the test
+                 will verify that the 'diff' file has been created, and the FIM event generated contains
+                 the 'More changes' tag in its 'content_changes' field.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM adds a 'diff' file when modifying the corresponding value.
+        - Verify that FIM events include the 'content_changes' field with the 'More changes' tag
+          when the changes made on a value exceed the characters limit.
+
+    input_description: A test case (test_report_changes) is contained in external YAML file
+                       (wazuh_registry_report_changes.yaml) which includes configuration
+                       settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     values = {value_name: generate_string(MAX_STR_MORE_CHANGES, '0')}
     error_str = 'Expected {} in event'.format(MORE_CHANGES_STR)


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2101


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`