### PR TITLE
Syscollector delta handling IT improvements

### DIFF
--- a/tests/integration/test_analysisd/test_syscollector/data/network_address.schema
+++ b/tests/integration/test_analysisd/test_syscollector/data/network_address.schema
@@ -368,9 +368,7 @@
                             "required": [
                                 "iface",
                                 "proto",
-                                "address",
-                                "netmask",
-                                "broadcast"
+                                "address"
                             ],
                             "properties": {
                                 "iface": {

--- a/tests/integration/test_analysisd/test_syscollector/data/network_iface.schema
+++ b/tests/integration/test_analysisd/test_syscollector/data/network_iface.schema
@@ -402,20 +402,7 @@
                                 }
                             ],
                             "required": [
-                                "name",
-                                "adapter",
-                                "type",
-                                "state",
-                                "mtu",
-                                "mac",
-                                "tx_packets",
-                                "rx_packets",
-                                "tx_bytes",
-                                "rx_bytes",
-                                "tx_errors",
-                                "rx_errors",
-                                "tx_dropped",
-                                "rx_dropped"
+                                "name"
                             ],
                             "properties": {
                                 "name": {

--- a/tests/integration/test_analysisd/test_syscollector/data/network_protocol.schema
+++ b/tests/integration/test_analysisd/test_syscollector/data/network_protocol.schema
@@ -367,10 +367,7 @@
                             ],
                             "required": [
                                 "iface",
-                                "type",
-                                "gateway",
-                                "dhcp",
-                                "metric"
+                                "type"
                             ],
                             "properties": {
                                 "iface": {

--- a/tests/integration/test_analysisd/test_syscollector/data/osinfo.schema
+++ b/tests/integration/test_analysisd/test_syscollector/data/osinfo.schema
@@ -356,16 +356,7 @@
                         }
                     ],
                     "required": [
-                        "hostname",
-                        "architecture",
-                        "name",
-                        "version",
-                        "codename",
-                        "major",
-                        "minor",
-                        "patch",
-                        "build",
-                        "platform"
+                        "name"
                     ],
                     "properties": {
                         "hostname": {

--- a/tests/integration/test_analysisd/test_syscollector/data/packages.schema
+++ b/tests/integration/test_analysisd/test_syscollector/data/packages.schema
@@ -362,18 +362,9 @@
                         }
                     ],
                     "required": [
-                        "format",
                         "name",
-                        "priority",
-                        "size",
-                        "vendor",
-                        "install_time",
                         "version",
-                        "architecture",
-                        "multiarch",
-                        "source",
-                        "description",
-                        "location"
+                        "architecture"
                     ],
                     "properties": {
                         "format": {

--- a/tests/integration/test_analysisd/test_syscollector/data/ports.schema
+++ b/tests/integration/test_analysisd/test_syscollector/data/ports.schema
@@ -321,14 +321,7 @@
                         "protocol",
                         "local_ip",
                         "local_port",
-                        "remote_ip",
-                        "remote_port",
-                        "tx_queue",
-                        "rx_queue",
-                        "inode",
-                        "state",
-                        "pid",
-                        "process"
+                        "inode"
                     ],
                     "properties": {
                         "protocol": {

--- a/tests/integration/test_analysisd/test_syscollector/data/syscollector.yaml
+++ b/tests/integration/test_analysisd/test_syscollector/data/syscollector.yaml
@@ -2,221 +2,173 @@
 -
   name: 'Test syscollector events'
   rule_file: 'syscollector_rules.xml'
-  event_header: 'd:[001] (myhostname) any->syscollector:'
+  event_header: '(myhostname) any->syscollector:'
   test_case:
   -
     description: 'Process creation'
     event_payload: '{"data":{"argvs":"180","checksum":"343ed10dc637334a7400d01b8a28deb8db5cba28","cmd":"sleep","egroup":"root","euser":"root","fgroup":"root","name":"sleep","nice":0,"nlwp":1,"pgrp":116167,"pid":"156102","ppid":116169,"priority":20,"processor":3,"resident":129,"rgroup":"root","ruser":"root","scan_time":"2021/10/13 14:57:07","session":116167,"sgroup":"root","share":114,"size":2019,"start_time":5799612,"state":"S","stime":0,"suser":"root","tgid":156102,"tty":0,"utime":0,"vm_size":8076},"operation":"INSERTED","type":"dbsync_processes"}'
-    alert_expected_schema : 'processes.schema'
+#   alert_expected_schema : 'processes.schema'
     alert_expected_values:
       rule.id: '100301'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_processes","process":{"pid":"156102","name":"sleep","state":"S","ppid":"116169","utime":"0","stime":"0","cmd":"sleep","args":"180","euser":"root","ruser":"root","suser":"root","egroup":"root","rgroup":"root","sgroup":"root","fgroup":"root","priority":"20","nice":"0","size":"2019","vm_size":"8076","resident":"129","share":"114","start_time":"5799612","pgrp":"116167","session":"116167","nlwp":"1","tgid":"156102","tty":"0","processor":"3"},"operation_type":"INSERTED"}'
   -
     description: 'Process modification'
-    event_payload: '{"data":{"checksum":"45cb0637a5b43ed1a819ac6cb4cf4d6d4f15f871","pid":"156102","processor":0,"scan_time":"2021/10/07 13:08:19","stime":72,"utime":54},"operation":"MODIFIED","type":"dbsync_processes"}'
-    alert_expected_schema : 'processes.schema'
+    event_payload: '{"data":{"checksum":"45cb0637a5b43ed1a819ac6cb4cf4d6d4f15f871","pid":"156102","processor":0,"scan_time":"2021/10/07 13:08:19","stime":72,"utime":54,"egroup":null,"rgroup":"NULL","fgroup":"piped|value"},"operation":"MODIFIED","type":"dbsync_processes"}'
+#   alert_expected_schema : 'processes.schema'
     alert_expected_values:
       rule.id: '100302'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_processes","process":{"pid":"156102","name":"sleep","state":"S","ppid":"116169","utime":"54","stime":"72","cmd":"sleep","args":"180","euser":"root","ruser":"root","suser":"root","rgroup":"NULL","sgroup":"root","fgroup":"piped|value","priority":"20","nice":"0","size":"2019","vm_size":"8076","resident":"129","share":"114","start_time":"5799612","pgrp":"116167","session":"116167","nlwp":"1","tgid":"156102","tty":"0","processor":"0"},"operation_type":"MODIFIED"}'
   -
     description: 'Process deletion'
     event_payload: '{"data":{"pid":"156102","scan_time":"2021/10/13 15:55:03"},"operation":"DELETED","type":"dbsync_processes"}'
-    alert_expected_schema : 'processes.schema'
+#   alert_expected_schema : 'processes.schema'
     alert_expected_values:
       rule.id: '100303'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_processes","process":{"pid":"156102","name":"sleep","state":"S","ppid":"116169","utime":"54","stime":"72","cmd":"sleep","args":"180","euser":"root","ruser":"root","suser":"root","rgroup":"NULL","sgroup":"root","fgroup":"piped|value","priority":"20","nice":"0","size":"2019","vm_size":"8076","resident":"129","share":"114","start_time":"5799612","pgrp":"116167","session":"116167","nlwp":"1","tgid":"156102","tty":"0","processor":"0"},"operation_type":"DELETED"}'
   -
     description: 'Port creation'
     event_payload: '{"data":{"checksum":"eff13e52290143eb5b5b9b8c191902609f37c712","inode":494908,"item_id":"e2c92964ad145a635139f6318057506e386e00a3","local_ip":"0.0.0.0","local_port":34340,"pid":0,"process":null,"protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"scan_time":"2021/10/13 14:40:02","state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"}'
-    alert_expected_schema : 'ports.schema'
+#   alert_expected_schema : 'ports.schema'
     alert_expected_values:
       rule.id: '100311'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_ports","port":{"protocol":"tcp","local_ip":"0.0.0.0","local_port":"34340","remote_ip":"0.0.0.0","remote_port":"0","tx_queue":"0","rx_queue":"0","inode":"494908","state":"listening","pid":"0"},"operation_type":"INSERTED"}'
   -
     description: 'Port modification'
-    event_payload: '{"data":{"checksum":"eff13e52290143eb5b5b9b8c191902609f37c713","inode":494908,"local_ip":"0.0.0.0","local_port":34340,"protocol":"tcp","scan_time":"2021/10/13 14:40:30","tx_queue":1000},"operation":"MODIFIED","type":"dbsync_ports"}'
-    alert_expected_schema : 'ports.schema'
+    event_payload: '{"data":{"checksum":"eff13e52290143eb5b5b9b8c191902609f37c713","inode":494908,"local_ip":"0.0.0.0","local_port":34340,"protocol":"tcp","scan_time":"2021/10/13 14:40:30","tx_queue":1000,"state":"NULL","remote_ip":"piped|value"},"operation":"MODIFIED","type":"dbsync_ports"}'
+#   alert_expected_schema : 'ports.schema'
     alert_expected_values:
       rule.id: '100312'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_ports","port":{"protocol":"tcp","local_ip":"0.0.0.0","local_port":"34340","remote_ip":"piped|value","remote_port":"0","tx_queue":"1000","rx_queue":"0","inode":"494908","state":"NULL","pid":"0"},"operation_type":"MODIFIED"}'
   -
     description: 'Port deletion'
     event_payload: '{"data":{"inode":494908,"local_ip":"0.0.0.0","local_port":34340,"protocol":"tcp","scan_time":"2021/10/13 14:40:43"},"operation":"DELETED","type":"dbsync_ports"}'
-    alert_expected_schema : 'ports.schema'
+#   alert_expected_schema : 'ports.schema'
     alert_expected_values:
       rule.id: '100313'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_ports","port":{"protocol":"tcp","local_ip":"0.0.0.0","local_port":"34340","remote_ip":"piped|value","remote_port":"0","tx_queue":"1000","rx_queue":"0","inode":"494908","state":"NULL","pid":"0"},"operation_type":"DELETED"}'
   -
     description: 'Osinfo creation'
     event_payload: '{"data":{"checksum":"1634140017886803554","architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601","os_display_version":"test"},"operation":"INSERTED","type":"dbsync_osinfo"}'
-    alert_expected_schema : 'osinfo.schema'
+#   alert_expected_schema : 'osinfo.schema'
     alert_expected_values:
       rule.id: '100321'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_osinfo","os":{"hostname":"UBUNTU","architecture":"x86_64","name":"Microsoft Windows 7","version":"6.1.7601","major":"6","minor":"1","build":"7601","os_release":"sp1","display_version":"test"},"operation_type":"INSERTED"}'
   -
     description: 'Osinfo modification'
     event_payload: '{"data":{"checksum":"1634140017886803555", "os_name":"Microsoft Windows 7","os_build":"7602","scan_time":"2021/10/13 14:41:43"},"operation":"MODIFIED","type":"dbsync_osinfo"}'
-    alert_expected_schema : 'osinfo.schema'
+#   alert_expected_schema : 'osinfo.schema'
     alert_expected_values:
       rule.id: '100322'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
-#  -
-#    description: 'Osinfo deletion'
-#    event_payload: ''
-#    alert_expected_schema : 'osinfo.schema'
-#    alert_expected_values:
-#      rule.id: '100323'
-#      agent.id: '001'
-#      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_osinfo","os":{"hostname":"UBUNTU","architecture":"x86_64","name":"Microsoft Windows 7","version":"6.1.7601","major":"6","minor":"1","build":"7602","os_release":"sp1","display_version":"1634140017886803554"},"operation_type":"MODIFIED"}'
   -
     description: 'Hwinfo creation'
     event_payload: '{"data":{"scan_time":"2021/10/13 14:41:43","board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"}'
-    alert_expected_schema : 'hwinfo.schema'
+#   alert_expected_schema : 'hwinfo.schema'
     alert_expected_values:
       rule.id: '100331'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_hwinfo","hardware":{"serial":"Intel Corporation","cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","cpu_cores":"2","cpu_mhz":"2904","ram_total":"4972208","ram_free":"2257872","ram_usage":"54"},"operation_type":"INSERTED"}'
   -
     description: 'Hwinfo modification'
     event_payload: '{"data":{"scan_time":"2021/10/13 14:42:43","board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d2896391a","ram_usage":99},"operation":"MODIFIED","type":"dbsync_hwinfo"}'
-    alert_expected_schema : 'hwinfo.schema'
+#   alert_expected_schema : 'hwinfo.schema'
     alert_expected_values:
       rule.id: '100332'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
-#  -
-#    description: 'Hwinfo deletion'
-#    event_payload: ''
-#    alert_expected_schema : 'hwinfo.schema'
-#    alert_expected_values:
-#      rule.id: '100333'
-#      agent.id: '001'
-#      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_hwinfo","hardware":{"serial":"Intel Corporation","cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","cpu_cores":"2","cpu_mhz":"2904.0","ram_total":"4972208","ram_free":"2257872","ram_usage":"99"},"operation_type":"MODIFIED"}'
   -
     description: 'Package creation'
     event_payload: '{"data":{"architecture":"amd64","checksum":"1c1bf8bbc20caef77010f960461cc20fb9c67568","description":"Qt 5 OpenGL module","format":"deb","groups":"libs","item_id":"caa4868d177fbebc5b145a2a92497ebcf566838a","multiarch":"same","name":"libqt5opengl5","priority":"optional","scan_time":"2021/10/13 15:10:49","size":572,"source":"qtbase-opensource-src","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"5.12.8+dfsg-0ubuntu1"},"operation":"INSERTED","type":"dbsync_packages"}'
-    alert_expected_schema : 'packages.schema'
+#   alert_expected_schema : 'packages.schema'
     alert_expected_values:
       rule.id: '100341'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_packages","program":{"format":"deb","name":"libqt5opengl5","priority":"optional","size":"572","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"5.12.8+dfsg-0ubuntu1","architecture":"amd64","multiarch":"same","source":"qtbase-opensource-src","description":"Qt 5 OpenGL module"},"operation_type":"INSERTED"}'
   -
     description: 'Package modification'
     event_payload: '{"data":{"architecture":"amd64","checksum":"1c1bf8bbc20caef77010f960461cc20fb9c67569","name":"libqt5opengl5","priority":"important","scan_time":"2021/10/13 15:11:50","version":"5.12.8+dfsg-0ubuntu1"},"operation":"MODIFIED","type":"dbsync_packages"}'
-    alert_expected_schema : 'packages.schema'
+#   alert_expected_schema : 'packages.schema'
     alert_expected_values:
       rule.id: '100342'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_packages","program":{"format":"deb","name":"libqt5opengl5","priority":"important","size":"572","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"5.12.8+dfsg-0ubuntu1","architecture":"amd64","multiarch":"same","source":"qtbase-opensource-src","description":"Qt 5 OpenGL module"},"operation_type":"MODIFIED"}'
   -
     description: 'Package deletion'
     event_payload: '{"data":{"architecture":"amd64","name":"libqt5opengl5","scan_time":"2021/10/13 15:14:35","version":"5.12.8+dfsg-0ubuntu1"},"operation":"DELETED","type":"dbsync_packages"}'
