### PR TITLE
Migrate test_office365 documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_office365/test_configuration/test_invalid.py
+++ b/tests/integration/test_office365/test_configuration/test_invalid.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The Wazuh 'office365' module allows you to collect all the logs from Office 365 using its API.
+       Specifically, these tests will check if that module detects invalid configurations and indicates
+       the location of the errors detected. The Office 365 Management Activity API aggregates actions
+       and events into tenant-specific content blobs, which are classified by the type and source
+       of the content they contain.
+
+tier: 0
+
+modules:
+    - office365
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+    - wazuh-monitord
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-documentation/blob/develop/source/office365/index.rst
+    - https://github.com/wazuh/wazuh-documentation/blob/develop/source/office365/monitoring-office365-activity.rst
+
+tags:
+    - office365_configuration
+'''
 import os
 import sys
 
@@ -200,19 +253,44 @@ def get_local_internal_options():
 
 def test_invalid(get_local_internal_options, configure_local_internal_options,
                  get_configuration, configure_environment, reset_ossec_log):
-    """
-    Checks if an invalid configuration is detected
+    '''
+    description: Check if the 'office365' module detects invalid configurations. For this purpose, the test
+                 will configure that module using invalid configuration settings with different attributes.
+                 Finally, it will verify that error events are generated indicating the source of the errors.
 
-    Using invalid configurations with different attributes,
-    expect an error message and office365 unable to start.
+    wazuh_min_version: 4.2.0
 
-    Args:
-        get_local_internal_options (fixture): Get internal configuration.
-        configure_local_internal_options (fixture): Set internal configuration for testing.
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        reset_ossec_log (fixture): Reset ossec.log and start a new monitor
-    """
+    parameters:
+        - get_local_internal_options:
+            type: fixture
+            brief: Get internal configuration.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Set internal configuration for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - reset_ossec_log:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that the 'office365' module generates error events when invalid configurations are used.
+
+    input_description: A configuration template (offic365_integration) is contained in an external YAML file
+                       (wazuh_conf.yaml). That template is combined with different test cases defined in
+                       the module. Those include configuration settings for the 'office365' module.
+
+    expected_output:
+        - r'wm_office365_read(): ERROR.* Invalid content for tag .*'
+        - r'wm_office365_read(): ERROR.* Empty content for tag .*'
+
+    tags:
+        - invalid_settings
+    '''
     # Configuration error -> ValueError raised
     try:
         control_service('restart')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1815|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 
The schema used is the one defined in issue #1694


## New tags
The following tags are added to the wiki: `office365_configuration`


# Generated documentation


<details><summary>test_invalid.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The Wazuh 'office365' module allows you to collect all the logs from Office 365 using its API. Specifically, these tests will check if that module detects invalid configurations and indicates the location of the errors detected. The Office 365 Management Activity API aggregates actions and events into tenant-specific content blobs, which are classified by the type and source of the content they contain.",
    "tier": 0,
    "modules": [
        "office365"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd",
        "wazuh-monitord",
        "wazuh-modulesd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://github.com/wazuh/wazuh-documentation/blob/develop/source/office365/index.rst",
        "https://github.com/wazuh/wazuh-documentation/blob/develop/source/office365/monitoring-office365-activity.rst"
    ],
    "tags": [
        "office365_configuration"
    ],
    "name": "test_invalid.py",
    "id": 1,
    "group_id": 0,
    "tests": [
        {
            "description": "Check if the 'office365' module detects invalid configurations. For this purpose, the test will configure that module using invalid configuration settings with different attributes. Finally, it will verify that error events are generated indicating the source of the errors.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_local_internal_options": {
                        "type": "fixture",
                        "brief": "Get internal configuration."
                    }
                },
                {
                    "configure_local_internal_options": {
                        "type": "fixture",
                        "brief": "Set internal configuration for testing."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "reset_ossec_log": {
                        "type": "fixture",
                        "brief": "Reset the 'ossec.log' file and start a new monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that the 'office365' module generates error events when invalid configurations are used."
            ],
            "input_description": "A configuration template (offic365_integration) is contained in an external YAML file (wazuh_conf.yaml). That template is combined with different test cases defined in the module. Those include configuration settings for the 'office365' module.",
            "expected_output": [
                {
                    "r'wm_office365_read()": "ERROR.* Invalid content for tag .*'"
                },
                {
                    "r'wm_office365_read()": "ERROR.* Empty content for tag .*'"
                }
            ],
            "tags": [
                "invalid_settings"
            ],
            "name": "test_invalid",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4",
                "get_configuration5",
                "get_configuration6",
                "get_configuration7"
            ]
        }
    ]
}
```
</p>
</details>


<details><summary>test_invalid.yaml</summary>
<p>

```yaml
brief: The Wazuh 'office365' module allows you to collect all the logs from Office
  365 using its API. Specifically, these tests will check if that module detects invalid
  configurations and indicates the location of the errors detected. The Office 365
  Management Activity API aggregates actions and events into tenant-specific content
  blobs, which are classified by the type and source of the content they contain.
components:
- manager
copyright: 'Copyright (C) 2015-2021, Wazuh Inc.

  Created by Wazuh, Inc. <info@wazuh.com>.

  This program is free software; you can redistribute it and/or modify it under the
  terms of GPLv2'
daemons:
- wazuh-analysisd
- wazuh-monitord
- wazuh-modulesd
group_id: 0
id: 1
modules:
- office365
name: test_invalid.py
os_platform:
- linux
os_version:
- Arch Linux
- Amazon Linux 2
- Amazon Linux 1
- CentOS 8
- CentOS 7
- CentOS 6
- Ubuntu Focal
- Ubuntu Bionic
- Ubuntu Xenial
- Ubuntu Trusty
- Debian Buster
- Debian Stretch
- Debian Jessie
- Debian Wheezy
- Red Hat 8
- Red Hat 7
- Red Hat 6
references:
- https://github.com/wazuh/wazuh-documentation/blob/develop/source/office365/index.rst
- https://github.com/wazuh/wazuh-documentation/blob/develop/source/office365/monitoring-office365-activity.rst
tags:
- office365_configuration
tests:
- assertions:
  - Verify that the 'office365' module generates error events when invalid configurations
    are used.
  description: Check if the 'office365' module detects invalid configurations. For
    this purpose, the test will configure that module using invalid configuration
    settings with different attributes. Finally, it will verify that error events
    are generated indicating the source of the errors.
  expected_output:
  - r'wm_office365_read(): ERROR.* Invalid content for tag .*'
  - r'wm_office365_read(): ERROR.* Empty content for tag .*'
  input_description: A configuration template (offic365_integration) is contained
    in an external YAML file (wazuh_conf.yaml). That template is combined with different
    test cases defined in the module. Those include configuration settings for the
    'office365' module.
  inputs:
  - get_configuration0
  - get_configuration1
  - get_configuration2
  - get_configuration3
  - get_configuration4
  - get_configuration5
  - get_configuration6
  - get_configuration7
  name: test_invalid
  parameters:
  - get_local_internal_options:
      brief: Get internal configuration.
      type: fixture
  - configure_local_internal_options:
      brief: Set internal configuration for testing.
      type: fixture
  - get_configuration:
      brief: Get configurations from the module.
      type: fixture
  - configure_environment:
      brief: Configure a custom environment for testing.
      type: fixture
  - reset_ossec_log:
      brief: Reset the 'ossec.log' file and start a new monitor.
      type: fixture
  tags:
  - invalid_settings
  wazuh_min_version: 4.2.0
tier: 0
type: integration
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The DocGenerator sanity check test does not return errors. `python3 DocGenerator.py -s`