### PR TITLE
Fix Logcollector test for MacOS

### DIFF
--- a/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
+++ b/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
@@ -5,6 +5,7 @@ import os
 import time
 import tempfile
 from datetime import datetime
+from time import sleep
 
 import pytest
 
@@ -32,6 +33,7 @@ local_internal_options = {'logcollector.vcheck_files': '0', 'logcollector.debug'
 now_date = datetime.now()
 folder_path = os.path.join(tempfile.gettempdir(), 'wazuh_testing_age')
 folder_path_regex = os.path.join(folder_path, '*')
+timeout_file_read = 3
 
 file_structure = [
     {
@@ -101,6 +103,8 @@ def test_configuration_age_datetime(get_configuration, configure_environment, co
     cfg = get_configuration['metadata']
     age_seconds = time_to_seconds(cfg['age'])
 
+    sleep(timeout_file_read)
+
     TimeMachine.travel_to_future(time_to_timedelta(new_datetime))
 
     for file in file_structure:
@@ -108,7 +112,7 @@ def test_configuration_age_datetime(get_configuration, configure_environment, co
             absolute_file_path = os.path.join(file['folder_path'], name)
 
             log_callback = logcollector.callback_match_pattern_file(cfg['location'], absolute_file_path)
-            log_monitor.start(timeout=5, callback=log_callback,
+            log_monitor.start(timeout=10, callback=log_callback,
                               error_message=f"{name} was not detected")
 
             fileinfo = os.stat(absolute_file_path)

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
@@ -173,6 +173,7 @@ def get_configuration(request):
     return request.param
 
 
+@pytest.mark.skip(reason="Test blocked by #2209")
 def test_only_future_events(get_configuration, configure_environment, restart_logcollector):
     """Check if Wazuh only future events field of logcollector works properly.
 

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_only_future_events.py
@@ -173,7 +173,6 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.mark.skip(reason="Test blocked by #2209")
 def test_only_future_events(get_configuration, configure_environment, restart_logcollector):
     """Check if Wazuh only future events field of logcollector works properly.
 

--- a/tests/integration/test_logcollector/test_macos/test_macos_multiline_values.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_multiline_values.py
@@ -16,8 +16,8 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_macos_format_basic.yaml')
 
 configurations = load_wazuh_configurations(configurations_path, __name__)
-local_internal_options = {'logcollector.debug': 2,
-                          'logcollector.sample_log_length': 200}
+local_internal_options = {'logcollector.debug': '2',
+                          'logcollector.sample_log_length': '200'}
 
 daemons_handler_configuration = {'daemons': ['wazuh-logcollector']}
 
@@ -46,7 +46,8 @@ def get_connection_configuration():
 
 @pytest.mark.parametrize('macos_message', macos_log_messages)
 def test_macos_multiline_values(restart_logcollector_required_daemons_package, get_configuration, configure_environment,
-                                macos_message, daemons_handler, file_monitoring):
+                                macos_message, configure_local_internal_options_module,
+                                daemons_handler, file_monitoring):
 
     """Check if logcollector correctly collects multiline events from the macOS unified logging system.
 


### PR DESCRIPTION
|Related issue|
|---|
| #2096|

## Description
Most of these tests were failing because after the merge of https://github.com/wazuh/wazuh-qa/pull/2043, the local internal options weren't set. Now the tests autoconfigure their local internal options.

## Package
| Version | Revision | Link|
|---|---|---|
4.3.0|2096.logcollector.testing|https://packages-dev.wazuh.com/warehouse/test/4.3/macos/wazuh-agent-4.3.0-2096.logcollector.testing.pkg|


## Testing

### MacOS Agent - tests/integration/test_logcollector

| OS | Jenkins | Notes |
|:--:|:--:|:--:|
| PS1 | [:red_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/16104/) | - |


* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress