### PR TITLE
Migrate `test_auth` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_authd/test_authd.py
+++ b/tests/integration/test_authd/test_authd.py
@@ -10,7 +10,7 @@ type: integration
 brief: These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment requests,
        generating consistent responses to the requests received on its IP v4 network socket.
        The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide
-       the key to the agent. It’s used along with the 'agent-auth' application.
+       the key to the agent. It is used along with the 'agent-auth' application.
 
 tier: 0
 

--- a/tests/integration/test_authd/test_authd.py
+++ b/tests/integration/test_authd/test_authd.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment requests,
+       generating consistent responses to the requests received on its IP v4 network socket.
+       The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide
+       the key to the agent. It’s used along with the 'agent-auth' application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
+
+tags:
+    - enrollment
+'''
 import os
 import subprocess
 import time
@@ -55,12 +107,49 @@ def get_configuration(request):
 def test_ossec_auth_messages(get_configuration, set_up_groups, configure_environment, configure_sockets_environment,
                              clean_client_keys_file_module, restart_authd, wait_for_authd_startup_module,
                              connect_to_sockets_module):
-    """Check that every input message in authd port generates the adequate output
+    '''
+    description: Check if when the `wazuh-authd` daemon receives different kinds of enrollment requests,
+                 it responds appropriately to them. In this case, the enrollment requests
+                 are sent to an IP v4 network socket.
 
