### PR TITLE
Add new `qa-ctl` module to run custom ansible tasks

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
+++ b/deps/wazuh_testing/wazuh_testing/data/qactl_conf_validator_schema.json
@@ -161,7 +161,7 @@
                     "system": {
                       "type": "string",
                       "enum": [
-                      "rpm", 
+                      "rpm",
                       "deb",
                       "windows",
                       "macos",
@@ -272,6 +272,76 @@
         }
       }
     },
+    "tasks": {
+      "type": "object",
+      "patternProperties": {
+        "^task_[0-9]*$": {
+          "type": "object",
+          "required": ["host_info", "playbooks"],
+          "properties": {
+            "host_info": {
+              "type": "object",
+              "required": [
+                "ansible_connection",
+                "ansible_user",
+                "ansible_port",
+                "ansible_python_interpreter",
+                "host",
+                "system"
+              ],
+              "properties": {
+                "ansible_connection": {
+                  "type" : "string"
+                },
+                "host": {
+                  "type" : "string"
+                },
+                "ansible_user": {
+                  "type": "string"
+                },
+                "ansible_password": {
+                  "type": "string",
+                  "default": "empty"
+                },
+                "ssh_private_key_file_path":{
+                  "type": "string"
+                },
+                "ansible_port": {
+                  "type": "integer"
+                },
+                "ansible_python_interpreter": {
+                  "type": "string"
+                },
+                "system": {
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "required": ["ansible_password"]
+                },
+                {
+                  "required": ["ssh_private_key_file_path"]
+                }
+              ]
+            },
+            "playbooks": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "required": ["local_path"]
+                  },
+                  {
+                    "required": ["remote_url"]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "tests": {
       "type": "object",
       "patternProperties": {
@@ -319,7 +389,6 @@
                 "system": {
                   "type": "string"
                 }
-
               },
               "oneOf": [
                 {

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/__init__.py
@@ -1,0 +1,40 @@
+from wazuh_testing.qa_ctl.provisioning.ansible.unix_ansible_instance import UnixAnsibleInstance
+from wazuh_testing.qa_ctl.provisioning.ansible.windows_ansible_instance import WindowsAnsibleInstance
+
+
+def read_ansible_instance(host_info):
+    """Read every host info and generate the AnsibleInstance object.
+
+    Args:
+        host_info (dict): Dict with the host info needed coming from config file.
+
+    Returns:
+        instance (AnsibleInstance): Contains the AnsibleInstance for a given host.
+    """
+    extra_vars = None if 'host_vars' not in host_info else host_info['host_vars']
+    private_key_path = None if 'local_private_key_file_path' not in host_info \
+        else host_info['local_private_key_file_path']
+
+    if host_info['system'] == 'windows':
+        instance = WindowsAnsibleInstance(
+            host=host_info['host'],
+            ansible_connection=host_info['ansible_connection'],
+            ansible_port=host_info['ansible_port'],
+            ansible_user=host_info['ansible_user'],
+            ansible_password=host_info['ansible_password'],
+            ansible_python_interpreter=host_info['ansible_python_interpreter'],
+            host_vars=extra_vars
+        )
+    else:
+        instance = UnixAnsibleInstance(
+            host=host_info['host'],
+            ansible_connection=host_info['ansible_connection'],
+            ansible_port=host_info['ansible_port'],
+            ansible_user=host_info['ansible_user'],
+            ansible_password=host_info['ansible_password'],
+            host_vars=extra_vars,
+            ansible_ssh_private_key_file=private_key_path,
+            ansible_python_interpreter=host_info['ansible_python_interpreter']
+        )
+
+    return instance

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_runner.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/ansible/ansible_runner.py
@@ -22,21 +22,24 @@ class AnsibleRunner:
         ansible_playbook_path (string): Path where is located the playbook file.
         private_data_dir (string): Path where the artifacts files (result files) will be stored.
         output (boolean): True for showing ansible task output in stdout False otherwise.
+        task_id (str): Runner task id. It allows to identify the task.
 
     Attributes:
         ansible_inventory_path (string): Path where is located the ansible inventory file.
         ansible_playbook_path (string): Path where is located the playbook file.
         private_data_dir (string): Path where the artifacts files (result files) will be stored.
         output (boolean): True for showing ansible task output in stdout False otherwise.
+        task_id (str): Runner task id. It allows to identify the task.
     """
     LOGGER = Logging.get_logger(QACTL_LOGGER)
 
     def __init__(self, ansible_inventory_path, ansible_playbook_path,
-                 private_data_dir=join(gettempdir(), 'wazuh_qa_ctl'), output=False):
+                 private_data_dir=join(gettempdir(), 'wazuh_qa_ctl'), output=False, task_id=None):
         self.ansible_inventory_path = ansible_inventory_path
         self.ansible_playbook_path = ansible_playbook_path
         self.private_data_dir = private_data_dir
         self.output = output
+        self.task_id = task_id
 
     def run(self, log_ansible_error=True):
         """Run the ansible playbook in the indicated hosts.

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -3,8 +3,7 @@ import sys
 from tempfile import gettempdir
 from time import sleep
 
-from wazuh_testing.qa_ctl.provisioning.ansible.unix_ansible_instance import UnixAnsibleInstance
-from wazuh_testing.qa_ctl.provisioning.ansible.windows_ansible_instance import WindowsAnsibleInstance
+from wazuh_testing.qa_ctl.provisioning.ansible import read_ansible_instance
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_inventory import AnsibleInventory
 from wazuh_testing.qa_ctl.provisioning.wazuh_deployment.wazuh_local_package import WazuhLocalPackage
 from wazuh_testing.qa_ctl.provisioning.wazuh_deployment.wazuh_s3_package import WazuhS3Package
@@ -52,43 +51,6 @@ class QAProvisioning():
 
         self.__process_inventory_data()
 
-    def __read_ansible_instance(self, host_info):
-        """Read every host info and generate the AnsibleInstance object.
-
-        Args:
-            host_info (dict): Dict with the host info needed coming from config file.
-
-        Returns:
-            instance (AnsibleInstance): Contains the AnsibleInstance for a given host.
-        """
-        extra_vars = None if 'host_vars' not in host_info else host_info['host_vars']
-        private_key_path = None if 'local_private_key_file_path' not in host_info \
-                                   else host_info['local_private_key_file_path']
-
-        if host_info['system'] == 'windows':
-            instance = WindowsAnsibleInstance(
-                host=host_info['host'],
-                ansible_connection=host_info['ansible_connection'],
-                ansible_port=host_info['ansible_port'],
-                ansible_user=host_info['ansible_user'],
-                ansible_password=host_info['ansible_password'],
-                ansible_python_interpreter=host_info['ansible_python_interpreter'],
-                host_vars=extra_vars
-            )
-        else:
-            instance = UnixAnsibleInstance(
-                host=host_info['host'],
-                ansible_connection=host_info['ansible_connection'],
-                ansible_port=host_info['ansible_port'],
-                ansible_user=host_info['ansible_user'],
-                ansible_password=host_info['ansible_password'],
-                host_vars=extra_vars,
-                ansible_ssh_private_key_file=private_key_path,
-                ansible_python_interpreter=host_info['ansible_python_interpreter']
-            )
-
-        return instance
-
     def __process_inventory_data(self):
         """Process config file info to generate the ansible inventory file."""
         QAProvisioning.LOGGER.debug('Processing inventory data from provisioning hosts info')
@@ -100,7 +62,7 @@ class QAProvisioning():
                         if module_key == "host_info":
                             current_host = module_value['host']
                             if current_host:
-                                self.instances_list.append(self.__read_ansible_instance(module_value))
+                                self.instances_list.append(read_ansible_instance(module_value))
             elif root_key == "groups":
                 self.group_dict.update(self.provision_info[root_key])
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tasks/qa_tasks_launcher.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tasks/qa_tasks_launcher.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from copy import deepcopy
 from tempfile import gettempdir
 
 from wazuh_testing.tools.file import download_text_file, remove_file
@@ -8,7 +10,9 @@ from wazuh_testing.qa_ctl.provisioning.ansible.ansible_inventory import AnsibleI
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_runner import AnsibleRunner
 from wazuh_testing.qa_ctl import QACTL_LOGGER
 from wazuh_testing.tools.logging import Logging
+from wazuh_testing.tools import file
 from wazuh_testing.tools.time import get_current_timestamp
+from wazuh_testing.qa_ctl.provisioning.local_actions import qa_ctl_docker_run
 
 
 class QATasksLauncher:
@@ -27,8 +31,9 @@ class QATasksLauncher:
     def __init__(self, tasks_data, qa_ctl_configuration):
         self.qa_ctl_configuration = qa_ctl_configuration
         self.ansible_runners = []
+        self.tasks_data = tasks_data
 
-        self.__process_tasks_data(tasks_data)
+        self.__process_tasks_data()
 
     def __read_ansible_instance(self, host_info):
         """Read every host info and generate the AnsibleInstance object.
@@ -67,7 +72,7 @@ class QATasksLauncher:
 
         return instance
 
-    def __process_tasks_data(self, tasks_data):
+    def __process_tasks_data(self):
         """Process tasks module info from the qa-ctl configuration file.
 
         Args:
@@ -75,7 +80,7 @@ class QATasksLauncher:
         """
         QATasksLauncher.LOGGER.debug('Processing tasks module data')
 
-        for task_id, task_data in tasks_data.items():
+        for task_id, task_data in self.tasks_data.items():
             playbooks_path = []
             inventory_path = ''
 
@@ -111,10 +116,39 @@ class QATasksLauncher:
     def run(self):
         """Run the ansible tasks specified in the tasks module."""
         try:
-            for task_runner in self.ansible_runners:
-                QATasksLauncher.LOGGER.info(f"Running {task_runner.task_id}")
-                task_runner.run()
-                QATasksLauncher.LOGGER.info(f"The {task_runner.task_id} has been finished successfully")
+            if sys.platform == 'win32':
+                # If Windows, run the qa-ctl tasks in a linux container due to ansible is not compatible with Windows
+                tmp_config_file_name = f"config_{get_current_timestamp()}.yaml"
+                tmp_path = os.path.join(gettempdir(), 'wazuh_qa_ctl')
+                tmp_config_file = os.path.join(tmp_path, tmp_config_file_name)
+
+                # Copy the tasks data to modify
+                container_tasks = deepcopy(self.tasks_data)
+
+                # Copy the local playbooks to the wazuh qa-ctl path, that is shared with the container through a volume
+                for _, task_data in container_tasks.items():
+                    if 'playbooks' in task_data:
+                        for playbook_data in task_data['playbooks']:
+                            if 'local_path' in playbook_data:
+                                file.copy(playbook_data['local_path'], tmp_path)
+                                playbook_file = os.path.split(playbook_data['local_path'])[1]
+
+                                # Update local path to specify the playbooks path in the container
+                                playbook_data['local_path'] = f"/wazuh_qa_ctl/{playbook_file}"
+
+                # Write a custom configuration file with tasks section modified (local paths)
+                file.write_yaml_file(tmp_config_file, {'tasks': container_tasks})
+
+                try:
+                    qa_ctl_docker_run(tmp_config_file_name, self.qa_ctl_configuration.qa_ctl_launcher_branch,
+                                      self.qa_ctl_configuration.debug_level, topic='launching the custom tasks')
+                finally:
+                    file.remove_file(tmp_config_file)
+            else:
+                for task_runner in self.ansible_runners:
+                    QATasksLauncher.LOGGER.info(f"Running {task_runner.task_id}")
+                    task_runner.run()
+                    QATasksLauncher.LOGGER.info(f"The {task_runner.task_id} has been finished successfully")
         finally:
             self.destroy()
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tasks/qa_tasks_launcher.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tasks/qa_tasks_launcher.py
@@ -4,8 +4,7 @@ from copy import deepcopy
 from tempfile import gettempdir
 
 from wazuh_testing.tools.file import download_text_file, remove_file
-from wazuh_testing.qa_ctl.provisioning.ansible.unix_ansible_instance import UnixAnsibleInstance
-from wazuh_testing.qa_ctl.provisioning.ansible.windows_ansible_instance import WindowsAnsibleInstance
+from wazuh_testing.qa_ctl.provisioning.ansible import read_ansible_instance
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_inventory import AnsibleInventory
 from wazuh_testing.qa_ctl.provisioning.ansible.ansible_runner import AnsibleRunner
 from wazuh_testing.qa_ctl import QACTL_LOGGER
@@ -35,43 +34,6 @@ class QATasksLauncher:
 
         self.__process_tasks_data()
 
-    def __read_ansible_instance(self, host_info):
-        """Read every host info and generate the AnsibleInstance object.
-
-        Args:
-            host_info (dict): Dict with the host info needed coming from config file.
-
-        Returns:
-            instance (AnsibleInstance): Contains the AnsibleInstance for a given host.
-        """
-        extra_vars = None if 'host_vars' not in host_info else host_info['host_vars']
-        private_key_path = None if 'local_private_key_file_path' not in host_info \
-            else host_info['local_private_key_file_path']
-
-        if host_info['system'] == 'windows':
-            instance = WindowsAnsibleInstance(
-                host=host_info['host'],
-                ansible_connection=host_info['ansible_connection'],
-                ansible_port=host_info['ansible_port'],
-                ansible_user=host_info['ansible_user'],
-                ansible_password=host_info['ansible_password'],
-                ansible_python_interpreter=host_info['ansible_python_interpreter'],
-                host_vars=extra_vars
-            )
-        else:
-            instance = UnixAnsibleInstance(
-                host=host_info['host'],
-                ansible_connection=host_info['ansible_connection'],
-                ansible_port=host_info['ansible_port'],
-                ansible_user=host_info['ansible_user'],
-                ansible_password=host_info['ansible_password'],
-                host_vars=extra_vars,
-                ansible_ssh_private_key_file=private_key_path,
-                ansible_python_interpreter=host_info['ansible_python_interpreter']
-            )
-
-        return instance
-
     def __process_tasks_data(self):
         """Process tasks module info from the qa-ctl configuration file.
 
@@ -85,7 +47,7 @@ class QATasksLauncher:
             inventory_path = ''
 
             if 'host_info' in task_data:
-                instance = self.__read_ansible_instance(task_data['host_info'])
+                instance = read_ansible_instance(task_data['host_info'])
                 inventory_instance = AnsibleInventory(ansible_instances=[instance])
                 inventory_path = inventory_instance.inventory_file_path
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tasks/qa_tasks_launcher.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/run_tasks/qa_tasks_launcher.py
@@ -1,0 +1,124 @@
+import os
+from tempfile import gettempdir
+
+from wazuh_testing.tools.file import download_text_file, remove_file
+from wazuh_testing.qa_ctl.provisioning.ansible.unix_ansible_instance import UnixAnsibleInstance
+from wazuh_testing.qa_ctl.provisioning.ansible.windows_ansible_instance import WindowsAnsibleInstance
+from wazuh_testing.qa_ctl.provisioning.ansible.ansible_inventory import AnsibleInventory
+from wazuh_testing.qa_ctl.provisioning.ansible.ansible_runner import AnsibleRunner
+from wazuh_testing.qa_ctl import QACTL_LOGGER
+from wazuh_testing.tools.logging import Logging
+from wazuh_testing.tools.time import get_current_timestamp
+
+
+class QATasksLauncher:
+    """Class to manage and launch the tasks specified in the qa-ctl configuration module.
+
+    Args:
+        tasks_data (dict): Dicionary with tasks info.
+        qa_ctl_configuration (QACTLConfiguration): QACTL configuration info.
+
+    Attributes:
+        tasks_data (dict): Dicionary with tasks info.
+        qa_ctl_configuration (QACTLConfiguration): QACTL configuration info.
+    """
+    LOGGER = Logging.get_logger(QACTL_LOGGER)
+
+    def __init__(self, tasks_data, qa_ctl_configuration):
+        self.qa_ctl_configuration = qa_ctl_configuration
+        self.ansible_runners = []
+
+        self.__process_tasks_data(tasks_data)
+
+    def __read_ansible_instance(self, host_info):
+        """Read every host info and generate the AnsibleInstance object.
+
+        Args:
+            host_info (dict): Dict with the host info needed coming from config file.
+
+        Returns:
+            instance (AnsibleInstance): Contains the AnsibleInstance for a given host.
+        """
+        extra_vars = None if 'host_vars' not in host_info else host_info['host_vars']
+        private_key_path = None if 'local_private_key_file_path' not in host_info \
+            else host_info['local_private_key_file_path']
+
+        if host_info['system'] == 'windows':
+            instance = WindowsAnsibleInstance(
+                host=host_info['host'],
+                ansible_connection=host_info['ansible_connection'],
+                ansible_port=host_info['ansible_port'],
+                ansible_user=host_info['ansible_user'],
+                ansible_password=host_info['ansible_password'],
+                ansible_python_interpreter=host_info['ansible_python_interpreter'],
+                host_vars=extra_vars
+            )
+        else:
+            instance = UnixAnsibleInstance(
+                host=host_info['host'],
+                ansible_connection=host_info['ansible_connection'],
+                ansible_port=host_info['ansible_port'],
+                ansible_user=host_info['ansible_user'],
+                ansible_password=host_info['ansible_password'],
+                host_vars=extra_vars,
+                ansible_ssh_private_key_file=private_key_path,
+                ansible_python_interpreter=host_info['ansible_python_interpreter']
+            )
+
+        return instance
+
+    def __process_tasks_data(self, tasks_data):
+        """Process tasks module info from the qa-ctl configuration file.
+
+        Args:
+            tasks_data (dict): Dicionary with tasks info.
+        """
+        QATasksLauncher.LOGGER.debug('Processing tasks module data')
+
+        for task_id, task_data in tasks_data.items():
+            playbooks_path = []
+            inventory_path = ''
+
+            if 'host_info' in task_data:
+                instance = self.__read_ansible_instance(task_data['host_info'])
+                inventory_instance = AnsibleInventory(ansible_instances=[instance])
+                inventory_path = inventory_instance.inventory_file_path
+
+            if 'playbooks' in task_data:
+                for playbook_data in task_data['playbooks']:
+                    if 'local_path' in playbook_data:
+                        playbooks_path.append(playbook_data['local_path'])
+                    elif 'remote_url' in playbook_data:
+                        # If a remote url file is specified, then download it and then save the playbook path
+                        playbook_name = os.path.split(playbook_data['remote_url'])[1]
+                        playbook_file_name = f"{get_current_timestamp()}_{playbook_name}"
+                        playbook_file_path = os.path.join(gettempdir(), 'wazuh_qa_ctl', playbook_file_name)
+
+                        download_text_file(playbook_data['remote_url'], playbook_file_path)
+                        playbooks_path.append(playbook_file_path)
+
+                        QATasksLauncher.LOGGER.debug(f"The {playbook_name} file has been downloaded from "
+                                                     f"{playbook_data['remote_url']} in {playbook_file_path} path")
+
+            # Create runner objects. One for each playbook using the same inventory for each host
+            for index, playbook in enumerate(playbooks_path):
+                self.ansible_runners.append(AnsibleRunner(inventory_path, playbook,
+                                                          output=self.qa_ctl_configuration.ansible_output,
+                                                          task_id=f"{task_id} - playbook_{index + 1}"))
+
+        QATasksLauncher.LOGGER.debug('Tasks module data has been processed successfully')
+
+    def run(self):
+        """Run the ansible tasks specified in the tasks module."""
+        try:
+            for task_runner in self.ansible_runners:
+                QATasksLauncher.LOGGER.info(f"Running {task_runner.task_id}")
+                task_runner.run()
+                QATasksLauncher.LOGGER.info(f"The {task_runner.task_id} has been finished successfully")
+        finally:
+            self.destroy()
+
+    def destroy(self):
+        """Remove temporarily runner files."""
+        for runner in self.ansible_runners:
+            remove_file(runner.ansible_inventory_path)

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -14,6 +14,7 @@ from tempfile import gettempdir
 from wazuh_testing.qa_ctl.deployment.qa_infraestructure import QAInfraestructure
 from wazuh_testing.qa_ctl.provisioning.qa_provisioning import QAProvisioning
 from wazuh_testing.qa_ctl.run_tests.qa_test_runner import QATestRunner
+from wazuh_testing.qa_ctl.run_tasks.qa_tasks_launcher import QATasksLauncher
 from wazuh_testing.qa_ctl.configuration.qa_ctl_configuration import QACTLConfiguration
 from wazuh_testing.qa_ctl import QACTL_LOGGER
 from wazuh_testing.tools.logging import Logging
@@ -28,6 +29,7 @@ from wazuh_testing.tools.file import recursive_directory_creation
 
 DEPLOY_KEY = 'deployment'
 PROVISION_KEY = 'provision'
+TASKS_KEY = 'tasks'
 TEST_KEY = 'tests'
 WAZUH_QA_FILES = os.path.join(gettempdir(), 'wazuh_qa_ctl', 'wazuh-qa')
 RUNNING_ON_DOCKER_CONTAINER = True if 'RUNNING_ON_DOCKER_CONTAINER' in os.environ else False
@@ -41,6 +43,7 @@ launched = {
     'config_generator': False,
     'instance_handler': False,
     'qa_provisioning': False,
+    'tasks_runner': False,
     'test_runner': False
 }
 
@@ -304,6 +307,9 @@ def get_script_parameters():
     parser.add_argument('--skip-provisioning', action='store_true',
                         help='Flag to skip the provisioning phase. Set it only if -c or --config was specified.')
 
+    parser.add_argument('--skip-tasks', action='store_true',
+                        help='Flag to skip the tasks phase. Set it only if -c or --config was specified.')
+
     parser.add_argument('--skip-testing', action='store_true',
                         help='Flag to skip the testing phase. Set it only if -c or --config was specified.')
 
@@ -375,6 +381,12 @@ def main():
             qa_provisioning = QAProvisioning(provision_dict, qactl_configuration)
             qa_provisioning.run()
             launched['qa_provisioning'] = True
+
+        if TASKS_KEY in configuration_data and not arguments.skip_tasks:
+            tasks_dict = configuration_data[TASKS_KEY]
+            tasks_runner = QATasksLauncher(tasks_dict, qactl_configuration)
+            tasks_runner.run()
+            launched['tasks_runner'] = True
 
         if TEST_KEY in configuration_data and not arguments.skip_testing:
             test_dict = configuration_data[TEST_KEY]

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -385,3 +385,22 @@ def count_file_lines(filepath):
     """
     with open(filepath, "r") as file:
         return sum(1 for line in file if line.strip())
+
+
+def download_text_file(file_url, local_destination_path):
+    """Download a remote file with text/plain content type.
+
+    Args:
+        file_url (str): Remote URL path where the text file is located.
+        local_destination_path (str): Local path where to save the file content.
+
+    Raises:
+        ValueError: if the URL content type is not 'text/plain'.
+
+    """
+    request = requests.get(file_url, allow_redirects=True)
+
+    if 'text/plain' not in request.headers.get('content-type'):
+        raise ValueError(f"The remote url {file_url} does not have text/plain content type to download it")
+
+    open(local_destination_path, 'wb').write(request.content)


### PR DESCRIPTION
|Related issue|
|---|
|close #2240 |

## PR changes

**Added**

- Add new module to `qa-ctl` to be able to launch ansible tasks in a customized way.
- Add new function to `file` module to download plain text files.
- Add tasks schema to the `qa-ctl` config validator.

**Fixed**

- Fix some uses of `file` module functions that are incompatible under Windows.

**Improved**

- Encapsulate `__read_ansible_instance` function. Now it is not duplicated in different modules.

## Description

This PR adds a new module to `qa-ctl` to be able to run custom tasks through `ansible-playbooks`. We can run as many playbooks and tasks as desired. The only thing to do is to specify the playbooks to launch, either because they are located in the local file system, or in a remote location, available from a URL.

To use such a module, the following must be specified in the `qa-ctl` configuration file.

```
tasks:
    task_1:
        host_info:
            ansible_connection: ssh
            ansible_user: vagrant
            ansible_password: vagrant
            ansible_port: 22
            ansible_python_interpreter: /usr/bin/python3
            system: deb
            host: 10.150.50.2

        playbooks:
            - local_path: /home/jmv74211/Documents/trash/test.yaml
            - remote_url: https://raw.githubusercontent.com/wazuh/wazuh-qa/2240-remote-playbooks/test2.yaml
    
    task_2:
        host_info:
            ...
        playbooks:
            ...
```

This module has been tested on both Linux and Windows.


<details>
<summary>Here we can see an example of execution in DEBUG mode</summary>

```
2021-11-24 12:52:00,974 - INFO - Validating input parameters
2021-11-24 12:52:01,648 - INFO - Input parameters validation has passed successfully
2021-11-24 12:52:01,648 - DEBUG - Reading configuration_data
2021-11-24 12:52:01,649 - DEBUG - The configuration data has been read successfully
2021-11-24 12:52:01,649 - DEBUG - Validating configuration schema
2021-11-24 12:52:01,653 - DEBUG - Schema validation has passed successfully
2021-11-24 12:52:01,653 - DEBUG - qa_tasks_launcher - Processing tasks module data
2021-11-24 12:52:01,776 - DEBUG - qa_tasks_launcher - The test2.yaml file has been downloaded from https://raw.githubusercontent.com/wazuh/wazuh-qa/2240-remote-playbooks/test2.yaml in /tmp/wazuh_qa_ctl/1637754721.654869_test2.yaml path
2021-11-24 12:52:01,776 - DEBUG - qa_tasks_launcher - Tasks module data has been processed successfully
2021-11-24 12:52:01,776 - INFO - qa_tasks_launcher - Running task_1 - playbook_1
2021-11-24 12:52:01,776 - DEBUG - ansible_runner - Running /home/jmv74211/Documents/trash/test.yaml ansible-playbook with /tmp/wazuh_qa_ctl/1637754721.653397.yaml inventory
2021-11-24 12:52:03,934 - INFO - qa_tasks_launcher - The task_1 - playbook_1 has been finished successfully
2021-11-24 12:52:03,935 - INFO - qa_tasks_launcher - Running task_1 - playbook_2
2021-11-24 12:52:03,935 - DEBUG - ansible_runner - Running /tmp/wazuh_qa_ctl/1637754721.654869_test2.yaml ansible-playbook with /tmp/wazuh_qa_ctl/1637754721.653397.yaml inventory
2021-11-24 12:52:05,545 - INFO - qa_tasks_launcher - The task_1 - playbook_2 has been finished successfully
```

</details>


<details>
<summary>Here we can see an example of execution in INFO mode</summary>

```
2021-11-24 12:52:00,974 - INFO - Validating input parameters
2021-11-24 12:52:01,648 - INFO - Input parameters validation has passed successfully
2021-11-24 12:52:01,776 - INFO - qa_tasks_launcher - Running task_1 - playbook_1
2021-11-24 12:52:03,934 - INFO - qa_tasks_launcher - The task_1 - playbook_1 has been finished successfully
2021-11-24 12:52:03,935 - INFO - qa_tasks_launcher - Running task_1 - playbook_2
2021-11-24 12:52:05,545 - INFO - qa_tasks_launcher - The task_1 - playbook_2 has been finished successfully
```

</details>