### PR TITLE
Fix syscollector deltas IT after CVEs alerts inventory feature

### DIFF
--- a/tests/integration/test_analysisd/test_syscollector/data/syscollector.yaml
+++ b/tests/integration/test_analysisd/test_syscollector/data/syscollector.yaml
@@ -59,7 +59,7 @@
 #   alert_expected_schema : 'osinfo.schema'
     alert_expected_values:
       rule.id: '100322'
-      data: '{"type":"dbsync_osinfo","os":{"hostname":"UBUNTU","architecture":"x86_64","name":"Microsoft Windows 7","version":"6.1.7601","major":"6","minor":"1","build":"7602","os_release":"sp1","display_version":"1634140017886803554"},"operation_type":"MODIFIED"}'
+      data: '{"type":"dbsync_osinfo","os":{"hostname":"UBUNTU","architecture":"x86_64","name":"Microsoft Windows 7","version":"6.1.7601","major":"6","minor":"1","build":"7602","os_release":"sp1","display_version":"test"},"operation_type":"MODIFIED"}'
   -
     description: 'Hwinfo creation'
     event_payload: '{"data":{"scan_time":"2021/10/13 14:41:43","board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"}'

--- a/tests/integration/test_wazuh_db/data/agent/syscollector_deltas_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent/syscollector_deltas_messages.yaml
@@ -172,7 +172,7 @@
   description: 'Test successfull and err while dealing with osinfo deltas'
   test_case:
   -
-    input: 'agent 001 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1633433046844390706||'
+    input: 'agent 001 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1637071785021722196||||'
     output: 'ok '
     stage: 'insert osinfo.'
   -
@@ -180,36 +180,32 @@
     output: 'err'
     stage: 'insert osinfo without enough fields.'
   -
-    input: 'agent 001 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|NULL|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1633433046844390706|'
+    input: 'agent 001 dbsync osinfo INSERTED 2021/10/01 00:00:00|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||||||'
     output: 'err'
     stage: 'insert osinfo with invalid field type.'
   -
-    input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:00|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1633433046844390800|mydisplayname|'
-    output: 'ok 2021/10/01 00:00:00|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1633433046844390800|mydisplayname|'
+    input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1637071785021722800|mydisplayname|NULL|NULL|'
+    output: 'ok 2021/10/01 00:00:20|wazuh-dev|x86_64|Ubuntu|20.04.1 LTS (Focal Fossa)|focal|20|04|1||ubuntu|Linux|5.4.0-42-generic|#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020||1637071785021722800|mydisplayname|||'
     stage: 'modify osinfo.'
   -
     input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
     output: 'err'
     stage: 'modify osinfo without enough fields.'
   -
-    input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu-nonexistent|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1633433046844300100|'
+    input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu-nonexistent|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1637071785021722800|mydisplayname|NULL|NULL|'
     output: 'err'
     stage: 'modify nonexistent osinfo.'
   -
-    input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|1633433046844300100|'
+    input: 'agent 001 dbsync osinfo MODIFIED 2021/10/01 00:00:20|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL||mydisplayname|NULL|NULL|'
     output: 'err'
     stage: 'modify osinfo with invalid field type.'
-  -
-    input: 'agent 001 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|'
-    output: 'err'
-    stage: 'modify osinfo without enough fields.'
   -
     input: 'agent 001 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|'
     output: 'err'
     ignore: 'yes'
     stage: 'delete osinfo without enough fields.'
   -
-    input: 'agent 001 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
+    input: 'agent 001 dbsync osinfo DELETED NULL|NULL|NULL|Ubuntu|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|NULL|'
     output: 'err'
     ignore: 'yes'
     stage: 'delete osinfo.'
@@ -231,7 +227,7 @@
     stage: 'insert hwinfo with invalid field type.'
   -
     input: 'agent 001 dbsync hwinfo MODIFIED 2021/10/01 00:00:20|0|NULL|NULL|NULL|NULL|NULL|50|78793071d887ba34f60a67da99c4068a93aaaaaa|'
-    output: 'ok 2021/10/01 00:00:20|0|AMD Ryzen 7 PRO 4750U with Radeon Graphics|8|1697.000000|7957428|138384|50|78793071d887ba34f60a67da99c4068a93aaaaaa|'
+    output: 'ok 2021/10/01 00:00:20|0|AMD Ryzen 7 PRO 4750U with Radeon Graphics|8|1697.0|7957428|138384|50|78793071d887ba34f60a67da99c4068a93aaaaaa|'
     stage: 'modify hwinfo.'
   -
     input: 'agent 001 dbsync hwinfo MODIFIED 2021/10/01 00:00:20|0|NULL|NULL|NULL|NULL|NULL|50|'


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#10853|

## Description

Hi team!

This PR aims to solve syscollector delta related IT after wazuh/wazuh#8237 merge and some minor fixes
- Fix wazuh_db syscollector deltas IT regarding to FLOAT field precision of osinfo deltas
- Fix wazuh_db syscollector deltas IT regarding to osinfo delta handling
- Fix osinfo input for modified delta, part of analysisd delta handling IT

## Configuration options

|  Jenkins branch  | QA branch   |  Version 	|   Revision |
|- |- |- |- |
|  master |  [10853-fix-syscollector-deltas-for-new-cves-inventory](https://github.com/wazuh/wazuh-qa/tree/10853-fix-syscollector-deltas-for-new-cves-inventory) | v4.3.0  |  0.commitcece96d | 

Type | Format | Architecture |   Tag | File name
-- | -- | -- | -- | -- | 
Server | rpm | x86_64 | 4.3.0 | [wazuh-manager-4.3.0-0.commitcece96d.x86_64.rpm](wazuh-manager-4.3.0-0.commitcece96d.x86_64.rpm)


## Configuration options 
Following the next wiki https://github.com/wazuh/wazuh-qa/wiki/Parameters-guide---4.2 for Analysisd and Wazuh-db tests
> analysisd.debug=2
> wazuh_modules.debug=2
> monitord.rotate_log=0


## Testing

### `test_wazuh_db`

|  OS  | Local   | Jenkins     | Notes
|---    |---    |---    |---    |
| PS1   |[:green_circle:](https://github.com/wazuh/wazuh-qa/files/7556448/PS1-2228-ubuntu-manager.zip) | [:green_circle:](https://ci.wazuh.info/job/Test_integration/16229/) | Some CVE test will fail until #1243 merge |
| PS2   | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7556450/PS2-2228-ubuntu-manager.zip) |  [:green_circle:](https://ci.wazuh.info/job/Test_integration/16230/)| Some CVE test will fail until #1243 merge |
| PS3   | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7556451/PS3-2228-ubuntu-manager.zip) | [:green_circle:](https://ci.wazuh.info/job/Test_integration/16231/) | Some CVE test will fail until #1243 merge |


### `test_analysisd/test_syscollector`

|  OS  | Local   | Jenkins     | Notes
|---    |---    |---    |---    |
| PS1   |[:green_circle:](https://github.com/wazuh/wazuh-qa/files/7556461/PS1-2228-ubuntu-manager.zip) | [:green_circle:](https://ci.wazuh.info/job/Test_integration/16226/)  |  |
| PS2   | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7556462/PS2-2228-ubuntu-manager.zip) |  [:green_circle:](https://ci.wazuh.info/job/Test_integration/16228/) | |
| PS3   | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7556463/PS3-2228-ubuntu-manager.zip) | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/16227/) | |


* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress 
- 
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.