### PR TITLE
Migrate `test_logtest` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -149,7 +149,7 @@ def test_agentd_state(configure_environment, test_case: list):
             brief: Configure a custom environment for testing.
         - test_case:
             type: list
-            brief: List of tests to be performed.
+            brief: List of test_case stages.
 
     assertions:
         - Verify that the 'wazuh-agentd.state' statistics file has been created.

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -149,7 +149,7 @@ def test_agentd_state(configure_environment, test_case: list):
             brief: Configure a custom environment for testing.
         - test_case:
             type: list
-            brief: List of test_case stages.
+            brief: List of tests to be performed.
 
     assertions:
         - Verify that the 'wazuh-agentd.state' statistics file has been created.

--- a/tests/integration/test_logtest/test_configuration/test_configuration_file.py
+++ b/tests/integration/test_logtest/test_configuration/test_configuration_file.py
@@ -8,9 +8,10 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 type: integration
 
 brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
-        remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
-        parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluate through
-        'wazuh-logtest' tool or making requests via RESTful API.
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
 
 tier: 0
 
@@ -115,7 +116,7 @@ def test_configuration_file(get_configuration, configure_environment, restart_wa
         - 'Event not found'
 
     tags:
-        - logtest_configuration_file
+        - logtest_configuration
     '''
     callback = None
     if 'valid_conf' in get_configuration['tags']:

--- a/tests/integration/test_logtest/test_configuration/test_configuration_file.py
+++ b/tests/integration/test_logtest/test_configuration/test_configuration_file.py
@@ -1,14 +1,63 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
 
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+        remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+        parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluate through
+        'wazuh-logtest' tool or making requests via RESTful API.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
-
 import pytest
+
 from wazuh_testing import global_parameters
-from wazuh_testing.logtest import (callback_logtest_started, callback_logtest_disabled,
-                                   callback_configuration_error)
+from wazuh_testing.logtest import (callback_logtest_started, callback_logtest_disabled, callback_configuration_error)
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -34,9 +83,40 @@ def get_configuration(request):
 
 # Test
 def test_configuration_file(get_configuration, configure_environment, restart_wazuh):
-    """Check multiples logtest configuration
-    """
+    '''
+    description: Checks if `wazuh-logtest` works as expected under different predefined configurations that cause
+                 `wazuh-logtest` to start correctly, to be disabled, or to register an error. To do this, it checks
+                 some values in these configurations from 'wazuh_conf.yaml' file.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing
+        - restart_wazuh:
+            type: fixture
+            brief: Restart wazuh, ossec.log and start a new monitor.
+
+    assertions:
+        - Verify that a valid configuration is loaded.
+        - Verify that wrong loaded configurations lead to an error.
+
+    input_description: Five test cases are defined in the module. These include some configurations stored in
+                       the 'wazuh_conf.yaml'.
+
+    expected_output:
+        - r'.* Logtest started'
+        - r'.* Logtest disabled'
+        - r'.* Invalid value for element'
+        - 'Event not found'
+
+    tags:
+        - logtest_configuration_file
+    '''
     callback = None
     if 'valid_conf' in get_configuration['tags']:
         callback = callback_logtest_started

--- a/tests/integration/test_logtest/test_configuration/test_configuration_file.py
+++ b/tests/integration/test_logtest/test_configuration/test_configuration_file.py
@@ -116,7 +116,8 @@ def test_configuration_file(get_configuration, configure_environment, restart_wa
         - 'Event not found'
 
     tags:
-        - logtest_configuration
+        - settings
+        - analysisd
     '''
     callback = None
     if 'valid_conf' in get_configuration['tags']:

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -8,9 +8,10 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 type: integration
 
 brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
-        remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
-        parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluate through
-        'wazuh-logtest' tool or making requests via RESTful API.
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
 
 tier: 0
 
@@ -123,7 +124,7 @@ def test_get_configuration_sock(get_configuration, configure_environment, restar
         - 'Expected value in session_timeout tag: .*.  Value received: .*'
 
     tags:
-        - logtest_configuration_sock
+        - logtest_configuration
     '''
     configuration = get_configuration['sections'][0]['elements']
 

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -124,7 +124,8 @@ def test_get_configuration_sock(get_configuration, configure_environment, restar
         - 'Expected value in session_timeout tag: .*.  Value received: .*'
 
     tags:
-        - logtest_configuration
+        - settings
+        - analysisd
     '''
     configuration = get_configuration['sections'][0]['elements']
 

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -1,7 +1,58 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+        remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+        parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluate through
+        'wazuh-logtest' tool or making requests via RESTful API.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
 import re
 
@@ -33,9 +84,46 @@ def get_configuration(request):
 
 # Test
 def test_get_configuration_sock(get_configuration, configure_environment, restart_wazuh, connect_to_sockets_function):
-    """Check analisis Unix socket returns the correct Logtest configuration
-    """
+    '''
+    description: Check analysis Unix socket returns the correct Logtest configuration under different sets of
+                 configurations, `wazuh-analisysd` returns the right information from the `rule_test` configuration
+                 block. To do this, it overwrites wrong field values and checks that the values within the received
+                 message are the same that the loaded fields from the 'wazuh_conf.yaml' file.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing
+        - restart_wazuh:
+            type: fixture
+            brief: Restart wazuh, ossec.log and start a new monitor.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that a valid configuration is loaded.
+        - Verify that wrong loaded configurations are fixed with limit values.
+        - Verify that each message field received matches the loaded configuration fields.
+
+    input_description: Five test cases are defined in the module. These include some configurations stored in
+                       the 'wazuh_conf.yaml'.
+
+    expected_output:
+        - 'Real message was: .*'
+        - 'Expected value in enabled tag: .*. Value received: .*'
+        - 'Expected value in threads tag: .*.  Value received: .*'
+        - 'Expected value in max_sessions tag: .*.  Value received: .*'
+        - 'Expected value in session_timeout tag: .*.  Value received: .*'
+
+    tags:
+        - logtest_configuration_sock
+    '''
     configuration = get_configuration['sections'][0]['elements']
 
     if 'invalid_threads_conf' in get_configuration['tags']:

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -88,7 +88,8 @@ def test_get_configuration_sock(get_configuration, configure_environment, restar
     description: Check analysis Unix socket returns the correct Logtest configuration under different sets of
                  configurations, `wazuh-analisysd` returns the right information from the `rule_test` configuration
                  block. To do this, it overwrites wrong field values and checks that the values within the received
-                 message are the same that the loaded fields from the 'wazuh_conf.yaml' file.
+                 message after establish connection using the logtest AF_UNIX socket that uses TCP are the same that the
+                 loaded fields from the 'wazuh_conf.yaml' file.
 
     wazuh_min_version: 4.2.0
 

--- a/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
+++ b/tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py
@@ -89,7 +89,7 @@ def test_get_configuration_sock(get_configuration, configure_environment, restar
     description: Check analysis Unix socket returns the correct Logtest configuration under different sets of
                  configurations, `wazuh-analisysd` returns the right information from the `rule_test` configuration
                  block. To do this, it overwrites wrong field values and checks that the values within the received
-                 message after establish connection using the logtest AF_UNIX socket that uses TCP are the same that the
+                 message after establishing a connection using the logtest AF_UNIX socket that uses TCP are the same that the
                  loaded fields from the 'wazuh_conf.yaml' file.
 
     wazuh_min_version: 4.2.0

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -110,7 +110,7 @@ def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,
                                 connect_to_sockets_function):
     '''
     description: Check if `wazuh-logtest` correctly detects and handles errors when processing a decoders file.
-                 To do this, it send a logtest request using the input configurations and parse the logtest reply
+                 To do this, it sends a logtest request using the input configurations and parses the logtest reply
                  received looking for errors.
 
     wazuh_min_version: 4.2.0

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -1,20 +1,72 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import pytest
 import os
-
-from wazuh_testing.tools import WAZUH_PATH
 from yaml import safe_load
 from shutil import copy
 from json import loads
+
+from wazuh_testing.tools import WAZUH_PATH
 
 # Marks
 
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 
-# Configurations
+# Configurationsa
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(test_data_path, 'invalid_decoder_syntax.yaml')
@@ -56,8 +108,43 @@ def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,
                                 restart_required_logtest_daemons,
                                 wait_for_logtest_startup,
                                 connect_to_sockets_function):
-    """Check that every input message in logtest socket generates the adequate output."""
+    '''
+    description: Check if `wazuh-logtest` correctly detects and handles errors when processing a decoders file.
+                 To do this, it send a logtest request using the input configurations and parse the logtest reply
+                 received looking for errors.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_local_decoders:
+            type: fixture
+            brief: Configure a custom decoder for testing.
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that `wazuh-logtest` retrieves errors when the loaded decoders are invalid.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'invalid_decoder_syntax.yaml'.
+
+    expected_output:
+        - r'Failed stage(s) : .*' (When an error occurs, it is appended)
+        - 'Error when executing {action} in daemon {daemon}. Exit status: {result}'
+
+    tags:
+        - logtest_invalid_rule_decoder_syntax
+    '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)
 

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -143,7 +143,10 @@ def test_invalid_decoder_syntax(get_configuration, configure_local_decoders,
         - 'Error when executing {action} in daemon {daemon}. Exit status: {result}'
 
     tags:
-        - logtest_invalid_rule_decoder_syntax
+        - errors
+        - invalid_settings
+        - decoder
+        - analysisd
     '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -144,7 +144,10 @@ def test_invalid_rule_syntax(get_configuration, configure_local_rules,
         - 'Error when executing {action} in daemon {daemon}. Exit status: {result}'
 
     tags:
-        - logtest_invalid_rule_decoder_syntax
+        - errors
+        - invalid_settings
+        - rules
+        - analysisd
     '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -1,14 +1,66 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import pytest
 import os
-
-from wazuh_testing.tools import WAZUH_PATH
 from yaml import safe_load
 from shutil import copy
 from json import loads
+
+from wazuh_testing.tools import WAZUH_PATH
 
 # Marks
 
@@ -56,8 +108,44 @@ def test_invalid_rule_syntax(get_configuration, configure_local_rules,
                              restart_required_logtest_daemons,
                              wait_for_logtest_startup,
                              connect_to_sockets_function):
-    """Check that every input message in logtest socket generates the adequate output """
+    '''
+    description: Check if `wazuh-logtest` correctly detects and handles errors when processing a rules file.
+                 To do this, it send a logtest request(via AF_UNIX socket) using the input configurations and parse
+                 the logtest reply received looking for errors.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_local_rules:
+            type: fixture
+            brief: Configure a custom rule in local_rules.xml for testing. Restart Wazuh is needed for applying the
+                   configuration.
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that `wazuh-logtest` retrieves errors when the loaded rules are invalid.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'invalid_rules_syntax.yaml'.
+
+    expected_output:
+        - r'Failed stage(s) : .*' (When an error occurs, it is appended)
+        - 'Error when executing {action} in daemon {daemon}. Exit status: {result}'
+
+    tags:
+        - logtest_invalid_rule_decoder_syntax
+    '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)
 

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -110,7 +110,7 @@ def test_invalid_rule_syntax(get_configuration, configure_local_rules,
                              connect_to_sockets_function):
     '''
     description: Check if `wazuh-logtest` correctly detects and handles errors when processing a rules file.
-                 To do this, it send a logtest request(via AF_UNIX socket) using the input configurations and parse
+                 To do this, it sends a logtest request(via AF_UNIX socket) using the input configurations and parses
                  the logtest reply received looking for errors.
 
     wazuh_min_version: 4.2.0

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -1,12 +1,64 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
-from struct import pack
-
 import pytest
 import yaml
+from struct import pack
+
 from wazuh_testing.tools import WAZUH_PATH
 
 # Marks
@@ -29,14 +81,44 @@ receiver_sockets = None  # Set in the fixtures
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-def test_invalid_socket_input(restart_required_logtest_daemons, wait_for_logtest_startup, connect_to_sockets_function, test_case: list):
-    """Check that every input message in logtest socket generates the adequate output
+def test_invalid_socket_input(restart_required_logtest_daemons, wait_for_logtest_startup, connect_to_sockets_function,
+                              test_case: list):
+    '''
+    description: Check if `wazuh-logtest` correctly detects and handles errors when sending a message through
+                 the socket to `wazuh-analysisd`. To do this, it sends the inputs through a socket(differentiating by
+                 oversized messages), receives and decodes the message. Then, that message is compared with the test
+                 case output.
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys)
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+        - test_case:
+            type: list
+            brief: List of test_case stages. (dicts with input, output and stage keys)
+
+    assertions:
+        - Verify that the comunication through the sockets works well by verifying that all the test cases produce
+          the right output.
+        - Verify that oversized messages log an error.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'invalid_socket_input.yaml'.
+
+    expected_output:
+        - r'Failed test case stage <test_case_index>: .*'
+
+    tags:
+        - logtest_invalid_socket_input
+    '''
     stage = test_case[0]
 
     if stage["stage"] != 'Oversize message':

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -106,7 +106,7 @@ def test_invalid_socket_input(restart_required_logtest_daemons, wait_for_logtest
             brief: List of test_case stages. (dicts with input, output and stage keys)
 
     assertions:
-        - Verify that the comunication through the sockets works well by verifying that all the test cases produce
+        - Verify that the communication through the sockets works well by verifying that all the test cases produce
           the right output.
         - Verify that oversized messages log an error.
 

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -117,7 +117,8 @@ def test_invalid_socket_input(restart_required_logtest_daemons, wait_for_logtest
         - r'Failed test case stage <test_case_index>: .*'
 
     tags:
-        - logtest_invalid_socket_input
+        - errors
+        - analysisd
     '''
     stage = test_case[0]
 

--- a/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
+++ b/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
@@ -99,7 +99,7 @@ def test_invalid_session_token(restart_required_logtest_daemons, wait_for_logtes
     '''
     description: Check if `wazuh-logtest` correctly detects and handles errors when using a session token.
                  To do this, it sends the inputs through a socket, receives and decodes the message. Then, it checks
-                 if any invalid token or session token is not catched.
+                 if any invalid token or session token is not caught.
 
     wazuh_min_version: 4.2.0
 

--- a/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
+++ b/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
@@ -1,12 +1,64 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import json
 import os
-
 import pytest
 import yaml
+
 from wazuh_testing.logtest import callback_session_initialized, callback_invalid_token
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.monitoring import SocketController
@@ -44,14 +96,41 @@ def close_connection(connection):
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
 def test_invalid_session_token(restart_required_logtest_daemons, wait_for_logtest_startup, test_case):
-    """Check that every input message in logtest socket generates the adequate output
+    '''
+    description: Check if `wazuh-logtest` correctly detects and handles errors when using a session token.
+                 To do this, it sends the inputs through a socket, receives and decodes the message. Then, it checks
+                 if any invalid token or session token is not catched.
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys)
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - test_case:
+            type: list
+            brief: List of test_case stages (dicts with input, output and stage keys)
+
+    assertions:
+        - Verify that new session is correctly initialized.
+        - Verify that invalid session token is received.
+        - Verify that errors are retrieved due to invalid session tokens.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'invalid_session_token.yaml'.
+
+    expected_output:
+        - r'Failed test case stage(s): .*' (When an error occurs, it is appended)
+        - r'.*: .* is not a valid token' (An error that could be appended)
+        - r'.*: Session initialized with token .*' (An error that could be appended)
+        - 'Error when executing .* in daemon .*. Exit status: .*'
+
+    tags:
+        - logtest_invalid_token
+    '''
     errors = []
     stage = test_case[0]
     connection = create_connection()

--- a/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
+++ b/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
@@ -129,7 +129,8 @@ def test_invalid_session_token(restart_required_logtest_daemons, wait_for_logtes
         - 'Error when executing .* in daemon .*. Exit status: .*'
 
     tags:
-        - logtest_invalid_token
+        - session_error
+        - analysisd
     '''
     errors = []
     stage = test_case[0]

--- a/tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py
+++ b/tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py
@@ -188,7 +188,8 @@ def test_rules_verbose(get_configuration, restart_required_logtest_daemons,
         - 'Error when executing .* in daemon .*. Exit status: .*'
 
     tags:
-        - logtest_log_process_options
+        - settings
+        - analysisd
     '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)

--- a/tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py
+++ b/tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py
@@ -149,7 +149,7 @@ def test_rules_verbose(get_configuration, restart_required_logtest_daemons,
     '''
     description: Check if 'wazuh-logtest' works correctly in 'verbose' mode for rules debugging. To do this, it sends
                  the inputs through a socket, receives and decodes the message. Then, it checks
-                 if any invalid token or session token is not catched.
+                 if any invalid token or session token is not caught.
 
     wazuh_min_version: 4.2.0
 
@@ -177,7 +177,7 @@ def test_rules_verbose(get_configuration, restart_required_logtest_daemons,
         - Verify that logtest is running in verbose mode.
         - Verify that when running in verbose mode the local rule debug messages has been written
         - Verify that when running in verbose mode the local rule debug messages written are the expected count.
-        - Verify that if a warning message is catched it matches with any test case message.
+        - Verify that if a warning message is caught it matches with any test case message.
 
     input_description: Some test cases are defined in the module. These include some input configurations stored in
                        the 'rules_verbose.yaml'.

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
@@ -146,7 +146,7 @@ def test_remove_old_session_for_inactivity(configure_local_internal_options_modu
         - r'Error when executing .* in daemon .*. Exit status: .*'
 
     tags:
-        - logtest_remove_old_sessions
+        - inactivity
         - analysisd
     '''
     session_timeout = int(get_configuration['sections'][0]['elements'][3]['session_timeout']['value'])

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+    - https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#analysisd
+
+tags:
+    - logtest_configuration
+'''
 import pytest
 import os
 
@@ -25,10 +78,11 @@ local_internal_options = {'analysisd.debug': '2'}
 receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 local_internal_options = {'analysisd.debug': '1'}
-create_session_data = {'version':1, 'command':'log_processing',
-                       'parameters':{'event': 'Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928',
-                                     'log_format': 'syslog',
-                                     'location': 'master->/var/log/syslog'}}
+create_session_data = {'version': 1, 'command': 'log_processing',
+                       'parameters': {'event': 'Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey '
+                                      'from 18.18.18.18 port 48928',
+                                      'log_format': 'syslog',
+                                      'location': 'master->/var/log/syslog'}}
 msg_create_session = dumps(create_session_data)
 
 
@@ -49,10 +103,52 @@ def test_remove_old_session_for_inactivity(configure_local_internal_options_modu
                                            file_monitoring,
                                            wait_for_logtest_startup,
                                            connect_to_sockets_function):
-    """Create more sessions than allowed and wait session_timeout seconds,
-    then check Wazuh-logtest has removed session for inactivity.
-    """
+    '''
+    description: Check if 'wazuh-logtest' correctly detects and handles the situation where trying to remove old
+                 sessions due to inactivity. To do this, it creates more sessions than allowed and waits session_timeout
+                 seconds, then checks that 'wazuh-logtest' has removed the session due to inactivity.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Configure the local internal options file.
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that the session is created.
+        - Verify that the old session is removed after 'session_timeout' delay due to inactivity.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'wazuh_conf.yaml' and the session creation data from the module.
+
+    expected_output:
+        - 'Session initialization event not found'
+        - 'Session removal event not found'
+        - r'Error when executing .* in daemon .*. Exit status: .*'
+
+    tags:
+        - logtest_remove_old_sessions
+        - analysisd
+    '''
     session_timeout = int(get_configuration['sections'][0]['elements'][3]['session_timeout']['value'])
 
     receiver_sockets[0].send(msg_create_session, True)
@@ -60,11 +156,11 @@ def test_remove_old_session_for_inactivity(configure_local_internal_options_modu
     msg_recived = msg_recived.decode()
 
     log_monitor.start(timeout=global_parameters.default_timeout,
-                            callback=callback_session_initialized,
-                            error_message="Session initialization event not found")
+                      callback=callback_session_initialized,
+                      error_message="Session initialization event not found")
 
     sleep(session_timeout)
 
     log_monitor.start(timeout=global_parameters.default_timeout,
-                            callback=callback_remove_session,
-                            error_message="Session removal event not found")
+                      callback=callback_remove_session,
+                      error_message="Session removal event not found")

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
@@ -1,7 +1,59 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import pytest
 import os
 
@@ -24,7 +76,8 @@ local_internal_options = {'analysisd.debug': '2'}
 # Variables
 local_internal_options = {'analysisd.debug': '1'}
 create_session_data = {'version': 1, 'command': 'log_processing',
-                       'parameters': {'event': 'Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928',
+                       'parameters': {'event': 'Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey '
+                                      'from 18.18.18.18 port 48928',
                                       'log_format': 'syslog',
                                       'location': 'master->/var/log/syslog'}}
 msg_create_session = dumps(create_session_data)
@@ -54,10 +107,55 @@ def test_remove_old_session(configure_local_internal_options_module,
                             get_configuration, configure_environment,
                             file_monitoring, restart_required_logtest_daemons,
                             wait_for_logtest_startup):
-    """Create more sessions than allowed and wait for the message which
-    informs that Wazuh-logtest has removed the oldest session.
-    """
+    '''
+    description: Check if 'wazuh-logtest' correctly detects and handles the situation where trying to use more
+                 sessions than allowed. To do this, it creates more sessions than allowed and wait for the message which
+                 informs that 'wazuh-logtest' has removed the oldest session.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Configure the local internal options file.
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+
+    assertions:
+        - Verify that the session will exceed the allowed sessions with the last one to verify that the first(oldest)
+         session is correctly removed.
+        - Verify that every session is correctly created.
+        - Verify that the first session is valid.
+        - Verify that the 'removal session' is created.
+        - Verify that the removed session is the first one.
+        - Verify that the session that exceeds the limit is created.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'wazuh_conf.yaml' and the session creation data from the module.
+
+    expected_output:
+        - 'Session initialization event not found'
+        - 'Session removal event not found'
+        - 'Incorrect session removed'
+        - r'Error when executing .* in daemon .*. Exit status: .*'
+
+    tags:
+        - logtest_remove_old_sessions
+        - analysisd
+    '''
     max_sessions = int(get_configuration['sections'][0]['elements'][2]['max_sessions']['value'])
 
     first_session_token = None

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
@@ -153,7 +153,7 @@ def test_remove_old_session(configure_local_internal_options_module,
         - r'Error when executing .* in daemon .*. Exit status: .*'
 
     tags:
-        - logtest_remove_old_sessions
+        - session_limit
         - analysisd
     '''
     max_sessions = int(get_configuration['sections'][0]['elements'][2]['max_sessions']['value'])

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -136,7 +136,6 @@ def test_remove_session(restart_required_logtest_daemons, wait_for_logtest_start
         - r'Failed test case stage <test_case_index>: .*'
 
     tags:
-        - logtest_remove_session
         - analysisd
     '''
     stage = test_case[0]

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import json
 import os
 
@@ -49,14 +103,42 @@ def create_session():
 @pytest.mark.parametrize('test_case',
                          [test_case['test_case'] for test_case in test_cases],
                          ids=[test_case['name'] for test_case in test_cases])
-def test_remove_session(restart_required_logtest_daemons, wait_for_logtest_startup, connect_to_sockets_function, test_case: list):
-    """Check that every input message in logtest socket generates the adequate output
+def test_remove_session(restart_required_logtest_daemons, wait_for_logtest_startup, connect_to_sockets_function,
+                        test_case: list):
+    '''
+    description: Check if 'wazuh-logtest' correctly detects and removes the sessions under pre-defined scenarios.
+                 To do this, the session input is sent and the output is received, then it checks if the received data
+                 within the logtest socket is the same that the test case expected output.
 
-    Parameters
-    ----------
-    test_case : list
-        List of test_case stages (dicts with input, output and stage keys)
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+        - test_case:
+            type: list
+            brief: List of test_case stages. (dicts with input, output and stage keys)
+
+    assertions:
+        - Verify that every test case output matches with the actual received.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'remove_session.yaml' and the session creation data from the module.
+
+    expected_output:
+        - r'Failed test case stage <test_case_index>: .*'
+
+    tags:
+        - logtest_remove_session
+        - analysisd
+    '''
     stage = test_case[0]
 
     if stage["stage"] != 'Remove session OK':

--- a/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
+++ b/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
@@ -113,9 +113,9 @@ def create_dummy_session():
 def test_load_rules_decoders(restart_required_logtest_daemons, wait_for_logtest_startup, test_case):
     '''
     description: Check if 'wazuh-logtest' does produce the right decoder/rule matching when processing a log under
-                 different sets of configurations. To do this, creates backup rules and decoders and copy the test case
-                 rules and decoders to restore after the checks. It sends the requests to the logtest socket and checks
-                 if the outputs match with the expected test cases.
+                 different sets of configurations. To do this, it creates backup rules and decoders and copies the test
+                 case rules and decoders to restore after the checks. It sends the requests to the logtest socket and
+                 checks if the outputs match with the expected test cases.
 
     wazuh_min_version: 4.2.0
 

--- a/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
+++ b/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import json
 import os
 import shutil
@@ -57,6 +111,44 @@ def create_dummy_session():
                          list(test_cases),
                          ids=[test_case['name'] for test_case in test_cases])
 def test_load_rules_decoders(restart_required_logtest_daemons, wait_for_logtest_startup, test_case):
+    '''
+    description: Check if 'wazuh-logtest' does produce the right decoder/rule matching when processing a log under
+                 different sets of configurations. To do this, creates backup rules and decoders and copy the test case
+                 rules and decoders to restore after the checks. It sends the requests to the logtest socket and checks
+                 if the outputs match with the expected test cases.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+        - test_case:
+            type: list
+            brief: List of test_case stages. (dicts with input, output and stage keys)
+
+    assertions:
+        - Verify that the predecoder output matches with test case expected.
+        - Verify that the decoder output matches with test case expected.
+        - Verify that the rule output matches with test case expected.
+        - Verify that the alert output matches with test case expected.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'remove_session.yaml' and the dummy session from the module.
+
+    expected_output:
+        - r'Failed stage(s) :.*'
+
+    tags:
+        - logtest_rules_decoders_load
+        - analysisd
+    '''
     # List to store assert messages
     errors = []
 

--- a/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
+++ b/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
@@ -146,7 +146,8 @@ def test_load_rules_decoders(restart_required_logtest_daemons, wait_for_logtest_
         - r'Failed stage(s) :.*'
 
     tags:
-        - logtest_rules_decoders_load
+        - decoder
+        - rules
         - analysisd
     '''
     # List to store assert messages

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
@@ -157,7 +157,7 @@ def test_rule_list(restart_required_logtest_daemons, get_configuration,
         - result.data.alert == test_case.alert
 
     tags:
-        - logtest_ruleset_refresh
+        - rules
         - analysisd
     '''
     # send the logtest request

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
@@ -117,8 +117,8 @@ def test_rule_list(restart_required_logtest_daemons, get_configuration,
                    configure_environment, configure_rules_list,
                    wait_for_logtest_startup, connect_to_sockets_function):
     '''
-    description: Check that after modifying the alert level it takes effect when opening a new logtest sessions, without
-                 having to reset the manager. To do this, it sends a request to logtest socket and get its response.
+    description: Check that after modifying the alert level it takes effect when opening new logtest sessions, without
+                 having to reset the manager. To do this, it sends a request to logtest socket and gets its response.
                  Then, it checks that the expected alert matches.
 
     wazuh_min_version: 4.2.0

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
 import pytest
 
@@ -30,7 +84,8 @@ receiver_sockets = None
 @pytest.fixture(scope='function')
 def configure_rules_list(get_configuration, request):
     """Configure a custom rules and log alert level for testing.
-    Restart Wazuh is not needed for applying the configuration is optional.
+
+    Restarting Wazuh is not needed for applying the configuration, it is optional.
     """
 
     # configuration for testing
@@ -61,8 +116,50 @@ def get_configuration(request):
 def test_rule_list(restart_required_logtest_daemons, get_configuration,
                    configure_environment, configure_rules_list,
                    wait_for_logtest_startup, connect_to_sockets_function):
-    """Check that every test case run on logtest generates the adequate output."""
+    '''
+    description: Check that after modifying the alert level it takes effect when opening a new logtest sessions, without
+                 having to reset the manager. To do this, it sends a request to logtest socket and get its response.
+                 Then, it checks that the expected alert matches.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
+        - configure_rules_list:
+            type: fixture
+            brief: Configure custom rules for testing.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that the result does not contain errors.
+        - Verify that the 'rule_id' sent matches with the result.
+        - Verify that the alert sent matches with the result.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'log_alert_level.yaml'.
+
+    expected_output:
+        - result.error == 0
+        - result.data.output.rule.id == test_case.rule_id
+        - result.data.alert == test_case.alert
+
+    tags:
+        - logtest_ruleset_refresh
+        - analysisd
+    '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)
 

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
 import pytest
 
@@ -30,7 +84,8 @@ receiver_sockets = None
 @pytest.fixture(scope='function')
 def configure_cdbs_list(get_configuration, request):
     """Configure a custom cdbs for testing.
-    Restart Wazuh is not needed for applying the configuration is optional.
+
+    Restarting Wazuh is not needed for applying the configuration, it is optional.
     """
 
     # cdb configuration for testing
@@ -73,8 +128,50 @@ def get_configuration(request):
 def test_cdb_list(restart_required_logtest_daemons, get_configuration,
                   configure_environment, configure_cdbs_list,
                   wait_for_logtest_startup, connect_to_sockets_function):
-    """Check that every test case run on logtest generates the adequate output."""
+    '''
+    description: Checks if modifying the configuration of the cdb list, by using its labels, takes effect when opening
+                 new logtest sessions without having to reset the manager. To do this, it sends a request to logtest
+                 socket with the test case and it checks that the result matches with the test case result.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
+        - configure_cdbs_list:
+            type: fixture
+            brief: Configure a custom cdbs for testing.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that the result does not contain errors.
+        - Verify that the result is from the cdb list.
+        - Verify that the 'rule_id' sent matches with the result.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'cdb_list.yaml'.
+
+    expected_output:
+        - result.error == 0
+        - cdb not in result.data.output
+        - result.data.output.rule.id == test_case.rule_id
+
+    tags:
+        - logtest_ruleset_refresh
+        - analysisd
+    '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)
 

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py
@@ -52,6 +52,7 @@ references:
     - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
     - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
     - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/cdb-list.html
 
 tags:
     - logtest_configuration
@@ -169,7 +170,8 @@ def test_cdb_list(restart_required_logtest_daemons, get_configuration,
         - result.data.output.rule.id == test_case.rule_id
 
     tags:
-        - logtest_ruleset_refresh
+        - cdb
+        - rules
         - analysisd
     '''
     # send the logtest request

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
 import pytest
 
@@ -30,7 +84,8 @@ receiver_sockets = None
 @pytest.fixture(scope='function')
 def configure_decoders_list(get_configuration, request):
     """Configure a custom decoder in local_decoder.xml for testing.
-    Restart Wazuh is needed for applying the configuration is optional.
+
+    Restarting Wazuh is needed for applying the configuration, it is optional.
     """
 
     # configuration for testing
@@ -61,8 +116,50 @@ def get_configuration(request):
 def test_rules_verbose(restart_required_logtest_daemons, get_configuration,
                        configure_environment, configure_decoders_list,
                        wait_for_logtest_startup, connect_to_sockets_function):
-    """Check that every test case run on logtest generates the adequate output."""
+    '''
+    description: Checks if modifying the configuration of the decoder, by using its labels, takes effect when opening
+                 new logtest sessions without having to reset the manager. To do this, it sends a request to logtest
+                 socket with the test case and it checks that the result matches with the test case.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
+        - configure_cdbs_list:
+            type: fixture
+            brief: Configure a custom cdbs for testing.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that the result does not contain errors.
+        - Verify that the result is from the decoder list.
+        - Verify that the 'rule_id' sent matches with the result.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'decoder_list.yaml'.
+
+    expected_output:
+        - result.error == 0
+        - name not in result.data.output.decoder
+        - result.data.output.decoder.name == test_case.decoder_name
+
+    tags:
+        - logtest_ruleset_refresh
+        - analysisd
+    '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)
 

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py
@@ -157,7 +157,7 @@ def test_rules_verbose(restart_required_logtest_daemons, get_configuration,
         - result.data.output.decoder.name == test_case.decoder_name
 
     tags:
-        - logtest_ruleset_refresh
+        - decoder
         - analysisd
     '''
     # send the logtest request

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples
+       remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work
+       parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through
+       the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest
+       configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.
+
+tier: 0
+
+modules:
+    - logtest
+
+components:
+    - manager
+
+daemons:
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html
+    - https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest
+    - https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html
+
+tags:
+    - logtest_configuration
+'''
 import os
 import pytest
 
@@ -61,8 +115,50 @@ def get_configuration(request):
 def test_rule_list(restart_required_logtest_daemons, get_configuration,
                    configure_environment, configure_rules_list,
                    wait_for_logtest_startup, connect_to_sockets_function):
-    """Check that every test case run on logtest generates the adequate output."""
+    '''
+    description: Checks if modifying the configuration of the decoder, by using its labels, takes effect when opening
+                 new logtest sessions without having to reset the manager. To do this, it sends a request to logtest
+                 socket with the test case and it checks that the result matches with the test case.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - restart_required_logtest_daemons:
+            type: fixture
+            brief: Wazuh logtests daemons handler.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
+        - configure_cdbs_list:
+            type: fixture
+            brief: Configure a custom cdbs for testing.
+        - wait_for_logtest_startup:
+            type: fixture
+            brief: Wait until logtest has begun.
+        - connect_to_sockets_function:
+            type: fixture
+            brief: Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test.
+
+    assertions:
+        - Verify that the result does not contain errors.
+        - Verify that the rule result is from the rule list.
+        - Verify that the 'rule_id' sent matches with the result.
+
+    input_description: Some test cases are defined in the module. These include some input configurations stored in
+                       the 'rule_list.yaml'.
+
+    expected_output:
+        - result.error == 0
+        - cdb not in result.data.output
+        - result.data.output.rule.id == test_case.rule_id
+
+    tags:
+        - logtest_ruleset_refresh
+        - analysisd
+    '''
     # send the logtest request
     receiver_sockets[0].send(get_configuration['input'], size=True)
 

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py
@@ -156,7 +156,7 @@ def test_rule_list(restart_required_logtest_daemons, get_configuration,
         - result.data.output.rule.id == test_case.rule_id
 
     tags:
-        - logtest_ruleset_refresh
+        - rules
         - analysisd
     '''
     # send the logtest request


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1814|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 

The schema used is the one defined in issue #1694


## New tags
The following tags are added to the wiki and tool: https://github.com/wazuh/wazuh-qa/commit/e7e517a6a47dacbb02d59d985563d497429dd31f


# Generated documentation


<details><summary>test_configuration_file.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_configuration_file.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_configuration/test_configuration_file.py",
    "tests": [
        {
            "description": "Checks if `wazuh-logtest` works as expected under different predefined configurations that cause `wazuh-logtest` to start correctly, to be disabled, or to register an error. To do this, it checks some values in these configurations from 'wazuh_conf.yaml' file.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing"
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Restart wazuh, ossec.log and start a new monitor."
                    }
                }
            ],
            "assertions": [
                "Verify that a valid configuration is loaded.",
                "Verify that wrong loaded configurations lead to an error."
            ],
            "input_description": "Five test cases are defined in the module. These include some configurations stored in the 'wazuh_conf.yaml'.",
            "expected_output": [
                "r'.* Logtest started'",
                "r'.* Logtest disabled'",
                "r'.* Invalid value for element'",
                "Event not found"
            ],
            "tags": [
                "settings",
                "analysisd"
            ],
            "name": "test_configuration_file",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_get_configuration_sock.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_get_configuration_sock.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_configuration/test_get_configuration_sock.py",
    "tests": [
        {
            "description": "Check analysis Unix socket returns the correct Logtest configuration under different sets of configurations, `wazuh-analisysd` returns the right information from the `rule_test` configuration block. To do this, it overwrites wrong field values and checks that the values within the received message after establishing a connection using the logtest AF_UNIX socket that uses TCP are the same that the loaded fields from the 'wazuh_conf.yaml' file.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing"
                    }
                },
                {
                    "restart_wazuh": {
                        "type": "fixture",
                        "brief": "Restart wazuh, ossec.log and start a new monitor."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that a valid configuration is loaded.",
                "Verify that wrong loaded configurations are fixed with limit values.",
                "Verify that each message field received matches the loaded configuration fields."
            ],
            "input_description": "Five test cases are defined in the module. These include some configurations stored in the 'wazuh_conf.yaml'.",
            "expected_output": [
                "Real message was: .*",
                "Expected value in enabled tag: .*. Value received: .*",
                "Expected value in threads tag: .*.  Value received: .*",
                "Expected value in max_sessions tag: .*.  Value received: .*",
                "Expected value in session_timeout tag: .*.  Value received: .*"
            ],
            "tags": [
                "settings",
                "analysisd"
            ],
            "name": "test_get_configuration_sock",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2",
                "get_configuration3",
                "get_configuration4"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_invalid_decoder_syntax.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_invalid_decoder_syntax.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py",
    "tests": [
        {
            "description": "Check if `wazuh-logtest` correctly detects and handles errors when processing a decoders file. To do this, it sends a logtest request using the input configurations and parses the logtest reply received looking for errors.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "configure_local_decoders": {
                        "type": "fixture",
                        "brief": "Configure a custom decoder for testing."
                    }
                },
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that `wazuh-logtest` retrieves errors when the loaded decoders are invalid."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'invalid_decoder_syntax.yaml'.",
            "expected_output": [
                "r'Failed stage(s): .*' (When an error occurs, it is appended)",
                "Error when executing {action} in daemon {daemon}. Exit status: {result}"
            ],
            "tags": [
                "errors",
                "invalid_settings",
                "decoder",
                "analysisd"
            ],
            "name": "test_invalid_decoder_syntax",
            "inputs": [
                "Invalid decoder syntax: garbage file",
                "Invalid decoder syntax: no closing XML tag",
                "Invalid decoder syntax: no existing parent",
                "Invalid decoder syntax: no existing attribute",
                "Invalid decoder syntax: decoder with no name",
                "Invalid decoder syntax: regex attribute without order attribute",
                "Invalid decoder syntax: regex attribute without prematch/program_name/parent attribute",
                "Invalid decoder syntax: order attribute without regex attribute",
                "Invalid decoder syntax: two-level order parenting",
                "Invalid decoder syntax: invalid plugin_decoder",
                "Invalid decoder syntax: invalid offset"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_invalid_rules_syntax.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_invalid_rules_syntax.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py",
    "tests": [
        {
            "description": "Check if `wazuh-logtest` correctly detects and handles errors when processing a rules file. To do this, it sends a logtest request(via AF_UNIX socket) using the input configurations and parses the logtest reply received looking for errors.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "configure_local_rules": {
                        "type": "fixture",
                        "brief": "Configure a custom rule in local_rules.xml for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that `wazuh-logtest` retrieves errors when the loaded rules are invalid."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'invalid_rules_syntax.yaml'.",
            "expected_output": [
                "r'Failed stage(s): .*' (When an error occurs, it is appended)",
                "Error when executing {action} in daemon {daemon}. Exit status: {result}"
            ],
            "tags": [
                "errors",
                "invalid_settings",
                "rules",
                "analysisd"
            ],
            "name": "test_invalid_rule_syntax",
            "inputs": [
                "Invalid rules syntax: garbage file",
                "Invalid rules syntax: no closing XML tag",
                "Invalid rules syntax: no group",
                "Invalid rules syntax: invalid level",
                "Invalid rules syntax: invalid rule overwrite",
                "Invalid rules syntax: same_* attribute without frequency and timeframe",
                "Invalid rules syntax: invalid weekday",
                "Invalid rules syntax: no existing if_sid rule number",
                "Invalid rules syntax: no existing if_matched_sid rule number attribute without frequency and timeframe",
                "Invalid rules syntax: non existing/invalid attribute",
                "Invalid rules syntax: no invalid rule label",
                "Invalid rules syntax: non existing group in if_group",
                "Invalid rules syntax: invalid values on option attribute",
                "Invalid rules syntax: different_* attribute without frequency and timeframe",
                "Invalid rules syntax: non existing decoder"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_invalid_socket_input.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_invalid_socket_input.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py",
    "tests": [
        {
            "description": "Check if `wazuh-logtest` correctly detects and handles errors when sending a message through the socket to `wazuh-analysisd`. To do this, it sends the inputs through a socket(differentiating by oversized messages), receives and decodes the message. Then, that message is compared with the test case output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of test_case stages. (dicts with input, output and stage keys)"
                    }
                }
            ],
            "assertions": [
                "Verify that the communication through the sockets works well by verifying that all the test cases produce the right output.",
                "Verify that oversized messages log an error."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'invalid_socket_input.yaml'.",
            "expected_output": [
                "r'Failed test case stage <test_case_index>: .*'"
            ],
            "tags": [
                "errors",
                "analysisd"
            ],
            "name": "test_invalid_socket_input",
            "inputs": [
                "Json malformed (Missing \")",
                "Missing event",
                "Bad type num - event",
                "Bad type array - event",
                "Bad type bool - event",
                "Null event",
                "Missing log_format",
                "Bad type num - log_format",
                "Bad type array - log_format",
                "Bad type bool - log_format",
                "Null log_format",
                "Missing location",
                "Bad type num - location",
                "Bad type array - location",
                "Bad type bool - location",
                "Null location",
                "Missing event/log_format",
                "Missing event/location",
                "Missing log_format/location",
                "Missing event/log_format/location",
                "Command not found",
                "Invalid command type - num",
                "Invalid command type - bool",
                "Invalid command type - array",
                "Invalid command type - Object",
                "Oversize message"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_invalid_session_token.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_invalid_session_token.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py",
    "tests": [
        {
            "description": "Check if `wazuh-logtest` correctly detects and handles errors when using a session token. To do this, it sends the inputs through a socket, receives and decodes the message. Then, it checks if any invalid token or session token is not caught.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of test_case stages (dicts with input, output and stage keys)"
                    }
                }
            ],
            "assertions": [
                "Verify that new session is correctly initialized.",
                "Verify that invalid session token is received.",
                "Verify that errors are retrieved due to invalid session tokens."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'invalid_session_token.yaml'.",
            "expected_output": [
                "r'Failed test case stage(s): .*' (When an error occurs, it is appended)",
                "r'.*: .* is not a valid token' (An error that could be appended)",
                "r'.*: Session initialized with token .*' (An error that could be appended)",
                "Error when executing .* in daemon .*. Exit status: .*"
            ],
            "tags": [
                "session_error",
                "analysisd"
            ],
            "name": "test_invalid_session_token",
            "inputs": [
                "Invalid token lenght",
                "Invalid token data type(number)",
                "Invalid token data type(boolean)",
                "Invalid token data type(null)",
                "Invalid token data type(array)",
                "Invalid token data type(json object)"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_rules_verbose.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_rules_verbose.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py",
    "tests": [
        {
            "description": "Check if 'wazuh-logtest' works correctly in 'verbose' mode for rules debugging. To do this, it sends the inputs through a socket, receives and decodes the message. Then, it checks if any invalid token or session token is not caught.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "configure_rules_list": {
                        "type": "fixture",
                        "brief": "Configure a custom rules for testing. Restart Wazuh is not needed for applying the configuration is optional."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the logtest reply message has no run error.",
                "Verify that the 'rule_id' within the reply message is correct.",
                "Verify that logtest is running in verbose mode.",
                "Verify that when running in verbose mode the local rule debug messages has been written",
                "Verify that when running in verbose mode the local rule debug messages written are the expected count.",
                "Verify that if a warning message is caught it matches with any test case message."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'rules_verbose.yaml'.",
            "expected_output": [
                "The rules_debug field was not found in the response data",
                "The warning message was not found in the response data",
                "Error when executing .* in daemon .*. Exit status: .*"
            ],
            "tags": [
                "settings",
                "analysisd"
            ],
            "name": "test_rules_verbose",
            "inputs": [
                "rules_debug_omitted",
                "rules_debug_true",
                "rules_debug_false",
                "rules_debug_bad_type_string",
                "rules_debug_bad_type_number",
                "rules_debug_bad_type_object",
                "rules_debug_bad_type_array",
                "options_bad_type_boolean",
                "options_bad_type_array",
                "options_bad_type_number",
                "options_bad_type_string"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_remove_old_session_for_inactivity.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html",
        "https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#analysisd"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_remove_old_session_for_inactivity.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py",
    "tests": [
        {
            "description": "Check if 'wazuh-logtest' correctly detects and handles the situation where trying to remove old sessions due to inactivity. To do this, it creates more sessions than allowed and waits session_timeout seconds, then checks that 'wazuh-logtest' has removed the session due to inactivity.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "configure_local_internal_options_module": {
                        "type": "fixture",
                        "brief": "Configure the local internal options file."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "file_monitoring": {
                        "type": "fixture",
                        "brief": "Handle the monitoring of a specified file."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the session is created.",
                "Verify that the old session is removed after 'session_timeout' delay due to inactivity."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'wazuh_conf.yaml' and the session creation data from the module.",
            "expected_output": [
                "Session initialization event not found",
                "Session removal event not found",
                "r'Error when executing .* in daemon .*. Exit status: .*'"
            ],
            "tags": [
                "inactivity",
                "analysisd"
            ],
            "name": "test_remove_old_session_for_inactivity",
            "inputs": [
                "get_configuration0"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_remove_old_sessions.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_remove_old_sessions.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py",
    "tests": [
        {
            "description": "Check if 'wazuh-logtest' correctly detects and handles the situation where trying to use more sessions than allowed. To do this, it creates more sessions than allowed and wait for the message which informs that 'wazuh-logtest' has removed the oldest session.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "configure_local_internal_options_module": {
                        "type": "fixture",
                        "brief": "Configure the local internal options file."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configuration from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "file_monitoring": {
                        "type": "fixture",
                        "brief": "Handle the monitoring of a specified file."
                    }
                },
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                }
            ],
            "assertions": [
                "Verify that the session will exceed the allowed sessions with the last one to verify that the first(oldest) session is correctly removed.",
                "Verify that every session is correctly created.",
                "Verify that the first session is valid.",
                "Verify that the 'removal session' is created.",
                "Verify that the removed session is the first one.",
                "Verify that the session that exceeds the limit is created."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'wazuh_conf.yaml' and the session creation data from the module.",
            "expected_output": [
                "Session initialization event not found",
                "Session removal event not found",
                "Incorrect session removed",
                "r'Error when executing .* in daemon .*. Exit status: .*'"
            ],
            "tags": [
                "session_limit",
                "analysisd"
            ],
            "name": "test_remove_old_session",
            "inputs": [
                "get_configuration0"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_remove_session.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_remove_session.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_remove_session/test_remove_session.py",
    "tests": [
        {
            "description": "Check if 'wazuh-logtest' correctly detects and removes the sessions under pre-defined scenarios. To do this, the session input is sent and the output is received, then it checks if the received data within the logtest socket is the same that the test case expected output.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of test_case stages. (dicts with input, output and stage keys)"
                    }
                }
            ],
            "assertions": [
                "Verify that every test case output matches with the actual received."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'remove_session.yaml' and the session creation data from the module.",
            "expected_output": [
                "r'Failed test case stage <test_case_index>: .*'"
            ],
            "tags": [
                "analysisd"
            ],
            "name": "test_remove_session",
            "inputs": [
                "Remove invalid numeric token",
                "Remove invalid json",
                "Remove invalid empty json object token",
                "Remove invalid array token",
                "Remove invalid token null",
                "Remove invalid boolean token ",
                "Remove invalid token len",
                "Remove non-exist session",
                "Remove session OK"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_load_rules_decoders.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_load_rules_decoders.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py",
    "tests": [
        {
            "description": "Check if 'wazuh-logtest' does produce the right decoder/rule matching when processing a log under different sets of configurations. To do this, It creates backup rules and decoders and copies the test case rules and decoders to restore after the checks. It sends the requests to the logtest socket and checks if the outputs match with the expected test cases.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                },
                {
                    "test_case": {
                        "type": "list",
                        "brief": "List of test_case stages. (dicts with input, output and stage keys)"
                    }
                }
            ],
            "assertions": [
                "Verify that the predecoder output matches with test case expected.",
                "Verify that the decoder output matches with test case expected.",
                "Verify that the rule output matches with test case expected.",
                "Verify that the alert output matches with test case expected."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'remove_session.yaml' and the dummy session from the module.",
            "expected_output": [
                "r'Failed stage(s) :.*'"
            ],
            "tags": [
                "decoder",
                "rules",
                "analysisd"
            ],
            "name": "test_load_rules_decoders",
            "inputs": [
                "Default ruleset - Simple",
                "Default ruleset - Group",
                "Default ruleset - Frequency (same user)",
                "Custom ruleset and decoder - Simple",
                "Custom ruleset and decoder - Group match",
                "Custom ruleset and decoder - Frecuency (same field)"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_alert_labels.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_alert_labels.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py",
    "tests": [
        {
            "description": "Check that after modifying the alert level it takes effect when opening new logtest sessions, without having to reset the manager. To do this, it sends a request to logtest socket and gets its response. Then, it checks that the expected alert matches.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "configure_rules_list": {
                        "type": "fixture",
                        "brief": "Configure custom rules for testing."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the result does not contain errors.",
                "Verify that the 'rule_id' sent matches with the result.",
                "Verify that the alert sent matches with the result."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'log_alert_level.yaml'.",
            "expected_output": [
                "result.error == 0",
                "result.data.output.rule.id == test_case.rule_id",
                "result.data.alert == test_case.alert"
            ],
            "tags": [
                "rules",
                "analysisd"
            ],
            "name": "test_rule_list",
            "inputs": [
                "check_no_alerts_default_log_alert_level",
                "check_alert_default_log_alert_level",
                "check_no_alerts_log_alert_level_8",
                "check_alert_log_alert_level_8"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_cdb_labels.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/cdb-list.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_cdb_labels.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py",
    "tests": [
        {
            "description": "Checks if modifying the configuration of the cdb list, by using its labels, takes effect when opening new logtest sessions without having to reset the manager. To do this, it sends a request to logtest socket with the test case and it checks that the result matches with the test case result.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "configure_cdbs_list": {
                        "type": "fixture",
                        "brief": "Configure a custom cdbs for testing."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the result does not contain errors.",
                "Verify that the result is from the cdb list.",
                "Verify that the 'rule_id' sent matches with the result."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'cdb_list.yaml'.",
            "expected_output": [
                "result.error == 0",
                "cdb not in result.data.output",
                "result.data.output.rule.id == test_case.rule_id"
            ],
            "tags": [
                "cdb",
                "rules",
                "analysisd"
            ],
            "name": "test_cdb_list",
            "inputs": [
                "check_list_label"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_decoder_labels.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_decoder_labels.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py",
    "tests": [
        {
            "description": "Checks if modifying the configuration of the decoder, by using its labels, takes effect when opening new logtest sessions without having to reset the manager. To do this, it sends a request to logtest socket with the test case and it checks that the result matches with the test case.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "configure_cdbs_list": {
                        "type": "fixture",
                        "brief": "Configure a custom cdbs for testing."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the result does not contain errors.",
                "Verify that the result is from the decoder list.",
                "Verify that the 'rule_id' sent matches with the result."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'decoder_list.yaml'.",
            "expected_output": [
                "result.error == 0",
                "name not in result.data.output.decoder",
                "result.data.output.decoder.name == test_case.decoder_name"
            ],
            "tags": [
                "decoder",
                "analysisd"
            ],
            "name": "test_rules_verbose",
            "inputs": [
                "check_loading_files_default_directory",
                "check_decoder_dir_label",
                "check_decoder_include_label",
                "check_decoder_exclude_label"
            ]
        }
    ]
}

```
</p>
</details>

<details><summary>test_rule_labels.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "The 'wazuh-logtest' tool allows the testing and verification of rules and decoders against provided log examples remotely inside a sandbox in 'wazuh-analysisd'. This functionality is provided by the manager, whose work parameters are configured in the ossec.conf file in the XML rule_test section. Test logs can be evaluated through the 'wazuh-logtest' tool or by making requests via RESTful API. These tests will check if the logtest configuration is valid. Also checks rules, decoders, decoders, alerts matching logs correctly.",
    "tier": 0,
    "modules": [
        "logtest"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/reference/tools/wazuh-logtest.html",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/index.html",
        "https://documentation.wazuh.com/current/user-manual/ruleset/testing.html?highlight=logtest",
        "https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-logtest/logtest-configuration.html",
        "https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-analysisd.html"
    ],
    "tags": [
        "logtest_configuration"
    ],
    "name": "test_rule_labels.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py",
    "tests": [
        {
            "description": "Checks if modifying the configuration of the decoder, by using its labels, takes effect when opening new logtest sessions without having to reset the manager. To do this, it sends a request to logtest socket with the test case and it checks that the result matches with the test case.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "restart_required_logtest_daemons": {
                        "type": "fixture",
                        "brief": "Wazuh logtests daemons handler."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration."
                    }
                },
                {
                    "configure_cdbs_list": {
                        "type": "fixture",
                        "brief": "Configure a custom cdbs for testing."
                    }
                },
                {
                    "wait_for_logtest_startup": {
                        "type": "fixture",
                        "brief": "Wait until logtest has begun."
                    }
                },
                {
                    "connect_to_sockets_function": {
                        "type": "fixture",
                        "brief": "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."
                    }
                }
            ],
            "assertions": [
                "Verify that the result does not contain errors.",
                "Verify that the rule result is from the rule list.",
                "Verify that the 'rule_id' sent matches with the result."
            ],
            "input_description": "Some test cases are defined in the module. These include some input configurations stored in the 'rule_list.yaml'.",
            "expected_output": [
                "result.error == 0",
                "cdb not in result.data.output",
                "result.data.output.rule.id == test_case.rule_id"
            ],
            "tags": [
                "rules",
                "analysisd"
            ],
            "name": "test_rule_list",
            "inputs": [
                "check_loading_files_default_directory",
                "check_rule_dir_label",
                "check_rule_include_label",
                "check_rule_exclude_label"
            ]
        }
    ]
}

```
</p>
</details>

## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The `qa-docs` tool does not raise any error.