### PR TITLE
Improve Vulnerability Detector documentation and tests IDs

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `enabled` option of the vulnerability detector module
+brief: These tests will check if the `enabled` option of the Vulnerability Detector module
        is working correctly. This option is located in its corresponding section of
        the `ossec.conf` file and allows enabling or disabling this module.
 
@@ -92,9 +92,9 @@ def get_configuration(request):
 def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_configuration, configure_environment,
                  restart_modulesd):
     '''
-    description: Check if the `enabled ` option is working correctly. To do this,
+    description: Checks if the `enabled ` option is working correctly. To do this,
                  it checks the `ossec.log` file for the message indicating that the
-                 vulnerability detector is enabled or disabled.
+                 Vulnerability Detector is enabled or disabled.
 
     wazuh_min_version: 4.2
 
@@ -119,8 +119,8 @@ def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_confi
             brief: Custom message to be printed when the test fails.
 
     assertions:
-        - Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.
-        - Verify that when the `enabled` option is set to `no`, the vulnerability detector module is stopped.
+        - Verify that when the `enabled` option is set to `yes`, the Vulnerability Detector module is running.
+        - Verify that when the `enabled` option is set to `no`, the Vulnerability Detector module is stopped.
 
     input_description: Two use cases are found in the test module and include
                        parameters for `enabled` option (`yes` and `no`).

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -19,8 +19,6 @@ modules:
 components:
     - manager
 
-path: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
-
 daemons:
     - wazuh-modulesd
 
@@ -73,14 +71,14 @@ configurations_path = os.path.join(test_data_path, 'wazuh_enabled.yaml')
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 
 parameters = [{'ENABLED': 'yes', 'TAG': 'enabled'}, {'ENABLED': 'no', 'TAG': 'disabled'}]
-metadata = [{'enabled': 'yes'}, {'enabled': 'no'}]
+metadata = [{'enabled': 'yes', 'id': "config_enabled"}, {'enabled': 'no', 'id': "config_disabled"}]
 
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 
 # fixtures
-@pytest.fixture(scope='module', params=configurations)
+@pytest.fixture(scope='module', params=configurations, ids=[f"{x['id']}" for x in metadata])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -88,8 +86,9 @@ def get_configuration(request):
 
 @pytest.mark.parametrize('tags_to_apply, custom_callback, custom_error_message', [
     ({'enabled'}, callback_detect_vulnerability_detector_enabled, 'Vulnerability detector is disabled'),
-    ({'disabled'}, callback_detect_vulnerability_detector_disabled, 'Vulnerability detector is enabled')
-])
+    ({'disabled'}, callback_detect_vulnerability_detector_disabled, 'Vulnerability detector is enabled')],
+    ids = ['expecting_vuldet_enabled', 'expecting_vuldet_disabled']
+)
 def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_configuration, configure_environment,
                  restart_modulesd):
     '''
@@ -112,9 +111,12 @@ def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_confi
         - tags_to_apply:
             type: string
             brief: Tags used for use cases.
-        - custom_callback_vulnerability:
+        - custom_callback:
+            type: callback
+            brief: Custom callback for searching the expected logs.
+        custom_error_message:
             type: string
-            brief: Custom callback for the use case.
+            brief: Custom message to be printed when the test fails.
 
     assertions:
         - Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `interval` option of the vulnerability detector module
+       is working correctly. This option is located in its corresponding section of
+       the `ossec.conf` file and allows to define the time between scans.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#interval
+
+tags:
+    - settings
+'''
 import os
 
 import pytest
@@ -46,10 +95,32 @@ def get_configuration(request):
 
 
 def test_interval(get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd waits `interval` between one vulnerability detector scan and another.
-    """
+    '''
+    description: Check if the `interval ` option is working correctly. To do this,
+                 it checks the `ossec.log` file for the message indicating that
+                 vulnerability detector will sleep N seconds until the next scan.
 
