### PR TITLE
Fix `expected_output` content format to index it properly to ES

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
@@ -223,8 +223,8 @@ class CodeParser:
                             test_cases = self.pytest.collect_test_cases(path)
                             if test_cases and test_cases[function.name]:
                                 function_doc['inputs'] = test_cases[function.name]
-                        # ES throwing error because of its format in some cases
-                        # -> Inserting it between double quotes fixs it
+                        # ES throwing errors because of the expected_output format in some cases
+                        # -> Inserting the raw string and its comment between double quotes fixes it
                         new_expected_output = []
                         for string in function_doc['expected_output']:
                             if isinstance(string, dict):


### PR DESCRIPTION
|Related issue|
|---|
|#2137|

## Description
This PR fixes an indexing error in some cases where the formatting of some contents for `expected_output` was bad. The `code_parser` module has been changed to avoid this problem, now the format is correct.

For example, these were throwing errors when indexing to ES:
```
- r'.*Sending FIM event: (.+)$' ('added', 'deleted' events)
- r'.*Sending FIM event (.+)$' ('added', 'deleted' events)
- r'.*Sending FIM event: (.+)$'
```

Now it is correctly working.
 
# Checks
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.