### PR TITLE
Test API IPV6 agent registration

### DIFF
--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -99,3 +99,24 @@ def wait_for_start(get_configuration, request):
 @pytest.fixture(scope='module')
 def get_api_details():
     return get_api_details_dict
+
+
+
+
+@pytest.fixture(scope='module')
+def restart_api_module():
+    # Stop Wazuh and Wazuh API
+    control_service('stop')
+    control_service('start')
+
+
+@pytest.fixture(scope='module')
+def wait_for_start_module():
+    # Wait for API to start
+    file_monitor = FileMonitor(API_LOG_FILE_PATH)
+    file_monitor.start(timeout=20, callback=callback_detect_api_start,
+                       error_message='Did not receive expected "INFO: Listening on ..." event')
+
+@pytest.fixture(scope='module')
+def restart_and_wait_api(restart_api_module, wait_for_start_module):
+    pass

--- a/tests/integration/test_api/test_registration/data/tcases.yaml
+++ b/tests/integration/test_api/test_registration/data/tcases.yaml
@@ -1,0 +1,450 @@
+- 
+  name: "Basic name and IPV4"
+  parameters:
+    -
+      agent_name: "api-registration-agent-1"
+      agent_ip: "172.14.1.1"
+      ipv6: False
+  expected:
+    -
+      json: 
+        data: &agent_create_response
+          id: ANY
+          key: ANY
+        error: 0
+
+- 
+  name: "Basic name and IPV6 exploded"
+  parameters:
+    -
+      agent_name: "api-registration-agent-2" 
+      agent_ip: "0000:0000:0000:0000:0000:ffff:ac0e:0102"
+      ipv6: True
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-3" 
+      agent_ip: "::ffff:ac0e:103"
+      ipv6: True
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-4" 
+      agent_ip: "::0000:0000:0000:0000:ffff:ac0e:0104"
+      ipv6: True
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+- 
+  name: "Basic name and IPV6 short short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-5" 
+      agent_ip: "::0000:0000:0000:ffff:ac0e:0105"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-6" 
+      agent_ip: "::0000:0000:ffff:ac0e:0106"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-7" 
+      agent_ip: "::0000:0000:ffff:ac0e:0107"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-8" 
+      agent_ip: "::0000:ffff:ac0e:0107"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-9" 
+      agent_ip: "2001:db80:0000::"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-10" 
+      agent_ip: "2002:db80:0000:0000::"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-11" 
+      agent_ip: "2003:db80:0000:0000:0000::"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-12" 
+      agent_ip: "2004:db80:0000:0000:0000:0000::"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-13" 
+      agent_ip: "2005:db80::0001"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-14" 
+      agent_ip: "2005:db80:0000:0000::0002"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-15" 
+      agent_ip: "2005:db80:0000::0000:0000:0003"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-16" 
+      agent_ip: "1:8::4:7"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-17" 
+      agent_ip: "1:8::"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-18" 
+      agent_ip: "1::8"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-19" 
+      agent_ip: "::1:8"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+- 
+  name: "Basic name and IPV6 short"
+  parameters:
+    -
+      agent_name: "api-registration-agent-20" 
+      agent_ip: "2001:db8::"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+
+- 
+  name: "Basic name and IPV6 repeated IP"
+  parameters:
+    -
+      agent_name: "api-registration-agent-21" 
+      agent_ip: "0001:0010:0100:1000:0000:0011:0111:1111"
+      ipv6: True
+
+    -   
+      agent_name: "api-registration-agent-22" 
+      agent_ip: "0001:0010:0100:1000:0000:0011:0111:1111"
+      ipv6: True
+
+    -   
+      agent_name: "api-registration-agent-23" 
+      agent_ip: "1:0010:0100:1000:0000:0011:0111:1111"
+      ipv6: True
+
+    -   
+      agent_name: "api-registration-agent-24" 
+      agent_ip: "0001:10:0100:1000:0000:0011:0111:1111"
+      ipv6: True
+
+    -   
+      agent_name: "api-registration-agent-25" 
+      agent_ip: "0001:0010:100:1000:0000:0011:0111:1111"
+      ipv6: True
+    -   
+      agent_name: "api-registration-agent-26" 
+      agent_ip: "0001:0010:0100:1000::0011:0111:1111"
+      ipv6: True
+
+    -   
+      agent_name: "api-registration-agent-27" 
+      agent_ip: "0001:0010:0100:1000:0000:11:0111:1111"
+      ipv6: True
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 0001:0010:0100:1000:0000:0011:0111:1111"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 0001:0010:0100:1000:0000:0011:0111:1111"
+        error: 1706
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 1:0010:0100:1000:0000:0011:0111:1111"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 1:0010:0100:1000:0000:0011:0111:1111"
+        error: 1706
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 0001:10:0100:1000:0000:0011:0111:1111"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 0001:10:0100:1000:0000:0011:0111:1111"
+        error: 1706
+
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 0001:0010:100:1000:0000:0011:0111:1111"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 0001:0010:100:1000:0000:0011:0111:1111"
+        error: 1706
+
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 0001:0010:0100:1000::0011:0111:1111"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 0001:0010:0100:1000::0011:0111:1111"
+        error: 1706
+
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 0001:0010:0100:1000:0000:11:0111:1111"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 0001:0010:0100:1000:0000:11:0111:1111"
+        error: 1706
+
+- 
+  name: "Basic name and IPV4 repeated IP"
+  parameters:
+    -
+      agent_name: "api-registration-agent-28" 
+      agent_ip: "172.14.1.2"
+      ipv6: False
+
+    -
+      agent_name: "api-registration-agent-29" 
+      agent_ip: "172.14.1.2"
+      ipv6: False
+
+  expected:
+    -
+      json:
+        data:
+          <<: *agent_create_response
+        error: 0
+
+    -
+      json:
+        title: "Bad Request"
+        detail: "There is an agent with the same IP or the IP is invalid: 172.14.1.2"
+        remediation: "Please choose another IP"
+        dapi_errors:
+          node01:
+            error: "There is an agent with the same IP or the IP is invalid: 172.14.1.2"
+        error: 1706

