### PR TITLE
Fix xfailed messages from API performance tests

### DIFF
--- a/tests/performance/test_api/test_api_endpoints_performance.py
+++ b/tests/performance/test_api/test_api_endpoints_performance.py
@@ -16,7 +16,8 @@ xfailed_items = {
     '/active-response': {'message': 'Agent simulator not handling active-response messages: '
                                     'https://github.com/wazuh/wazuh-qa/issues/1266',
                          'method': 'put'},
-    '/agents/group': {'message': 'Slow agent-group files creation: https://github.com/wazuh/wazuh/issues/8625',
+    '/agents/group': {'message': 'Agent-group files will be deprecated in: '
+                                 'https://github.com/wazuh/wazuh/issues/10771',
                       'method': 'put'},
     '/syscheck': {'message': 'The `queue/alerts/ar` socket does not accept agent lists: '
                              'https://github.com/wazuh/wazuh/issues/9125',
@@ -27,8 +28,8 @@ xfailed_items = {
     '/agents': {'message': 'The `queue/sockets/auth` socket does not accept agent lists: '
                            'https://github.com/wazuh/wazuh/issues/9127',
                 'method': 'delete'},
-    '/groups': {'message': 'Timeout caused by agent-group file manipulation in the Framework: '
-                           'https://github.com/wazuh/wazuh/issues/9141',
+    '/groups': {'message': 'Agent-group files will be deprecated in: '
+                           'https://github.com/wazuh/wazuh/issues/10771',
                 'method': 'delete'}
 }
 


### PR DESCRIPTION
## Description
This PR is a simple modification of a pair of messages from our API performance tests.
More precise these two:
https://github.com/wazuh/wazuh-qa/blob/cc712b04e766969eacd421b0ba044752fefcbc13/tests/performance/test_api/test_api_endpoints_performance.py#L19-L20
https://github.com/wazuh/wazuh-qa/blob/cc712b04e766969eacd421b0ba044752fefcbc13/tests/performance/test_api/test_api_endpoints_performance.py#L30-L32

We noticed that the message itself and the referenced issue are not correct.

* Related issues from `wazuh/wazuh`:
  * https://github.com/wazuh/wazuh/issues/9141
  * https://github.com/wazuh/wazuh/issues/8625
  * https://github.com/wazuh/wazuh/issues/10771

Regards,
Alexis