### PR TITLE
Migrate `test_glcoud` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_gcloud/test_configuration/test_invalid.py
+++ b/tests/integration/test_gcloud/test_configuration/test_invalid.py
@@ -130,10 +130,10 @@ def test_invalid(get_configuration, configure_environment, reset_ossec_log):
                        can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'.*read_main_elements.*: ERROR: .*: Invalid element in the configuration.*'
-        - r'.*at _sched_scan_validate_parameters.*: ERROR:.*'
-        - r'.*at sched_scan_read.*: ERROR:.*'
-        - r'.*at sched_scan_read.*: ERROR:.*'
+        - r'.*read_main_elements.*: ERROR.* Invalid element in the configuration.*'
+        - r'.*at _sched_scan_validate_parameters.*: ERROR.*'
+        - r'.*at sched_scan_read.*: ERROR.*'
+        - r'.*at sched_scan_read.*: ERROR.*'
 
     tags:
         - invalid_settings

--- a/tests/integration/test_gcloud/test_configuration/test_invalid.py
+++ b/tests/integration/test_gcloud/test_configuration/test_invalid.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if that module detects invalid configurations and indicates
+       the location of the errors detected.
+
+tier: 1
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html
+
+tags:
+    - gcloud_configuration
+'''
 import os
 import sys
 
@@ -50,12 +104,40 @@ def get_configuration(request):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_invalid(get_configuration, configure_environment, reset_ossec_log):
-    """
-    Checks if an invalid configuration is detected
+    '''
+    description: Check if the 'gcp-pubsub' module detects invalid configurations. For this purpose, the test
+                 will configure 'gcp-pubsub' using invalid configuration settings with different attributes.
+                 Finally, it will verify that error events are generated indicating the source of the errors.
 
-    Using invalid configurations with different attributes,
-    expect an error message and gcp-pubsub unable to start.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - reset_ossec_log:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module generates error events when invalid configurations are used.
+
+    input_description: Different test cases are contained in an external YAML file (invalid_conf.yaml) which
+                       includes configuration settings for the 'gcp-pubsub' module. The GCP access credentials
+                       can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'.*read_main_elements.*: ERROR: .*: Invalid element in the configuration.*'
+        - r'.*at _sched_scan_validate_parameters.*: ERROR:.*'
+        - r'.*at sched_scan_read.*: ERROR:.*'
+        - r'.*at sched_scan_read.*: ERROR:.*'
+
+    tags:
+        - invalid_settings
+    '''
     # Configuration error -> ValueError raised
     with pytest.raises(ValueError):
         control_service('restart')

--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if the remote configuration used by GCP matches
+       the local one set in the 'ossec.conf' file.
+
+tier: 1
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html
+
+tags:
+    - gcloud_configuration
+'''
 import os
 import pytest
 import json
@@ -95,11 +149,38 @@ def get_remote_configuration(component_name, config):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_remote_configuration(get_configuration, configure_environment,
                               restart_wazuh, wait_for_gcp_start):
-    """
-    These tests verify remote configuration matches with the ossec_configuration.
-    The first test checks the default options. The second checks the configuration when it is completed.
-    The last one checks repeated options in ossec.conf, so the last value will be applied.
-    """
+    '''
+    description: Check if the remote configuration matches the local configuration of the 'gcp-pubsub' module.
+                 For this purpose, the test will use different settings and get the remote configuration applied.
+                 Then, it will verify that the default and custom local options match. It will also verify that,
+                 when repeated options are used in the configuration, the last one detected is the one applied.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the remote configuration used by GCP matches the local one set in the 'ossec.conf' file.
+
+    input_description: Different test cases are contained in an external YAML file (wazuh_remote_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - The current configuration settings from GCP to compare them with the local ones.
+    '''
     tags_to_apply = get_configuration['tags'][0]
 
     # get xml configuration

--- a/tests/integration/test_gcloud/test_configuration/test_schedule.py
+++ b/tests/integration/test_gcloud/test_configuration/test_schedule.py
@@ -132,7 +132,7 @@ def test_schedule(get_configuration, configure_environment, restart_wazuh):
                        credentials can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'.*at _sched_scan_validate_parameters.*: WARNING:.*'
+        - r'.*at _sched_scan_validate_parameters.*: WARNING.*'
 
     tags:
         - scheduled

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -1,7 +1,63 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if the 'gcp-pubsub' module gets the GCP logs at the date-time
+       specified in the configuration and sleeps up to it.
+
+tier: 0
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#day
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#wday
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#time
+
+tags:
+    - gcloud_functionality
+'''
 import datetime
 import os
 import sys
@@ -74,10 +130,51 @@ def get_configuration(request):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_day_wday(tags_to_apply, get_configuration, configure_environment,
                   restart_wazuh, wait_for_gcp_start):
-    """
-    These tests verify the module starts to pull according to the day of the week
-    or month and time.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module starts to pull logs according to the day of the week,
+                 of the month, or time set in the configuration. For this purpose, the test will use
+                 different values for the 'day', 'wday', and 'time' tags (depending on the test case).
+                 Then, it will check that the 'sleep' event is triggered and matches with the set interval.
+                 Finally, the test will travel in time to the specified interval and verify that
+                 the 'fetch' event is generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module sleeps up to the date-time specified in the configuration.
+        - Verify that the 'gcp-pubsub' module starts to pull logs at the date-time specified in the configuration.
+
+    input_description: Tree test cases are contained in an external YAML file (wazuh_schedule_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. Those are
+                       combined with the scheduling values defined in the module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*'
+        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
+
+    tags:
+        - logs
+        - scheduled
+        - time_travel
+    '''
     def get_next_scan(next_scan_time: str):
         next_scan_time = next_scan_time_log.split()
         date = next_scan_time[0].split('/')