+    wazuh_min_version: 4.2
+
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Verify that the scans are delayed until the time configured is up.
+
+    input_description: The combination of interval_values and interval_units is used.
+
+    expected_output:
+        - rf"{VULNERABILITY_DETECTOR_PREFIX} Sleeping for (.*)..."
+    '''
     check_apply_test({'interval'}, get_configuration['tags'])
 
     sleeping_interval = wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `interval` option of the vulnerability detector module
+brief: These tests will check if the `interval` option of the Vulnerability Detector module
        is working correctly. This option is located in its corresponding section of
        the `ossec.conf` file and allows to define the time between scans.
 
@@ -96,9 +96,9 @@ def get_configuration(request):
 
 def test_interval(get_configuration, configure_environment, restart_modulesd):
     '''
-    description: Check if the `interval ` option is working correctly. To do this,
+    description: Checks if the `interval ` option is working correctly. To do this,
                  it checks the `ossec.log` file for the message indicating that
-                 vulnerability detector will sleep N seconds until the next scan.
+                 Vulnerability Detector will sleep N seconds until the next scan.
 
     wazuh_min_version: 4.2
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
@@ -1,6 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `min_full_scan_interval` option of the vulnerability detector module
+       is working correctly. This option is located in its corresponding section of the `ossec.conf` file
+       and allows to define the minimum time before performing a full scan even if the feed was updated.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#min_full_scan_interval
+
+tags:
+    - settings
+'''
 import os
 import time
 from datetime import datetime, timedelta
@@ -73,21 +123,37 @@ def mock_system(mock_agent):
 
 
 def test_min_full_scan_interval(get_configuration, configure_environment, restart_modulesd, mock_system):
-    """Check if the Vulnerability Detector module waits the minimal time set in "min_full_scan_interval"
-    to perform FULL_SCAN type scanning.
+    '''
+    description: Check if the `min_full_scan_interval ` option is working correctly. To do this,
+                 it checks the `ossec.log` file for the message indicating that a baseline scan occurred. After this, it
+                 time travels to the future and waits for the a full scan start log to occur in the expected time.
 
-    To do so, a simulated agent is added to the system, as soon as it is detected, the Vulnerability Detector
-    will launch an initial scan (BASELINE_SCAN) on it. Then the system date is changed to a time after
-    the date of the initial baseline scan, but before the minimum period set in "min_full_scan_interval",
-    so that the full scan should not be triggered. Finally, the date is changed again to a time when
-    the period set in "min_full_scan_interval" has expired, at which point the full scan should be triggered.
+    wazuh_min_version: 4.3
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset wazuh_modulesd daemon, truncates ossec.log file and starts a new monitor.
-        mock_system (fixture): Add a simulated agent to the manager for testing.
-    """
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - mock_system:
+            type: callable
+            brief: Add a simulated agent to the manager for testing.
+
+    assertions:
+        - Verify that the full_scans are delayed until the time configured is up.
+
+    input_description: The combination of min_full_scan_interval_values and min_full_scan_interval_units is used.
+
+    expected_output:
+        - f"A full scan will be run on agent '{agent_id}'"
+        - f"A baseline scan will be run on agent '{agent_id}'"
+        - f"Finished vulnerability assessment for agent '{agent_id}'"
+    '''
     check_apply_test({'min_full_scan_interval'}, get_configuration['tags'])
     config = get_configuration['metadata']
     agent_id = mock_system

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_min_full_scan_interval.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `min_full_scan_interval` option of the vulnerability detector module
+brief: These tests will check if the `min_full_scan_interval` option of the Vulnerability Detector module
        is working correctly. This option is located in its corresponding section of the `ossec.conf` file
        and allows to define the minimum time before performing a full scan even if the feed was updated.
 
@@ -124,7 +124,7 @@ def mock_system(mock_agent):
 
 def test_min_full_scan_interval(get_configuration, configure_environment, restart_modulesd, mock_system):
     '''
-    description: Check if the `min_full_scan_interval ` option is working correctly. To do this,
+    description: Checks if the `min_full_scan_interval ` option is working correctly. To do this,
                  it checks the `ossec.log` file for the message indicating that a baseline scan occurred. After this, it
                  time travels to the future and waits for the a full scan start log to occur in the expected time.
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -1,6 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `retry_interval` option of the vulnerability detector module
+       is working correctly. This option is located in its corresponding section of the `ossec.conf` file
+       and allows to define the time to wait to re-scan an agent that wasn't able to be scanned the first time.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#retry_interval
+
+tags:
+    - settings
+'''
 import os
 import time
 import re
@@ -68,25 +118,36 @@ def mock_system(mock_agent):
 
 
 def test_retry_interval(get_configuration, configure_environment, restart_modulesd, mock_system):
-    """Check if the Vulnerability Detector module retries the scan after a failure attempt when the value set in
-    retry_interval expires.
+    '''
+    description: Check if the `retry_interval ` option is working correctly. To do this,
+                 it checks the `ossec.log` file for the message indicating that Vulnerability Detector will sleep before
+                 attempting to scan the pending agents. After that, waits for the log saying that the agent will be
+                 scanned again. And the time between both events is compared.
+    wazuh_min_version: 4.3
 
-    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
-    with a test package. This package is added to the database of the mocked agent and, after the enrollment
-    of the agent, the vulnerability detector must attempt to launch the first scan on it.
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - mock_system:
+            type: callable
+            brief: Add a simulated agent to the manager for testing.
 
-    As the syscollector database is not synchronized (last_completion attribute in sync_info table does not match
-    with the last_attemp attribute) the scan on the agent is skipped.
+    assertions:
+        - Verify that the retry to scan a failing agent is delayed until the time configured is up.
 
-    After the syscollector database is synchronized (last_completion attribute in sync_info table match
-    with the last_attemp attribute) the scan on the agent is performed.
+    input_description: The combination of retry_interval_values and retry_interval_units is used.
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset wazuh_modulesd daemon, truncates ossec.log file and starts a new monitor.
-        mock_system (fixture): Add a mocked agent to the manager for testing.
-    """
+    expected_output:
+        - 'Going to sleep \\d+ seconds before retrying pending agents'
+        - f"Analyzing OVAL vulnerabilities for agent '{agent_id}'"
+    '''
     check_apply_test({'retry_interval'}, get_configuration['tags'])
     agent_id = mock_system
     retry_interval = time_to_seconds(get_configuration['metadata']['retry_interval'])

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `retry_interval` option of the vulnerability detector module
+brief: These tests will check if the `retry_interval` option of the Vulnerability Detector module
        is working correctly. This option is located in its corresponding section of the `ossec.conf` file
        and allows to define the time to wait to re-scan an agent that wasn't able to be scanned the first time.
 
@@ -119,7 +119,7 @@ def mock_system(mock_agent):
 
 def test_retry_interval(get_configuration, configure_environment, restart_modulesd, mock_system):
     '''
-    description: Check if the `retry_interval ` option is working correctly. To do this,
+    description: Checks if the `retry_interval ` option is working correctly. To do this,
                  it checks the `ossec.log` file for the message indicating that Vulnerability Detector will sleep before
                  attempting to scan the pending agents. After that, waits for the log saying that the agent will be
                  scanned again. And the time between both events is compared.

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `run_on_start` option of the vulnerability detector module
+brief: These tests will check if the `run_on_start` option of the Vulnerability Detector module
        is working correctly. This option is located in its corresponding section of the `ossec.conf` file
        and allows to define if Vulnerability Detector must run a scan as soon as it is started.
 
@@ -97,7 +97,7 @@ def get_configuration(request):
 
 def test_run_on_start(get_configuration, configure_environment, restart_modulesd):
     '''
-    description: Check if the `run_on_start ` option is working correctly. To do this, when the option is enabled
+    description: Checks if the `run_on_start ` option is working correctly. To do this, when the option is enabled
                  it restarts Vulnerability Detector and checks the `ossec.log` file for the message indicating that
                  a scan starts; and, when the option is disabled, it restarts Vulnerability Detector and checks in the
                  'ossec.log' that the scan doesn't start.

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -1,6 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `run_on_start` option of the vulnerability detector module
+       is working correctly. This option is located in its corresponding section of the `ossec.conf` file
+       and allows to define if Vulnerability Detector must run a scan as soon as it is started.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#run_on_start
+
+tags:
+    - settings
+'''
 
 import os
 
@@ -46,12 +96,34 @@ def get_configuration(request):
 
 
 def test_run_on_start(get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd detects the vulnerability detector scan after starting.
+    '''
+    description: Check if the `run_on_start ` option is working correctly. To do this, when the option is enabled
+                 it restarts Vulnerability Detector and checks the `ossec.log` file for the message indicating that
+                 a scan starts; and, when the option is disabled, it restarts Vulnerability Detector and checks in the
+                 'ossec.log' that the scan doesn't start.
 
