### PR TITLE
Change `time_to_sync`  variable

### DIFF
--- a/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
+++ b/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
@@ -16,7 +16,7 @@ worker_hosts = test_hosts[1:]
 inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
                               'provisioning', 'agentless_cluster', 'inventory.yml')
 
-time_to_sync = 10
+time_to_sync = 21
 host_manager = HostManager(inventory_path)
 client_keys_path = os.path.join(WAZUH_PATH, "etc", "client.keys")
 


### PR DESCRIPTION
|Related issue|
|---|
|#2274|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This closes #2274. In this issue, we saw an error that happened due to a very low value of the `tiime_to_sync` variable, which made the test fail almost half of the executions.