-    alert_expected_schema : 'packages.schema'
+#   alert_expected_schema : 'packages.schema'
     alert_expected_values:
       rule.id: '100343'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_packages","program":{"format":"deb","name":"libqt5opengl5","priority":"important","size":"572","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"5.12.8+dfsg-0ubuntu1","architecture":"amd64","multiarch":"same","source":"qtbase-opensource-src","description":"Qt 5 OpenGL module"},"operation_type":"DELETED"}'
   -
     description: 'Network interface creation'
     event_payload: '{"data":{"adapter":null,"checksum":"ce57e9ae697de4e427b67fea0d28c25e130249b7","item_id":"7ca46dd4c59f73c36a44ee5ebb0d0a37db4187a9","mac":"92:27:3b:ee:11:96","mtu":1500,"name":"dummy0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"scan_time":"2021/10/13 18:32:06","state":"down","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"}'
-    alert_expected_schema : 'network_iface.schema'
+#   alert_expected_schema : 'network_iface.schema'
     alert_expected_values:
       rule.id: '100351'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_network_iface","netinfo":{"iface":{"name":"dummy0","type":"ethernet","state":"down","mtu":"1500","mac":"92:27:3b:ee:11:96","tx_packets":"0","rx_packets":"0","tx_bytes":"0","rx_bytes":"0","tx_errors":"0","rx_errors":"0","tx_dropped":"0","rx_dropped":"0"}},"operation_type":"INSERTED"}'
   -
     description: 'Network interface modification'
     event_payload: '{"data":{"adapter":null,"checksum":"ce57e9ae697de4e427b67fea0d28c25e130249b8","name":"dummy0","type":"ethernet","rx_bytes":1000,"scan_time":"2021/10/13 18:33:06"},"operation":"MODIFIED","type":"dbsync_network_iface"}'
-    alert_expected_schema : 'network_iface.schema'
+#   alert_expected_schema : 'network_iface.schema'
     alert_expected_values:
       rule.id: '100352'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_network_iface","netinfo":{"iface":{"name":"dummy0","type":"ethernet","state":"down","mtu":"1500","mac":"92:27:3b:ee:11:96","tx_packets":"0","rx_packets":"0","tx_bytes":"0","rx_bytes":"1000","tx_errors":"0","rx_errors":"0","tx_dropped":"0","rx_dropped":"0"}},"operation_type":"MODIFIED"}'
   -
     description: 'Network protocol creation'
     event_payload: '{"data":{"checksum":"3d8855caa85501d22b40fa6616c0670f206b2c4e","gateway":" ","dhcp":"enabled","iface":"dummy0","item_id":"7ca46dd4c59f73c36a44ee5ebb0d0a37db4187a9","scan_time":"2021/10/13 18:32:06","type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_protocol"}'
-    alert_expected_schema : 'network_protocol.schema'
+#   alert_expected_schema : 'network_protocol.schema'
     alert_expected_values:
       rule.id: '100361'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_network_protocol","netinfo":{"proto":{"iface":"dummy0","type":"ethernet","gateway":" ","dhcp":"enabled"}},"operation_type":"INSERTED"}'
   -
     description: 'Network protocol modification'
     event_payload: '{"data":{"checksum":"3d8855caa85501d22b40fa6616c0670f206b2c4a","gateway":"10.0.0.2","iface":"dummy0","scan_time":"2021/10/13 18:32:06","type":"ethernet"},"operation":"MODIFIED","type":"dbsync_network_protocol"}'