-    If we have set the parameter run_on_start to 'yes', modulesd will have to report the
-    vulnerability detector scan, and in case of the value 'no', do not report anything
-    """
+    wazuh_min_version: 4.2
+
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Verify that a scan is run on start or not, as configured in the options.
+
+    input_description: The different values to enable/disable the run_on_scan option.
+
+    expected_output:
+        - 'Starting vulnerability scan'
+        - 'Vulnerability scan finished'
+    '''
 
     check_apply_test({'run_on_start'}, get_configuration['tags'])
 

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -1,6 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the Vulnerability Detector module performs the baseline scan type correctly.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/\
+       how_it_works.html#scan_types"
+
+tags:
+    - settings
+'''
 import os
 import time
 
@@ -40,7 +88,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 
 # fixtures
-@pytest.fixture(scope='module', params=configurations)
+@pytest.fixture(scope='module', params=configurations, ids=["baseline_scan_config"])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -69,21 +117,37 @@ def mock_system(mock_agent):
 
 
 def test_baseline_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):
-    """Check if the Vulnerability Detector module performs the baseline scan type correctly.
+    '''
+    description: Check if the baseline scan is performed as expected. To do this,
+                 a fresh agent (without a previous scan) is inserted and a feed update is simulated. After this,
+                 it checks the `ossec.log` file for the message indicating that a baseline scan is being performed.
 
-    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
-    with a test package. This package is added to the database of the simulated agent and, after enrollment
-    of the agent, the vulnerability detector must launch the first scan on it, which is of BASELINE type.
+    wazuh_min_version: 4.3
 
-    When the scan is done, we verify the vulnerability has been detected and no alerts have been
-    generated for such vulnerability in their respective logs.
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - mock_system:
+            type: callable
+            brief: Add a simulated agent to the manager for testing.
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset wazuh_modulesd daemon, truncates ossec.log file and starts a new monitor.
-        mock_system (fixture): Add a simulated agent to the manager for testing.
-    """
+    assertions:
+        - A baseline scan is performed when the agent wasn't scanned yet.
+
+    input_description: A configuration to perform VUlnerability Detector scans.
+
+    expected_output:
+        - f"A baseline scan will be run on agent '{agent_id}'"
+        - f"Finished vulnerability assessment for agent '{agent_id}'"
+        - f"CVE-000 affects wazuhintegrationpackage-0"
+    '''
     check_apply_test({'baseline_scan_type'}, get_configuration['tags'])
     agent_id = mock_system
 

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -118,7 +118,7 @@ def mock_system(mock_agent):
 
 def test_baseline_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):
     '''
-    description: Check if the baseline scan is performed as expected. To do this,
+    description: Checks if the baseline scan is performed as expected. To do this,
                  a fresh agent (without a previous scan) is inserted and a feed update is simulated. After this,
                  it checks the `ossec.log` file for the message indicating that a baseline scan is being performed.
 
@@ -141,7 +141,7 @@ def test_baseline_scan_type(get_configuration, configure_environment, restart_mo
     assertions:
         - A baseline scan is performed when the agent wasn't scanned yet.
 
-    input_description: A configuration to perform VUlnerability Detector scans.
+    input_description: A configuration to perform Vulnerability Detector scans.
 
     expected_output:
         - f"A baseline scan will be run on agent '{agent_id}'"

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
@@ -1,6 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the Vulnerability Detector module performs the full scan type correctly.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/\
+       how_it_works.html#scan_types"
+
+tags:
+    - settings
+'''
 import datetime
 import os
 import time
@@ -47,7 +95,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 
 # fixtures
