### PR TITLE
Migrate `test_registry_restrict` and `test_registry_tags` of `test_fim/test_registry`, and `test_fim/test_synchronization` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_fim/test_registry/test_registry_restrict/test_registry_restrict.py
+++ b/tests/integration/test_fim/test_registry/test_registry_restrict/test_registry_restrict.py
@@ -1,6 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will verify that FIM generates events
+       only for registry entry operations in monitored keys that do not match the 'restrict_key'
+       or the 'restrict_value' attributes.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_restrict
+'''
 import os
 
 import pytest
@@ -62,24 +115,66 @@ def get_configuration(request):
 def test_restrict_value(key, subkey, arch, value_name, triggers_event, tags_to_apply,
                         get_configuration, configure_environment, restart_syscheckd,
                         wait_for_fim_start):
-    """
-    Check the only registry values detected are those matching the restrict regex
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects or ignores events in monitored registry entries
+                 depending on the value set in the 'restrict_value' attribute. This attribute limit checks to
+                 values that match the entered string or regex and its name. For this purpose, the test will
+                 monitor a key, create testing values inside it, and make operations on that values. Finally,
+                 the test will verify that FIM 'added' and 'modified' events are generated only for the testing
+                 values that are not restricted.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        path of the registry.
-    arch : str
-        Architecture of the registry.
-    value_name : str
-        Name of the value that will be created
-    triggers_event : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - value_name:
+            type: str
+            brief: Name of the testing value that will be created.
+        - triggers_event:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are only generated for operations in monitored values
+          that do not match the 'restrict_value' attribute.
+        - Verify that FIM 'ignoring' events are generated for monitored values that are restricted.
+
+    input_description: A test case (value_restrict) is contained in external YAML file
+                       (wazuh_restrict_conf.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing
+                       registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified' events)
+        - r'.*Ignoring entry .* due to restriction .*'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     # This shouldn't create an alert because the key is already created
     key_h = create_registry(registry_parser[key], subkey, arch)
@@ -146,24 +241,66 @@ def test_restrict_value(key, subkey, arch, value_name, triggers_event, tags_to_a
 def test_restrict_key(key, subkey, test_subkey, arch, triggers_event, tags_to_apply,
                       get_configuration, configure_environment, restart_syscheckd,
                       wait_for_fim_start):
-    """
-    Check the only registry keys detected are those matching the restrict regex
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects or ignores events in monitored registry entries
+                 depending on the value set in the 'restrict_key' attribute. This attribute limit checks to
+                 keys that match the entered string or regex and its name. For this purpose, the test will
+                 monitor a key, create testing subkeys inside it, and make operations on those subkeys. Finally,
+                 the test will verify that FIM 'added' and 'deleted' events are generated only for the testing
+                 subkeys that are not restricted.
 
-    Parameters
-    ----------
-    key : str
-        Root key (HKEY_*)
-    subkey : str
-        Path of the registry.
-    test_subkey : str
-        Name of the key that will be used for the test
-    arch : str
-        Architecture of the registry.
-    triggers_event : bool
-        True if an event must be generated, False otherwise.
-    tags_to_apply : set
-        Run test if match with a configuration identifier, skip otherwise.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - test_subkey:
+            type: str
+            brief: Name of the key that will be used for the test
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - triggers_event:
+            type: bool
+            brief: True if an event must be generated, False otherwise.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events are only generated for operations in monitored keys
+          that do not match the 'restrict_key' attribute.
+        - Verify that FIM 'ignoring' events are generated for monitored keys that are restricted.
+
+    input_description: A test case (key_restrict) is contained in external YAML file
+                       (wazuh_restrict_conf.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing
+                       registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'deleted' events)
+        - r'.*Ignoring entry .* due to restriction .*'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     test_key = os.path.join(subkey, test_subkey)
     create_registry(registry_parser[key], test_key, arch)

--- a/tests/integration/test_fim/test_registry/test_registry_tags/test_registry_tags.py
+++ b/tests/integration/test_fim/test_registry/test_registry_tags/test_registry_tags.py
@@ -1,6 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM events include
+       all tags set in the 'tags' attribute.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#windows-registry
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_registry_tags
+'''
 import os
 
 import pytest
