### PR TITLE
Add test cases for IPv6 to Authd tests

### DIFF
--- a/cambios.patch
+++ b/cambios.patch
@@ -1,0 +1,38 @@
+diff --git a/tests/integration/test_authd/data/test_authd_use_source_ip.yaml b/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
+index 176b6e44c..ff48749b7 100644
+--- a/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
++++ b/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
+@@ -43,3 +43,15 @@
+         status: 'success'
+         name: 'user1'
+         ip: '127.0.0.1'
++  -
++    name: 'Let manager decide IPv6'
++    description: 'Let manager decide'
++    ipv6: 'yes'
++    ip_specified: 'yes'
++    test_case:
++    -
++      input: "OSSEC A:'user1' IP:'src'"
++      output:
++        status: 'success'
++        name: 'user1'
++        ip: ' ::1/128'
+diff --git a/tests/integration/test_authd/test_authd_use_source_ip.py b/tests/integration/test_authd/test_authd_use_source_ip.py
+index 8d16d139b..f395052c6 100644
+--- a/tests/integration/test_authd/test_authd_use_source_ip.py
++++ b/tests/integration/test_authd/test_authd_use_source_ip.py
+@@ -83,7 +83,12 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
+ # Variables
+ 
+ log_monitor_paths = []
+-receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
++for test_case in test_authd_use_source_ip_tests:
++    if 'ipv6' in test_case:
++        receiver_sockets_params = [(("localhost", 1515), 'AF_INET6', 'SSL_TLSv1_2')]
++    else:
++        receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
++
+ monitored_sockets_params = [('wazuh-modulesd', None, True), ('wazuh-db', None, True), ('wazuh-authd', None, True)]
+ receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
+ 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -240,6 +240,8 @@ class SocketController:
             self.family = socket.AF_UNIX
         elif family == 'AF_INET':
             self.family = socket.AF_INET
+        elif family == 'AF_INET6':
+            self.family = socket.AF_INET6
         else:
             raise TypeError(f'Invalid family type detected: {family}. Valid ones are AF_UNIX or AF_INET')
 

--- a/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
+++ b/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
@@ -33,18 +33,7 @@
         name: 'user1'
         ip: 'any'
   -
-    name: 'Let manager decide'
-    description: 'Let manager decide'
-    ip_specified: 'yes'
-    test_case:
-    -
-      input: "OSSEC A:'user1' IP:'src'"
-      output:
-        status: 'success'
-        name: 'user1'
-        ip: '127.0.0.1'
-  -
-    name: 'Let manager decide IPv6'
+    name: 'Let manager decide - IPv6'
     description: 'Let manager decide'
     ipv6: 'yes'
     ip_specified: 'yes'
@@ -54,4 +43,16 @@
       output:
         status: 'success'
         name: 'user1'
-        ip: ' ::1/128'
+        ip: '::1'
+  -
+    name: 'Not specific IPv6'
+    description: 'Not specific IPv6'
+    ipv6: 'yes'
+    ip_specified: 'no'
+    test_case:
+    -
+      input: "OSSEC A:'user1' "
+      output:
+        status: 'success'
+        name: 'user1'
+        ip: 'any'

--- a/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
+++ b/tests/integration/test_authd/data/test_authd_use_source_ip.yaml
@@ -43,3 +43,15 @@
         status: 'success'
         name: 'user1'
         ip: '127.0.0.1'
+  -
+    name: 'Let manager decide IPv6'
+    description: 'Let manager decide'
+    ipv6: 'yes'
+    ip_specified: 'yes'
+    test_case:
+    -
+      input: "OSSEC A:'user1' IP:'src'"
+      output:
+        status: 'success'
+        name: 'user1'
+        ip: ' ::1/128'

--- a/tests/integration/test_authd/data/test_authd_valid_name_ip.yaml
+++ b/tests/integration/test_authd/data/test_authd_valid_name_ip.yaml
@@ -212,3 +212,32 @@
       output:
         status: 'error'
         message: 'Invalid IP: 10.10.10.1'
+  -
+    name: 'Valid IPv6'
+    description: 'Try register an agent with valid IPv6: register'
+    test_case:
+    -
+      input: "OSSEC A:'user1' IP:'02db:4660:46af:e523:d05e:a62e:4ca7:8e58'"
+      output:
+        status: 'success'
+        name: 'user1'
+        ip: '02db:4660:46af:e523:d05e:a62e:4ca7:8e58'
+  -
+    name: 'Valid compressed IPv6'
+    description: 'Try register an agent with valid compressed IPv6: register'
+    test_case:
+    -
+      input: "OSSEC A:'user1' IP:'2001:db8:0:b::1A'"
+      output:
+        status: 'success'
+        name: 'user1'
+        ip: '2001:db8:0:b::1A8'
+  -
+    name: 'Invalid IPv6: 2 double colons'
+    description: 'Try register an agent with invalid IPv6: rejected'
+    test_case:
+    -
+      input: "OSSEC A:'user1' IP:'56FE::2159:5BBC::6594'"
+      output:
+        status: 'error'
+        message: 'Invalid IP: 56FE::2159:5BBC::6594'

--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -105,7 +105,7 @@ def get_configuration(request):
 
 @pytest.mark.parametrize('test_case', [case for case in test_authd_use_source_ip_tests],
                          ids=[test_case['name'] for test_case in test_authd_use_source_ip_tests])
-def test_authd_force_options(get_configuration, configure_environment, configure_sockets_environment,
+def test_authd_use_source_ip(get_configuration, configure_environment, configure_sockets_environment,
                              clean_client_keys_file_function, restart_authd_function, wait_for_authd_startup_function,
                              connect_to_sockets_function, test_case, tear_down):
     '''

--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -78,6 +78,7 @@ configurations_path = os.path.join(test_data_path, 'wazuh_authd_configuration.ya
 client_keys_path = os.path.join(WAZUH_PATH, 'etc', 'client.keys')
 test_authd_use_source_ip_tests = read_yaml(os.path.join(test_data_path, 'test_authd_use_source_ip.yaml'))
 configuration_ids = [f"Use_source_ip_{x['USE_SOURCE_IP']}" for x in parameters]
+test_cases_ids = [case['name'].replace(' ', '_') for case in test_authd_use_source_ip_tests]
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 
 # Variables
@@ -97,7 +98,7 @@ def get_configuration(request):
     return request.param
 
 
-@pytest.fixture(scope='function', params=test_authd_use_source_ip_tests)
+@pytest.fixture(scope='function', params=test_authd_use_source_ip_tests, ids=test_cases_ids)
 def get_current_test_case(request):
     """Get current test case from the module"""
     return request.param

--- a/tests/integration/test_authd/test_authd_use_source_ip.py
+++ b/tests/integration/test_authd/test_authd_use_source_ip.py
@@ -83,7 +83,12 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 # Variables
 
 log_monitor_paths = []
-receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
+for test_case in test_authd_use_source_ip_tests:
+    if 'ipv6' in test_case:
+        receiver_sockets_params = [(("localhost", 1515), 'AF_INET6', 'SSL_TLSv1_2')]
+    else:
+        receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
+
 monitored_sockets_params = [('wazuh-modulesd', None, True), ('wazuh-db', None, True), ('wazuh-authd', None, True)]
 receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
 


### PR DESCRIPTION
|Related issue|
|---|
|#2252|


## Description

We have added the following test cases:

- `test_authd_use_source_ip.py`:
    - Manager will decide the source IP
    - IP is not specified
- `test_valid_name_ip.py` :
    - Valid IPv6
    - Valid compressed IPv6
    - Invalid IPv6

