### PR TITLE
Add scripts to add agents to client.keys, create agent-groups and unsynchronize agents

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -38,7 +38,8 @@ scripts_list = [
     'qa-docs=wazuh_testing.scripts.qa_docs:main',
     'qa-ctl=wazuh_testing.scripts.qa_ctl:main',
     'add-agents-client-keys=wazuh_testing.scripts.add_agents_client_keys:main',
-    'add-agents-to-default-group=wazuh_testing.scripts.add_agents_to_default_group:main'
+    'add-agents-to-default-group=wazuh_testing.scripts.add_agents_to_default_group:main',
+    'unsync-agents=wazuh_testing.scripts.unsync_agents:main'
 ]
 
 

--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -36,7 +36,8 @@ scripts_list = [
     'simulate-api-load=wazuh_testing.scripts.simulate_api_load:main',
     'wazuh-log-metrics=wazuh_testing.scripts.wazuh_log_metrics:main',
     'qa-docs=wazuh_testing.scripts.qa_docs:main',
-    'qa-ctl=wazuh_testing.scripts.qa_ctl:main'
+    'qa-ctl=wazuh_testing.scripts.qa_ctl:main',
+    'add-agents-client-keys=wazuh_testing.scripts.add_agents_client_keys:main'
 ]
 
 

--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -37,7 +37,8 @@ scripts_list = [
     'wazuh-log-metrics=wazuh_testing.scripts.wazuh_log_metrics:main',
     'qa-docs=wazuh_testing.scripts.qa_docs:main',
     'qa-ctl=wazuh_testing.scripts.qa_ctl:main',
-    'add-agents-client-keys=wazuh_testing.scripts.add_agents_client_keys:main'
+    'add-agents-client-keys=wazuh_testing.scripts.add_agents_client_keys:main',
+    'add-agents-to-default-group=wazuh_testing.scripts.add_agents_to_default_group:main'
 ]
 
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/add_agents_client_keys.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/add_agents_client_keys.py
@@ -4,6 +4,13 @@ from wazuh_testing.tools import CLIENT_KEYS_PATH
 
 
 def main():
+    """Add fake agents to client.keys. To use the script, pass two arguments indicating the first agent ID and the last
+    agent ID from the range of agents to be added.
+
+    The agents added will have ID={agent_id}, name=new_agent_{agent_id}, address=any; and password={agent_id}.
+
+    This script must be used in the Wazuh master node.
+    """
     if len(sys.argv) != 3:
         print(f"add_agents_client_keys.py <first_id> <last_id> (you used {' '.join(sys.argv)})")
         exit(1)

--- a/deps/wazuh_testing/wazuh_testing/scripts/add_agents_client_keys.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/add_agents_client_keys.py
@@ -1,0 +1,24 @@
+import sys
+
+from wazuh_testing.tools import CLIENT_KEYS_PATH
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"add_agents_client_keys.py <first_id> <last_id> (you used {' '.join(sys.argv)})")
+        exit(1)
+
+    first_id = min(int(sys.argv[1]), int(sys.argv[2]))
+    last_id = max(int(sys.argv[1]), int(sys.argv[2]))
+
+    agents_list = [str(agent_id).zfill(3) for agent_id in range(first_id, last_id + 1)]
+
+    with open(file=CLIENT_KEYS_PATH, mode='a') as f:
+        for agent_id in agents_list:
+            f.write(f"{agent_id} new_agent_{agent_id} any {agent_id}\n")
+            f.flush()  # Avoid bytes staying in the buffer until the loop has finished
+    exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/deps/wazuh_testing/wazuh_testing/scripts/add_agents_to_default_group.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/add_agents_to_default_group.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+from wazuh_testing.tools import CLIENT_KEYS_PATH
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"add_agents_to_default_group.py <first_id> <last_id> (you used {' '.join(sys.argv)})")
+        exit(1)
+
+    first_id = min(int(sys.argv[1]), int(sys.argv[2]))
+    last_id = max(int(sys.argv[1]), int(sys.argv[2]))
+
+    agents_list = [str(agent_id).zfill(3) for agent_id in range(first_id, last_id + 1)]
+
+    with open(file=CLIENT_KEYS_PATH, mode='r') as f:
+        agents_in_client_keys = f.read().split('\n')[:-1]
+    available_agents = [agent.split()[0] for agent in agents_in_client_keys]
+
+    for agent_id in set(agents_list).intersection(available_agents):
+        agent_group_file = f"/var/ossec/queue/agent-groups/{agent_id}"
+        if not os.path.exists(agent_group_file):
+            with open(file=agent_group_file, mode='w') as f:
+                f.write('default')
+
+    exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/deps/wazuh_testing/wazuh_testing/scripts/add_agents_to_default_group.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/add_agents_to_default_group.py
@@ -5,6 +5,14 @@ from wazuh_testing.tools import CLIENT_KEYS_PATH
 
 
 def main():