-    alert_expected_schema : 'network_protocol.schema'
+#   alert_expected_schema : 'network_protocol.schema'
     alert_expected_values:
       rule.id: '100362'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_network_protocol","netinfo":{"proto":{"iface":"dummy0","type":"ethernet","gateway":"10.0.0.2","dhcp":"enabled"}},"operation_type":"MODIFIED"}'
   -
     description: 'Network protocol deletion'
     event_payload: '{"data":{"iface":"dummy0","scan_time":"2021/10/13 18:32:06","type":"ethernet"},"operation":"DELETED","type":"dbsync_network_protocol"}'
-    alert_expected_schema : 'network_protocol.schema'
+#   alert_expected_schema : 'network_protocol.schema'
     alert_expected_values:
       rule.id: '100363'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_network_protocol","netinfo":{"proto":{"iface":"dummy0","type":"ethernet","gateway":"10.0.0.2","dhcp":"enabled"}},"operation_type":"DELETED"}'
   -
     description: 'Network interface deletion'
     event_payload: '{"data":{"adapter":null,"name":"dummy0","scan_time":"2021/10/13 18:53:53","type":"ethernet"},"operation":"DELETED","type":"dbsync_network_iface"}'
-    alert_expected_schema : 'network_iface.schema'
+#   alert_expected_schema : 'network_iface.schema'
     alert_expected_values:
       rule.id: '100353'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_network_iface","netinfo":{"iface":{"name":"dummy0","type":"ethernet","state":"down","mtu":"1500","mac":"92:27:3b:ee:11:96","tx_packets":"0","rx_packets":"0","tx_bytes":"0","rx_bytes":"1000","tx_errors":"0","rx_errors":"0","tx_dropped":"0","rx_dropped":"0"}},"operation_type":"DELETED"}'
   -
     description: 'Network address creation'
     event_payload: '{"data":{"address":"192.168.100.12","broadcast":"192.168.100.255","checksum":"ec5e14340b8ced5b39cbcfa9abecbfdbd1f2873f","dhcp":"unknown","iface":"enp0s3","item_id":"7b4e5f1da50834d71d895a3065a3bb098a0b8a5c","metric":"100","netmask":"255.255.255.0","proto":0,"scan_time":"2021/10/13 16:46:37"},"operation":"INSERTED","type":"dbsync_network_address"}'
