### PR TITLE
Added XFails to NFS test for issue with Jenkins

### DIFF
--- a/tests/integration/test_fim/test_files/test_skip/test_skip.py
+++ b/tests/integration/test_fim/test_files/test_skip/test_skip.py
@@ -376,6 +376,7 @@ def test_skip_dev(modify_inode_mock, directory, tags_to_apply, get_configuration
 @pytest.mark.parametrize('directory,  tags_to_apply', [
     (os.path.join('/', 'nfs-mount-point'), {'skip_nfs'})
 ])
+@pytest.mark.xfail(reason='Xfail on Jenkins to issue: https://github.com/wazuh/wazuh-qa/issues/2186')
 @patch('wazuh_testing.fim.modify_file_inode')
 def test_skip_nfs(modify_inode_mock, directory, tags_to_apply, configure_nfs, get_configuration, configure_environment,
                   restart_syscheckd, wait_for_fim_start):


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/2093|

## Description

The tests/integration/test_fim/test_files/test_skip test was skipped with an xfail associated a new issue https://github.com/wazuh/wazuh-qa/issues/2186. 



### Packages details

|  Jenkins branch  | QA branch   |  Version 	|   Revision | 
|- |- |- |- |
| master |   2093-fim-manager-nfs | 4.3  |  0.fullgreenCe9f  | 

Type | Format | Architecture |   Tag | File name
-- | -- | -- | -- | -- | 
Server | rpm | x86_64 | 4.3.0 | wazuh-manager-4.3.0-0.fullgreenCe9f.x86_64.rpm

### Environment 

Provider| Box| OS| CPU| Memory | 
--|--|--|--|--|
Vagrant | centos/8 | CentOS 8 | 2 | 1024 |


## Configuration options

> syscheck.debug=2
> analysisd.debug=2
> monitord.rotate_log=0

## Logs example

Pytest ARGS - Local 

> --tier 0 --tier 1 --tier 2 --fim_mode="realtime" --fim_mode="whodata" --fim_mode="scheduled"


| Test Path | Type | Status
|--|--|--|
test_fim/test_files/test_skip/ | Local | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/15294/) 
test_fim/test_files/test_skip/ | Local | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/15293/) 

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