-@pytest.fixture(scope='module', params=configurations)
+@pytest.fixture(scope='module', params=configurations, ids=["full_scan_config"])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -78,26 +126,48 @@ def mock_system(mock_agent):
 
 
 def test_full_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):
-    """Check if the Vulnerability Detector module performs the full scan type correctly.
+    '''
+    description: Check if the full scan is performed as expected. To do this,
+                 a fresh agent (without a previous scan) is inserted and a feed update is simulated. After this,
+                 it checks the `ossec.log` file for the message indicating that a baseline scan is being performed and
+                 the vulnerabilities detected are checked. Then, the vulnerable packages are modified and
+                 a full scan is forced by modifying the LAST_FULL_SCAN value in the agent database. Once the scan
+                 finished, the vulnerabilities are controlled again to identify that new vulnerabilities are reported,
+                 but old ones don´t.
 
-    For this purpose, the manager is configured to use custom feeds that include vulnerabilities associated
-    with test packages. Two packages are added to the database of the simulated agent and, after enrollment
-    of the agent, the vulnerability detector must launch the first scan on it, which is of BASELINE type.
+    wazuh_min_version: 4.3
 
-    When the BASELINE scan has been performed, an additional package will be inserted and the second package
-    installed on the tested agent will be updated to a non-vulnerable version, then the necessary conditions
-    to launch a FULL_SCAN scan type will be triggered.
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - mock_system:
+            type: callable
+            brief: Add a simulated agent to the manager for testing.
 
-    Once the full scan is complete, we will verify that two vulnerabilities remain in the "vuln_cves" table
-    and two alerts have been generated (one for the vulnerability detected and another for the vulnerability
-    removed by the update). This will be confirmed by checking the log and alert files respectively.
+    assertions:
+        - A baseline scan is performed when the agent wasn't scanned yet.
+        - A full scan will be performed after the baseline scan if the feeds are updated.
+        - The full scan will be able to detect the introduced or removed vulnerabilities.
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset wazuh_modulesd daemon, truncates ossec.log file and starts a new monitor.
-        mock_system (fixture): Add a simulated agent to the manager for testing.
-    """
+    input_description: A configuration to perform VUlnerability Detector scans.
+
+    expected_output:
+        - f"A baseline scan will be run on agent '{agent_id}'"
+        - f"A full scan will be run on agent '{agent_id}'"
+        - f"Finished vulnerability assessment for agent '{agent_id}'"
+        - f"Package '{test_packet_0_name}' inserted into the vulnerability '{test_packet_0_cve}'."
+        - f"Package '{test_packet_1_name}' not vulnerable to '{test_packet_1_cve}'."
+        - f"Package '{test_packet_2_name}' inserted into the vulnerability '{test_packet_2_cve}'."
+        - f"{test_packet_1_cve} affecting {test_packet_1_name} was eliminated"
+        - f"{test_packet_2_cve} affects {test_packet_2_name}"
+    '''
     check_apply_test({'full_scan_type'}, get_configuration['tags'])
     agent_id = mock_system
 

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
@@ -127,7 +127,7 @@ def mock_system(mock_agent):
 
 def test_full_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):
     '''
-    description: Check if the full scan is performed as expected. To do this,
+    description: Checks if the full scan is performed as expected. To do this,
                  a fresh agent (without a previous scan) is inserted and a feed update is simulated. After this,
                  it checks the `ossec.log` file for the message indicating that a baseline scan is being performed and
                  the vulnerabilities detected are checked. Then, the vulnerable packages are modified and