-    alert_expected_schema : 'network_address.schema'
+#   alert_expected_schema : 'network_address.schema'
     alert_expected_values:
       rule.id: '100371'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
+      data: '{"type":"dbsync_network_address","netinfo":{"addr":{"iface":"enp0s3","proto":"0","address":"192.168.100.12","netmask":"255.255.255.0","broadcast":"192.168.100.255"}},"operation_type":"INSERTED"}'
   -
     description: 'Network address modification'
     event_payload: '{"data":{"address":"192.168.100.12","checksum":"ec5e14340b8ced5b39cbcfa9abecbfdbd1f28aaa","iface":"enp0s3","metric":"90","proto":0,"scan_time":"2021/10/13 16:46:67"},"operation":"MODIFIED","type":"dbsync_network_address"}'
-    alert_expected_schema : 'network_address.schema'
+#   alert_expected_schema : 'network_address.schema'
     alert_expected_values:
       rule.id: '100372'
-      agent.id: '001'
-      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_network_address","netinfo":{"addr":{"iface":"enp0s3","proto":"0","address":"192.168.100.12","netmask":"255.255.255.0","broadcast":"192.168.100.255"}},"operation_type":"MODIFIED"}'
   -
     description: 'Network address deletion'
     event_payload: '{"data":{"address":"192.168.100.12","iface":"enp0s3","proto":0,"scan_time":"2021/10/13 16:48:17"},"operation":"DELETED","type":"dbsync_network_address"}'
