### PR TITLE
Implement Authd tests code improvements.

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -159,3 +159,29 @@ def query_wdb(command):
         sock.close()
 
     return data
+
+
+def clean_agents_from_db():
+    """
+    Clean agents from DB
+    """
+    command = 'global sql DELETE FROM agent WHERE id != 0'
+    try:
+        query_wdb(command)
+    except Exception:
+        raise Exception('Unable to clean agents')
+
+
+def insert_agent_in_db(id=1, name='TestAgent', ip='any', registration_time=0, connection_status=0,
+                       disconnection_time=0):
+    """
+    Write agent in global.db
+    """
+    insert_command = f'global insert-agent {{"id":{id},"name":"{name}","ip":"{ip}","date_add":{registration_time}}}'
+    update_command = f'global sql UPDATE agent SET connection_status = "{connection_status}",\
+                       disconnection_time = "{disconnection_time}" WHERE id = {id};'
+    try:
+        query_wdb(insert_command)
+        query_wdb(update_command)
+    except Exception:
+        raise Exception(f"Unable to add agent {id}")

--- a/tests/integration/test_authd/conftest.py
+++ b/tests/integration/test_authd/conftest.py
@@ -1,15 +1,15 @@
 import pytest
+import time
 import os
 import yaml
+
 from wazuh_testing.tools import LOG_FILE_PATH, CLIENT_KEYS_PATH
+from wazuh_testing.wazuh_db import insert_agent_in_db, clean_agents_from_db
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor, make_callback, AUTHD_DETECTOR_PREFIX
 from wazuh_testing.tools.configuration import write_wazuh_conf, get_wazuh_conf, set_section_wazuh_conf,\
                                               load_wazuh_configurations
-from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs
-from wazuh_testing.tools.monitoring import QueueMonitor
-
-
+from wazuh_testing.tools.services import control_service
 from wazuh_testing.authd import DAEMON_NAME
 
 
@@ -149,3 +149,42 @@ def override_authd_force_conf(format_configuration):
 
     # Restore previous configuration
     write_wazuh_conf(backup_config)
+
+
+@pytest.fixture(scope='function')
+def insert_pre_existent_agents(get_current_test_case, stop_authd_function):
+    agents = get_current_test_case.get('pre_existent_agents', [])
+    time_now = int(time.time())
+    try:
+        keys_file = open(CLIENT_KEYS_PATH, 'w')
+    except IOError as exception:
+        raise exception
+
+    clean_agents_from_db()
+
+    for agent in agents:
+        id = agent['id'] if 'id' in agent else '001'
+        name = agent['name'] if 'name' in agent else f'TestAgent{id}'
+        ip = agent['ip'] if 'ip' in agent else 'any'
+        key = agent['key'] if 'key' in agent else 'TopSecret'
+        connection_status = agent['connection_status'] if 'connection_status' in agent else 'never_connected'
+        if 'disconnection_time' in agent and 'delta' in agent['disconnection_time']:
+            disconnection_time = time_now + agent['disconnection_time']['delta']
+        elif 'disconnection_time' in agent and 'value' in agent['disconnection_time']:
+            disconnection_time = agent['disconnection_time']['value']
+        else:
+            disconnection_time = time_now
+        if 'registration_time' in agent and 'delta' in agent['registration_time']:
+            registration_time = time_now + agent['registration_time']['delta']
+        elif 'registration_time' in agent and 'value' in agent['registration_time']:
+            registration_time = agent['registration_time']['value']
+        else:
+            registration_time = time_now
+
+        # Write agent in client.keys
+        keys_file.write(f'{id} {name} {ip} {key}\n')
+
+        # Write agent in global.db
+        insert_agent_in_db(id, name, ip, registration_time, connection_status, disconnection_time)
+
+    keys_file.close()

--- a/tests/integration/test_authd/conftest.py
+++ b/tests/integration/test_authd/conftest.py
@@ -164,7 +164,7 @@ def insert_pre_existent_agents(get_current_test_case, stop_authd_function):
 
     for agent in agents:
         id = agent['id'] if 'id' in agent else '001'
-        name = agent['name'] if 'name' in agent else f'TestAgent{id}'
+        name = agent['name'] if 'name' in agent else f"TestAgent{id}"
         ip = agent['ip'] if 'ip' in agent else 'any'
         key = agent['key'] if 'key' in agent else 'TopSecret'
         connection_status = agent['connection_status'] if 'connection_status' in agent else 'never_connected'
@@ -182,7 +182,7 @@ def insert_pre_existent_agents(get_current_test_case, stop_authd_function):
             registration_time = time_now
 
         # Write agent in client.keys
-        keys_file.write(f'{id} {name} {ip} {key}\n')
+        keys_file.write(f"{id} {name} {ip} {key}\n")
 
         # Write agent in global.db
         insert_agent_in_db(id, name, ip, registration_time, connection_status, disconnection_time)

--- a/tests/integration/test_authd/force_options/README.md
+++ b/tests/integration/test_authd/force_options/README.md
@@ -1,2 +1,0 @@
-# force options tests
-These tests aim to check the correct behavior of Authd under the different possible configurations of the force block.