+    """Add agents to default group. To use the script, pass two arguments indicating the first agent ID and the last
+    agent ID from the range of agents to be added to the default group.
+
+    The result of the intersection of the agents list generated, and the list of agents with which ID is in the
+    client.keys file; will be the agents for which agent-groups will be created.
+
+    This script must be used in a Wazuh worker node.
+    """
     if len(sys.argv) != 3:
         print(f"add_agents_to_default_group.py <first_id> <last_id> (you used {' '.join(sys.argv)})")
         exit(1)

--- a/deps/wazuh_testing/wazuh_testing/scripts/add_agents_to_default_group.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/add_agents_to_default_group.py
@@ -8,8 +8,8 @@ def main():
     """Add agents to default group. To use the script, pass two arguments indicating the first agent ID and the last
     agent ID from the range of agents to be added to the default group.
 
-    The result of the intersection of the agents list generated, and the list of agents with which ID is in the
-    client.keys file; will be the agents for which agent-groups will be created.
+    The agents for which agent-groups will be created will be the intersection of the agent list generated and the list
+    of agents whose ID is in the client.keys file.
 
     This script must be used in a Wazuh worker node.
     """

--- a/deps/wazuh_testing/wazuh_testing/scripts/unsync_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/unsync_agents.py
@@ -1,0 +1,64 @@
+import socket
+import struct
+import sys
+import time
+
+
+def main():
+    def send_msg(msg):
+        msg = struct.pack('<I', len(msg)) + msg.encode()
+
+        # Send msg
+        sock.send(msg)
+
+        # Receive response
+        data = sock.recv(4)
+        data_size = struct.unpack('<I', data[0:4])[0]
+        data = sock.recv(data_size).decode(encoding='utf-8', errors='ignore').split(" ", 1)
+
+        return data
+
+    if len(sys.argv) != 4:
+        msg = f"unsync.py <first_id> <last_id> <node_name> (you used {' '.join(sys.argv)})"
+        print(msg)
+        exit(1)
+
+    first_id = min(int(sys.argv[1]), int(sys.argv[2]))
+    last_id = max(int(sys.argv[1]), int(sys.argv[2]))
+    node_name = sys.argv[3]
+
+    ADDR = '/var/ossec/queue/db/wdb'
+
+    while True:
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.connect(ADDR)
+            msg = f'global sql UPDATE agent SET node_name = "{node_name}", version="Wazuh v4.0.0" ' \
+                  f'where id>{first_id} and id<={last_id}'
+            print(f"Updating node_name ({node_name}) and version of the agents: {send_msg(msg)}")
+            sock.close()
+            break
+        except Exception as e:
+            print(f"Could not find wdb socket: {e}. Retrying in 10 seconds...")
+            time.sleep(10)
+
+    while True:
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.connect(ADDR)
+            msg = f'global sql UPDATE agent SET sync_status="syncreq", last_keepalive="{int(time.time())}", ' \
+                  f'connection_status="active" where id>{first_id} and id<={last_id}'
+            print(f"Updating sync_status of agents between {first_id} and {last_id}: {send_msg(msg)}")
+            sock.close()
+            time.sleep(10)
+        except KeyboardInterrupt:
+            print("Closing socket")
+            sock.close()
+            exit(1)
+        except Exception as e:
+            print(f"An exception was raised: {e}. Retrying in 10 seconds...")
+            time.sleep(10)
+
+
+if __name__ == '__main__':
+    main()

--- a/deps/wazuh_testing/wazuh_testing/scripts/unsync_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/unsync_agents.py
@@ -5,7 +5,22 @@ import time
 
 
 def main():
+    """Desynchronize agents in the worker's global.db. To use the script, pass three arguments indicating the first
+    agent ID, the last agent ID from the range of agents to be added to the default group; and the node name.
+
+    The script updates the global.db agent table entries where ID is one in the range specified. This update includes
+    setting the node_name and the agent version. After that, each agent is marked as required to be synchronized
+    (synreq) every 10 seconds.
+
+    This script must be used in a Wazuh worker node.
+    """
+
     def send_msg(msg):
+        """Send message to a socket.
+
+        Args:
+            msg (str): Message to be sent to the socket.
+        """
         msg = struct.pack('<I', len(msg)) + msg.encode()
 
         # Send msg


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/10932|


## Description

This PR is related to https://github.com/wazuh/wazuh/issues/10932. In that issue, some scripts have been created to test some cluster capabilities in a long-term stability test. 

The capabilities tested were the local integrity process, agent-info tasks, and extra valid files synchronization process.
This pull request adds these scripts to the `wazuh_testing` module in order to reuse them in the future if we had to.


## Tests

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