@@ -85,7 +182,8 @@ def test_day_wday(tags_to_apply, get_configuration, configure_environment,
 
         date_before = datetime.datetime.now()
 
-        date_after = datetime.datetime(int(date[0]), int(date[1]), int(date[2]), int(hour[0]), int(hour[1]), int(hour[2]))
+        date_after = datetime.datetime(int(date[0]), int(date[1]), int(date[2]),
+                                       int(hour[0]), int(hour[1]), int(hour[2]))
         diff_time = (date_after - date_before).total_seconds()
 
         return int(diff_time)
@@ -113,10 +211,47 @@ def test_day_wday(tags_to_apply, get_configuration, configure_environment,
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environment,
                            restart_wazuh, wait_for_gcp_start):
-    """
-    These tests verify the module calculates correctly the next scan using
-    time intervals greater than one month, one week or one day.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module calculates the next scan correctly using time intervals
+                 greater than one month, one week, or one day. For this purpose, the test will use different
+                 values for the 'day', 'wday', and 'time' tags (depending on the test case). Finally, it
+                 will check that the 'sleep' event is triggered and matches with the set interval.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if matches with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module calculates the next scan correctly from
+          the date-time and interval values specified in the configuration.
+
+    input_description: Tree test cases are contained in an external YAML file (wazuh_schedule_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. Those are
+                       combined with the scheduling values defined in the module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*'
+
+    tags:
+        - logs
+        - scheduled
+    '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -167,8 +167,8 @@ def test_day_wday(tags_to_apply, get_configuration, configure_environment,
                        credentials can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*'
-        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
+        - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*'
+        - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
 
     tags:
         - logs
@@ -246,7 +246,7 @@ def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environme
                        credentials can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*'
+        - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*'
 
     tags:
         - logs

--- a/tests/integration/test_gcloud/test_functionality/test_interval.py
+++ b/tests/integration/test_gcloud/test_functionality/test_interval.py
@@ -144,8 +144,8 @@ def test_interval(get_configuration, configure_environment,
                        credentials can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*'
-        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
+        - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*'
+        - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
 
     tags:
         - logs

--- a/tests/integration/test_gcloud/test_functionality/test_interval.py
+++ b/tests/integration/test_gcloud/test_functionality/test_interval.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if the 'gcp-pubsub' module gets the GCP logs at the intervals
+       specified in the configuration and sleeps up to them.
+
+tier: 0
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#interval
+
+tags:
+    - gcloud_functionality
+'''
 import datetime
 import os
 import sys
@@ -58,10 +112,45 @@ def get_configuration(request):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_interval(get_configuration, configure_environment,
                   restart_wazuh, wait_for_gcp_start):
-    """
-    These tests verify the module starts to pull after the time interval
-    that has to match the value of the 'interval' parameter.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module starts to pull logs at the periods set in the configuration
+                 by the 'interval' tag. For this purpose, the test will use different intervals and check if
+                 the 'sleep' event is triggered and matches with the set interval. Finally, the test will wait
+                 the time specified in that interval and verify that the 'fetch' event is generated.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module sleeps between the intervals specified in the configuration.
+        - Verify that the 'gcp-pubsub' module starts to pull logs at the intervals specified in the configuration.
+
+    input_description: A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. That is
+                       combined with the interval values defined in the module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*'
+        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
+
+    tags:
+        - logs
+        - scheduled
+    '''
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
     if 'm' in str_interval:

--- a/tests/integration/test_gcloud/test_functionality/test_logging.py
+++ b/tests/integration/test_gcloud/test_functionality/test_logging.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if the 'gcp-pubsub' module gets only the GCP events whose
+       logging level matches the one specified in the 'logging' tag.
+
+tier: 0
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#logging
+
+tags:
+    - gcloud_functionality
+'''
 import os
 import sys
 
@@ -60,10 +114,46 @@ def get_configuration(request):
 ], indirect=True)
 def test_logging(get_configuration, configure_environment, publish_messages,
                  restart_wazuh, wait_for_gcp_start):