--- a/tests/integration/test_api/test_registration/data/wazuh_conf.yaml
+++ b/tests/integration/test_api/test_registration/data/wazuh_conf.yaml
@@ -1,0 +1,12 @@
+---
+- tags:
+  - test_api_registration
+  apply_to_modules:
+  - test_api_registration
+  sections:
+  - section: auth
+    elements:
+    - disabled:
+        value: 'no'
+    - ipv6:
+        value: 'IPV6'

--- a/tests/integration/test_api/test_registration/test_api_registration.py
+++ b/tests/integration/test_api/test_registration/test_api_registration.py
@@ -1,0 +1,151 @@
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+'''
+import os
+import pytest
+import yaml
+import requests
+import time
+import re
+import ipaddress
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+
+from wazuh_testing.api import get_api_details_dict
+from wazuh_testing.tools import CLIENT_KEYS_PATH
+from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools.wazuh_manager import remove_all_agents
+
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0)]
+
+# Configuration
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+api_registration_requets_file = os.path.join(test_data_path, 'tcases.yaml')
+daemons_handler_configuration = {'all_daemons': True}
+api_registration_requests = []
+with open(api_registration_requets_file) as tcases:
+    api_registration_requests = yaml.load(tcases)
+
+expected_json_ipv6_not_valid = {'error': 1}
+
+parameters = [
+    {'IPV6': 'yes'},
+    {'IPV6': 'no'}
+]
+metadata = [
+    {'ipv6': 'yes'},
+    {'ipv6': 'no'},
+]
+
+configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
+configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+configuration_ids = [f"{x['ipv6']}" for x in metadata]
+
+
+# fixtures
+@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
+def get_configuration(request):
+    """Get configurations from the module."""
+    return request.param
+
+def retrieve_client_key_entry(agent_parameters):
+    with open(CLIENT_KEYS_PATH) as client_keys_file:
+        client_keys_content = client_keys_file.readlines()
+        client_keys_dictionary = []
+        for entry in client_keys_content:
+            client_key_agent_list = entry.split()
+
+            client_key_agent_dict = {}
+            client_key_agent_dict.update({'id': client_key_agent_list[0], 'name': client_key_agent_list[1], 
+                                          'ip': client_key_agent_list[2], 'key': client_key_agent_list[3]})
+
+            client_keys_dictionary.append(client_key_agent_dict)
+
+    desired_entries = []
+    for client_keys_entry_dict in client_keys_dictionary:
+        if agent_parameters.items() <= client_keys_entry_dict.items():
+            desired_entries.append(agent_parameters)
+    return desired_entries
+
+
+@pytest.fixture(scope="module")
+def clean_registered_agents():
+    truncate_file(CLIENT_KEYS_PATH)
+    time.sleep(10)
+    remove_all_agents('manage_agents')
+    time.sleep(5)
+
+    yield
+
+    remove_all_agents('manage_agents')
+
+
+def check_valid_agent_id(id):
+    return re.match("(^[0-9][0-9][0-9]$)", id)
+
+
+def check_valid_agent_key(key):
+    return len(key) > 0
+
+
+def check_api_data_response(api_response, expected_response):
+    api_response_error = api_response['error']
+    assert api_response_error == expected_response['error']
+
+    if api_response_error == 0:
+        if 'key' in expected_response['data']:
+            assert check_valid_agent_key(api_response['data']['key'])
+            del api_response['data']['key']
+            del expected_response['data']['key']
+
+        if 'id' in expected_response['data']:
+            assert check_valid_agent_id(api_response['data']['id']) 
+            del api_response['data']['id']
+            del expected_response['data']['id']
+
+    return  api_response == expected_response
+
+
+@pytest.mark.parametrize("api_registration_parameters", api_registration_requests)
+def test_agentd_server_configuration(api_registration_parameters, get_configuration, configure_environment, 
+                                     restart_and_wait_api, clean_registered_agents):
+
+    for stage in range(len(api_registration_parameters['parameters'])):
+
+        request_parameters = api_registration_parameters['parameters'][stage]
+        expected = api_registration_parameters['expected'][stage]
+        registration_ip_ipv6 = api_registration_parameters['parameters'][stage]['ipv6']
+
+
+        api_details = get_api_details_dict()
+        api_query = f"{api_details['base_url']}/agents?"
+
+        expected_client_keys_ip = request_parameters['agent_ip']
+        if api_registration_parameters['parameters'][stage]['ipv6']:
+            expected_client_keys_ip = ipaddress.IPv6Address(request_parameters['agent_ip']).exploded 
+
+        expected_client_keys_entry = {'name': request_parameters['agent_name'],
+                                      'ip':  expected_client_keys_ip}
+        request_json = {'name': request_parameters['agent_name'],
+                        'ip':  request_parameters['agent_ip']}
+
+        response = requests.post(api_query, headers=api_details['auth_headers'], json=request_json,
+                                 verify=False)
+
+        if get_configuration['metadata']['ipv6'] == 'no' and registration_ip_ipv6:
+            assert check_api_data_response(response.json(), expected_json_ipv6_not_valid)
+        else:
+            # Assert response is the same specified in the api_registration_parameters
+            assert check_api_data_response(response.json(), expected['json'])
+        
+        # Ensure client keys is updated
+        if response.json()['error'] == 0:
+            assert retrieve_client_key_entry(expected_client_keys_entry)


### PR DESCRIPTION
|Related issue|
|---|
|#2284|

## Description
closes #2284

This PR adds a new test [for API registration](https://documentation.wazuh.com/current/user-manual/registering/restful-api-registration.html) for IPV6 support.

This test check:
- Agents can/cannot be registered using IPV6 when this is enabled/disabled. 
- Agents registered using IPV6 stored their IP in a complete format in the client.keys file
- Agents can not be registered using the same IP

This test should be used along with https://github.com/wazuh/wazuh/issues/10930.

## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.