@@ -47,19 +99,52 @@ def get_configuration(request):
 ])
 def test_tags(key, subkey, arch,
               get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Check the tags functionality by applying some tags an ensuring the events raised for the monitored directory has
-    the expected tags.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon generates the tags required for each event depending
+                 on the values set in the 'tags' attribute. This attribute allows adding tags to alerts for
+                 monitored registry entries. For this purpose, the test will monitor a key and make value
+                 operations inside it. Finally, it will verify that FIM events generated include in the
+                 'tags' field all tags set in the configuration.
 
-    Parameters
-    ----------
-    folder : str
-        Directory where the file is being created.
-    name : str
-        Name of the file to be created.
-    content : str, bytes
-        Content to fill the new file.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key:
+            type: str
+            brief: Path of the registry root key (HKEY_* constants).
+        - subkey:
+            type: str
+            brief: The registry key being monitored by syscheck.
+        - arch:
+            type: str
+            brief: Architecture of the registry.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM events include all tags set in the 'tags' attribute.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_registry_tag_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined
+                       with the testing registry keys to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending FIM event: (.+)$' ('added', 'modified', and 'deleted' events)
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     defined_tags = get_configuration['metadata']['fim_tags']
 
     def tag_validator(event):

--- a/tests/integration/test_fim/test_synchronization/test_invalid_sync_response.py
+++ b/tests/integration/test_fim/test_synchronization/test_invalid_sync_response.py
@@ -1,6 +1,68 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM detects invalid
+       values for the 'interval' tag of the 'synchronization' feature.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 
 import pytest
@@ -37,7 +99,41 @@ def get_configuration(request):
 # Tests
 
 def test_invalid_sync_response(get_configuration, configure_environment, restart_syscheckd):
-    """Checks if an invalid ignore configuration is detected by catching the warning message displayed on the log"""
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects invalid synchronization intervals
+                 by catching the warning message displayed on the log file. For this purpose,
+                 the test will monitor a testing directory and setup the 'synchronization' option
+                 using invalid values for its 'interval' tag. Finally, it will verify that the FIM
+                 'warning' event has been generated, indicating that an invalid value is used.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that FIM 'warning' event is generated when using an invalid value
+          for the interval tag of the 'synchronization' option.
+
+    input_description: A test case (sync_invalid) is contained in external YAML file (wazuh_invalid_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined
+                       with the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'.*WARNING:.* Invalid value for element'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test({'sync_invalid'}, get_configuration['tags'])
 
     wazuh_log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_configuration_warning,

--- a/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_registry_responses_win32.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM synchronizes the
+       registry DB when a modification is performed while the agent is down and decodes
+       the synchronization events properly.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 import pytest
 import wazuh_testing.fim as fim
@@ -135,21 +187,53 @@ def remove_key_and_restart(request):
 @pytest.mark.parametrize('value_name', [':value1', 'value2:', ':value3:'])
 def test_registry_sync_after_restart(key_name, value_name, tags_to_apply, get_configuration, configure_environment,
                                      remove_key_and_restart):
-    """
-    Test to check that FIM synchronizes the registry DB when a modification is performed while the agent is down.
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon synchronizes the registry DB when a modification
+                 is performed while the agent is down. For this purpose, the test will monitor a key and
+                 wait for the synchronization. Then it will stop the agent, make key/value operations inside
+                 the monitored key, and start the agent again. Finally, it will wait for the synchronization
+                 and verify that FIM sync events generated include the key and value paths for
+                 the modifications made.
 
-    Params:
-        key_name (str): Name of the subkey that will be created in the test.
-        value_name (str): Name of the value that will be created in the test. If
-        tags_to_apply (set): Run test if matches with a configuration identifier, skip otherwise.
-        get_configuration (fixture): Gets the current configuration of the test.
-        configure_environment (fixture): Configure the environment for the execution of the test.
-        restart_syscheckd (fixture): Restarts syscheck.
-        wait_for_fim_start (fixture): Waits until the first FIM scan is completed.
-    Raises:
-        TimeoutError: If an expected event couldn't be captured.
-        ValueError: If a path or value are not in the sync event.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - key_name:
+            type: str
+            brief: Name of the subkey that will be created in the test.
+        - value_name:
+            type: str
+            brief: Name of the value that will be created in the test.
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - remove_key_and_restart:
+            type: fixture
+            brief: Remove the test key and restart the agent.
+
+    assertions:
+        - Verify that FIM sync events generated include the monitored value path and
+          its parent key path of the changes made while the agent was stopped.
+
+    input_description: A test case (registry_sync_responses) is contained in external YAML file
+                       (wazuh_conf_registry_responses_win32.yaml) which includes configuration
+                       settings for the 'wazuh-syscheckd' daemon. That is combined with the
+                       testing registry key to be monitored defined in this module.
+
+    expected_output:
+        - r'.*#!-fim_registry dbsync no_data (.+)'
+        - r'.*Sending integrity control message'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     key_path = os.path.join(monitored_key, key_name)
     value_path = os.path.join(key, key_path, value_name)

--- a/tests/integration/test_fim/test_synchronization/test_sync_disabled.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_disabled.py
@@ -1,6 +1,68 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM disables the synchronization
+       on Linux systems when the 'enabled' tag of the synchronization option is set to 'no'.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 
 import pytest
@@ -41,9 +103,43 @@ def get_configuration(request):
 
 
 def test_sync_disabled(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Verify that synchronization is disabled when enabled is set to no in the configuration.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon uses the value of the 'enabled' tag to disable
+                 the file synchronization. For this purpose, the test will monitor a testing directory,
+                 and finally, it will verify that no FIM 'integrity' event is generated when
+                 the synchronization is disabled.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that no FIM 'integrity' event is generated when the value
+          of the 'enabled' tag is set yo 'no' (synchronization disabled).
+
+    input_description: A test case (sync_disabled) is contained in external YAML file (wazuh_disabled_sync_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'Initializing FIM Integrity Synchronization check'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     # Check if the test should be skipped
     check_apply_test({'sync_disabled'}, get_configuration['tags'])
 

--- a/tests/integration/test_fim/test_synchronization/test_sync_disabled_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_disabled_win32.py
@@ -1,6 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM disables the synchronization
+       of file/registry on Windows systems when the 'enabled' tag of the synchronization option is
+       set to 'no', and vice versa.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 
 import pytest
@@ -55,21 +108,57 @@ def get_configuration(request):
 ])
 def test_sync_disabled(tags_to_apply, file_sync, registry_sync,
                        get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start_sync_disabled):
-    """
-    Verify that synchronization is disabled when enabled is set to no in the configuration.
-    The expected events are
-        DEBUG: (6317): Sending integrity control message: {"component":"fim_file", ........}
-        DEBUG: (6317): Sending integrity control message: {"component":"fim_registry",.....}
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon uses the value of the 'enabled' tag to start/stop
+                 the file/registry synchronization. For this purpose, the test will monitor a directory/key.
+                 Finally, it will verify that no FIM 'integrity' event is generated when the synchronization
+                 is disabled, and verify that the FIM 'integrity' event generated corresponds with a
+                 file or a registry when the synchronization is enabled, depending on the test case.
 
-    Parameters
-    ----------
-    tags_to_apply: set
-        Configuration that will be used in the test.
-    file_sync: boolean
-        True if file synchronization is enabled
-    registry_sync: boolean
-        True if registry synchronization is enabled
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - file_sync:
+            type: bool
+            brief: True if file synchronization is enabled. False otherwise.
+        - registry_sync:
+            type: bool
+            brief: True if registry synchronization is enabled. False otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start_sync_disabled:
+            type: fixture
+            brief: Wait for end of initial FIM scan.
+
+    assertions:
+        - Verify that no FIM 'integrity' events are generated when the value
+          of the 'enabled' tag is set yo 'no' (synchronization disabled).
+        - Verify that FIM 'integrity' events generated correspond to a file/registry depending on
+          the value of the 'enabled' and the 'registry_enabled' tags (synchronization enabled).
+
+    input_description: Different test cases are contained in external YAML file (wazuh_disabled_sync_conf_win32.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the testing directory/key to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending integrity control message'
+
+    tags:
+        - scheduled
+        - time_travel
+        - realtime
+        - who_data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
     if not file_sync:
         # The file synchronization event shouldn't be triggered

--- a/tests/integration/test_fim/test_synchronization/test_sync_interval.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_interval.py
@@ -1,6 +1,68 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM synchronizes the database on
+       Linux systems at the period specified in the 'interval' tag.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 
 import pytest
@@ -42,9 +104,44 @@ def get_configuration(request):
 # Tests
 
 def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Verify that synchronization checks take place at the expected time given SYNC_INTERVAL variable.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon performs the file synchronization at the intervals
+                 specified in the configuration, using the 'interval' tag. For this purpose, the test
+                 will monitor a testing directory. Then, it will travel in time to the next synchronization
+                 time and verify that the FIM 'integrity' event is trigered. Finally, the test will travel
+                 in time to half of the interval and verify that no FIM 'integrity' event is generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM 'integrity' event is generated when the interval specified has elapsed.
+        - Verify that no FIM 'integrity' event is generated at half of the interval specified.
+
+    input_description: A test case (sync_interval) is contained in external YAML file (wazuh_conf.yaml) which
+                       includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined with
+                       the interval periods and the testing directory to be monitored defined in this module.
+
+    expected_output:
+        - r'Initializing FIM Integrity Synchronization check'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     # Check if the test should be skipped
     check_apply_test({'sync_interval'}, get_configuration['tags'])
     interval = time_to_timedelta(get_configuration['metadata']['interval'])

--- a/tests/integration/test_fim/test_synchronization/test_sync_interval_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_interval_win32.py
@@ -1,6 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM synchronizes the database on
+       Windows systems at the period specified in the 'interval' and the 'max_interval' tags.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 2
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 
 import pytest
@@ -46,9 +98,44 @@ def get_configuration(request):
 # Tests
 
 def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
-    """
-    Verify that synchronization checks take place at the expected time given SYNC_INTERVAL variable.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon performs the file/registry synchronization at the intervals
+                 specified in the configuration, using the 'interval' and the 'max_interval' tags. For this purpose,
+                 the test will monitor a testing directory and registry key. Then, it will travel in time to the next
+                 synchronization time and verify that the FIM 'integrity' event is trigered. Finally, the test
+                 will travel in time to half of the interval and verify that no FIM 'integrity' event is generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+        - wait_for_fim_start:
+            type: fixture
+            brief: Wait for realtime start, whodata start, or end of initial FIM scan.
+
+    assertions:
+        - Verify that FIM 'integrity' event is generated when the interval specified has elapsed.
+        - Verify that no FIM 'integrity' event is generated at half of the interval specified.
+
+    input_description: A test case (sync_interval) is contained in external YAML file (wazuh_conf_win32.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon. That is combined
+                       with the interval periods and the testing directory/key to be monitored defined in this module.
+
+    expected_output:
+        - r'Initializing FIM Integrity Synchronization check'
+
+    tags:
+        - scheduled
+        - time_travel
+    '''
     # Check if the test should be skipped
     check_apply_test({'sync_interval'}, get_configuration['tags'])
 

--- a/tests/integration/test_fim/test_synchronization/test_synchronize_integrity_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_synchronize_integrity_win32.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when
+       these files are modified. Specifically, these tests will check if FIM generates events
+       while a database synchronization is being performed simultaneously on Windows systems.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured
+       files for changes to the checksums, permissions, and ownership.
+
+tier: 1
+
+modules:
+    - fim
+
+components:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#synchronization
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_synchronization
+'''
 import os
 from datetime import timedelta
 
@@ -81,8 +132,48 @@ def callback_integrity_or_whodata(line):
     {'synchronize_events_conf'}
 ])
 def test_events_while_integrity_scan(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
-    """Check that events are being generated while a synchronization is being performed simultaneously.
-    """
+    '''
+    description: Check if the 'wazuh-syscheckd' daemon detects events while the synchronization is performed
+                 simultaneously. For this purpose, the test will monitor a testing directory and registry key.
+                 Then, it will create a subkey inside the monitored key. After this, the test  will check if
+                 the FIM 'integrity' and 'wodata' (if needed) events are triggered. Finally, the test will
+                 create a testing file and registry value and verify that the FIM 'added' events are generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that FIM 'integrity' and 'wodata' (if needed) events are generated.
+        - Check that FIM 'added' events are generated both when adding test files and
+          registry values while synchronizing.
+
+    input_description: A test case (synchronize_events_conf) is contained in external YAML file
+                       (wazuh_conf_integrity_scan_win32.yaml) which includes configuration settings
+                       for the 'wazuh-syscheckd' daemon. That is combined with the testing
+                       directories/keys to be monitored defined in this module.
+
+    expected_output:
+        - r'File integrity monitoring real-time Whodata engine started'
+        - r'Initializing FIM Integrity Synchronization check'
+        - r'.*Sending FIM event: (.+)$' ('added' and 'modified' events)
+
+    tags:
+        - realtime
+        - who_data
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     folder = testdir1 if get_configuration['metadata']['fim_mode'] == 'realtime' else testdir2


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796 and the issue #1810, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation
- #2106


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`