-    """
-    When a logging option is used, it cannot be an event that has another logging option.
-    For example, events from gcp-pubusb will only have '- INFO -' if logging = info.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module generates logs according to the set type in the 'logging' tag.
+                 For this purpose, the test will use different logging levels (depending on the test case) and
+                 gets the GCP events. Finally, the test will verify that the type of all retrieved events matches
+                 the one specified in the configuration.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - publish_messages:
+            type: list
+            brief: List of testing GCP logs.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the logging level of retrieved GCP events matches the one specified in the 'logging' tag.
+
+    input_description: A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. That is
+                       combined with the logging levels defined in the module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'.*wazuh-modulesd:gcp-pubsub.*'
+
+    tags:
+        - logs
+        - scheduled
+    '''
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     logging_opt = get_configuration['sections'][0]['elements'][6]['logging']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -1,7 +1,62 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if the 'gcp-pubsub' module gets GCP messages up to the limit
+       set in the 'max_messages' tag on the same operation when the number
+       of them exceeds that limit.
+
+tier: 0
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#max-messages
+
+tags:
+    - gcloud_functionality
+'''
 import os
 import sys
 
@@ -63,11 +118,54 @@ def get_configuration(request):
 ], indirect=True)
 def test_max_messages(get_configuration, configure_environment, publish_messages,
                       restart_wazuh, wait_for_gcp_start):
-    """
-    Verify the module gcp-pubsub pull a number of messages less than or equal to max_messages.
-    If the number of messages is greater than max_messages, the module will only pull max_messages
-    and the rest will be pulled in the next iteration.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module pulls a message number less than or equal to the limit set
+                 in the 'max_messages' tag. For this purpose, the test will use a fixed limit and generate a
+                 number of GCP events lower and upper than the limit (depending on the test case). Then, it
+                 will wait for the 'fetching' event, and finally, the test will verify that, if the message
+                 number exceeds that limit, the module will only pull messages up to the limit, and the rest
+                 will be pulled in successive iterations, and if not, the module will pull all messages in
+                 the same operation.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - publish_messages:
+            type: list
+            brief: List of testing GCP logs.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module pulls all GCP messages in one operation if
+          the number of them does not exceed the limit set in the 'max_messages' tag.
+        - Verify that the 'gcp-pubsub' module pulls GCP messages up to the limit set
+          in the 'max_messages' tag when the number of them exceeds that limit, and
+          the remaining ones are pulled in the successive operations.
+
+    input_description: A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. That is
+                       combined with the message limit defined in the module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
+        - r'.*wm_gcp_run.*: INFO: - INFO - Received and acknowledged .* messages'
+
+    tags:
+        - logs
+        - scheduled
+    '''
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
 

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -159,8 +159,8 @@ def test_max_messages(get_configuration, configure_environment, publish_messages
                        credentials can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
-        - r'.*wm_gcp_run.*: INFO: - INFO - Received and acknowledged .* messages'
+        - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
+        - r'.*wm_gcp_run.*: INFO.* - INFO - Received and acknowledged .* messages'
 
     tags:
         - logs

--- a/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
+++ b/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
@@ -145,8 +145,8 @@ def test_pull_on_start(get_configuration, configure_environment,
                        credentials can be found in the 'configuration_template.yaml' file.
 
     expected_output:
-        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
-        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*' (when 'pull_on_start=no')
+        - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
+        - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*' (when 'pull_on_start=no')
 
     tags:
         - logs

--- a/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
+++ b/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests
+       will check if the 'gcp-pubsub' module gets GCP messages when it starts
+       if the 'pull_on_start' tag is set to 'yes', and sleeps otherwise.
+
+tier: 0
+
+modules:
+    - gcloud
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#pull-on-start
+
+tags:
+    - gcloud_functionality
+'''
 import os
 import sys
 
@@ -56,11 +110,48 @@ def get_configuration(request):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_pull_on_start(get_configuration, configure_environment,
                        restart_wazuh, wait_for_gcp_start):
