### PR TITLE
Remove expected `force` option from the received request in the `agent_enrollment` system tests

### DIFF
--- a/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_enrollment/data/messages.yml
@@ -3,7 +3,7 @@ wazuh-master:
   - regex: ".*Agent key generated for agent.*"
     path: "/var/ossec/logs/ossec.log"
     timeout: 60
-  - regex: '.*Received request:.*{"daemon_name":"authd","message":{"arguments":{"name":".*","ip":"any","force":0},"function":"add"}}'
+  - regex: '.*Received request:.*{"daemon_name":"authd","message":{"arguments":{"name":".*","ip":"any"},"function":"add"}}'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60
   - regex: '.*Worker wazuh-worker1.*Integrity sync.*Finished in.*'


### PR DESCRIPTION
|Related issue|
|---|
|#2283|

## Description

This closes #2283. The aim of this PR is to update the expected log in the `agent_enrollment` system test. Before 4.3.0 version the expected request contained an `int` type `force` field, but in 4.3.0, it is no longer necessary to specify this value as the default one, or the established one will be taken from the master. We will only receive this field if we manually specify it in the request. 
