### PR TITLE
QA-CTL: Update JSON schema validator file

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
+++ b/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
@@ -9,7 +9,7 @@
       "$id": "#/properties/deployment",
       "type": "object",
       "patternProperties": {
-        "^host[0-9]*$": {
+        "^host_[0-9]*$": {
           "type": "object",
           "properties": {
             "provider": {
@@ -48,7 +48,8 @@
                       "type": "string"
                     },
                     "vm_system": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": ["linux","windows"]
                     },
                     "label": {
                       "type": "string"
@@ -117,7 +118,7 @@
       "properties": {
         "hosts": {
           "patternProperties": {
-            "^host[0-9]*$": {
+            "^host_[0-9]*$": {
               "type": "object",
               "required": [
                 "host_info"
@@ -126,31 +127,49 @@
                 "host_info": {
                   "type": "object",
                   "required": [
-                    "connection_method",
-                    "host",
-                    "user",
-                    "password",
-                    "connection_port",
-                    "ansible_python_interpreter"
+                    "ansible_connection",
+                    "ansible_user",
+                    "ansible_password",
+                    "ansible_port",
+                    "system",
+                    "installation_files_path",
+                    "ansible_python_interpreter",
+                    "host"
                   ],
                   "properties": {
-                    "connection_method": {
+                    "ansible_connection": {
                       "type": "string"
                     },
                     "host": {
                       "type": "string"
                     },
-                    "user": {
+                    "ansible_user": {
                       "type": "string"
                     },
-                    "password": {
+                    "ansible_password": {
                       "type": "string"
                     },
-                    "connection_port": {
+                    "ansible_port": {
                       "type": "integer"
                     },
                     "ansible_python_interpreter": {
                       "type": "string"
+                    },
+                    "installation_files_path": {
+                      "type": "string"
+                    },
+                    "system": {
+                      "type": "string",
+                      "enum": [
+                      "rpm", 
+                      "deb",
+                      "windows",
+                      "macos",
+                      "solaris10",
+                      "solaris11",
+                      "rpm5",
+                      "wpk-linux",
+                      "wpk-windows"]
                     }
                   }
                 },
@@ -159,7 +178,8 @@
                   "required": [
                     "type",
                     "target",
-                    "installation_files_path"
+                    "installation_files_path",
+                    "wazuh_install_path"
                   ],
                   "properties": {
                     "type": {
@@ -255,46 +275,55 @@
     "tests": {
       "type": "object",
       "patternProperties": {
-        "^host[0-9]*$": {
+        "^host_[0-9]*$": {
           "type": "object",
           "required": ["host_info", "test"],
           "properties": {
             "host_info": {
               "type": "object",
               "required": [
-                "connection_method",
+                "ansible_connection",
+                "ansible_user",
+                "ansible_port",
+                "installation_files_path",
+                "ansible_python_interpreter",
                 "host",
-                "user",
-                "connection_port",
-                "ansible_python_interpreter"
+                "system"
               ],
               "properties": {
-                "connection_method": {
+                "ansible_connection": {
                   "type" : "string"
                 },
                 "host": {
                   "type" : "string"
                 },
-                "user": {
+                "ansible_user": {
                   "type": "string"
                 },
-                "password": {
+                "ansible_password": {
                   "type": "string",
                   "default": "empty"
                 },
                 "ssh_private_key_file_path":{
                   "type": "string"
                 },
-                "connection_port": {
+                "ansible_port": {
                   "type": "integer"
                 },
                 "ansible_python_interpreter": {
                   "type": "string"
+                },
+                "installation_files_path": {
+                  "type": "string"
+                },
+                "system": {
+                  "type": "string"
                 }
+
               },
               "oneOf": [
                 {
-                  "required": ["password"]
+                  "required": ["ansible_password"]
                 },
                 {
                   "required": ["ssh_private_key_file_path"]
@@ -303,7 +332,10 @@
             },
             "test": {
               "type": "object",
-              "required": ["path"],
+              "required": [
+                "path",
+                "type"
+              ],
               "properties": {
                 "hosts": {
                   "type": "string"
@@ -367,30 +399,33 @@
           }
         }
       }
-    }
-  },
-  "config": {
-    "$id": "#/properties/config",
-    "type": "object",
-    "patternProperties": {
-      "vagrant_output": {
-        "type": "boolean"
-      },
-      "ansible_output": {
-        "type": "boolean"
-      },
-      "logging":{
-        "type": "object",
-        "properties": {
-          "enable": {
-            "type": "boolean"
-          },
-          "level": {
-            "type": "string",
-            "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-          },
-          "file": {
-            "type": "string"
+    },
+    "config": {
+      "$id": "#/properties/config",
+      "type": "object",
+      "patternProperties": {
+        "qa_ctl_launcher_branch": {
+          "type": "string"
+        },
+        "vagrant_output": {
+          "type": "boolean"
+        },
+        "ansible_output": {
+          "type": "boolean"
+        },
+        "logging":{
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean"
+            },
+            "level": {
+              "type": "string",
+              "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+            },
+            "file": {
+              "type": "string"
+            }
           }
         }
       }


### PR DESCRIPTION
|Related issue|
|---|
| close #2164 |


## Description
While the new version of `qa-ctl (V0.2)` was being developed, new parameters were added to the `YAML` configuration file for the tool. The validator, however, does not support these new parameters as they are not included in the JSON file. It is needed to update the JSON schema validator with the new parameters added for this version of `qa-ctl` 

This PR makes the next changes:
- [X] Add new validation parameters in the `qa-ctl` JSON schema file

To check that the new values are validated correctly, there has been tested some use cases where the validation process should fail:

# Proven error case scenarios
## Deployment module
### Vagrant scenario

| Error Case |  Function's output|
| ------------- | ------------- |
| Incorrect entry parameter given  | ValidationError:'centos' is not one of ['linux', 'windows']  |

## Provision module
### Host info section


| Error Case |  Function's output|
| ------------- | ------------- |
| Undeclared required field (installation_files_path)  | ValidationError: 'installation_files_path' is a required property  |
| Empty entry for required properties (ansible_connection) | ValidationError: None is not of type 'string' |


### Wazuh deployment section


| Error Case |  Function's output|
| ------------- | ------------- |
|  Undeclared required field (wazuh_install_path)  | ValidationError: 'wazuh_install_path' is a required property |
|  Incorrect entry parameter given (system) | ValidationError: 'linux' is not one of ['rpm', 'deb', 'windows', 'macos', 'solaris10', 'solaris11', 'rpm5', 'wpk-linux', 'wpk-windows'] |
| Wrong argument for field(type:"source")  | ValidationError: 'source' is not one of ['sources', 'package']  |
| No conditional required entry parameter given( manager_ip when target: agent) | ValidationError: 'manager_ip' is a required property |

### QA framework section
| Error Case |  Function's output|
| ------------- | ------------- |
| Wrong format argument for field(wazuh_qa_branch: 1123) | ValidationError: 1123 is not of type 'string' |
| No required entry parameter given (qa_workdir) | ValidationError: 'qa_workdir' is a required property |


## Testing module

### Host info section

| Error Case |  Function's output|
| ------------- | ------------- |
| No password parameter given |  ValidationError: 'ssh_private_key_file_path' is a required property |
| Undeclared required field (ansible_connection)  | ValidationError: 'ansible_connection' is a required property  |
| Empty required field (ansible_connection) | ValidationError: None is not of type 'string'  |
| Undeclared required field (ansible_port)  | ValidationError: 'ansible_port' is a required property |
| Wrong format argument given(ansible_port: '22') | ValidationError: '22' is not of type 'integer' |
| Undeclared required field (ansible_password)  | ValidationError: 'ansible_password' is a required property |


### Test section

| Error Case |  Function's output|
| ------------- | ------------- |
| No required parameter given(test_files_path) | ValidationError: 'test_files_path' is a required property |
| Empty entry for required parameter(run_tests_dir_path) | ValidationError: None is not of type 'string' |


## Config section

| Error Case |  Function's output|
| ------------- | ------------- |
| Wrong format argument given(ansible_port: 'true') | ValidationError: 'true' is not of type 'boolean' |
| Wrong format argument given(level: TEST ) | ValidationError: 'TEST' is not one of ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] |
| Empty entry for parameter(qa_ctl_launcher_branch) | ValidationError: None is not of type 'string' |