-    """
-    Verify the module gcp-pubsub starts if pull_on_start is set to yes and
-    the module sleeps if pull_on_start is set to no.
-    In the second case, the module will start to pull messages after time interval.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module pulls messages when starting if the 'pull_on_start' is
+                 set to 'yes', or sleeps up to the next interval if that one is set to 'no'. For this
+                 purpose, the test will use the possible values for that tag ('yes' and 'no'). Then, it
+                 will wait for the 'fetching' event if the pull on start opction is enabled. Otherwise,
+                 the test will verify that the 'sleep' event is generated, and the 'fetching' event is not.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module gets GCP messages when it starts
+          if the 'pull_on_start' tag is set to 'yes'.
+        - Verify that the 'gcp-pubsub' module sleeps up to the next interval when it starts
+          if the 'pull_on_start' tag is set to 'no'.
+
+    input_description: A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. That is
+                       combined with the 'pull_on_start' values defined in the module. The GCP access
+                       credentials can be found in the 'configuration_template.yaml' file.
+
+    expected_output:
+        - r'wm_gcp_main(): DEBUG: Starting fetching of logs.'
+        - r'.*wm_gcp_main.*: DEBUG: Sleeping until: .*' (when 'pull_on_start=no')
+
+    tags:
+        - logs
+        - scheduled
+    '''
     pull_start = get_configuration['sections'][0]['elements'][3]['pull_on_start']['value'] == 'yes'
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))

--- a/tests/integration/test_gcloud/test_functionality/test_rules.py
+++ b/tests/integration/test_gcloud/test_functionality/test_rules.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events
+       (Data access, Admin activity, System events, DNS queries, etc.) from the
+       Google Cloud infrastructure. Once events are collected, Wazuh processes
+       them using its threat detection rules. Specifically, these tests will check
+       if the module pulls messages that match the specified GCP rules and
+       the generated alerts contain the expected rule ID.
+
+tier: 0
+
+modules:
+    - gcloud
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html
+
+tags:
+    - gcloud_functionality
+'''
 import os
 import sys
 
@@ -56,10 +109,45 @@ def get_configuration(request):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_rules(get_configuration, configure_environment,
                restart_wazuh, wait_for_gcp_start):
-    """
-    Verify the module gcp-pubsub pulls messages that matches with GCP rules.
-    Alerts are generated and compared with expected rule ID.
-    """
+    '''
+    description: Check if the 'gcp-pubsub' module gets messages matching the GCP rules. It also checks
+                 if the triggered alerts contain the proper rule ID. For this purpose, the test will
+                 publish multiple GCP messages and pull them later to generate alerts. Then, it
+                 will verify that each alert triggered match the expected rule ID.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - wait_for_gcp_start:
+            type: fixture
+            brief: Wait for the 'gpc-pubsub' module to start.
+
+    assertions:
+        - Verify that the 'gcp-pubsub' module triggers an alert for each GCP event pulled.
+        - Verify that the rule ID of the 'gcp-pubsub' alerts generated matches the expected one.
+
+    input_description: A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml)
+                       which includes configuration settings for the 'gcp-pubsub' module. The GCP events
+                       used for testing are contained in the 'gcp_events.txt' file, and the GCP access
+                       credentials can be found in the 'configuration_template.yaml' one.
+
+    expected_output:
+        - r'.*Sending gcp event: (.+)$'
+
+    tags:
+        - alerts
+        - logs
+        - rules
+    '''
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
     rules_id = []


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1811|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


## New tags
The following tags are added to the wiki: `invalid_settings`, `gcloud_configuration`, `gcloud_functionality`, `scheduled`


# Generated documentation


## `test_configuration`


<details><summary>test_invalid.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if that module detects invalid configurations and indicates the location of the errors detected.",
    "tier": 1,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html"
    ],
    "tags": [
        "gcloud_configuration"
    ],
    "name": "test_invalid.py",
    "id": 2,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module detects invalid configurations. For this purpose, the test will configure 'gcp-pubsub' using invalid configuration settings with different attributes. Finally, it will verify that error events are generated indicating the source of the errors.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "reset_ossec_log": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module generates error events when invalid configurations are used."
            ],
            "input_description": "Different test cases are contained in an external YAML file (invalid_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'.*read_main_elements.*": "ERROR.* Invalid element in the configuration.*'"
                },
                {
                    "r'.*at _sched_scan_validate_parameters.*": "ERROR.*'"
                },
                {
                    "r'.*at sched_scan_read.*": "ERROR.*'"
                },
                {
                    "r'.*at sched_scan_read.*": "ERROR.*'"
                }
            ],
            "tags": [
                "invalid_settings"
            ],
            "name": "test_invalid",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8",
                "get_configuration9",
                "get_configuration10",
                "get_configuration11",
                "get_configuration12",
                "get_configuration13",
                "get_configuration14",
                "get_configuration15",
                "get_configuration16",
                "get_configuration17",
                "get_configuration18",
                "get_configuration19",
                "get_configuration20",
                "get_configuration21",
                "get_configuration22",
                "get_configuration23",
                "get_configuration24",
                "get_configuration25",
                "get_configuration26"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_invalid.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if that module detects invalid
  configurations and indicates the location of the errors detected.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 2
modules:
- gcloud
name: test_invalid.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html
tags:
- gcloud_configuration
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module generates error events when invalid configurations
    are used.
  description: Check if the 'gcp-pubsub' module detects invalid configurations. For
    this purpose, the test will configure 'gcp-pubsub' using invalid configuration
    settings with different attributes. Finally, it will verify that error events
    are generated indicating the source of the errors.
  expected_output:
  - r'.*read_main_elements.*: ERROR.* Invalid element in the configuration.*'
  - r'.*at _sched_scan_validate_parameters.*: ERROR.*'
  - r'.*at sched_scan_read.*: ERROR.*'
  - r'.*at sched_scan_read.*: ERROR.*'
  input_description: Different test cases are contained in an external YAML file (invalid_conf.yaml)
    which includes configuration settings for the 'gcp-pubsub' module. The GCP access
    credentials can be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  - get_configuration9
  - get_configuration10
  - get_configuration11
  - get_configuration12
  - get_configuration13
  - get_configuration14
  - get_configuration15
  - get_configuration16
  - get_configuration17
  - get_configuration18
  - get_configuration19
  - get_configuration20
  - get_configuration21
  - get_configuration22
  - get_configuration23
  - get_configuration24
  - get_configuration25
  - get_configuration26
  name: test_invalid
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - reset_ossec_log:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  tags:
  - invalid_settings
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_remote_configuration.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the remote configuration used by GCP matches the local one set in the 'ossec.conf' file.",
    "tier": 1,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html"
    ],
    "tags": [
        "gcloud_configuration"
    ],
    "name": "test_remote_configuration.py",
    "id": 3,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the remote configuration matches the local configuration of the 'gcp-pubsub' module. For this purpose, the test will use different settings and get the remote configuration applied. Then, it will verify that the default and custom local options match. It will also verify that, when repeated options are used in the configuration, the last one detected is the one applied.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the remote configuration used by GCP matches the local one set in the 'ossec.conf' file."
            ],
            "input_description": "Different test cases are contained in an external YAML file (wazuh_remote_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                "The current configuration settings from GCP to compare them with the local ones."
            ],
            "name": "test_remote_configuration",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_remote_configuration.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the remote configuration
  used by GCP matches the local one set in the 'ossec.conf' file.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 3
modules:
- gcloud
name: test_remote_configuration.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html
tags:
- gcloud_configuration
tests:
- assertions:
  - Verify that the remote configuration used by GCP matches the local one set in
    the 'ossec.conf' file.
  description: Check if the remote configuration matches the local configuration of
    the 'gcp-pubsub' module. For this purpose, the test will use different settings
    and get the remote configuration applied. Then, it will verify that the default
    and custom local options match. It will also verify that, when repeated options
    are used in the configuration, the last one detected is the one applied.
  expected_output:
  - The current configuration settings from GCP to compare them with the local ones.
  input_description: Different test cases are contained in an external YAML file (wazuh_remote_conf.yaml)
    which includes configuration settings for the 'gcp-pubsub' module. The GCP access
    credentials can be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  name: test_remote_configuration
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_schedule.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the 'gcp-pubsub' module executes at the periods set in the 'interval' tag.",
    "tier": 1,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#interval"
    ],
    "tags": [
        "gcloud_configuration"
    ],
    "name": "test_schedule.py",
    "id": 4,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module is executed in the periods specified in the 'interval' tag. For this purpose, the test will use different values for the 'interval' tag (a positive number with a suffix character indicating a time unit, such as d (days), w (weeks), M (months)). Finally, it will verify that the module starts by detecting the events that indicate the validation of the parameters and vice versa.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module executes at the periods set in the 'interval' tag."
            ],
            "input_description": "Different test cases are contained in an external YAML file (schedule_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. Those are combined with the scheduling values defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'.*at _sched_scan_validate_parameters.*": "WARNING.*'"
                }
            ],
            "tags": [
                "scheduled"
            ],
            "name": "test_schedule",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7",
                "get_configuration8"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_schedule.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the 'gcp-pubsub' module
  executes at the periods set in the 'interval' tag.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 4
modules:
- gcloud
name: test_schedule.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#interval
tags:
- gcloud_configuration
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module executes at the periods set in the 'interval'
    tag.
  description: Check if the 'gcp-pubsub' module is executed in the periods specified
    in the 'interval' tag. For this purpose, the test will use different values for
    the 'interval' tag (a positive number with a suffix character indicating a time
    unit, such as d (days), w (weeks), M (months)). Finally, it will verify that the
    module starts by detecting the events that indicate the validation of the parameters
    and vice versa.
  expected_output:
  - r'.*at _sched_scan_validate_parameters.*: WARNING.*'
  input_description: Different test cases are contained in an external YAML file (schedule_conf.yaml)
    which includes configuration settings for the 'gcp-pubsub' module. Those are combined
    with the scheduling values defined in the module. The GCP access credentials can
    be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  - get_configuration8
  name: test_schedule
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  tags:
  - scheduled
  wazuh_min_version: 4.2.0
tier: 1
type: integration
```
</p>
</details>


## `test_functionality`


<details><summary>test_day_wday.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the 'gcp-pubsub' module gets the GCP logs at the date-time specified in the configuration and sleeps up to it.",
    "tier": 0,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#day",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#wday",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#time"
    ],
    "tags": [
        "gcloud_functionality"
    ],
    "name": "test_day_wday.py",
    "id": 5,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module starts to pull logs according to the day of the week, of the month, or time set in the configuration. For this purpose, the test will use different values for the 'day', 'wday', and 'time' tags (depending on the test case). Then, it will check that the 'sleep' event is triggered and matches with the set interval. Finally, the test will travel in time to the specified interval and verify that the 'fetch' event is generated.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if matches with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module sleeps up to the date-time specified in the configuration.",
                "Verify that the 'gcp-pubsub' module starts to pull logs at the date-time specified in the configuration."
            ],
            "input_description": "Tree test cases are contained in an external YAML file (wazuh_schedule_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. Those are combined with the scheduling values defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'.*wm_gcp_main.*": "DEBUG.* Sleeping until.*'"
                },
                {
                    "r'wm_gcp_main()": "DEBUG.* Starting fetching of logs.'"
                }
            ],
            "tags": [
                "logs",
                "scheduled",
                "time_travel"
            ],
            "name": "test_day_wday",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration0-tags_to_apply2",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1",
                "get_configuration1-tags_to_apply2",
                "get_configuration2-tags_to_apply0",
                "get_configuration2-tags_to_apply1",
                "get_configuration2-tags_to_apply2",
                "get_configuration3-tags_to_apply0",
                "get_configuration3-tags_to_apply1",
                "get_configuration3-tags_to_apply2",
                "get_configuration4-tags_to_apply0",
                "get_configuration4-tags_to_apply1",
                "get_configuration4-tags_to_apply2",
                "get_configuration5-tags_to_apply0",
                "get_configuration5-tags_to_apply1",
                "get_configuration5-tags_to_apply2"
            ]
        },
        {
            "description": "Check if the 'gcp-pubsub' module calculates the next scan correctly using time intervals greater than one month, one week, or one day. For this purpose, the test will use different values for the 'day', 'wday', and 'time' tags (depending on the test case). Finally, it will check that the 'sleep' event is triggered and matches with the set interval.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "set",
                        "brief": "Run test if matches with a configuration identifier, skip otherwise."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module calculates the next scan correctly from the date-time and interval values specified in the configuration."
            ],
            "input_description": "Tree test cases are contained in an external YAML file (wazuh_schedule_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. Those are combined with the scheduling values defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'.*wm_gcp_main.*": "DEBUG.* Sleeping until.*'"
                }
            ],
            "tags": [
                "logs",
                "scheduled"
            ],
            "name": "test_day_wday_multiple",
            "inputs": [
                "get_configuration0-tags_to_apply0",
                "get_configuration0-tags_to_apply1",
                "get_configuration0-tags_to_apply2",
                "get_configuration1-tags_to_apply0",
                "get_configuration1-tags_to_apply1",
                "get_configuration1-tags_to_apply2",
                "get_configuration2-tags_to_apply0",
                "get_configuration2-tags_to_apply1",
                "get_configuration2-tags_to_apply2",
                "get_configuration3-tags_to_apply0",
                "get_configuration3-tags_to_apply1",
                "get_configuration3-tags_to_apply2",
                "get_configuration4-tags_to_apply0",
                "get_configuration4-tags_to_apply1",
                "get_configuration4-tags_to_apply2",
                "get_configuration5-tags_to_apply0",
                "get_configuration5-tags_to_apply1",
                "get_configuration5-tags_to_apply2"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_day_wday.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the 'gcp-pubsub' module
  gets the GCP logs at the date-time specified in the configuration and sleeps up
  to it.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 5
modules:
- gcloud
name: test_day_wday.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#day
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#wday
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#time
tags:
- gcloud_functionality
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module sleeps up to the date-time specified in the
    configuration.
  - Verify that the 'gcp-pubsub' module starts to pull logs at the date-time specified
    in the configuration.
  description: Check if the 'gcp-pubsub' module starts to pull logs according to the
    day of the week, of the month, or time set in the configuration. For this purpose,
    the test will use different values for the 'day', 'wday', and 'time' tags (depending
    on the test case). Then, it will check that the 'sleep' event is triggered and
    matches with the set interval. Finally, the test will travel in time to the specified
    interval and verify that the 'fetch' event is generated.
  expected_output:
  - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*'
  - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
  input_description: Tree test cases are contained in an external YAML file (wazuh_schedule_conf.yaml)
    which includes configuration settings for the 'gcp-pubsub' module. Those are combined
    with the scheduling values defined in the module. The GCP access credentials can
    be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration0-tags_to_apply2
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  - get_configuration1-tags_to_apply2
  - get_configuration2-tags_to_apply0
  - get_configuration2-tags_to_apply1
  - get_configuration2-tags_to_apply2
  - get_configuration3-tags_to_apply0
  - get_configuration3-tags_to_apply1
  - get_configuration3-tags_to_apply2
  - get_configuration4-tags_to_apply0
  - get_configuration4-tags_to_apply1
  - get_configuration4-tags_to_apply2
  - get_configuration5-tags_to_apply0
  - get_configuration5-tags_to_apply1
  - get_configuration5-tags_to_apply2
  name: test_day_wday
  parameters:
  - tags_to_apply:
      brief: Run test if matches with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - logs
  - scheduled
  - time_travel
  wazuh_min_version: 4.2.0
- assertions:
  - Verify that the 'gcp-pubsub' module calculates the next scan correctly from the
    date-time and interval values specified in the configuration.
  description: Check if the 'gcp-pubsub' module calculates the next scan correctly
    using time intervals greater than one month, one week, or one day. For this purpose,
    the test will use different values for the 'day', 'wday', and 'time' tags (depending
    on the test case). Finally, it will check that the 'sleep' event is triggered
    and matches with the set interval.
  expected_output:
  - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*'
  input_description: Tree test cases are contained in an external YAML file (wazuh_schedule_conf.yaml)
    which includes configuration settings for the 'gcp-pubsub' module. Those are combined
    with the scheduling values defined in the module. The GCP access credentials can
    be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0-tags_to_apply0
  - get_configuration0-tags_to_apply1
  - get_configuration0-tags_to_apply2
  - get_configuration1-tags_to_apply0
  - get_configuration1-tags_to_apply1
  - get_configuration1-tags_to_apply2
  - get_configuration2-tags_to_apply0
  - get_configuration2-tags_to_apply1
  - get_configuration2-tags_to_apply2
  - get_configuration3-tags_to_apply0
  - get_configuration3-tags_to_apply1
  - get_configuration3-tags_to_apply2
  - get_configuration4-tags_to_apply0
  - get_configuration4-tags_to_apply1
  - get_configuration4-tags_to_apply2
  - get_configuration5-tags_to_apply0
  - get_configuration5-tags_to_apply1
  - get_configuration5-tags_to_apply2
  name: test_day_wday_multiple
  parameters:
  - tags_to_apply:
      brief: Run test if matches with a configuration identifier, skip otherwise.
      type: set
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - logs
  - scheduled
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_interval.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the 'gcp-pubsub' module gets the GCP logs at the intervals specified in the configuration and sleeps up to them.",
    "tier": 0,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#interval"
    ],
    "tags": [
        "gcloud_functionality"
    ],
    "name": "test_interval.py",
    "id": 6,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module starts to pull logs at the periods set in the configuration by the 'interval' tag. For this purpose, the test will use different intervals and check if the 'sleep' event is triggered and matches with the set interval. Finally, the test will wait the time specified in that interval and verify that the 'fetch' event is generated.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module sleeps between the intervals specified in the configuration.",
                "Verify that the 'gcp-pubsub' module starts to pull logs at the intervals specified in the configuration."
            ],
            "input_description": "A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. That is combined with the interval values defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'.*wm_gcp_main.*": "DEBUG.* Sleeping until.*'"
                },
                {
                    "r'wm_gcp_main()": "DEBUG.* Starting fetching of logs.'"
                }
            ],
            "tags": [
                "logs",
                "scheduled"
            ],
            "name": "test_interval",
            "inputs": [
                "get_configuration0",
                "get_configuration1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_interval.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the 'gcp-pubsub' module
  gets the GCP logs at the intervals specified in the configuration and sleeps up
  to them.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 6
modules:
- gcloud
name: test_interval.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#interval
tags:
- gcloud_functionality
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module sleeps between the intervals specified in
    the configuration.
  - Verify that the 'gcp-pubsub' module starts to pull logs at the intervals specified
    in the configuration.
  description: Check if the 'gcp-pubsub' module starts to pull logs at the periods
    set in the configuration by the 'interval' tag. For this purpose, the test will
    use different intervals and check if the 'sleep' event is triggered and matches
    with the set interval. Finally, the test will wait the time specified in that
    interval and verify that the 'fetch' event is generated.
  expected_output:
  - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*'
  - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
  input_description: A test case (ossec_conf) is contained in an external YAML file
    (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module.
    That is combined with the interval values defined in the module. The GCP access
    credentials can be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0
  - get_configuration1
  name: test_interval
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - logs
  - scheduled
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_logging.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the 'gcp-pubsub' module gets only the GCP events whose logging level matches the one specified in the 'logging' tag.",
    "tier": 0,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#logging"
    ],
    "tags": [
        "gcloud_functionality"
    ],
    "name": "test_logging.py",
    "id": 7,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module generates logs according to the set type in the 'logging' tag. For this purpose, the test will use different logging levels (depending on the test case) and gets the GCP events. Finally, the test will verify that the type of all retrieved events matches the one specified in the configuration.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "publish_messages": {
                        "type": "list",
                        "brief": "List of testing GCP logs."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the logging level of retrieved GCP events matches the one specified in the 'logging' tag."
            ],
            "input_description": "A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. That is combined with the logging levels defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                "r'.*wazuh-modulesd:gcp-pubsub.*'"
            ],
            "tags": [
                "logs",
                "scheduled"
            ],
            "name": "test_logging",
            "inputs": [
                "get_configuration0-publish_messages0",
                "get_configuration1-publish_messages0",
                "get_configuration2-publish_messages0",
                "get_configuration3-publish_messages0",
                "get_configuration4-publish_messages0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_logging.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the 'gcp-pubsub' module
  gets only the GCP events whose logging level matches the one specified in the 'logging'
  tag.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 7
modules:
- gcloud
name: test_logging.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#logging
tags:
- gcloud_functionality
tests:
- assertions:
  - Verify that the logging level of retrieved GCP events matches the one specified
    in the 'logging' tag.
  description: Check if the 'gcp-pubsub' module generates logs according to the set
    type in the 'logging' tag. For this purpose, the test will use different logging
    levels (depending on the test case) and gets the GCP events. Finally, the test
    will verify that the type of all retrieved events matches the one specified in
    the configuration.
  expected_output:
  - r'.*wazuh-modulesd:gcp-pubsub.*'
  input_description: A test case (ossec_conf) is contained in an external YAML file
    (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module.
    That is combined with the logging levels defined in the module. The GCP access
    credentials can be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0-publish_messages0
  - get_configuration1-publish_messages0
  - get_configuration2-publish_messages0
  - get_configuration3-publish_messages0
  - get_configuration4-publish_messages0
  name: test_logging
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - publish_messages:
      brief: List of testing GCP logs.
      type: list
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - logs
  - scheduled
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_max_messages.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the 'gcp-pubsub' module gets GCP messages up to the limit set in the 'max_messages' tag on the same operation when the number of them exceeds that limit.",
    "tier": 0,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#max-messages"
    ],
    "tags": [
        "gcloud_functionality"
    ],
    "name": "test_max_messages.py",
    "id": 8,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module pulls a message number less than or equal to the limit set in the 'max_messages' tag. For this purpose, the test will use a fixed limit and generate a number of GCP events lower and upper than the limit (depending on the test case). Then, it will wait for the 'fetching' event, and finally, the test will verify that, if the message number exceeds that limit, the module will only pull messages up to the limit, and the rest will be pulled in successive iterations, and if not, the module will pull all messages in the same operation.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "publish_messages": {
                        "type": "list",
                        "brief": "List of testing GCP logs."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module pulls all GCP messages in one operation if the number of them does not exceed the limit set in the 'max_messages' tag.",
                "Verify that the 'gcp-pubsub' module pulls GCP messages up to the limit set in the 'max_messages' tag when the number of them exceeds that limit, and the remaining ones are pulled in the successive operations."
            ],
            "input_description": "A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. That is combined with the message limit defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'wm_gcp_main()": "DEBUG.* Starting fetching of logs.'"
                },
                {
                    "r'.*wm_gcp_run.*": "INFO.* - INFO - Received and acknowledged .* messages'"
                }
            ],
            "tags": [
                "logs",
                "scheduled"
            ],
            "name": "test_max_messages",
            "inputs": [
                "get_configuration0-publish_messages0",
                "get_configuration0-publish_messages1",
                "get_configuration0-publish_messages2"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_max_messages.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the 'gcp-pubsub' module
  gets GCP messages up to the limit set in the 'max_messages' tag on the same operation
  when the number of them exceeds that limit.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 8
modules:
- gcloud
name: test_max_messages.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#max-messages
tags:
- gcloud_functionality
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module pulls all GCP messages in one operation if
    the number of them does not exceed the limit set in the 'max_messages' tag.
  - Verify that the 'gcp-pubsub' module pulls GCP messages up to the limit set in
    the 'max_messages' tag when the number of them exceeds that limit, and the remaining
    ones are pulled in the successive operations.
  description: Check if the 'gcp-pubsub' module pulls a message number less than or
    equal to the limit set in the 'max_messages' tag. For this purpose, the test will
    use a fixed limit and generate a number of GCP events lower and upper than the
    limit (depending on the test case). Then, it will wait for the 'fetching' event,
    and finally, the test will verify that, if the message number exceeds that limit,
    the module will only pull messages up to the limit, and the rest will be pulled
    in successive iterations, and if not, the module will pull all messages in the
    same operation.
  expected_output:
  - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
  - r'.*wm_gcp_run.*: INFO.* - INFO - Received and acknowledged .* messages'
  input_description: A test case (ossec_conf) is contained in an external YAML file
    (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module.
    That is combined with the message limit defined in the module. The GCP access
    credentials can be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0-publish_messages0
  - get_configuration0-publish_messages1
  - get_configuration0-publish_messages2
  name: test_max_messages
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - publish_messages:
      brief: List of testing GCP logs.
      type: list
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - logs
  - scheduled
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_pull_on_start.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the 'gcp-pubsub' module gets GCP messages when it starts if the 'pull_on_start' tag is set to 'yes', and sleeps otherwise.",
    "tier": 0,
    "modules": [
        "gcloud"
    ],
    "components": [
        "agent",
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#pull-on-start"
    ],
    "tags": [
        "gcloud_functionality"
    ],
    "name": "test_pull_on_start.py",
    "id": 9,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module pulls messages when starting if the 'pull_on_start' is set to 'yes', or sleeps up to the next interval if that one is set to 'no'. For this purpose, the test will use the possible values for that tag ('yes' and 'no'). Then, it will wait for the 'fetching' event if the pull on start opction is enabled. Otherwise, the test will verify that the 'sleep' event is generated, and the 'fetching' event is not.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module gets GCP messages when it starts if the 'pull_on_start' tag is set to 'yes'.",
                "Verify that the 'gcp-pubsub' module sleeps up to the next interval when it starts if the 'pull_on_start' tag is set to 'no'."
            ],
            "input_description": "A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. That is combined with the 'pull_on_start' values defined in the module. The GCP access credentials can be found in the 'configuration_template.yaml' file.",
            "expected_output": [
                {
                    "r'wm_gcp_main()": "DEBUG.* Starting fetching of logs.'"
                },
                {
                    "r'.*wm_gcp_main.*": "DEBUG.* Sleeping until.*' (when 'pull_on_start=no')"
                }
            ],
            "tags": [
                "logs",
                "scheduled"
            ],
            "name": "test_pull_on_start",
            "inputs": [
                "get_configuration0",
                "get_configuration1"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_pull_on_start.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the 'gcp-pubsub' module
  gets GCP messages when it starts if the 'pull_on_start' tag is set to 'yes', and
  sleeps otherwise.
components:
- agent
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 9
modules:
- gcloud
name: test_pull_on_start.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#pull-on-start
tags:
- gcloud_functionality
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module gets GCP messages when it starts if the 'pull_on_start'
    tag is set to 'yes'.
  - Verify that the 'gcp-pubsub' module sleeps up to the next interval when it starts
    if the 'pull_on_start' tag is set to 'no'.
  description: Check if the 'gcp-pubsub' module pulls messages when starting if the
    'pull_on_start' is set to 'yes', or sleeps up to the next interval if that one
    is set to 'no'. For this purpose, the test will use the possible values for that
    tag ('yes' and 'no'). Then, it will wait for the 'fetching' event if the pull
    on start opction is enabled. Otherwise, the test will verify that the 'sleep'
    event is generated, and the 'fetching' event is not.
  expected_output:
  - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
  - r'.*wm_gcp_main.*: DEBUG.* Sleeping until.*' (when 'pull_on_start=no')
  input_description: A test case (ossec_conf) is contained in an external YAML file
    (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module.
    That is combined with the 'pull_on_start' values defined in the module. The GCP
    access credentials can be found in the 'configuration_template.yaml' file.
  inputs:
  - get_configuration0
  - get_configuration1
  name: test_pull_on_start
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - logs
  - scheduled
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


&nbsp;


<details><summary>test_rules.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data access, Admin activity, System events, DNS queries, etc.) from the Google Cloud infrastructure. Once events are collected, Wazuh processes them using its threat detection rules. Specifically, these tests will check if the module pulls messages that match the specified GCP rules and the generated alerts contain the expected rule ID.",
    "tier": 0,
    "modules": [
        "gcloud"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html"
    ],
    "tags": [
        "gcloud_functionality"
    ],
    "name": "test_rules.py",
    "id": 10,
    "group_id": 1,
    "tests": [
        {
            "description": "Check if the 'gcp-pubsub' module gets messages matching the GCP rules. It also checks if the triggered alerts contain the proper rule ID. For this purpose, the test will publish multiple GCP messages and pull them later to generate alerts. Then, it will verify that each alert triggered match the expected rule ID.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                },
                {
                    "wait_for_gcp_start": {
                        "type": "fixture",
                        "brief": "Wait for the 'gpc-pubsub' module to start."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'gcp-pubsub' module triggers an alert for each GCP event pulled.",
                "Verify that the rule ID of the 'gcp-pubsub' alerts generated matches the expected one."
            ],
            "input_description": "A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module. The GCP events used for testing are contained in the 'gcp_events.txt' file, and the GCP access credentials can be found in the 'configuration_template.yaml' one.",
            "expected_output": [
                {
                    "r'.*Sending gcp event": "(.+)$'"
                }
            ],
            "tags": [
                "alerts",
                "logs",
                "rules"
            ],
            "name": "test_rules",
            "inputs": [
                "get_configuration0"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_rules.yaml</summary>
<p>

```yaml
brief: The Wazuh 'gcp-pubsub' module uses it to fetch different kinds of events (Data
  access, Admin activity, System events, DNS queries, etc.) from the Google Cloud
  infrastructure. Once events are collected, Wazuh processes them using its threat
  detection rules. Specifically, these tests will check if the module pulls messages
  that match the specified GCP rules and the generated alerts contain the expected
  rule ID.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 1
id: 10
modules:
- gcloud
name: test_rules.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html
tags:
- gcloud_functionality
tests:
- assertions:
  - Verify that the 'gcp-pubsub' module triggers an alert for each GCP event pulled.
  - Verify that the rule ID of the 'gcp-pubsub' alerts generated matches the expected
    one.
  description: Check if the 'gcp-pubsub' module gets messages matching the GCP rules.
    It also checks if the triggered alerts contain the proper rule ID. For this purpose,
    the test will publish multiple GCP messages and pull them later to generate alerts.
    Then, it will verify that each alert triggered match the expected rule ID.
  expected_output:
  - r'.*Sending gcp event: (.+)$'
  input_description: A test case (ossec_conf) is contained in an external YAML file
    (wazuh_conf.yaml) which includes configuration settings for the 'gcp-pubsub' module.
    The GCP events used for testing are contained in the 'gcp_events.txt' file, and
    the GCP access credentials can be found in the 'configuration_template.yaml' one.
  inputs:
  - get_configuration0
  name: test_rules
  parameters:
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - restart_wazuh:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  - wait_for_gcp_start:
      brief: Wait for the 'gpc-pubsub' module to start.
      type: fixture
  tags:
  - alerts
  - logs
  - rules
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`