@@ -156,7 +156,7 @@ def test_full_scan_type(get_configuration, configure_environment, restart_module
         - A full scan will be performed after the baseline scan if the feeds are updated.
         - The full scan will be able to detect the introduced or removed vulnerabilities.
 
-    input_description: A configuration to perform VUlnerability Detector scans.
+    input_description: A configuration to perform Vulnerability Detector scans.
 
     expected_output:
         - f"A baseline scan will be run on agent '{agent_id}'"

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -1,6 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the Vulnerability Detector module performs the partial scan type correctly.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/\
+       how_it_works.html#scan_types"
+
+tags:
+    - settings
+'''
 import os
 import time
 
@@ -43,7 +91,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 
 # fixtures
-@pytest.fixture(scope='module', params=configurations)
+@pytest.fixture(scope='module', params=configurations, ids=["partial_scan_config"])
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
@@ -72,24 +120,46 @@ def mock_system(mock_agent):
 
 
 def test_partial_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):
-    """Check if the Vulnerability Detector module performs the partial scan type correctly.
+    '''
+    description: Check if the partial scan is performed as expected. To do this,
+                 a fresh agent (without a previous scan) is inserted and a feed update is simulated. After this,
+                 it checks the `ossec.log` file for the message indicating that a baseline scan is being performed and
+                 the vulnerabilities detected are checked. After this, the vulnerable packages are modified and
+                 a partial scan is waited. Once the scan finished, the vulnerabilities are controlled again to identify
+                 that new vulnerabilities are reported, but old ones don´t.
 
-    For this purpose, the manager is configured to use custom feeds that include a vulnerability associated
-    with a test package. This package is added to the database of the simulated agent and, after enrollment
-    of the agent, the vulnerability detector must launch the first scan on it, which is of BASELINE type.
+    wazuh_min_version: 4.3
 
-    When the BASELINE scan is done, we will insert a new test package and wait for the partial scan to start.
-    Once the PARTIAL scan is completed, it will check that a new vulnerability has been detected and an alert
-    has been generated for that vulnerability by analyzing its respective logs. It will also be checked that
-    no alerts have been generated for the first package that had already been previously analyzed by
-    the BASELINE scan.
+    parameters:
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - mock_system:
+            type: callable
+            brief: Add a simulated agent to the manager for testing.
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset wazuh_modulesd daemon, truncates ossec.log file and starts a new monitor.
-        mock_system (fixture): Add a simulated agent to the manager for testing.
-    """
+    assertions:
+        - A baseline scan is performed when the agent wasn't scanned yet.
+        - A partial scan will be performed after the baseline scan after the configured time.
+        - The partial scan will be able to detect the introduced or removed vulnerabilities.
+
+    input_description: A configuration to perform VUlnerability Detector scans.
+
+    expected_output:
+        - f"A baseline scan will be run on agent '{agent_id}'"
+        - f"A partial scan will be run on agent '{agent_id}'"
+        - f"Finished vulnerability assessment for agent '{agent_id}'")
+        - f"Package '{test_packet_0_name}' inserted into the vulnerability '{test_packet_0_cve}'."
+        - f"Package '{test_packet_1_name}' inserted into the vulnerability '{test_packet_1_cve}'."
+        - f"{test_packet_0_cve} affects {test_packet_0_name}"
+        - f"{test_packet_1_cve} affects {test_packet_1_name}"
+    '''
     check_apply_test({'partial_scan_type'}, get_configuration['tags'])
     agent_id = mock_system
 

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -121,7 +121,7 @@ def mock_system(mock_agent):
 
 def test_partial_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):
     '''
-    description: Check if the partial scan is performed as expected. To do this,
+    description: Checks if the partial scan is performed as expected. To do this,
                  a fresh agent (without a previous scan) is inserted and a feed update is simulated. After this,
                  it checks the `ossec.log` file for the message indicating that a baseline scan is being performed and
                  the vulnerabilities detected are checked. After this, the vulnerable packages are modified and
@@ -149,7 +149,7 @@ def test_partial_scan_type(get_configuration, configure_environment, restart_mod
         - A partial scan will be performed after the baseline scan after the configured time.
         - The partial scan will be able to detect the introduced or removed vulnerabilities.
 
-    input_description: A configuration to perform VUlnerability Detector scans.
+    input_description: A configuration to perform Vulnerability Detector scans.
 
     expected_output:
         - f"A baseline scan will be run on agent '{agent_id}'"


### PR DESCRIPTION
|Related issue|
|---|
|#2150|

## Description
This PR adds self documented blocks to the tests under **test_scan_types** and **test_general_settings** following the DocGenerator schema 2.0.
It also improves the test Ids of these files, to provide readable names.
It doesn´t modify the behavior of any test.


## Tests

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the DocGenerator schema 2.0