--- a/tests/integration/test_authd/force_options/test_authd_force_options.py
+++ b/tests/integration/test_authd/force_options/test_authd_force_options.py
@@ -46,15 +46,16 @@ os_version:
 
 tags:
     - enrollment
+    - authd
 '''
 import os
 import time
 import pytest
-from wazuh_testing.tools.monitoring import make_callback, AUTHD_DETECTOR_PREFIX
+
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.file import read_yaml
 from wazuh_testing.authd import create_authd_request, validate_authd_response, validate_authd_logs, \
-                                insert_pre_existent_agents, AUTHD_KEY_REQUEST_TIMEOUT
+                                AUTHD_KEY_REQUEST_TIMEOUT
 
 
 # Data paths
@@ -70,7 +71,7 @@ local_internal_options = {'authd.debug': '2'}
 tests = []
 test_case_ids = []
 for file in os.listdir(tests_path):
-    group_name = file.split(".")[0]
+    group_name = file.split('.')[0]
     file_tests = read_yaml(os.path.join(tests_path, file))
     tests = tests + file_tests
     test_case_ids = test_case_ids + [f"{group_name} {test_case['name']}" for test_case in file_tests]
@@ -78,7 +79,7 @@ for file in os.listdir(tests_path):
 # Variables
 log_monitor_paths = []
 
-receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
+receiver_sockets_params = [(('localhost', 1515), 'AF_INET', 'SSL_TLSv1_2')]
 monitored_sockets_params = [('wazuh-authd', None, True), ('wazuh-db', None, True)]
 receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
 

--- a/tests/integration/test_authd/force_options/test_authd_force_options_invalid_config.py
+++ b/tests/integration/test_authd/force_options/test_authd_force_options_invalid_config.py
@@ -45,6 +45,7 @@ os_version:
 
 tags:
     - enrollment
+    - authd
 '''
 import os
 import pytest
@@ -68,7 +69,7 @@ local_internal_options = {'authd.debug': '2'}
 tests = []
 test_case_ids = []
 for file in os.listdir(tests_path):
-    group_name = file.split(".")[0]
+    group_name = file.split('.')[0]
     file_tests = read_yaml(os.path.join(tests_path, file))
     tests = tests + file_tests
     test_case_ids = test_case_ids + [f"{group_name} {test_case['name']}" for test_case in file_tests]
@@ -135,9 +136,9 @@ def test_authd_force_options_invalid_config(get_current_test_case, configure_loc
 
     truncate_file(LOG_FILE_PATH)
     try:
-        control_service("restart", daemon=DAEMON_NAME)
+        control_service('restart', daemon=DAEMON_NAME)
     except Exception:
         pass
     else:
-        raise Exception("Authd started when it was expected to fail")
+        raise Exception('Authd started when it was expected to fail')
     validate_authd_logs(get_current_test_case.get('log', []))

--- a/tests/integration/test_authd/test_authd_key_hash.py
+++ b/tests/integration/test_authd/test_authd_key_hash.py
@@ -51,11 +51,9 @@ import subprocess
 import time
 
 import pytest
-from wazuh_testing.tools import CLIENT_KEYS_PATH, LOG_FILE_PATH, WAZUH_DB_SOCKET_PATH
+from wazuh_testing.tools import WAZUH_DB_SOCKET_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.services import control_service
-from wazuh_testing.tools.file import read_yaml, truncate_file
-from wazuh_testing.authd import DAEMON_NAME, insert_pre_existent_agents
+from wazuh_testing.tools.file import read_yaml
 
 # Marks
 

--- a/tests/integration/test_authd/test_authd_local.py
+++ b/tests/integration/test_authd/test_authd_local.py
@@ -51,15 +51,10 @@ import os
 import subprocess
 
 import pytest
-import yaml
-import time
 
-from wazuh_testing.tools import WAZUH_PATH, CLIENT_KEYS_PATH, WAZUH_DB_SOCKET_PATH
+from wazuh_testing.tools import WAZUH_PATH, WAZUH_DB_SOCKET_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.wazuh_db import query_wdb
-from wazuh_testing.tools.services import control_service
-from wazuh_testing.tools.file import read_yaml, truncate_file
-from wazuh_testing.authd import insert_pre_existent_agents
+from wazuh_testing.tools.file import read_yaml
 
 # Marks
 


### PR DESCRIPTION
|Related issue|
|---|
|#2184|

## Description
This PR implements all the pending suggestions from https://github.com/wazuh/wazuh-qa/pull/2171.
Basically:
- It fixes all the code style observations.
- Relocates **Authd.py** methods related to **Wazuh-db** into **wazuh-db.py**
- Relocates **Authd.py** fixtures into the **Authd** contest .
- Refactor **validate_authd_response()** logic to be more readable.
- Removes a deprecated README file with the test group definition.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [X] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [X] Python codebase is documented following the Google Style for Python docstrings.
- [X] The test is documented in following the DocGenerator schema V2.0