### PR TITLE
Add new check files fields

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/check_files.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/check_files.py
@@ -152,15 +152,15 @@ def get_data_information(item):
     mode_str = str(mode).replace('o', '')
     mode = mode_str[-3:] if len(mode_str) > 3 else mode_str
     _type = 'directory' if os.path.isdir(item) else 'file'
-    protection = get_filemode(stat_info.st_mode)
+    permissions = get_filemode(stat_info.st_mode)
     last_update = datetime.fromtimestamp(os.path.getmtime(item)).strftime('%Y-%m-%d %H:%M:%S')
     if _type != 'directory':
         checksum = hashlib.md5(open(item, 'rb').read()).hexdigest()
 
-        return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'permission': protection,
+        return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'permissions': permissions,
                 'last_update': last_update, 'checksum': checksum}
     else:
-        return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'permission': protection,
+        return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'permissions': permissions,
                 'last_update': last_update}
 
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/check_files.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/check_files.py
@@ -5,7 +5,8 @@ import grp
 import pwd
 import json
 import logging
-
+import hashlib
+from datetime import datetime
 
 script_logger = logging.getLogger('check_files')
 _filemode_list = [
@@ -152,8 +153,15 @@ def get_data_information(item):
     mode = mode_str[-3:] if len(mode_str) > 3 else mode_str
     _type = 'directory' if os.path.isdir(item) else 'file'
     protection = get_filemode(stat_info.st_mode)
+    last_update = datetime.fromtimestamp(os.path.getmtime(item)).strftime('%Y-%m-%d %H:%M:%S')
+    if _type != 'directory':
+        checksum = hashlib.md5(open(item, 'rb').read()).hexdigest()
 
-    return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'prot': protection}
+        return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'permission': protection,
+                'last_update': last_update, 'checksum': checksum}
+    else:
+        return {'type': _type, 'user': user, 'group': group, 'mode': mode, 'permission': protection,
+                'last_update': last_update}
 
 
 def write_data_to_file(data, output_file_path):

--- a/tests/check_files/test_check_files/test_system_check_files.py
+++ b/tests/check_files/test_check_files/test_system_check_files.py
@@ -5,12 +5,13 @@
 import json
 import os
 import pytest
+import time
 from datetime import datetime
 from deepdiff import DeepDiff
 
 from wazuh_testing.tools.file import validate_json_file, read_json_file, write_json_file
 
-OUTPUT_FILE = f"system_checkfiles_{datetime.now().timestamp()}.json"
+OUTPUT_FILE = f"system_checkfiles_{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(datetime.now().timestamp()))}.json"
 
 
 @pytest.fixture
@@ -86,8 +87,7 @@ def test_system_check_files(get_first_file, get_second_file, get_output_path):
     # Given difference key example:
     # "root['/home/jmv74211/Documents/trash/t/test_check_files/dockerfiles/ubuntu_20_04/entrypoint.py']['mode']"
     # Result: /home/jmv74211/Documents/trash/t/test_check_files/dockerfiles/ubuntu_20_04/entrypoint.py - mode"
-    differences_str = differences.to_json().replace('][', ' - ').replace('root[', '').replace(']', '') \
-                                           .replace('[', '')
+    differences_str = differences.to_json().replace('root', '')
     # If there are differences between the given files
     if differences != {}:
         # If the user specified an output path, the differences are saved in JSON format


### PR DESCRIPTION
|Related issue|
|---|
|#2268|

## Description

This PR adds new check files fields: `last_update` and `checksum` to correctly identify a file.

## Examples

```json
{
"/swapfile": {
        "type": "file",
        "user": "root",
        "group": "root",
        "mode": "600",
        "permission": "-rw-------",
        "last_update": "2020-04-30 22:09:11",
        "checksum": "fd4a7db940b4769c890b2da2502928bf"
    },
    "/etc": {
        "type": "directory",
        "user": "root",
        "group": "root",
        "mode": "755",
        "permission": "drwxr-xr-x",
        "last_update": "2021-12-01 09:47:44"
    },
    "/etc/fstab": {
        "type": "file",
        "user": "root",
        "group": "root",
        "mode": "644",
        "permission": "-rw-r--r--",
        "last_update": "2021-11-25 10:08:23",
        "checksum": "03fba5384809f19db77ec7ebdc3a0b70"
    },
    .
    .
    .
}
```

## Checks
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.