### PR TITLE
Remove old check

### DIFF
--- a/tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.py
+++ b/tests/system/test_cluster/test_agent_info_sync/test_agent_info_sync.py
@@ -68,9 +68,6 @@ def test_agent_info_sync(clean_cluster_logs, remove_labels):
                                    replace=f'<labels><label key="{label}">value</label></labels>')
     host_manager.get_host(modified_agent).ansible('command', f'service wazuh-agent restart', check=False)
 
-    # Run the callback checks for the Master and Worker nodes
-    HostMonitor(inventory_path=inventory_path, messages_path=messages_path, tmp_path=tmp_path).run()
-
     # Check that the agent label is updated in the master's database.
     for i in range(10):
         if host_manager.run_command(
@@ -79,7 +76,7 @@ def test_agent_info_sync(clean_cluster_logs, remove_labels):
                 global_db_path,
                 "SELECT id FROM labels WHERE key='{}'".format(f'\\"{label}\\"'))):
             break
-        sleep(10)
+        sleep(21)
     else:
         pytest.fail(f"Label {label} couldn't be found in master's global.db database.")
 


### PR DESCRIPTION
|Related issue|
|---|
|#2280|

## Description

This closes #2280. In this pull request, we removed a check the test was performing. This check looked in the `cluster.log` file, looking for a particular file. Due to a change in the code, these chunks are not going to be displayed anymore. As they are not shown anymore, the test was failing when trying to find them. The test is still functional, as now it only looks for this new information in the `global.db` database. 