### PR TITLE
Fix autoconfigure `test_add_old_resource`

### DIFF
--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -99,3 +99,18 @@ def wait_for_start(get_configuration, request):
 @pytest.fixture(scope='module')
 def get_api_details():
     return get_api_details_dict
+
+
+@pytest.fixture(scope='module')
+def restart_api_module(request):
+    # Stop Wazuh and Wazuh API
+    control_service('stop')
+    control_service('start')
+
+
+@pytest.fixture(scope='module')
+def wait_for_start_module(request):
+    # Wait for API to start
+    file_monitor = FileMonitor(API_LOG_FILE_PATH)
+    file_monitor.start(timeout=20, callback=callback_detect_api_start,
+                       error_message='Did not receive expected "INFO: Listening on ..." event')

--- a/tests/integration/test_api/test_rbac/test_add_old_resource.py
+++ b/tests/integration/test_api/test_rbac/test_add_old_resource.py
@@ -66,7 +66,7 @@ user_id, role_id, policy_id, rule_id = None, None, None, None
 
 # Tests
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
-def test_add_old_user(set_security_resources, get_api_details):
+def test_add_old_user(restart_api_module, wait_for_start_module, set_security_resources, get_api_details):
     '''
     description: Check if the security relationships of a previous user are maintained
                  in the system after adding a new user with the same ID.


### PR DESCRIPTION
|Related issue|
|---|
|#2355|


## Description
This PR closes #2355, fixing API tests in Jenkins environment.

## Testing

### Package
| Version | Revision | Link|
---|---|---|
|4.3.0|1|https://packages-dev.wazuh.com/pre-release/yum/wazuh-manager-4.3.0-1.x86_64.rpm


## Testing

### API

|  CentOS: 8 |  Jenkins    | Notes
|---    |---    |---    
| R1  |   [:green_circle: ](https://ci.wazuh.info/view/Tests/job/Test_integration/17635/console)  | |
| R2   |   [:green_circle: ](https://ci.wazuh.info/view/Tests/job/Test_integration/17636/console)  | |
| R3   |  [:green_circle: ](https://ci.wazuh.info/view/Tests/job/Test_integration/17637/console)   | |

* *  *




*  * *
- :green_circle: All pass
- :yellow_circle: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress 