### PR TITLE
Add test fim with file currently open

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -121,7 +121,7 @@ def write_file(file_path, data):
 
 
 def write_file_without_close(file_path, data=''):
-     """
+    """
     Create and write file without close
 
     Args:

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -120,6 +120,11 @@ def write_file(file_path, data):
         f.write(data)
 
 
+def write_file_without_close(file_path, data=''):
+    file = open(file_path, "w")
+    file.write(data)
+
+
 def read_json_file(file_path):
     return json.loads(read_file(file_path))
 

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -120,8 +120,15 @@ def write_file(file_path, data):
         f.write(data)
 
 
-# Created and writre file without close
 def write_file_without_close(file_path, data=''):
+     """
+    Create and write file without close
+
+    Args:
+        file_path: File path where the file will create.
+        data: Data to write.
+        
+    """
     file = open(file_path, "w")
     file.write(data)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -120,6 +120,7 @@ def write_file(file_path, data):
         f.write(data)
 
 
+# Created and writre file without close
 def write_file_without_close(file_path, data=''):
     file = open(file_path, "w")
     file.write(data)

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_basic_conf.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_basic_conf.yaml
@@ -1,0 +1,31 @@
+---
+# conf 1
+- tags:
+  - ossec_conf
+  apply_to_modules:
+  - MODULE_NAME
+  sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - directories:
+        value: TEST_DIRECTORIES
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+          

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
@@ -59,11 +59,9 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import generate_params, callback_detect_integrity_event
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
-from wazuh_testing.tools.file import write_file_without_close
+from wazuh_testing.tools.file import write_file_without_close, remove_file
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools import PREFIX
-
-from deps.wazuh_testing.wazuh_testing.tools.file import remove_file
 
 
 # Marks

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
@@ -70,7 +70,7 @@ pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # variables
 
-directory_str = os.path.join(PREFIX, 'testdir123')
+directory_str = os.path.join(PREFIX, 'testdir')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_basic_conf.yaml')
 
@@ -91,9 +91,7 @@ def get_configuration(request):
 
 
 # tests
-@pytest.mark.parametrize('tags_to_apply', [
-    {'ossec_conf'}
-])
+@pytest.mark.parametrize('tags_to_apply', [{'ossec_conf'}])
 def test_file_currently_open(tags_to_apply, get_configuration, configure_environment, file_monitoring,
                              restart_syscheckd):
     '''

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
@@ -1,0 +1,155 @@
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: File Integrity Monitoring (FIM) system watches selected files and triggering alerts when these
+       files are modified. Specifically, these tests will check if FIM could work correctly when a file is open.
+       The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
+       for changes to the checksums, permissions, and ownership.
+
+tier: 0
+
+modules:
+    - fim
+
+components:
+    - agent
+    - manager
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows 10
+    - Windows 8
+    - Windows 7
+    - Windows Server 2019
+    - Windows Server 2016
+    - Windows Server 2012
+    - Windows Server 2003
+    - Windows XP
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+pytest_args:
+    - fim_mode:
+        realtime: Enable real-time monitoring on Linux (using the 'inotify' system calls) and Windows systems.
+        whodata: Implies real-time monitoring but adding the 'who-data' information.
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - fim_basic_usage
+'''
+import os
+import pytest
+
+from wazuh_testing import global_parameters
+from wazuh_testing.fim import generate_params, callback_detect_integrity_event
+from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.file import write_file_without_close
+from wazuh_testing.tools.services import control_service
+from wazuh_testing.tools import PREFIX
+
+from deps.wazuh_testing.wazuh_testing.tools.file import remove_file
+
+
+# Marks
+
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
+
+
+# variables
+
+directory_str = os.path.join(PREFIX, 'testdir123')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+configurations_path = os.path.join(test_data_path, 'wazuh_basic_conf.yaml')
+
+
+# configurations
+
+conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}
+parameters, metadata = generate_params(extra_params=conf_params, modes=['scheduled'])
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
+# fixtures
+
+@pytest.fixture(scope='module', params=configurations)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+
+# tests
+@pytest.mark.parametrize('tags_to_apply', [
+    {'ossec_conf'}
+])
+def test_file_currently_open(tags_to_apply, get_configuration, configure_environment, file_monitoring,
+                             restart_syscheckd):
+    '''
+    description: Check if FIM could work correctly when a file is open..
+                 For this purpose, the test uses open a file without close and restart Wazuh
+                 in order to get the first scan of FIM. Finally, it verifies that
+                 the FIM events have been generated properly.
+
+    wazuh_min_version: 4.1.0
+
+    parameters:
+        - tags_to_apply:
+            type: set
+            brief: Run test if match with a configuration identifier, skip otherwise.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+        - restart_syscheckd:
+            type: fixture
+            brief: Clear the 'ossec.log' file and start a new monitor.
+
+    assertions:
+        - Verify that FIM events are generated for the operations performed.
+
+    input_description: A test case (ossec_conf) is contained in external YAML file (wazuh_basic_conf.yaml)
+                       which includes configuration settings for the 'wazuh-syscheckd' daemon and, it
+                       is combined with the testing directories to be monitored defined in this module.
+
+    expected_output:
+        - r'.*Sending integrity control message: (.+)$' (Sending integrity control when restarting Wazuh)
+
+    tags:
+        - scheduled
+    '''
+    check_apply_test(tags_to_apply, get_configuration['tags'])
+
+    # Created and writre file without close
+    write_file_without_close(directory_str, directory_str)
+
+    # Restart Wazuh and check FIM logs
+    try:
+        # File integrity monitoring scan
+        control_service('restart')
+        log_monitor.start(timeout=global_parameters.default_timeout, callback=callback_detect_integrity_event,
+                          error_message='Did not receive expected '
+                          '"Sending integrity control message: ..." event')
+
+    # Delete directory
+    finally:
+        remove_file(directory_str)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
@@ -19,7 +19,6 @@ modules:
 
 components:
     - agent