-    Raises:
-        ConnectionResetError: if wazuh-authd does not send the response to the agent through the socket.
-        AssertionError: if the response does not match the expected message.
-    """
+    wazuh_min_version: 4.2
+
+    parameters:
+        - clean_client_keys_file:
+            type: fixture
+            brief: Delete the agent keys stored in the `client.keys` file.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents and provide the test case list.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of `connect_to_sockets` fixture.
+        - wait_for_agentd_startup:
+            type: fixture
+            brief: Wait until the `wazuh-agentd` has begun.
+
+    assertions:
+        - Verify that the response messages are consistent with the enrollment requests received.
+
+    input_description: Different test cases are contained in an external `YAML` file (enroll_messages.yaml)
+                       that includes enrollment events and the expected output.
+
+    expected_output:
+        - Multiple values located in the `enroll_messages.yaml` file.
+
+    tags:
+        - keys
+        - ssl
+    '''
     test_case = set_up_groups['test_case']
     for stage in test_case:
         # Reopen socket (socket is closed by manager after sending message with client key)

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment requests
+       from agents with pre-existing IP addresses or names. The 'wazuh-authd' daemon can automatically
+       add a Wazuh agent to a Wazuh manager and provide the key to the agent. It’s used along with
+       the 'agent-auth' application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
+
+tags:
+    - enrollment
+'''
 import os
 import shutil
 import subprocess
@@ -339,6 +391,45 @@ def duplicate_name_agent_delete_test(server):
 
 def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure_environment,
                                      configure_sockets_environment, connect_to_sockets_module):
+    '''
+    description: Check if when the 'wazuh-authd' daemon receives an enrollment request from an agent
+                 that has an IP address or name that is already registered, 'authd' creates a record
+                 for the new agent and deletes the old one. In this case, the enrollment requests
+                 are sent to an IP v4 network socket.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of 'connect_to_sockets' fixture.
+
+    assertions:
+        - Verify that agents using an already registered IP address can successfully enroll.
+        - Verify that agents using an already registered name can successfully enroll.
+
+    input_description: Different test cases are contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-authd' daemon.
+
+    expected_output:
+        - r'Accepting connections on port 1515' (When the 'wazuh-authd' daemon is ready to accept enrollments)
+        - r'OSSEC K:' (When the agent has enrolled in the manager)
+    tags:
+        - keys
+        - ssl
+    '''
     control_service('stop', daemon='wazuh-authd')
     check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     time.sleep(1)
@@ -358,6 +449,44 @@ def test_ossec_authd_agents_ctx_main(get_configuration, set_up_groups, configure
 
 def test_ossec_authd_agents_ctx_local(get_configuration, set_up_groups, configure_environment,
                                       configure_sockets_environment, connect_to_sockets_module):
+    '''
+    description: Check if when the 'wazuh-authd' daemon receives an enrollment request from an agent
+                 that has an IP address or name that is already registered, 'authd' creates a record
+                 for the new agent and deletes the old one. In this case, the enrollment requests
+                 are sent to a local 'UNIX' socket.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - set_up_groups:
+            type: fixture
+            brief: Create a testing group for agents.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of 'connect_to_sockets' fixture.
+
+    assertions:
+        - Verify that agents using an already registered IP address can successfully enroll.
+        - Verify that agents using an already registered name can successfully enroll.
+
+    input_description: Different test cases are contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'wazuh-authd' daemon.
+
+    expected_output:
+        - r'Accepting connections on port 1515' (When the 'wazuh-authd' daemon is ready to accept enrollments)
+        - r'{"error":0,' (When the agent has enrolled)
+    tags:
+        - keys
+    '''
     control_service('stop', daemon='wazuh-authd')
     check_daemon_status(running_condition=False, target_daemon='wazuh-authd')
     time.sleep(1)

--- a/tests/integration/test_authd/test_authd_agents_ctx.py
+++ b/tests/integration/test_authd/test_authd_agents_ctx.py
@@ -9,7 +9,7 @@ type: integration
 
 brief: These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment requests
        from agents with pre-existing IP addresses or names. The 'wazuh-authd' daemon can automatically
-       add a Wazuh agent to a Wazuh manager and provide the key to the agent. It’s used along with
+       add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used along with
        the 'agent-auth' application.
 
 tier: 0

--- a/tests/integration/test_authd/test_authd_force_insert.py
+++ b/tests/integration/test_authd/test_authd_force_insert.py
@@ -20,7 +20,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_force_insert.py
+++ b/tests/integration/test_authd/test_authd_force_insert.py
@@ -1,22 +1,28 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: This module verifies the correct behavior of the setting force_insert
-tier:
-    0
+
+brief: This module verifies the correct behavior of the setting 'force_insert'.
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_force_insert.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,10 +40,10 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
-tags:
-    - Enrollment
-'''
 
+tags:
+    - enrollment
+'''
 import os
 import time
 import pytest
@@ -116,52 +122,54 @@ def test_authd_force_options(configure_sockets_environment, configure_environmen
                              file_monitoring, restart_authd, wait_for_authd_startup_module,
                              connect_to_sockets_configuration, register_previous_agent, tear_down, test_case,
                              get_configuration):
-    """
-        description:
-           "Check that every input message in authd port generates the adequate output"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - configure_sockets_environment:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - clean_client_keys_file_module:
-                type: fixture
-                brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
-            - restart_authd:
-                type: fixture
-                brief: Restart Authd daemon to force new configurations.
-            - wait_for_authd_startup_module:
-                type: fixcture
-                brief: Wait until Authd is accepting connections.
-            - connect_to_sockets_configuration:
-                type: fixture
-                brief: Bind to the configured sockets at configuration scope.
-            - register_previous_agent:
-                type: fixture
-                brief: Register agents to simulate a scenario with pre existent keys.
-            - tear_down:
-                type: fixture
-                brief: Roll back the daemon and client.keys state after the test ends.
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - test_case:
-                type: list
-                brief: List with all the test cases for the test.
-        assertions:
-            - The received output must match with expected when the setting is used
-            - The agent can't have a duplicate IP or name when the setting is disabled
-        input_description:
-            Different test cases are contained in an external YAML file (test_authd_force_insert.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every input message in authd port generates the adequate output.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - clean_client_keys_file_module:
+            type: fixture
+            brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
+        - restart_authd:
+            type: fixture
+            brief: Restart Authd daemon to force new configurations.
+        - wait_for_authd_startup_module:
+            type: fixcture
+            brief: Wait until Authd is accepting connections.
+        - connect_to_sockets_configuration:
+            type: fixture
+            brief: Bind to the configured sockets at configuration scope.
+        - register_previous_agent:
+            type: fixture
+            brief: Register agents to simulate a scenario with pre existent keys.
+        - tear_down:
+            type: fixture
+            brief: Roll back the daemon and client.keys state after the test ends.
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - test_case:
+            type: list
+            brief: List with all the test cases for the test.
+
+    assertions:
+        - The received output must match with expected when the setting is used.
+        - The agent can't have a duplicate IP or name when the setting is disabled.
+
+    input_description:
+        Different test cases are contained in an external YAML file (test_authd_force_insert.yaml) which
+        includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on 'authd' socket.
+    '''
     metadata = get_configuration['metadata']
 
     for stage in test_case['test_case']:

--- a/tests/integration/test_authd/test_authd_key_hash.py
+++ b/tests/integration/test_authd/test_authd_key_hash.py
@@ -20,7 +20,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_key_hash.py
+++ b/tests/integration/test_authd/test_authd_key_hash.py
@@ -1,22 +1,28 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: This module verifies the correct behavior of the enrollment daemon authd under different messages
-tier:
-    0
+
+brief: This module verifies the correct behavior of the enrollment daemon 'wazuh-authd' under different messages.
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_key_hash.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,10 +40,10 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
-tags:
-    - Enrollment
-'''
 
+tags:
+    - enrollment
+'''
 import os
 import subprocess
 import time
@@ -113,43 +119,46 @@ def set_up_groups_keys(request):
 def test_ossec_auth_messages_with_key_hash(get_configuration, configure_environment,  configure_sockets_environment,
                                            clean_client_keys_file_module, set_up_groups_keys,
                                            wait_for_authd_startup_function, connect_to_sockets_function):
-    """
-        description:
-           "Check that every input message in authd port generates the adequate output"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - configure_sockets_environment:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets.
-            - clean_client_keys_file_module:
-                type: fixture
-                brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
-            - set_up_groups_keys:
-                type: fixture
-                brief: Set pre-existent groups and keys.
-            - wait_for_authd_startup_function:
-                type: fixture
-                brief: Waits until Authd is accepting connections.
-            - connect_to_sockets_function:
-                type: fixture
-                brief: Bind to the configured sockets at function scope.
-        assertions:
-            - The received output must match with expected
-            - The enrollment messages are parsed as expected
-            - The agent keys are denied if the hash is the same than the manager's
-        input_description:
-            Different test cases are contained in an external YAML file (authd_key_hash.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every input message in authd port generates the adequate output.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets.
+        - clean_client_keys_file_module:
+            type: fixture
+            brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
+        - set_up_groups_keys:
+            type: fixture
+            brief: Set pre-existent groups and keys.
+        - wait_for_authd_startup_function:
+            type: fixture
+            brief: Waits until Authd is accepting connections.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Bind to the configured sockets at function scope.
+
+    assertions:
+        - The received output must match with expected.
+        - The enrollment messages are parsed as expected.
+        - The agent keys are denied if the hash is the same than the manager's.
+
+    input_description:
+        Different test cases are contained in an external YAML file (authd_key_hash.yaml) which
+        includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on 'authd' socket.
+    '''
     test_case = set_up_groups_keys['test_case']
 
     for stage in test_case:

--- a/tests/integration/test_authd/test_authd_local.py
+++ b/tests/integration/test_authd/test_authd_local.py
@@ -21,7 +21,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_local.py
+++ b/tests/integration/test_authd/test_authd_local.py
@@ -1,22 +1,29 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: This module verifies the correct behavior of authd under different messages in a Cluster scenario (for Master)
-tier:
-    0
+
+brief: This module verifies the correct behavior of 'wazuh-authd' under different messages
+       in a Cluster scenario (for Master).
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_local.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,8 +41,9 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
+
 tags:
-    - Enrollment
+    - enrollment
 '''
 
 import os
@@ -117,40 +125,43 @@ def set_up_groups_keys(request):
 def test_ossec_auth_messages(set_up_groups_keys, get_configuration, configure_environment,
                              configure_sockets_environment_function, connect_to_sockets_function,
                              wait_for_authd_startup_module):
-    """
-        description:
-            "Check that every input message in trough local authd port generates the adequate response to worker"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - set_up_groups_keys:
-                type: fixture
-                brief: Set pre-existent groups and keys.
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - configure_sockets_environment_function:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets at function scope.
-            - connect_to_sockets_function:
-                type: fixture
-                brief: Bind to the configured sockets at function scope.
-            - wait_for_authd_startup_module:
-                type: fixture
-                brief: Waits until Authd is accepting connections.
-        assertions:
-            - The received output must match with expected
-            - The enrollment messages are parsed as expected
-            - The agent keys are denied if the hash is the same than the manager's
-        input_description:
-            Different test cases are contained in an external YAML file (local_enroll_messages.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every input message in trough local 'authd' port generates the adequate response to worker.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - set_up_groups_keys:
+            type: fixture
+            brief: Set pre-existent groups and keys.
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment_function:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets at function scope.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Bind to the configured sockets at function scope.
+        - wait_for_authd_startup_module:
+            type: fixture
+            brief: Waits until Authd is accepting connections.
+
+    assertions:
+        - The received output must match with expected.
+        - The enrollment messages are parsed as expected.
+        - The agent keys are denied if the hash is the same than the manager's.
+
+    input_description:
+        Different test cases are contained in an external YAML file (local_enroll_messages.yaml) which
+        includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on 'authd' socket.
+    '''
     test_case = set_up_groups_keys['test_case']
     for stage in test_case:
         # Reopen socket (socket is closed by manager after sending message with client key)

--- a/tests/integration/test_authd/test_authd_ssl_certs.py
+++ b/tests/integration/test_authd/test_authd_ssl_certs.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'wazuh-authd' daemon is able to handle secure connections using
+       the 'SSL' (Secure Socket Layer) protocol. The 'wazuh-authd' daemon can automatically add
+       a Wazuh agent to a Wazuh manager and provide the key to the agent.
+       It’s used along with the 'agent-auth' application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/registering/host-verification-registration.html
+
+tags:
+    - enrollment
+'''
 import os
 import ssl
 import time
@@ -113,8 +165,37 @@ def override_wazuh_conf(configuration):
 
 
 def test_authd_ssl_certs(get_configuration, generate_ca_certificate):
-    """
-    """
+    '''
+    description: Check if the 'wazuh-authd' daemon can manage 'SSL' connections with agents
+                 and the 'host verification' feature is working properly. For this purpose,
+                 it generates and signs the necessary certificates and builds the
+                 enrollment requests using them.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - generate_ca_certificate:
+            type: fixture
+            brief: Build the 'CA' (Certificate of Authority) and sign the certificate used by the testing agent.
+
+    assertions:
+        - Verify that the agent can only connect to the 'wazuh-authd' daemon socket using a valid certificate.
+        - Verify that using a valid certificate the agent can only enroll using the IP address linked to it.
+
+    input_description: Different test cases are found in the test module and include
+                       parameters for the environment setup, the requests
+                       to be made, and the expected result.
+
+    expected_output:
+        - r'OSSEC K:' (When the agent has enrolled in the manager)
+
+    tags:
+        - keys
+        - ssl
+    '''
     verify_host = (get_configuration['metadata']['verify_host'] == 'yes')
     option = get_configuration['metadata']['sim_option']
     override_wazuh_conf(get_configuration)

--- a/tests/integration/test_authd/test_authd_ssl_certs.py
+++ b/tests/integration/test_authd/test_authd_ssl_certs.py
@@ -10,7 +10,7 @@ type: integration
 brief: These tests will check if the 'wazuh-authd' daemon is able to handle secure connections using
        the 'SSL' (Secure Socket Layer) protocol. The 'wazuh-authd' daemon can automatically add
        a Wazuh agent to a Wazuh manager and provide the key to the agent.
-       It’s used along with the 'agent-auth' application.
+       It is used along with the 'agent-auth' application.
 
 tier: 0
 

--- a/tests/integration/test_authd/test_authd_ssl_options.py
+++ b/tests/integration/test_authd/test_authd_ssl_options.py
@@ -10,7 +10,7 @@ type: integration
 brief: These tests will check if the 'SSL' (Secure Socket Layer) protocol-related settings of
        the 'wazuh-authd' daemon are working correctly. The 'wazuh-authd' daemon can
        automatically add a Wazuh agent to a Wazuh manager and provide the key
-       to the agent. It’s used along with the 'agent-auth' application.
+       to the agent. It is used along with the 'agent-auth' application.
 
 tier: 0
 

--- a/tests/integration/test_authd/test_authd_ssl_options.py
+++ b/tests/integration/test_authd/test_authd_ssl_options.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'SSL' (Secure Socket Layer) protocol-related settings of
+       the 'wazuh-authd' daemon are working correctly. The 'wazuh-authd' daemon can
+       automatically add a Wazuh agent to a Wazuh manager and provide the key
+       to the agent. It’s used along with the 'agent-auth' application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html
+
+tags:
+    - enrollment
+'''
 import os
 import ssl
 import time
@@ -103,20 +155,38 @@ def override_wazuh_conf(configuration):
 
 
 def test_ossec_auth_configurations(get_configuration, configure_environment, configure_sockets_environment):
-    """Check that every input message in authd port generates the adequate output
+    '''
+    description: Check if the 'SSL' settings of the 'wazuh-authd' daemon work correctly by enrolling agents
+                 that use different values for these settings. Different types of encryption and secure
+                 connection protocols are tested, in addition to the 'ssl_auto_negotiate' option
+                 that automatically chooses the protocol to be used.
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_cases, dict with following keys:
-            - expect: What we are expecting to happen
-                1. open_error: Should fail when trying to do ssl handshake
-                2. output: Expects an output message from the manager
-            - ciphers: Value for ssl ciphers
-            - protocol: Value for ssl protocol
-            - input: message that will be tried to send to the manager
-            - output: expected response (if any)
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+
+    assertions:
+        - Verify that the response messages are consistent with the enrollment requests received.
+
+    input_description: Different test cases are contained in an external YAML file (enroll_ssl_options_tests.yaml)
+                       that includes enrollment events and the expected output.
+
+    expected_output:
+        - Multiple values located in the 'enroll_ssl_options_tests.yaml' file.
+
+    tags:
+        - keys
+        - ssl
+    '''
     current_test = get_current_test()
 
     test_case = ssl_configuration_tests[current_test]['test_case']

--- a/tests/integration/test_authd/test_authd_use_password.py
+++ b/tests/integration/test_authd/test_authd_use_password.py
@@ -1,22 +1,28 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: This module verifies the correct behavior of the setting use_password
-tier:
-    0
+
+brief: This module verifies the correct behavior of the setting 'use_password'.
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_use_password.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,10 +40,10 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
-tags:
-    - Enrollment
-'''
 
+tags:
+    - enrollment
+'''
 import os
 import ssl
 import time
@@ -161,53 +167,55 @@ def test_authd_force_options(get_configuration, configure_environment, configure
                              clean_client_keys_file_function, reset_password, restart_authd_function,
                              wait_for_authd_startup_function, connect_to_sockets_function,
                              test_case, tear_down):
-    """
-        description:
-           "Check that every input message in authd port generates the adequate output"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - clean_client_keys_file_module:
-                type: fixture
-                brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
-            - clean_client_keys_file_function:
-                type: fixture
-                brief: Cleans any previus key in client.keys file at function scope.
-            - reset_password:
-                type: fixture
-                brief: Write the password file.
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - configure_sockets_environment:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets.
-            - connect_to_sockets_module:
-                type: fixture
-                brief: Bind to the configured sockets at module scope.
-            - test_case:
-                type: list
-                brief: List with all the test cases for the test.
-            - register_previous_agent:
-                type: fixture
-                brief: Register agents to simulate a scenario with pre existent keys.
-            - tear_down:
-                type: fixture
-                brief: Roll back the daemon and client.keys state after the test ends.
-        assertions:
-            - The random password works as expected
-            - A wrong password is rejected
-            - A request with password and use_password = 'no' is rejected
-        input_description:
-            Different test cases are contained in an external YAML file (test_authd_use_password.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every input message in authd port generates the adequate output.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_client_keys_file_module:
+            type: fixture
+            brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
+        - clean_client_keys_file_function:
+            type: fixture
+            brief: Cleans any previus key in client.keys file at function scope.
+        - reset_password:
+            type: fixture
+            brief: Write the password file.
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Bind to the configured sockets at module scope.
+        - test_case:
+            type: list
+            brief: List with all the test cases for the test.
+        - register_previous_agent:
+            type: fixture
+            brief: Register agents to simulate a scenario with pre existent keys.
+        - tear_down:
+            type: fixture
+            brief: Roll back the daemon and client.keys state after the test ends.
+
+    assertions:
+        - The random password works as expected.
+        - A wrong password is rejected.
+        - A request with password and use_password = 'no' is rejected.
+
+    input_description:
+        Different test cases are contained in an external YAML file (test_authd_use_password.yaml) which
+        includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on 'authd' socket.
+    '''
     metadata = get_configuration['metadata']
 
     for stage in test_case['test_case']:

--- a/tests/integration/test_authd/test_authd_use_password.py
+++ b/tests/integration/test_authd/test_authd_use_password.py
@@ -20,7 +20,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -1,22 +1,28 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: This module verifies the correct behavior of the setting use_source_ip
-tier:
-    0
+
+brief: This module verifies the correct behavior of the setting 'use_source_ip'.
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_use_source_ip.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,10 +40,10 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
-tags:
-    - Enrollment
-'''
 
+tags:
+    - enrollment
+'''
 import os
 import ssl
 import time
@@ -136,44 +142,46 @@ def tear_down():
 def test_authd_force_options(get_configuration, configure_environment, configure_sockets_environment,
                              restart_authd, wait_for_authd_startup_module, connect_to_sockets_configuration,
                              test_case, tear_down):
-    """
-        description:
-           "Check that every input message in authd port generates the adequate output"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - configure_sockets_environment:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets.
-            - wait_for_authd_startup_function:
-                type: fixture
-                brief: Waits until Authd is accepting connections.
-            - connect_to_sockets_configuration:
-                type: fixture
-                brief: Bind to the configured sockets at configuration scope.
-            - test_case:
-                type: list
-                brief: List with all the test cases for the test.
-            - tear_down:
-                type: fixture
-                brief: Roll back the daemon and client.keys state after the test ends.
-        assertions:
-            - The manager uses the agent's IP as requested
-            - Setting an IP overrides the configuration
-            - If the IP is not defined an the setting is disabled, use 'any'
-        input_description:
-            Different test cases are contained in an external YAML file (test_authd_use_source_ip.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every input message in 'authd' port generates the adequate output.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets.
+        - wait_for_authd_startup_function:
+            type: fixture
+            brief: Waits until Authd is accepting connections.
+        - connect_to_sockets_configuration:
+            type: fixture
+            brief: Bind to the configured sockets at configuration scope.
+        - test_case:
+            type: list
+            brief: List with all the test cases for the test.
+        - tear_down:
+            type: fixture
+            brief: Roll back the daemon and client.keys state after the test ends.
+
+    assertions:
+        - The manager uses the agent's IP as requested.
+        - Setting an IP overrides the configuration.
+        - If the IP is not defined an the setting is disabled, use 'any'.
+
+    input_description:
+        Different test cases are contained in an external YAML file (test_authd_use_source_ip.yaml) which
+        includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on 'authd' socket.
+    '''
     metadata = get_configuration['metadata']
 
     for stage in test_case['test_case']:

--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -20,7 +20,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_valid_name_ip.py
+++ b/tests/integration/test_authd/test_authd_valid_name_ip.py
@@ -1,22 +1,28 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: This module verifies the correct behavior of authd under different name/IP combinations
-tier:
-    0
+
+brief: This module verifies the correct behavior of 'authd' under different name/IP combinations.
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_valid_name_ip.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,10 +40,10 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
-tags:
-    - Enrollment
-'''
 
+tags:
+    - enrollment
+'''
 import os
 import socket
 import time
@@ -86,46 +92,48 @@ def get_configuration(request):
 def test_authd_force_options(get_configuration, configure_environment, configure_sockets_environment,
                              clean_client_keys_file_module, restart_authd, wait_for_authd_startup_module,
                              connect_to_sockets_module, test_case, tear_down):
-    """
-        description:
-           "Check that every input message in authd port generates the adequate output"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - clean_client_keys_file_module:
-                type: fixture
-                brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
-            - clean_client_keys_file_function:
-                type: fixture
-                brief: Cleans any previus key in client.keys file at function scope.
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - configure_sockets_environment:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets.
-            - connect_to_sockets_module:
-                type: fixture
-                brief: Bind to the configured sockets at module scope.
-            - test_case:
-                type: list
-                brief: List with all the test cases for the test.
-            - tear_down:
-                type: fixture
-                brief: Roll back the daemon and client.keys state after the test ends.
-        assertions:
-            - The manager registers agents with valid IP and name
-            - The manager rejects invalid input
-        input_description:
-            Different test cases are contained in an external YAML file (test_authd_valid_name_ip.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every input message in 'authd' port generates the adequate output.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_client_keys_file_module:
+            type: fixture
+            brief: Stops Wazuh and cleans any previus key in client.keys file at module scope.
+        - clean_client_keys_file_function:
+            type: fixture
+            brief: Cleans any previus key in client.keys file at function scope.
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Bind to the configured sockets at module scope.
+        - test_case:
+            type: list
+            brief: List with all the test cases for the test.
+        - tear_down:
+            type: fixture
+            brief: Roll back the daemon and client.keys state after the test ends.
+
+    assertions:
+        - The manager registers agents with valid IP and name.
+        - The manager rejects invalid input.
+
+    input_description:
+        Different test cases are contained in an external YAML file (test_authd_valid_name_ip.yaml) which
+        includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on 'authd' socket.
+    '''
     for stage in test_case['test_case']:
         # Reopen socket (socket is closed by manager after sending message with client key)
         receiver_sockets[0].open()

--- a/tests/integration/test_authd/test_authd_valid_name_ip.py
+++ b/tests/integration/test_authd/test_authd_valid_name_ip.py
@@ -20,7 +20,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -20,7 +20,7 @@ components:
 daemons:
     - wazuh-authd
 
-os_platform
+os_platform:
     - linux
 
 os_version:

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -147,7 +147,7 @@ def test_ossec_auth_messages(get_configuration, set_up_groups, configure_environ
         - get_configuration:
             type: fixture
             brief: Get the configuration of the test.
-        - set_up_groups
+        - set_up_groups:
             type: fixture
             brief: Set the pre-defined groups.
         - configure_environment:

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -1,22 +1,28 @@
 '''
-copyright:
-    Copyright (C) 2015-2021, Wazuh Inc.
-    Created by Wazuh, Inc. <info@wazuh.com>.
-    This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
+
 brief: This module verifies the correct behavior of authd under different messages in a Cluster scenario (for Worker)
-tier:
-    0
+
+tier: 0
+
 modules:
-    - Authd
+    - authd
+
 components:
     - manager
+
 daemons:
-    - Authd
-path:
-    /tests/integration/test_authd/test_authd_worker_ip.py
+    - wazuh-authd
+
 os_platform
     - linux
+
 os_version:
     - Amazon Linux 1
     - Amazon Linux 2
@@ -34,10 +40,10 @@ os_version:
     - Ubuntu Bionic
     - Ubuntu Trusty
     - Ubuntu Xenial
-tags:
-    - Enrollment
-'''
 
+tags:
+    - enrollment
+'''
 import os
 import subprocess
 import time
@@ -131,40 +137,42 @@ def get_configuration(request):
 
 def test_ossec_auth_messages(get_configuration, set_up_groups, configure_environment, configure_sockets_environment,
                              connect_to_sockets_module, wait_for_authd_startup_module):
-    """
-        description:
-           "Check that every message from the agent is correctly formatted for master, and every master
-            response is correctly parsed for agent"
-        wazuh_min_version:
-            4.2
-        parameters:
-            - get_configuration:
-                type: fixture
-                brief: Get the configuration of the test.
-            - set_up_groups
-                type: fixture
-                brief: Set the pre-defined groups.
-            - configure_environment:
-                type: fixture
-                brief: Configure a custom environment for testing.
-            - configure_sockets_environment:
-                type: fixture
-                brief: Configure the socket listener to receive and send messages on the sockets.
-            - connect_to_sockets_module:
-                type: fixture
-                brief: Bind to the configured sockets at module scope.
-            - wait_for_authd_startup:
-                type: fixture
-                brief: Waits until Authd is accepting connections.
-        assertions:
-            - The 'port_input' from agent is formatted to 'cluster_input' for master
-            - The 'cluster_output' response from master is correctly parsed to 'port_output' for agent
-        input_description:
-            Different test cases are contained in an external YAML file (worker_messages.yaml) which includes
-            the different possible registration requests and the expected responses.
-        expected_output:
-            - Registration request responses on Authd socket
-    """
+    '''
+    description: Check that every message from the agent is correctly formatted for master, and every master
+                 response is correctly parsed for agent"
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get the configuration of the test.
+        - set_up_groups
+            type: fixture
+            brief: Set the pre-defined groups.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure the socket listener to receive and send messages on the sockets.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Bind to the configured sockets at module scope.
+        - wait_for_authd_startup:
+            type: fixture
+            brief: Waits until Authd is accepting connections.
+
+    assertions:
+        - The 'port_input' from agent is formatted to 'cluster_input' for master
+        - The 'cluster_output' response from master is correctly parsed to 'port_output' for agent
+
+    input_description: Different test cases are contained in an external YAML file (worker_messages.yaml)
+                        which includes the different possible registration requests and the expected responses.
+
+    expected_output:
+        - Registration request responses on authd socket
+    '''
     test_case = set_up_groups['test_case']
     for stage in test_case:
         # Push expected info to mitm queue

--- a/tests/integration/test_authd/test_remote_enrollment.py
+++ b/tests/integration/test_authd/test_remote_enrollment.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the 'remote enrollment' option of the 'wazuh-authd' daemon
+       settings is working properly. The 'wazuh-authd' daemon can automatically add
+       a Wazuh agent to a Wazuh manager and provide the key to the agent.
+       It’s used along with the 'agent-auth' application.
+
+tier: 0
+
+modules:
+    - authd
+
+components:
+    - manager
+
+daemons:
+    - wazuh-authd
+    - wazuh-db
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html#remote-enrollment
+
+tags:
+    - enrollment
+'''
 import os
 import pytest
 
@@ -52,8 +103,8 @@ receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in t
 cluster_socket_address = ('localhost', 1516)
 remote_enrollment_address = ('localhost', 1515)
 
-@pytest.fixture(scope="module", params=configurations,
-                ids=[f"{x['id']}" for x in metadata])
+
+@pytest.fixture(scope="module", params=configurations, ids=[f"{x['id']}" for x in metadata])
 def get_configuration(request):
     """Get configurations from the module"""
     yield request.param
@@ -68,17 +119,43 @@ def not_raises(exception):
 
 
 def test_remote_enrollment(get_configuration, configure_environment, restart_authd):
-    """Check that Authd remote enrollment is enabled/disabled according to the configuration.
+    '''
+    description: Check if the 'wazuh-authd' daemon remote enrollment is enabled/disabled according
+                 to the configuration. By default, remote enrollment is enabled. When disabled,
+                 the 'authd' 'TLS' port (1515 by default) won't be listening to new connections,
+                 but requests to the local socket will still be attended.
 
-    By default, remote enrollment is enabled. When disabled, Authd TLS port (1515 by default) won't be listening
-    to new connection, but requests to local socket will still be attended.
+    wazuh_min_version: 4.2.0
 
-    Raises:
-        TimeoutError: if the expected logs do not appear or the port 1515 is not available when it should.
-        ConnectionRefusedError: if remote enrollment is enabled but authd refuse external connections.
-        assertRaises: if the expected OSSEC K message doesn't appear in authd response when remote connection
-                      are enabled.
-    """
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_authd:
+            type: fixture
+            brief: Restart the 'wazuh-authd' daemon, clear the 'ossec.log' file and start a new file monitor.
+
+    assertions:
+        - Verify that the port '1515' opens or closes depending on the value of the 'remote_enrollment' option.
+        - Verify that when a 'worker' node receives an enrollment request, it tries to connect to the 'master' node.
+
+    input_description: Different test cases are found in the test module and include
+                       parameters for the environment setup, the requests
+                       to be made, and the expected result.
+
+    expected_output:
+        - r'Accepting connections on port 1515. No password required.' (When the 'wazuh-authd' daemon)
+        - r'OSSEC K:' (When the agent has enrolled in the manager)
+        - r'.*Port 1515 was set as disabled.*' (When remote enrollment is disabled)
+        - r'ERROR: Cannot comunicate with master'
+
+    tags:
+        - keys
+        - ssl
+    '''
     expectation = not_raises(ConnectionRefusedError)
     expected_answer = 'OSSEC K:'
 

--- a/tests/integration/test_authd/test_remote_enrollment.py
+++ b/tests/integration/test_authd/test_remote_enrollment.py
@@ -10,7 +10,7 @@ type: integration
 brief: These tests will check if the 'remote enrollment' option of the 'wazuh-authd' daemon
        settings is working properly. The 'wazuh-authd' daemon can automatically add
        a Wazuh agent to a Wazuh manager and provide the key to the agent.
-       It’s used along with the 'agent-auth' application.
+       It is used along with the 'agent-auth' application.
 
 tier: 0
 


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_authd_agents_ctx.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment requests from agents with pre-existing IP addresses or names. The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used along with the 'agent-auth' application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_agents_ctx.py",
    "id": 3,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when the 'wazuh-authd' daemon receives an enrollment request from an agent that has an IP address or name that is already registered, 'authd' creates a record for the new agent and deletes the old one. In this case, the enrollment requests are sent to an IP v4 network socket.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of 'connect_to_sockets' fixture."
                    }
                }
            ],
            "assertions": [
                "Verify that agents using an already registered IP address can successfully enroll.",
                "Verify that agents using an already registered name can successfully enroll."
            ],
            "input_description": "Different test cases are contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-authd' daemon.",
            "expected_output": [
                "r'Accepting connections on port 1515' (When the 'wazuh-authd' daemon is ready to accept enrollments)",
                "r'OSSEC K:' (When the agent has enrolled in the manager)"
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_authd_agents_ctx_main",
            "inputs": [
                "get_configuration0"
            ]
        },
        {
            "description": "Check if when the 'wazuh-authd' daemon receives an enrollment request from an agent that has an IP address or name that is already registered, 'authd' creates a record for the new agent and deletes the old one. In this case, the enrollment requests are sent to a local 'UNIX' socket.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of 'connect_to_sockets' fixture."
                    }
                }
            ],
            "assertions": [
                "Verify that agents using an already registered IP address can successfully enroll.",
                "Verify that agents using an already registered name can successfully enroll."
            ],
            "input_description": "Different test cases are contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'wazuh-authd' daemon.",
            "expected_output": [
                "r'Accepting connections on port 1515' (When the 'wazuh-authd' daemon is ready to accept enrollments)",
                "r'{\"error\":0,' (When the agent has enrolled)"
            ],
            "tags": [
                "keys"
            ],
            "name": "test_ossec_authd_agents_ctx_local",
            "inputs": [
                "get_configuration0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_agents_ctx.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment
  requests from agents with pre-existing IP addresses or names. The 'wazuh-authd'
  daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key
  to the agent. It is used along with the 'agent-auth' application.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 3
modules:
- authd
name: test_authd_agents_ctx.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
tags:
- enrollment
tests:
- assertions:
  - Verify that agents using an already registered IP address can successfully enroll.
  - Verify that agents using an already registered name can successfully enroll.
  description: Check if when the 'wazuh-authd' daemon receives an enrollment request
    from an agent that has an IP address or name that is already registered, 'authd'
    creates a record for the new agent and deletes the old one. In this case, the
    enrollment requests are sent to an IP v4 network socket.
  expected_output:
  - r'Accepting connections on port 1515' (When the 'wazuh-authd' daemon is ready
    to accept enrollments)
  - r'OSSEC K:' (When the agent has enrolled in the manager)
  input_description: Different test cases are contained in an external YAML file (wazuh_conf.yaml)
    which includes configuration settings for the 'wazuh-authd' daemon.
  inputs:
  - get_configuration0
  name: test_ossec_authd_agents_ctx_main
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of 'connect_to_sockets' fixture.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that agents using an already registered IP address can successfully enroll.
  - Verify that agents using an already registered name can successfully enroll.
  description: Check if when the 'wazuh-authd' daemon receives an enrollment request
    from an agent that has an IP address or name that is already registered, 'authd'
    creates a record for the new agent and deletes the old one. In this case, the
    enrollment requests are sent to a local 'UNIX' socket.
  expected_output:
  - r'Accepting connections on port 1515' (When the 'wazuh-authd' daemon is ready
    to accept enrollments)
  - r'{"error":0,' (When the agent has enrolled)
  input_description: Different test cases are contained in an external YAML file (wazuh_conf.yaml)
    which includes configuration settings for the 'wazuh-authd' daemon.
  inputs:
  - get_configuration0
  name: test_ossec_authd_agents_ctx_local
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of 'connect_to_sockets' fixture.
      type: fixture
  tags:
  - keys
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_force_insert.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of the setting 'force_insert'.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_force_insert.py",
    "id": 9,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every input message in authd port generates the adequate output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "clean_client_keys_file_module": {
                        "type": "fixture",
                        "brief": "Stops Wazuh and cleans any previus key in client.keys file at module scope."
                    }
                },
                {
                    "restart_authd": {
                        "type": "fixture",
                        "brief": "Restart Authd daemon to force new configurations."
                    }
                },
                {
                    "wait_for_authd_startup_module": {
                        "type": "fixcture",
                        "brief": "Wait until Authd is accepting connections."
                    }
                },
                {
                    "connect_to_sockets_configuration": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at configuration scope."
                    }
                },
                {
                    "register_previous_agent": {
                        "type": "fixture",
                        "brief": "Register agents to simulate a scenario with pre existent keys."
                    }
                },
                {
                    "tear_down": {
                        "type": "fixture",
                        "brief": "Roll back the daemon and client.keys state after the test ends."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List with all the test cases for the test."
                    }
                }
            ],
            "assertions": [
                "The received output must match with expected when the setting is used.",
                "The agent can't have a duplicate IP or name when the setting is disabled."
            ],
            "input_description": "Different test cases are contained in an external YAML file (test_authd_force_insert.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on 'authd' socket."
            ],
            "name": "test_authd_force_options",
            "inputs": [
                "Use_source_ip_yes-Let manager decide, use_source_ip enabled",
                "Use_source_ip_yes-Override use_source_ip",
                "Use_source_ip_yes-Not specific IP",
                "Use_source_ip_yes-Let manager decide",
                "Use_source_ip_no-Let manager decide, use_source_ip enabled",
                "Use_source_ip_no-Override use_source_ip",
                "Use_source_ip_no-Not specific IP",
                "Use_source_ip_no-Let manager decide",
                "Force_insert_yes-Overwrite agent name",
                "Force_insert_yes-Valid and duplicate IP",
                "Force_insert_no-Overwrite agent name",
                "Force_insert_no-Valid and duplicate IP"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_force_insert.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of the setting 'force_insert'.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 9
modules:
- authd
name: test_authd_force_insert.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The received output must match with expected when the setting is used.
  - The agent can't have a duplicate IP or name when the setting is disabled.
  description: Check that every input message in authd port generates the adequate
    output.
  expected_output:
  - Registration request responses on 'authd' socket.
  input_description: Different test cases are contained in an external YAML file (test_authd_force_insert.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - Use_source_ip_yes-Let manager decide, use_source_ip enabled
  - Use_source_ip_yes-Override use_source_ip
  - Use_source_ip_yes-Not specific IP
  - Use_source_ip_yes-Let manager decide
  - Use_source_ip_no-Let manager decide, use_source_ip enabled
  - Use_source_ip_no-Override use_source_ip
  - Use_source_ip_no-Not specific IP
  - Use_source_ip_no-Let manager decide
  - Force_insert_yes-Overwrite agent name
  - Force_insert_yes-Valid and duplicate IP
  - Force_insert_no-Overwrite agent name
  - Force_insert_no-Valid and duplicate IP
  name: test_authd_force_options
  parameters:
  - configure_sockets_environment:
      brief: Configure the socket listener to receive and send messages on the sockets.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - clean_client_keys_file_module:
      brief: Stops Wazuh and cleans any previus key in client.keys file at module
        scope.
      type: fixture
  - restart_authd:
      brief: Restart Authd daemon to force new configurations.
      type: fixture
  - wait_for_authd_startup_module:
      brief: Wait until Authd is accepting connections.
      type: fixcture
  - connect_to_sockets_configuration:
      brief: Bind to the configured sockets at configuration scope.
      type: fixture
  - register_previous_agent:
      brief: Register agents to simulate a scenario with pre existent keys.
      type: fixture
  - tear_down:
      brief: Roll back the daemon and client.keys state after the test ends.
      type: fixture
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - test_case:
      brief: List with all the test cases for the test.
      type: list
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_key_hash.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of the enrollment daemon 'wazuh-authd' under different messages.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_key_hash.py",
    "id": 10,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every input message in authd port generates the adequate output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets."
                    }
                },
                {
                    "clean_client_keys_file_module": {
                        "type": "fixture",
                        "brief": "Stops Wazuh and cleans any previus key in client.keys file at module scope."
                    }
                },
                {
                    "set_up_groups_keys": {
                        "type": "fixture",
                        "brief": "Set pre-existent groups and keys."
                    }
                },
                {
                    "wait_for_authd_startup_function": {
                        "type": "fixture",
                        "brief": "Waits until Authd is accepting connections."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at function scope."
                    }
                }
            ],
            "assertions": [
                "The received output must match with expected.",
                "The enrollment messages are parsed as expected.",
                "The agent keys are denied if the hash is the same than the manager's."
            ],
            "input_description": "Different test cases are contained in an external YAML file (authd_key_hash.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on 'authd' socket."
            ],
            "name": "test_ossec_auth_messages_with_key_hash",
            "inputs": [
                "get_configuration0-set_up_groups_keys0",
                "get_configuration0-set_up_groups_keys1",
                "get_configuration0-set_up_groups_keys2",
                "get_configuration0-set_up_groups_keys3",
                "get_configuration0-set_up_groups_keys4",
                "get_configuration0-set_up_groups_keys5",
                "get_configuration0-set_up_groups_keys6"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_key_hash.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of the enrollment daemon 'wazuh-authd'
  under different messages.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 10
modules:
- authd
name: test_authd_key_hash.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The received output must match with expected.
  - The enrollment messages are parsed as expected.
  - The agent keys are denied if the hash is the same than the manager's.
  description: Check that every input message in authd port generates the adequate
    output.
  expected_output:
  - Registration request responses on 'authd' socket.
  input_description: Different test cases are contained in an external YAML file (authd_key_hash.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - get_configuration0-set_up_groups_keys0
  - get_configuration0-set_up_groups_keys1
  - get_configuration0-set_up_groups_keys2
  - get_configuration0-set_up_groups_keys3
  - get_configuration0-set_up_groups_keys4
  - get_configuration0-set_up_groups_keys5
  - get_configuration0-set_up_groups_keys6
  name: test_ossec_auth_messages_with_key_hash
  parameters:
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure the socket listener to receive and send messages on the sockets.
      type: fixture
  - clean_client_keys_file_module:
      brief: Stops Wazuh and cleans any previus key in client.keys file at module
        scope.
      type: fixture
  - set_up_groups_keys:
      brief: Set pre-existent groups and keys.
      type: fixture
  - wait_for_authd_startup_function:
      brief: Waits until Authd is accepting connections.
      type: fixture
  - connect_to_sockets_function:
      brief: Bind to the configured sockets at function scope.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_local.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of 'wazuh-authd' under different messages in a Cluster scenario (for Master).",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_local.py",
    "id": 4,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every input message in trough local 'authd' port generates the adequate response to worker.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "set_up_groups_keys": {
                        "type": "fixture",
                        "brief": "Set pre-existent groups and keys."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment_function": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets at function scope."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at function scope."
                    }
                },
                {
                    "wait_for_authd_startup_module": {
                        "type": "fixture",
                        "brief": "Waits until Authd is accepting connections."
                    }
                }
            ],
            "assertions": [
                "The received output must match with expected.",
                "The enrollment messages are parsed as expected.",
                "The agent keys are denied if the hash is the same than the manager's."
            ],
            "input_description": "Different test cases are contained in an external YAML file (local_enroll_messages.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on 'authd' socket."
            ],
            "name": "test_ossec_auth_messages",
            "inputs": [
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups10",
                "get_configuration0-set_up_groups11",
                "get_configuration0-set_up_groups12",
                "get_configuration0-set_up_groups13",
                "get_configuration0-set_up_groups_keys0",
                "get_configuration0-set_up_groups_keys1",
                "get_configuration0-set_up_groups_keys2",
                "get_configuration0-set_up_groups_keys3",
                "get_configuration0-set_up_groups_keys4",
                "get_configuration0-set_up_groups_keys5",
                "get_configuration0-set_up_groups_keys6",
                "get_configuration0-set_up_groups_keys7",
                "get_configuration0-set_up_groups_keys8",
                "get_configuration0-set_up_groups_keys9",
                "get_configuration0-set_up_groups_keys10",
                "get_configuration0-set_up_groups_keys11",
                "get_configuration0-set_up_groups_keys12",
                "get_configuration0-set_up_groups_keys13",
                "get_configuration0-set_up_groups_keys14",
                "get_configuration0-set_up_groups_keys15",
                "get_configuration0-set_up_groups_keys16"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_local.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of 'wazuh-authd' under different
  messages in a Cluster scenario (for Master).
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 4
modules:
- authd
name: test_authd_local.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The received output must match with expected.
  - The enrollment messages are parsed as expected.
  - The agent keys are denied if the hash is the same than the manager's.
  description: Check that every input message in trough local 'authd' port generates
    the adequate response to worker.
  expected_output:
  - Registration request responses on 'authd' socket.
  input_description: Different test cases are contained in an external YAML file (local_enroll_messages.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups10
  - get_configuration0-set_up_groups11
  - get_configuration0-set_up_groups12
  - get_configuration0-set_up_groups13
  - get_configuration0-set_up_groups_keys0
  - get_configuration0-set_up_groups_keys1
  - get_configuration0-set_up_groups_keys2
  - get_configuration0-set_up_groups_keys3
  - get_configuration0-set_up_groups_keys4
  - get_configuration0-set_up_groups_keys5
  - get_configuration0-set_up_groups_keys6
  - get_configuration0-set_up_groups_keys7
  - get_configuration0-set_up_groups_keys8
  - get_configuration0-set_up_groups_keys9
  - get_configuration0-set_up_groups_keys10
  - get_configuration0-set_up_groups_keys11
  - get_configuration0-set_up_groups_keys12
  - get_configuration0-set_up_groups_keys13
  - get_configuration0-set_up_groups_keys14
  - get_configuration0-set_up_groups_keys15
  - get_configuration0-set_up_groups_keys16
  name: test_ossec_auth_messages
  parameters:
  - set_up_groups_keys:
      brief: Set pre-existent groups and keys.
      type: fixture
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment_function:
      brief: Configure the socket listener to receive and send messages on the sockets
        at function scope.
      type: fixture
  - connect_to_sockets_function:
      brief: Bind to the configured sockets at function scope.
      type: fixture
  - wait_for_authd_startup_module:
      brief: Waits until Authd is accepting connections.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_ssl_certs.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'wazuh-authd' daemon is able to handle secure connections using the 'SSL' (Secure Socket Layer) protocol. The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used along with the 'agent-auth' application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/registering/host-verification-registration.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_ssl_certs.py",
    "id": 5,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'wazuh-authd' daemon can manage 'SSL' connections with agents and the 'host verification' feature is working properly. For this purpose, it generates and signs the necessary certificates and builds the enrollment requests using them.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "generate_ca_certificate": {
                        "type": "fixture",
                        "brief": "Build the 'CA' (Certificate of Authority) and sign the certificate used by the testing agent."
                    }
                }
            ],
            "assertions": [
                "Verify that the agent can only connect to the 'wazuh-authd' daemon socket using a valid certificate.",
                "Verify that using a valid certificate the agent can only enroll using the IP address linked to it."
            ],
            "input_description": "Different test cases are found in the test module and include parameters for the environment setup, the requests to be made, and the expected result.",
            "expected_output": [
                "r'OSSEC K:' (When the agent has enrolled in the manager)"
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_authd_ssl_certs",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_ssl_certs.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'wazuh-authd' daemon is able to handle secure
  connections using the 'SSL' (Secure Socket Layer) protocol. The 'wazuh-authd' daemon
  can automatically add a Wazuh agent to a Wazuh manager and provide the key to the
  agent. It is used along with the 'agent-auth' application.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 5
modules:
- authd
name: test_authd_ssl_certs.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/registering/host-verification-registration.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the agent can only connect to the 'wazuh-authd' daemon socket using
    a valid certificate.
  - Verify that using a valid certificate the agent can only enroll using the IP address
    linked to it.
  description: Check if the 'wazuh-authd' daemon can manage 'SSL' connections with
    agents and the 'host verification' feature is working properly. For this purpose,
    it generates and signs the necessary certificates and builds the enrollment requests
    using them.
  expected_output:
  - r'OSSEC K:' (When the agent has enrolled in the manager)
  input_description: Different test cases are found in the test module and include
    parameters for the environment setup, the requests to be made, and the expected
    result.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  name: test_authd_ssl_certs
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - generate_ca_certificate:
      brief: Build the 'CA' (Certificate of Authority) and sign the certificate used
        by the testing agent.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_ssl_options.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'SSL' (Secure Socket Layer) protocol-related settings of the 'wazuh-authd' daemon are working correctly. The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used along with the 'agent-auth' application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_ssl_options.py",
    "id": 6,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'SSL' settings of the 'wazuh-authd' daemon work correctly by enrolling agents that use different values for these settings. Different types of encryption and secure connection protocols are tested, in addition to the 'ssl_auto_negotiate' option that automatically chooses the protocol to be used.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external YAML file (enroll_ssl_options_tests.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the 'enroll_ssl_options_tests.yaml' file."
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_auth_configurations",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_ssl_options.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'SSL' (Secure Socket Layer) protocol-related
  settings of the 'wazuh-authd' daemon are working correctly. The 'wazuh-authd' daemon
  can automatically add a Wazuh agent to a Wazuh manager and provide the key to the
  agent. It is used along with the 'agent-auth' application.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 6
modules:
- authd
name: test_authd_ssl_options.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if the 'SSL' settings of the 'wazuh-authd' daemon work correctly
    by enrolling agents that use different values for these settings. Different types
    of encryption and secure connection protocols are tested, in addition to the 'ssl_auto_negotiate'
    option that automatically chooses the protocol to be used.
  expected_output:
  - Multiple values located in the 'enroll_ssl_options_tests.yaml' file.
  input_description: Different test cases are contained in an external YAML file (enroll_ssl_options_tests.yaml)
    that includes enrollment events and the expected output.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  name: test_ossec_auth_configurations
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_use_password.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of the setting 'use_password'.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_use_password.py",
    "id": 11,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every input message in authd port generates the adequate output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "clean_client_keys_file_module": {
                        "type": "fixture",
                        "brief": "Stops Wazuh and cleans any previus key in client.keys file at module scope."
                    }
                },
                {
                    "clean_client_keys_file_function": {
                        "type": "fixture",
                        "brief": "Cleans any previus key in client.keys file at function scope."
                    }
                },
                {
                    "reset_password": {
                        "type": "fixture",
                        "brief": "Write the password file."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at module scope."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List with all the test cases for the test."
                    }
                },
                {
                    "register_previous_agent": {
                        "type": "fixture",
                        "brief": "Register agents to simulate a scenario with pre existent keys."
                    }
                },
                {
                    "tear_down": {
                        "type": "fixture",
                        "brief": "Roll back the daemon and client.keys state after the test ends."
                    }
                }
            ],
            "assertions": [
                "The random password works as expected.",
                "A wrong password is rejected.",
                "A request with password and use_password = 'no' is rejected."
            ],
            "input_description": "Different test cases are contained in an external YAML file (test_authd_use_password.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on 'authd' socket."
            ],
            "name": "test_authd_force_options",
            "inputs": [
                "Use_source_ip_yes-Let manager decide, use_source_ip enabled",
                "Use_source_ip_yes-Override use_source_ip",
                "Use_source_ip_yes-Not specific IP",
                "Use_source_ip_yes-Let manager decide",
                "Use_source_ip_no-Let manager decide, use_source_ip enabled",
                "Use_source_ip_no-Override use_source_ip",
                "Use_source_ip_no-Not specific IP",
                "Use_source_ip_no-Let manager decide",
                "Force_insert_yes-Overwrite agent name",
                "Force_insert_yes-Valid and duplicate IP",
                "Force_insert_no-Overwrite agent name",
                "Force_insert_no-Valid and duplicate IP",
                "Use_password_yes-Request with default password",
                "Use_password_yes-Register without password",
                "Use_password_yes-Register with wrong password",
                "Use_password_yes-Random password, request with correct password",
                "Use_password_yes-Random password, request with wrong password",
                "Use_password_yes-Random password, request without password",
                "Use_password_no-Request with default password",
                "Use_password_no-Register without password",
                "Use_password_no-Register with wrong password",
                "Use_password_no-Random password, request with correct password",
                "Use_password_no-Random password, request with wrong password",
                "Use_password_no-Random password, request without password"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_use_password.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of the setting 'use_password'.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 11
modules:
- authd
name: test_authd_use_password.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The random password works as expected.
  - A wrong password is rejected.
  - A request with password and use_password = 'no' is rejected.
  description: Check that every input message in authd port generates the adequate
    output.
  expected_output:
  - Registration request responses on 'authd' socket.
  input_description: Different test cases are contained in an external YAML file (test_authd_use_password.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - Use_source_ip_yes-Let manager decide, use_source_ip enabled
  - Use_source_ip_yes-Override use_source_ip
  - Use_source_ip_yes-Not specific IP
  - Use_source_ip_yes-Let manager decide
  - Use_source_ip_no-Let manager decide, use_source_ip enabled
  - Use_source_ip_no-Override use_source_ip
  - Use_source_ip_no-Not specific IP
  - Use_source_ip_no-Let manager decide
  - Force_insert_yes-Overwrite agent name
  - Force_insert_yes-Valid and duplicate IP
  - Force_insert_no-Overwrite agent name
  - Force_insert_no-Valid and duplicate IP
  - Use_password_yes-Request with default password
  - Use_password_yes-Register without password
  - Use_password_yes-Register with wrong password
  - Use_password_yes-Random password, request with correct password
  - Use_password_yes-Random password, request with wrong password
  - Use_password_yes-Random password, request without password
  - Use_password_no-Request with default password
  - Use_password_no-Register without password
  - Use_password_no-Register with wrong password
  - Use_password_no-Random password, request with correct password
  - Use_password_no-Random password, request with wrong password
  - Use_password_no-Random password, request without password
  name: test_authd_force_options
  parameters:
  - clean_client_keys_file_module:
      brief: Stops Wazuh and cleans any previus key in client.keys file at module
        scope.
      type: fixture
  - clean_client_keys_file_function:
      brief: Cleans any previus key in client.keys file at function scope.
      type: fixture
  - reset_password:
      brief: Write the password file.
      type: fixture
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure the socket listener to receive and send messages on the sockets.
      type: fixture
  - connect_to_sockets_module:
      brief: Bind to the configured sockets at module scope.
      type: fixture
  - test_case:
      brief: List with all the test cases for the test.
      type: list
  - register_previous_agent:
      brief: Register agents to simulate a scenario with pre existent keys.
      type: fixture
  - tear_down:
      brief: Roll back the daemon and client.keys state after the test ends.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_use_source_ip.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of the setting 'use_source_ip'.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_use_source_ip.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every input message in 'authd' port generates the adequate output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets."
                    }
                },
                {
                    "wait_for_authd_startup_function": {
                        "type": "fixture",
                        "brief": "Waits until Authd is accepting connections."
                    }
                },
                {
                    "connect_to_sockets_configuration": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at configuration scope."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List with all the test cases for the test."
                    }
                },
                {
                    "tear_down": {
                        "type": "fixture",
                        "brief": "Roll back the daemon and client.keys state after the test ends."
                    }
                }
            ],
            "assertions": [
                "The manager uses the agent's IP as requested.",
                "Setting an IP overrides the configuration.",
                "If the IP is not defined an the setting is disabled, use 'any'."
            ],
            "input_description": "Different test cases are contained in an external YAML file (test_authd_use_source_ip.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on 'authd' socket."
            ],
            "name": "test_authd_force_options",
            "inputs": [
                "Use_source_ip_yes-Let manager decide, use_source_ip enabled",
                "Use_source_ip_yes-Override use_source_ip",
                "Use_source_ip_yes-Not specific IP",
                "Use_source_ip_yes-Let manager decide",
                "Use_source_ip_no-Let manager decide, use_source_ip enabled",
                "Use_source_ip_no-Override use_source_ip",
                "Use_source_ip_no-Not specific IP",
                "Use_source_ip_no-Let manager decide"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_use_source_ip.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of the setting 'use_source_ip'.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 1
modules:
- authd
name: test_authd_use_source_ip.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The manager uses the agent's IP as requested.
  - Setting an IP overrides the configuration.
  - If the IP is not defined an the setting is disabled, use 'any'.
  description: Check that every input message in 'authd' port generates the adequate
    output.
  expected_output:
  - Registration request responses on 'authd' socket.
  input_description: Different test cases are contained in an external YAML file (test_authd_use_source_ip.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - Use_source_ip_yes-Let manager decide, use_source_ip enabled
  - Use_source_ip_yes-Override use_source_ip
  - Use_source_ip_yes-Not specific IP
  - Use_source_ip_yes-Let manager decide
  - Use_source_ip_no-Let manager decide, use_source_ip enabled
  - Use_source_ip_no-Override use_source_ip
  - Use_source_ip_no-Not specific IP
  - Use_source_ip_no-Let manager decide
  name: test_authd_force_options
  parameters:
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure the socket listener to receive and send messages on the sockets.
      type: fixture
  - wait_for_authd_startup_function:
      brief: Waits until Authd is accepting connections.
      type: fixture
  - connect_to_sockets_configuration:
      brief: Bind to the configured sockets at configuration scope.
      type: fixture
  - test_case:
      brief: List with all the test cases for the test.
      type: list
  - tear_down:
      brief: Roll back the daemon and client.keys state after the test ends.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_valid_name_ip.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of 'authd' under different name/IP combinations.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_valid_name_ip.py",
    "id": 12,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every input message in 'authd' port generates the adequate output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "clean_client_keys_file_module": {
                        "type": "fixture",
                        "brief": "Stops Wazuh and cleans any previus key in client.keys file at module scope."
                    }
                },
                {
                    "clean_client_keys_file_function": {
                        "type": "fixture",
                        "brief": "Cleans any previus key in client.keys file at function scope."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at module scope."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List with all the test cases for the test."
                    }
                },
                {
                    "tear_down": {
                        "type": "fixture",
                        "brief": "Roll back the daemon and client.keys state after the test ends."
                    }
                }
            ],
            "assertions": [
                "The manager registers agents with valid IP and name.",
                "The manager rejects invalid input."
            ],
            "input_description": "Different test cases are contained in an external YAML file (test_authd_valid_name_ip.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on 'authd' socket."
            ],
            "name": "test_authd_force_options",
            "inputs": [
                "Use_source_ip_yes-Let manager decide, use_source_ip enabled",
                "Use_source_ip_yes-Override use_source_ip",
                "Use_source_ip_yes-Not specific IP",
                "Use_source_ip_yes-Let manager decide",
                "Use_source_ip_no-Let manager decide, use_source_ip enabled",
                "Use_source_ip_no-Override use_source_ip",
                "Use_source_ip_no-Not specific IP",
                "Use_source_ip_no-Let manager decide",
                "Force_insert_yes-Overwrite agent name",
                "Force_insert_yes-Valid and duplicate IP",
                "Force_insert_no-Overwrite agent name",
                "Force_insert_no-Valid and duplicate IP",
                "Use_password_yes-Request with default password",
                "Use_password_yes-Register without password",
                "Use_password_yes-Register with wrong password",
                "Use_password_yes-Random password, request with correct password",
                "Use_password_yes-Random password, request with wrong password",
                "Use_password_yes-Random password, request without password",
                "Use_password_no-Request with default password",
                "Use_password_no-Register without password",
                "Use_password_no-Register with wrong password",
                "Use_password_no-Random password, request with correct password",
                "Use_password_no-Random password, request with wrong password",
                "Use_password_no-Random password, request without password",
                "test_authd_valid_name_ip-Agent name same as Manager",
                "test_authd_valid_name_ip-Register with Default config",
                "test_authd_valid_name_ip-Too short agent name",
                "test_authd_valid_name_ip-Min len agent name",
                "test_authd_valid_name_ip-Max len agent name",
                "test_authd_valid_name_ip-Too long agent name",
                "test_authd_valid_name_ip-Check non-alphanumeric '*'",
                "test_authd_valid_name_ip-Check non-alphanumeric '-'",
                "test_authd_valid_name_ip-Check non-alphanumeric '_'",
                "test_authd_valid_name_ip-Check non-alphanumeric '.'",
                "test_authd_valid_name_ip-Valid IP",
                "test_authd_valid_name_ip-Invalid IP: incomplete",
                "test_authd_valid_name_ip-Invalid IP: alphabetic character",
                "test_authd_valid_name_ip-Invalid IP: greater than 255: 1",
                "test_authd_valid_name_ip-Invalid IP: greater than 255: 2",
                "test_authd_valid_name_ip-Invalid IP: 4 digits",
                "test_authd_valid_name_ip-Ip with mask/0",
                "test_authd_valid_name_ip-Ip with mask /24 ",
                "test_authd_valid_name_ip-Ip with mask /32",
                "test_authd_valid_name_ip-Invalid mask",
                "test_authd_valid_name_ip-Invalid mask, wrong character0",
                "test_authd_valid_name_ip-Invalid mask, wrong character1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_valid_name_ip.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of 'authd' under different name/IP
  combinations.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 12
modules:
- authd
name: test_authd_valid_name_ip.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The manager registers agents with valid IP and name.
  - The manager rejects invalid input.
  description: Check that every input message in 'authd' port generates the adequate
    output.
  expected_output:
  - Registration request responses on 'authd' socket.
  input_description: Different test cases are contained in an external YAML file (test_authd_valid_name_ip.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - Use_source_ip_yes-Let manager decide, use_source_ip enabled
  - Use_source_ip_yes-Override use_source_ip
  - Use_source_ip_yes-Not specific IP
  - Use_source_ip_yes-Let manager decide
  - Use_source_ip_no-Let manager decide, use_source_ip enabled
  - Use_source_ip_no-Override use_source_ip
  - Use_source_ip_no-Not specific IP
  - Use_source_ip_no-Let manager decide
  - Force_insert_yes-Overwrite agent name
  - Force_insert_yes-Valid and duplicate IP
  - Force_insert_no-Overwrite agent name
  - Force_insert_no-Valid and duplicate IP
  - Use_password_yes-Request with default password
  - Use_password_yes-Register without password
  - Use_password_yes-Register with wrong password
  - Use_password_yes-Random password, request with correct password
  - Use_password_yes-Random password, request with wrong password
  - Use_password_yes-Random password, request without password
  - Use_password_no-Request with default password
  - Use_password_no-Register without password
  - Use_password_no-Register with wrong password
  - Use_password_no-Random password, request with correct password
  - Use_password_no-Random password, request with wrong password
  - Use_password_no-Random password, request without password
  - test_authd_valid_name_ip-Agent name same as Manager
  - test_authd_valid_name_ip-Register with Default config
  - test_authd_valid_name_ip-Too short agent name
  - test_authd_valid_name_ip-Min len agent name
  - test_authd_valid_name_ip-Max len agent name
  - test_authd_valid_name_ip-Too long agent name
  - test_authd_valid_name_ip-Check non-alphanumeric '*'
  - test_authd_valid_name_ip-Check non-alphanumeric '-'
  - test_authd_valid_name_ip-Check non-alphanumeric '_'
  - test_authd_valid_name_ip-Check non-alphanumeric '.'
  - test_authd_valid_name_ip-Valid IP
  - 'test_authd_valid_name_ip-Invalid IP: incomplete'
  - 'test_authd_valid_name_ip-Invalid IP: alphabetic character'
  - 'test_authd_valid_name_ip-Invalid IP: greater than 255: 1'
  - 'test_authd_valid_name_ip-Invalid IP: greater than 255: 2'
  - 'test_authd_valid_name_ip-Invalid IP: 4 digits'
  - test_authd_valid_name_ip-Ip with mask/0
  - 'test_authd_valid_name_ip-Ip with mask /24 '
  - test_authd_valid_name_ip-Ip with mask /32
  - test_authd_valid_name_ip-Invalid mask
  - test_authd_valid_name_ip-Invalid mask, wrong character0
  - test_authd_valid_name_ip-Invalid mask, wrong character1
  name: test_authd_force_options
  parameters:
  - clean_client_keys_file_module:
      brief: Stops Wazuh and cleans any previus key in client.keys file at module
        scope.
      type: fixture
  - clean_client_keys_file_function:
      brief: Cleans any previus key in client.keys file at function scope.
      type: fixture
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure the socket listener to receive and send messages on the sockets.
      type: fixture
  - connect_to_sockets_module:
      brief: Bind to the configured sockets at module scope.
      type: fixture
  - test_case:
      brief: List with all the test cases for the test.
      type: list
  - tear_down:
      brief: Roll back the daemon and client.keys state after the test ends.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd_worker.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "This module verifies the correct behavior of authd under different messages in a Cluster scenario (for Worker)",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Amazon Linux 1",
        "Amazon Linux 2",
        "Arch Linux",
        "CentOS 6",
        "CentOS 7",
        "CentOS 8",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 6",
        "Red Hat 7",
        "Red Hat 8",
        "Ubuntu Bionic",
        "Ubuntu Trusty",
        "Ubuntu Xenial"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd_worker.py",
    "id": 7,
    "group_id": 0,
    "tests": [
        {
            "description": "Check that every message from the agent is correctly formatted for master, and every master response is correctly parsed for agent\"",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get the configuration of the test."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Set the pre-defined groups."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure the socket listener to receive and send messages on the sockets."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Bind to the configured sockets at module scope."
                    }
                },
                {
                    "wait_for_authd_startup": {
                        "type": "fixture",
                        "brief": "Waits until Authd is accepting connections."
                    }
                }
            ],
            "assertions": [
                "The 'port_input' from agent is formatted to 'cluster_input' for master",
                "The 'cluster_output' response from master is correctly parsed to 'port_output' for agent"
            ],
            "input_description": "Different test cases are contained in an external YAML file (worker_messages.yaml) which includes the different possible registration requests and the expected responses.",
            "expected_output": [
                "Registration request responses on authd socket"
            ],
            "name": "test_ossec_auth_messages",
            "inputs": [
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups10",
                "get_configuration0-set_up_groups11",
                "get_configuration0-set_up_groups12",
                "get_configuration0-set_up_groups13",
                "get_configuration0-set_up_groups_keys0",
                "get_configuration0-set_up_groups_keys1",
                "get_configuration0-set_up_groups_keys2",
                "get_configuration0-set_up_groups_keys3",
                "get_configuration0-set_up_groups_keys4",
                "get_configuration0-set_up_groups_keys5",
                "get_configuration0-set_up_groups_keys6",
                "get_configuration0-set_up_groups_keys7",
                "get_configuration0-set_up_groups_keys8",
                "get_configuration0-set_up_groups_keys9",
                "get_configuration0-set_up_groups_keys10",
                "get_configuration0-set_up_groups_keys11",
                "get_configuration0-set_up_groups_keys12",
                "get_configuration0-set_up_groups_keys13",
                "get_configuration0-set_up_groups_keys14",
                "get_configuration0-set_up_groups_keys15",
                "get_configuration0-set_up_groups_keys16",
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd_worker.yaml</summary>
<p>

```yaml
brief: This module verifies the correct behavior of authd under different messages
  in a Cluster scenario (for Worker)
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
group_id: 0
id: 7
modules:
- authd
name: test_authd_worker.py
os_platform:
- linux
os_version:
- Amazon Linux 1
- Amazon Linux 2
- Arch Linux
- CentOS 6
- CentOS 7
- CentOS 8
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 6
- Red Hat 7
- Red Hat 8
- Ubuntu Bionic
- Ubuntu Trusty
- Ubuntu Xenial
tags:
- enrollment
tests:
- assertions:
  - The 'port_input' from agent is formatted to 'cluster_input' for master
  - The 'cluster_output' response from master is correctly parsed to 'port_output'
    for agent
  description: Check that every message from the agent is correctly formatted for
    master, and every master response is correctly parsed for agent"
  expected_output:
  - Registration request responses on authd socket
  input_description: Different test cases are contained in an external YAML file (worker_messages.yaml)
    which includes the different possible registration requests and the expected responses.
  inputs:
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups10
  - get_configuration0-set_up_groups11
  - get_configuration0-set_up_groups12
  - get_configuration0-set_up_groups13
  - get_configuration0-set_up_groups_keys0
  - get_configuration0-set_up_groups_keys1
  - get_configuration0-set_up_groups_keys2
  - get_configuration0-set_up_groups_keys3
  - get_configuration0-set_up_groups_keys4
  - get_configuration0-set_up_groups_keys5
  - get_configuration0-set_up_groups_keys6
  - get_configuration0-set_up_groups_keys7
  - get_configuration0-set_up_groups_keys8
  - get_configuration0-set_up_groups_keys9
  - get_configuration0-set_up_groups_keys10
  - get_configuration0-set_up_groups_keys11
  - get_configuration0-set_up_groups_keys12
  - get_configuration0-set_up_groups_keys13
  - get_configuration0-set_up_groups_keys14
  - get_configuration0-set_up_groups_keys15
  - get_configuration0-set_up_groups_keys16
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  name: test_ossec_auth_messages
  parameters:
  - get_configuration:
      brief: Get the configuration of the test.
      type: fixture
  - set_up_groups:
      brief: Set the pre-defined groups.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure the socket listener to receive and send messages on the sockets.
      type: fixture
  - connect_to_sockets_module:
      brief: Bind to the configured sockets at module scope.
      type: fixture
  - wait_for_authd_startup:
      brief: Waits until Authd is accepting connections.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_authd.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment requests, generating consistent responses to the requests received on its IP v4 network socket. The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used along with the 'agent-auth' application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_authd.py",
    "id": 2,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if when the `wazuh-authd` daemon receives different kinds of enrollment requests, it responds appropriately to them. In this case, the enrollment requests are sent to an IP v4 network socket.",
            "wazuh_min_version": 4.2,
            "parameters": [
                {
                    "clean_client_keys_file": {
                        "type": "fixture",
                        "brief": "Delete the agent keys stored in the `client.keys` file."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "set_up_groups": {
                        "type": "fixture",
                        "brief": "Create a testing group for agents and provide the test case list."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_sockets_environment": {
                        "type": "fixture",
                        "brief": "Configure environment for sockets and MITM."
                    }
                },
                {
                    "connect_to_sockets_module": {
                        "type": "fixture",
                        "brief": "Module scope version of `connect_to_sockets` fixture."
                    }
                },
                {
                    "wait_for_agentd_startup": {
                        "type": "fixture",
                        "brief": "Wait until the `wazuh-agentd` has begun."
                    }
                }
            ],
            "assertions": [
                "Verify that the response messages are consistent with the enrollment requests received."
            ],
            "input_description": "Different test cases are contained in an external `YAML` file (enroll_messages.yaml) that includes enrollment events and the expected output.",
            "expected_output": [
                "Multiple values located in the `enroll_messages.yaml` file."
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_ossec_auth_messages",
            "inputs": [
                "get_configuration0-set_up_groups0",
                "get_configuration0-set_up_groups1",
                "get_configuration0-set_up_groups2",
                "get_configuration0-set_up_groups3",
                "get_configuration0-set_up_groups4",
                "get_configuration0-set_up_groups5",
                "get_configuration0-set_up_groups6",
                "get_configuration0-set_up_groups7",
                "get_configuration0-set_up_groups8",
                "get_configuration0-set_up_groups9",
                "get_configuration0-set_up_groups10",
                "get_configuration0-set_up_groups11",
                "get_configuration0-set_up_groups12",
                "get_configuration0-set_up_groups13"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_authd.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'wazuh-authd' daemon correctly handles the enrollment
  requests, generating consistent responses to the requests received on its IP v4
  network socket. The 'wazuh-authd' daemon can automatically add a Wazuh agent to
  a Wazuh manager and provide the key to the agent. It is used along with the 'agent-auth'
  application.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 2
modules:
- authd
name: test_authd.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html
- https://documentation.wazuh.com/current/user-manual/reference/tools/agent_groups.html
tags:
- enrollment
tests:
- assertions:
  - Verify that the response messages are consistent with the enrollment requests
    received.
  description: Check if when the `wazuh-authd` daemon receives different kinds of
    enrollment requests, it responds appropriately to them. In this case, the enrollment
    requests are sent to an IP v4 network socket.
  expected_output:
  - Multiple values located in the `enroll_messages.yaml` file.
  input_description: Different test cases are contained in an external `YAML` file
    (enroll_messages.yaml) that includes enrollment events and the expected output.
  inputs:
  - get_configuration0-set_up_groups0
  - get_configuration0-set_up_groups1
  - get_configuration0-set_up_groups2
  - get_configuration0-set_up_groups3
  - get_configuration0-set_up_groups4
  - get_configuration0-set_up_groups5
  - get_configuration0-set_up_groups6
  - get_configuration0-set_up_groups7
  - get_configuration0-set_up_groups8
  - get_configuration0-set_up_groups9
  - get_configuration0-set_up_groups10
  - get_configuration0-set_up_groups11
  - get_configuration0-set_up_groups12
  - get_configuration0-set_up_groups13
  name: test_ossec_auth_messages
  parameters:
  - clean_client_keys_file:
      brief: Delete the agent keys stored in the `client.keys` file.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - set_up_groups:
      brief: Create a testing group for agents and provide the test case list.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - configure_sockets_environment:
      brief: Configure environment for sockets and MITM.
      type: fixture
  - connect_to_sockets_module:
      brief: Module scope version of `connect_to_sockets` fixture.
      type: fixture
  - wait_for_agentd_startup:
      brief: Wait until the `wazuh-agentd` has begun.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_remote_enrollment.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the 'remote enrollment' option of the 'wazuh-authd' daemon settings is working properly. The 'wazuh-authd' daemon can automatically add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used along with the 'agent-auth' application.",
    "tier": 0,
    "modules": [
        "authd"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-authd",
        "wazuh-db",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html#remote-enrollment"
    ],
    "tags": [
        "enrollment"
    ],
    "name": "test_remote_enrollment.py",
    "id": 8,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'wazuh-authd' daemon remote enrollment is enabled/disabled according to the configuration. By default, remote enrollment is enabled. When disabled, the 'authd' 'TLS' port (1515 by default) won't be listening to new connections, but requests to the local socket will still be attended.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_authd": {
                        "type": "fixture",
                        "brief": "Restart the 'wazuh-authd' daemon, clear the 'ossec.log' file and start a new file monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that the port '1515' opens or closes depending on the value of the 'remote_enrollment' option.",
                "Verify that when a 'worker' node receives an enrollment request, it tries to connect to the 'master' node."
            ],
            "input_description": "Different test cases are found in the test module and include parameters for the environment setup, the requests to be made, and the expected result.",
            "expected_output": [
                "r'Accepting connections on port 1515. No password required.' (When the 'wazuh-authd' daemon)",
                "r'OSSEC K:' (When the agent has enrolled in the manager)",
                "r'.*Port 1515 was set as disabled.*' (When remote enrollment is disabled)",
                {
                    "r'ERROR": "Cannot comunicate with master'"
                }
            ],
            "tags": [
                "keys",
                "ssl"
            ],
            "name": "test_remote_enrollment",
            "inputs": [
                "no_remote_enrollment_standalone",
                "yes_remote_enrollment_standalone",
                "no_remote_enrollment_cluster_master",
                "yes_remote_enrollment_cluster_master",
                "no_remote_enrollment_cluster_worker",
                "yes_remote_enrollment_cluster_worker"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_remote_enrollment.yaml</summary>
<p>

```yaml
brief: These tests will check if the 'remote enrollment' option of the 'wazuh-authd'
  daemon settings is working properly. The 'wazuh-authd' daemon can automatically
  add a Wazuh agent to a Wazuh manager and provide the key to the agent. It is used
  along with the 'agent-auth' application.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-authd
- wazuh-db
- wazuh-modulesd
group_id: 0
id: 8
modules:
- authd
name: test_remote_enrollment.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html#remote-enrollment
tags:
- enrollment
tests:
- assertions:
  - Verify that the port '1515' opens or closes depending on the value of the 'remote_enrollment'
    option.
  - Verify that when a 'worker' node receives an enrollment request, it tries to connect
    to the 'master' node.
  description: Check if the 'wazuh-authd' daemon remote enrollment is enabled/disabled
    according to the configuration. By default, remote enrollment is enabled. When
    disabled, the 'authd' 'TLS' port (1515 by default) won't be listening to new connections,
    but requests to the local socket will still be attended.
  expected_output:
  - r'Accepting connections on port 1515. No password required.' (When the 'wazuh-authd'
    daemon)
  - r'OSSEC K:' (When the agent has enrolled in the manager)
  - r'.*Port 1515 was set as disabled.*' (When remote enrollment is disabled)
  - r'ERROR: Cannot comunicate with master'
  input_description: Different test cases are found in the test module and include
    parameters for the environment setup, the requests to be made, and the expected
    result.
  inputs:
  - no_remote_enrollment_standalone
  - yes_remote_enrollment_standalone
  - no_remote_enrollment_cluster_master
  - yes_remote_enrollment_cluster_master
  - no_remote_enrollment_cluster_worker
  - yes_remote_enrollment_cluster_worker
  name: test_remote_enrollment
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_authd:
      brief: Restart the 'wazuh-authd' daemon, clear the 'ossec.log' file and start
        a new file monitor.
      type: fixture
  tags:
  - keys
  - ssl
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`