-    alert_expected_schema : 'network_address.schema'
+#   alert_expected_schema : 'network_address.schema'
     alert_expected_values:
       rule.id: '100373'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_network_address","netinfo":{"addr":{"iface":"enp0s3","proto":"0","address":"192.168.100.12","netmask":"255.255.255.0","broadcast":"192.168.100.255"}},"operation_type":"DELETED"}'
   -
     description: 'Hotfix creation'
     event_payload: '{"data":{"checksum":"ded25e55c93121675adcb8d429dc586cbb351e3a","hotfix":"KB5005539","scan_time":"2021/10/14 02:24:18"},"operation":"INSERTED","type":"dbsync_hotfixes"}'
-    alert_expected_schema : 'hotfixes.schema'
+#   alert_expected_schema : 'hotfixes.schema'
     alert_expected_values:
       rule.id: '100381'
-      agent.id: '001'
-      data.operation_type: 'INSERTED'
-#  -
-#    description: 'Hotfix modification'
-#    event_payload: ''
-#    alert_expected_schema : 'hotfixes.schema'
-#    alert_expected_values:
-#      rule.id: '100382'
-#      agent.id: '001'
-#      data.operation_type: 'MODIFIED'
+      data: '{"type":"dbsync_hotfixes","hotfix":"KB5005539","operation_type":"INSERTED"}'
   -
     description: 'Hotfix deletion'
     event_payload: '{"data":{"hotfix":"KB5005539","scan_time":"2021/10/14 02:40:41"},"operation":"DELETED","type":"dbsync_hotfixes"}'
-    alert_expected_schema : 'hotfixes.schema'
+#   alert_expected_schema : 'hotfixes.schema'
     alert_expected_values:
       rule.id: '100383'
-      agent.id: '001'
-      data.operation_type: 'DELETED'
+      data: '{"type":"dbsync_hotfixes","hotfix":"KB5005539","operation_type":"DELETED"}'


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#10695|
|wazuh/wazuh#10758|
|wazuh/wazuh#10741|
|wazuh/wazuh#10778|

## Description

Hi team!

This PR aims to add some hardness to syscollector deltas handling by wazuh-analisisd and wazuh-db

- Change json schema files to only require PKs
- Make json schema validation optional
- Add agent mocking to fixture to better setup/cleanup
- Change delta header and alert checking according to dynamic agent_id
- Reduce FileMonitor timeout to 5s
- Improve alert value checking to make more rigorous validations
- Modification of syscollector.yaml according to this changes

## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.