### PR TITLE
Fix DeprecationWarning in VD tests

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_multiple_providers.py
@@ -62,7 +62,7 @@ def get_configuration(request):
 
 
 def test_multiple_providers(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """This test verifies the path/url and multipath/url options work properly according to the configuration
+    r"""This test verifies the path/url and multipath/url options work properly according to the configuration
     and check there are no conflicts when downloading or reading the feeds.
 
 


### PR DESCRIPTION
|Related issue|
|---|
| #2092 |
## Description
VD tests were giving a deprecation warning about "invalid escape sequence". To fix this warning, we have to use raw strings in docstrings (`r"""...."""`) if they contain any `\`.

## Configuration options

Same configuration as #2092.

## Tests
| Test | Status | Date | Note |
|:--:|:--:|:--:|:--:|
| `test_vulnerability_detector/test_providers` | [:yellow_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/15917/consoleFull) | 2021/11/12 | Not fixed |
| `test_vulnerability_detector/test_providers` | [:green_circle:](https://ci.wazuh.info/job/Test_integration/15918/consoleFull) | 2021/11/12 | Applying the fix |