### PR TITLE
Mark use of MD5 in Azure integration as false positive

### DIFF
--- a/tests/scans/code_analysis/known_flaws/known_flaws_wodles.json
+++ b/tests/scans/code_analysis/known_flaws/known_flaws_wodles.json
@@ -1,6 +1,5 @@
 {
-    "false_positives": [],
-    "to_fix": [
+    "false_positives": [
         {
             "code": "     # Build the request\n     md5_hash = md5(args.la_query.encode()).hexdigest()\n     url = f\"{url_analytics}/v1/workspaces/{args.workspace}/query\"\n",
             "filename": "wodles/azure/azure-logs.py",
@@ -42,7 +41,9 @@
             "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md5",
             "test_id": "B303",
             "test_name": "blacklist"
-        },
+        }
+    ],
+    "to_fix": [
         {
             "code": "     try:\n         proc = subprocess.Popen([wazuh_control, option], stdout=subprocess.PIPE)\n         (stdout, stderr) = proc.communicate()\n",
             "filename": "wodles/utils.py",


### PR DESCRIPTION
|Related issue|
|---|
|#2330|

## Description
After the investigation made in wazuh/wazuh#10116, we concluded that the use of the MD5 hashing algorithm that's being made in the Azure integration doesn't incur in a security flaw, and therefore  in this PR we are marking it as a false positive for the `test_python_flaws.py` test.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.