### PR TITLE
Add test documentation validation when running `qa-ctl` in automatic mode

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -220,10 +220,14 @@ class DocGenerator:
 
                 self.dump_output(test, doc_path)
                 DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' "
-                                          "was created with ID:{self.__id_counter}")
+                                          f"was created with ID:{self.__id_counter}")
                 return self.__id_counter
 
             elif self.conf.mode == Mode.PARSE_TESTS:
+                # If qa-docs is run with --check-doc flag then the output files wont be generated
+                if self.conf.check_doc:
+                    return
+
                 if self.conf.documentation_path:
                     doc_path = self.conf.documentation_path
                     doc_path = os.path.join(doc_path, test_name)
@@ -292,7 +296,7 @@ class DocGenerator:
 
     def check_test_exists(self, path):
         """Check that a test exists within the tests path input.
-        
+
         Args:
             path (str): A string with the tests path.
         """
@@ -301,6 +305,16 @@ class DocGenerator:
                 print(f'{test_name} exists in {path}')
             else:
                 print(f'{test_name} does not exist in {path}')
+
+    def check_documentation(self):
+        for test_name in self.conf.test_names:
+            test_path = self.locate_test(test_name)
+            test = self.parser.parse_test(test_path, self.__id_counter, 0)
+
+            if test:
+                print(f"{test_name} is documented using qa-docs current schema")
+            else:
+                print(f"{test_name} is not documented using qa-docs current schema")
 
     def print_test_info(self, test):
         """Print the test info to standard output.
@@ -340,3 +354,6 @@ class DocGenerator:
 
         elif self.conf.mode == Mode.PARSE_TESTS:
             self.parse_test_list()
+
+        if not self.conf.check_doc:
+            DocGenerator.LOGGER.info(f"Run completed, documentation location: {self.conf.documentation_path}")

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -309,12 +309,14 @@ class DocGenerator:
     def check_documentation(self):
         for test_name in self.conf.test_names:
             test_path = self.locate_test(test_name)
-            test = self.parser.parse_test(test_path, self.__id_counter, 0)
+            try:
+                test = self.parser.parse_test(test_path, self.__id_counter, 0)
+            except Exception as qaerror:
+                test = None
+                print(f"{test_name} is not documented using qa-docs current schema")
 
             if test:
                 print(f"{test_name} is documented using qa-docs current schema")
-            else:
-                print(f"{test_name} is not documented using qa-docs current schema")
 
     def print_test_info(self, test):
         """Print the test info to standard output.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/config.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/config.py
@@ -39,7 +39,8 @@ class Config():
     """
     LOGGER = Logging.get_logger(QADOCS_LOGGER)
 
-    def __init__(self, schema_path, test_dir, output_path='', test_types=None, test_modules=None, test_names=None):
+    def __init__(self, schema_path, test_dir, output_path='', test_types=None, test_modules=None, test_names=None,
+                 check_doc=False):
         """Constructor that loads the schema file and set the `qa-docs` configuration.
 
         If a test name is passed, it would be run in `single test mode`.
@@ -57,6 +58,7 @@ class Config():
             test_types (list): A list that contains the test type(s) that the user specifies.
             test_modules (list): A list that contains the test module(s) that the user specifies.
             test_names (list): A list that contains the test name(s) that the user specifies.
