### PR TITLE
Mark API flaws as false positive

### DIFF
--- a/tests/scans/code_analysis/known_flaws/known_flaws_api.json
+++ b/tests/scans/code_analysis/known_flaws/known_flaws_api.json
@@ -1,6 +1,5 @@
 {
-    "false_positives": [],
-    "to_fix": [
+    "false_positives": [
         {
             "code": " default_api_configuration = {\n     \"host\": \"0.0.0.0\",\n     \"port\": 55000,\n     \"drop_privileges\": True,\n     \"experimental_features\": False,\n     \"max_upload_size\": 10485760,\n     \"intervals\": {\n         \"request_timeout\": 10\n     },\n38     \"https\": {\n39         \"enabled\": True,\n40         \"key\": \"api/configuration/ssl/server.key\",\n41         \"cert\": \"api/configuration/ssl/server.crt\",\n42         \"use_ca\": False,\n43         \"ca\": \"api/configuration/ssl/ca.crt\",\n44         \"ssl_protocol\": \"TLSv1.2\",\n45         \"ssl_ciphers\": \"\"\n46     },\n47     \"logs\": {\n48         \"level\": \"info\",\n49         \"path\": \"logs/api.log\"\n50     },\n51     \"cors\": {\n52         \"enabled\": False,\n53         \"source_route\": \"*\",\n54         \"expose_headers\": \"*\",\n55         \"allow_headers\": \"*\",\n56         \"allow_credentials\": False,\n57     },\n58     \"cache\": {\n59         \"enabled\": True,\n60         \"time\": 0.750\n61     },\n62     \"access\": {\n63         \"max_login_attempts\": 50,\n64         \"block_time\": 300,\n65         \"max_request_per_minute\": 300\n66     },\n67     \"remote_commands\": {\n68         \"localfile\": {\n69             \"enabled\": True,\n70             \"exceptions\": []\n71         },\n72         \"wodle_command\": {\n73             \"enabled\": True,\n74             \"exceptions\": []\n75         }\n76     }\n",
             "filename": "api/api/configuration.py",
@@ -31,5 +30,6 @@
             "test_id": "B106",
             "test_name": "hardcoded_password_funcarg"
         }
-    ]
+    ],
+    "to_fix": []
 }


### PR DESCRIPTION
|Related issue|
|---|
| #2330 |

## Description
* Wazuh main issue: https://github.com/wazuh/wazuh/issues/10142.
* Flaw status: **FALSE POSITIVE**.

Under this development, the related possible code flaw is set as solved using [Code Analysis Tool](https://github.com/wazuh/wazuh-qa/tree/master/tests/scans/code_analysis).

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.