### PR TITLE
Tests WPK - Fix failures related to Rollback on Windows.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/remoted_sim.py
@@ -487,6 +487,7 @@ class RemotedSimulator:
         """
         self.upgrade_errors = False
         self.upgrade_success = False
+        upgrade_socket_closed_timeout = 100
 
         while not self.upgrade_errors and self.running:
             try:


### PR DESCRIPTION
|Related issue|
|---|
| #2099 |



## Description

### Windows Agent

### Manager

## Configuration options

<table>
 <tr>
  <td>Manager -  Agent (Linux) </td>
  <td>wazuh_modules.debug=2</td>
  <td>--wpk_version=v4.3.0 --wpk_package_path=packages-dev.wazuh.com/warehouse/test/4.3/wpk/</td>
 </tr>
  <td>Agent (Windows)</td>
  <td>windows.debug=2</td>
  <td>--wpk_version=v4.3.0 --wpk_package_path=packages-dev.wazuh.com/warehouse/test/4.3/wpk/</td>
 </tr>

</table>



### Packages details
| Type | Format | Architecture | Versión | Revision |  Tag | File name |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| Windows | msi | x86_64 | 4.3.0 | 4.3.2040 | - | wazuh-agent-4.3.0-0.msi |
| Manager | src | x86_64 | 4.3.0 | 4.3.2040 | - | master |

### Environment 
Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
VirtualBox | ubuntu/focal64 | ubuntu 20.04 | 16 | 16386 |
Windows | gusztavvargadr/windows-10 | Windows 10 | 8 | 16386 |

### Test results
| Status | Type| OS| Date | By |
|:--:|:--:|:--:|:--:|:--:|
|[ :green_circle: ](https://github.com/wazuh/wazuh-qa/files/7461999/qa-report_test_1.zip) |Local |Agent - Windows 10| 2021/11/02 | @juliancnn 
|[ :green_circle: ](https://github.com/wazuh/wazuh-qa/files/7462000/qa-report_test_2.zip) |Local |Agent - Windows 10| 2021/11/02 | @juliancnn 