+            check_dock (boolean): Flag to indicate if the test specified (with -t parameter) is documented.
         """
         self.mode = Mode.DEFAULT
         self.project_path = test_dir
@@ -71,6 +73,7 @@ class Config():
         self.test_types = []
         self.test_modules = []
         self.predefined_values = {}
+        self.check_doc = check_doc
 
         self.__read_schema_file(schema_path)
         self.__read_output_fields()

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -199,11 +199,17 @@ def validate_parameters(parameters):
     if parameters.run_test:
         for test in parameters.run_test:
             tests_path = os.path.join(WAZUH_QA_FILES, 'tests')
+            # Validate if the specified tests exist
             if f"{test} exists" not in local_actions.run_local_command_with_output(f"qa-docs -e {test} -I {tests_path} "
                                                                                    ' --no-logging'):
                 raise QAValueError(f"{test} does not exist in {tests_path}", qactl_logger.error, QACTL_LOGGER)
 
-    ## --> Add os validation for each test
+            # Validate if the selected tests are documented
+            test_documentation_check = local_actions.run_local_command_with_output(f"qa-docs -t {test} -I {tests_path} "
+                                                                                   '--check-documentation --no-logging')
+            if f'{test} is not documented' in test_documentation_check:
+                raise QAValueError(f"{test} is not documented using qa-docs current schema", qactl_logger.error,
+                                   QACTL_LOGGER)
 
     qactl_logger.info('Input parameters validation has passed successfully')
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -97,6 +97,9 @@ def get_parameters():
     parser.add_argument('-e', '--exist', nargs='+', default=[], dest='test_exist',
                         help="Checks if test(s) exist or not.",)
 
+    parser.add_argument('--check-documentation', action='store_true', dest='check_doc',
+                        help="Checks if test(s) are correctly documentated according to qa-docs current schema.",)
+
     return parser.parse_args(), parser
 
 
@@ -170,7 +173,8 @@ def validate_parameters(parameters, parser):
 
         for test_name in parameters.test_names:
             if doc_check.locate_test(test_name) is None:
-                raise QAValueError(f"{test_name} has not been not found in {parameters.tests_path}.", qadocs_logger.error)
+                raise QAValueError(f"{test_name} has not been not found in "
+                                   f"{parameters.tests_path}.", qadocs_logger.error)
 
     # Check that the index exists
     if parameters.app_index_name:
@@ -217,10 +221,12 @@ def parse_data(args):
 
         # When output path is specified by user, a json is generated within that path
         if args.output_path:
-            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, args.output_path, test_names=args.test_names))
-        # When no output is specified, it is printed
+            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, args.output_path, test_names=args.test_names,
+                                       check_doc=args.check_doc))
+        # When no output is specified, it is generated within the default qa-docs output folder
         else:
-            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, test_names=args.test_names))
+            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, test_names=args.test_names,
+                                       check_doc=args.check_doc))
 
     # Parse a list of test types
     elif args.test_types:
@@ -240,9 +246,11 @@ def parse_data(args):
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH))
             docs.run()
 
-    if args.test_types or args.test_modules or args.test_names:
+    if args.test_types or args.test_modules or args.test_names and not args.check_doc:
         qadocs_logger.info('Running QADOCS')
         docs.run()
+    elif args.test_names and args.check_doc:
+        docs.check_documentation()
 
 
 def index_and_visualize_data(args):


### PR DESCRIPTION
|Related issue|
|---|
|close #2023 |


## Description

The aim of this PR is to validate if the specified tests in the `qa-ctl` run are documented or not according to the current `qa-docs` schema. This is a necessary validation before proceeding with the execution of the tests automatically.

This PR makes the following changes:

- Add new parameter in `qa-docs` to check the test documentation
- Validate if the tests are well documented before running the `qa-ctl` build.

## Checks

<details>
<summary>Test does not exist</summary>

```
qa-ctl -r test_x --qa-branch  2023-qa-ctl-doc-validation --dry-run
2021-11-02 12:42:58,263 - INFO - Validating input parameters
2021-11-02 12:42:59,718 - ERROR - test_x does not exist in /tmp/wazuh_qa_ctl/wazuh-qa/tests
wazuh_testing.tools.exceptions.QAValueError: test_x does not exist in /tmp/wazuh_qa_ctl/wazuh-qa/tests

```

</details>

<details>
<summary>Test is not documented</summary>

```
qa-ctl -r test_general_settings_enabled --qa-branch  2023-qa-ctl-doc-validation --dry-run
2021-11-02 12:30:46,038 - INFO - Validating input parameters
2021-11-02 12:30:47,700 - INFO - Input parameters validation has passed successfully
2021-11-02 12:30:48,333 - INFO - Run as dry-run mode. Configuration file saved in /tmp/wazuh_qa_ctl/config_1635852647.700738.yaml
```

</details>

<details>
<summary>Check with multiple tests</summary>

```
qa-ctl -r test_general_settings_enabled test_ambiguous_complex --qa-branch  2023-qa-ctl-doc-validation --dry-run
2021-11-02 12:40:32,084 - INFO - Validating input parameters
2021-11-02 12:40:35,049 - ERROR - test_ambiguous_complex is not documented using qa-docs current schema
wazuh_testing.tools.exceptions.QAValueError: test_ambiguous_complex is not documented using qa-docs current schema
```

</details>