-    - manager
 
 daemons:
     - wazuh-syscheckd
@@ -99,11 +98,11 @@ def test_file_currently_open(tags_to_apply, get_configuration, configure_environ
                              restart_syscheckd):
     '''
     description: Check if FIM could work correctly when a file is open..
-                 For this purpose, the test uses open a file without close and restart Wazuh
+                 For this purpose, the test open a file without close and restart Wazuh
                  in order to get the first scan of FIM. Finally, it verifies that
                  the FIM events have been generated properly.
 
-    wazuh_min_version: 4.1.0
+    wazuh_min_version: 4.1.3
 
     parameters:
         - tags_to_apply:

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py
@@ -12,7 +12,7 @@ brief: File Integrity Monitoring (FIM) system watches selected files and trigger
        The FIM capability is managed by the 'wazuh-syscheckd' daemon, which checks configured files
        for changes to the checksums, permissions, and ownership.
 
-tier: 0
+tier: 1
 
 modules:
     - fim
@@ -65,7 +65,7 @@ from wazuh_testing.tools import PREFIX
 
 # Marks
 
-pytestmark = [pytest.mark.win32, pytest.mark.tier(level=0)]
+pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 
 
 # variables


### PR DESCRIPTION
|Related issue|
|---|
| #1150 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In order to test #1150 we add a test that checks that FIM correctly work when a file is currently open
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

Type | Format |   Tag | File name
-- | -- | -- | -- | 
Agent | msi | 4.3.0 | [wazuh-agent-4.3.0-0.40302.20211119.msi)](https://packages-dev.wazuh.com/staging/windows/wazuh-agent-4.3.0-0.40302.20211119.msi)


## Configuration options 
> syscheck.debug=2
> agent.debug=2
> monitord.rotate_log=0
> windows.debug=2

## Test

### test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py

| Test path |  OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |
| test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py | Agent   | Jenkins | 4.3 | 03/12/2021| [:green_circle: ](https://ci.wazuh.info/job/Test_integration/16932/) | Camila |
| test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py | Agent   | Jenkins | 4.3 |03/12/2021 | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/16933/)  | Camila|
| test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py | Agent   | Jenkins | 4.3 | 03/12/2021| [:green_circle: ](https://ci.wazuh.info/job/Test_integration/16934/) | Camila|
| test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py | Agent   | Local | 4.3 |03/12/2021 |  [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7651657/r1-1150.zip) | Camila |
| test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py | Agent   | Local | 4.3 | 03/12/2021|  [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7651658/r2-1150.zip) | Camila |
| test_fim/test_files/test_basic_usage/test_basic_usage_currently_open.py | Agent   | Local | 4.3 |03/12/2021 |  [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7651659/r3-1150.zip)  | Camila |

### test_fim/

| Test path | OS  | Type  | Version | Date | Status | Executed by |
|---   |---    |---    |--- |--- |--- |--- |
| test_fim/ | Agent   | Jenkins | 4.3 | 03/12/2021 |[:green_circle: ](https://ci.wazuh.info/job/Test_integration/16942/) | Camila |
| test_fim/ | Agent   | Jenkins | 4.3 | 03/12/2021 |[:green_circle: ](https://ci.wazuh.info/job/Test_integration/16943/)  | Camila |
| test_fim/ | Agent   | Jenkins | 4.3 | 03/12/2021 |[:green_circle: ](https://ci.wazuh.info/job/Test_integration/16944/) | Camila |
| test_fim/ | Agent   | Local | 4.3 | 06/12/2021 |[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7661176/R1-1150.zip)| Camila |
| test_fim/ | Agent   | Local | 4.3 | 06/12/2021 |[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7661177/R2-1150.zip)  | Camila |
| test_fim/ | Agent   | Local | 4.3 | 06/12/2021 |[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/7661179/R3-1150.zip) | Camila |

<!--
Paste here related logs and alerts
-->

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
