### PR TITLE
Update remoted CSV headers in visualization tool

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -35,7 +35,8 @@ ANALYSISD_CSV_HEADERS = {
 }
 REMOTED_CSV_HEADERS = {
     'events_info': {'title': 'Events sent and count',
-                    'columns': ["evt_count", "ctrl_msg_count", "discarded_count", "msg_sent", 'dequeued_after_close']
+                    'columns': ["evt_count", "ctrl_msg_count", "discarded_count", "queued_msgs",
+                                'sent_bytes', 'dequeued_after_close']
                     },
     'queue_size': {'title': 'Queue status',
                    'columns': ['queue_size', 'total_queue_size']


### PR DESCRIPTION
|Related issue|
|---|
|close #2195|


## Description

This PR fixes the `KeyError: 'msg_sent'` bug in the tool to be able to plot the `remoted` statistics data. This bug caused the images not to be generated in the cluster test pipeline.

After the fix, you can see how the images are generated correctly.

```
stats
└── remoted
    ├── wazuh-remoted_stats_events_info.svg
    ├── wazuh-remoted_stats_queue_size.svg
    ├── wazuh-remoted_stats_recv_bytes.svg
    └── wazuh-remoted_stats_tcp_sessions.svg
```

Regarding the monitoring of the stats, no changes were necessary, since all the lines of the `wazuh-remoted.state` file are dynamically parsed.