### PR TITLE
Migrate test_general_setting documentation to qa-docs

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: Set of tests that check the behavior of Vulnerability Detector when there is any extra tag in the feed.
+brief: Set of tests that check the behavior of Vulnerability Detector when there is an extra tag in the feed.
 
 tier: 2
 
@@ -19,6 +19,8 @@ components:
 
 daemons:
     - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
 
 os_platform:
     - linux
@@ -44,7 +46,8 @@ os_version:
 
 references:
     - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.md#test-extra-tags-alas-feed
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/alas/
+      test_extra_tags_alas_feed.md#test-extra-tags-alas-feed
 
 tags:
     - vulnerability
@@ -95,7 +98,9 @@ daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'waz
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
@@ -114,12 +119,20 @@ def copy_files(get_configuration):
 
 @pytest.fixture(scope='module')
 def set_system():
+    '''
+    Set custom system in global DB Agent info
+
+    Args
+        system (str): system to set. Available systems in SYSTEM_DATA variable
+    '''
     vd.set_system(system='ALAS')
 
 
 @pytest.fixture
 def modify_feed(test_values, get_configuration, request):
-    """Modify the Amazon Linux JSON feed by setting a test tag value."""
+    '''
+    Modify the Amazon Linux JSON feed by setting a test tag value.
+    '''
     alas_feed_path = get_configuration['metadata']['alas_custom_feed']
 
     backup_data = read_json_file(alas_feed_path)
@@ -136,9 +149,54 @@ def modify_feed(test_values, get_configuration, request):
     vd.clean_vuln_and_sys_programs_tables()
 
 
-def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration, configure_environment, daemons_handler,
-                         file_monitoring):
-    """Check if the feed is imported successfully by default."""
+def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration,
+                         configure_environment, daemons_handler, file_monitoring):
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is launched
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - after_execution_clean_vuln_tables_function:
+            type: fixture
+            brief: Clean vulnerabilities tables after execution.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
+          different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if alas_feed_files[get_configuration['metadata']['os']] == custom_alas_json_feed_path:
         vd.check_feed_imported_successfully(wazuh_log_monitor=log_monitor, log_system_name=vd.ALAS_LOG,
                                             expected_vulnerabilities_number=vd.ALAS_NUM_CUSTOM_VULNERABILITIES)
@@ -148,9 +206,62 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
 
 
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
-def test_extra_tags_alas_linux_feed(copy_files, modify_feed, daemons_handler, test_values, set_system, get_configuration, configure_environment,
-                                    restart_modulesd_function, file_monitoring):
-    """Check if Vulnerability Detector behaves as expected while importing Amazon Linux JSON feed with extra tags."""
+def test_extra_tags_alas_linux_feed(copy_files, modify_feed, daemons_handler, test_values, set_system,
+                                    get_configuration, configure_environment, restart_modulesd_function,
+                                    file_monitoring):
+    '''
+    description: Check if Vulnerability Detector behaves as expected while importing Amazon Linux JSON feed with extra
+                 tags. To do this, a vulnerability event is launched and check if the number of vulnerabilities inserted
+                 in the VULNERABILITIES table of CVE DB is the expected and finally check if the process is still
+                 running.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
+        - set_system:
+            type: fixture
+            brief: Set custom system in global DB Agent info.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Perform the restart operation with Wazuh.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if process is running.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
+          different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     field = test_values[0]
 
     if type(field) in [str]:

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
@@ -45,9 +45,7 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/alas/
-      test_extra_tags_alas_feed.md#test-extra-tags-alas-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
 
 tags:
     - vulnerability
@@ -98,9 +96,7 @@ daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'waz
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
@@ -119,17 +115,13 @@ def copy_files(get_configuration):
 
 @pytest.fixture(scope='module')
 def set_system():
-    '''
-    Set custom system in global DB Agent info
-    '''
+    """Set custom system in global DB Agent info."""
     vd.set_system(system='ALAS')
 
 
 @pytest.fixture
 def modify_feed(test_values, get_configuration, request):
-    '''
-    Modify the Amazon Linux JSON feed by setting a test tag value.
-    '''
+    """Modify the Amazon Linux JSON feed by setting a test tag value."""
     alas_feed_path = get_configuration['metadata']['alas_custom_feed']
 
     backup_data = read_json_file(alas_feed_path)

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
@@ -1,6 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when there is any extra tag in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.md#test-extra-tags-alas-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 from copy import deepcopy
 from tempfile import gettempdir

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
@@ -121,9 +121,6 @@ def copy_files(get_configuration):
 def set_system():
     '''
     Set custom system in global DB Agent info
-
-    Args
-        system (str): system to set. Available systems in SYSTEM_DATA variable
     '''
     vd.set_system(system='ALAS')
 
@@ -152,7 +149,7 @@ def modify_feed(test_values, get_configuration, request):
 def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration,
                          configure_environment, daemons_handler, file_monitoring):
     '''
-    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is launched
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
                  and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
                  expected.
 
@@ -247,8 +244,8 @@ def test_extra_tags_alas_linux_feed(copy_files, modify_feed, daemons_handler, te
             brief: Handle the monitoring of a specified file.
 
     assertions:
-        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
-          VULNERABILITIES table of CVE DB and if process is running.
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
         - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
@@ -257,6 +254,9 @@ def test_extra_tags_alas_linux_feed(copy_files, modify_feed, daemons_handler, te
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'
         - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
 
     tags:
         - vulnerability

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
@@ -183,7 +183,7 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
           VULNERABILITIES table of CVE DB.
 
     input_description:
-        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
           different kinds of vulnerability.
 
     expected_output:
@@ -248,8 +248,9 @@ def test_extra_tags_alas_linux_feed(copy_files, modify_feed, daemons_handler, te
           VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
-          different kinds of vulnerability.
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability. Also, there is a test_values list where each item of the list contains a tag
+          and a value. Based on the tag the feed is checked to be imported successful or not.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
@@ -244,8 +244,9 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
 def test_invalid_syntax_alas_feed(copy_files, modify_feed, daemons_handler, test_data, set_system, get_configuration,
                                   configure_environment, restart_modulesd_function, file_monitoring):
     '''
-    description: Check if the feed is imported successfully by default. To do this, check an error message when
-                 importing the feeds and checks that the vulnerabilities table is empty
+    description: Check if Vulnerability Detector behaves as expected while importing Amazon Linux feed with syntax
+                 errors. To do this, check an error message when importing the feeds and checks that the vulnerabilities
+                 table is empty.
 
     wazuh_min_version: 4.2.0
 
@@ -284,7 +285,7 @@ def test_invalid_syntax_alas_feed(copy_files, modify_feed, daemons_handler, test
 
     input_description:
         - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
-          different kinds of vulnerability. Also, there is a test_values list where each item of the list contains a tag
+          different kinds of vulnerability. Also, there is a test_data list where each item of the list contains a tag
           and a value. Based on the tag the feed is checked to be imported successful or not.
 
     expected_output:

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when the feed has some kind of syntactic error
+       such as missing character or closing tag, etc..
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import json
 import os
 from tempfile import gettempdir
@@ -86,7 +134,9 @@ daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'waz
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
@@ -105,12 +155,17 @@ def copy_files(get_configuration):
 
 @pytest.fixture(scope='module')
 def set_system():
+    '''
+    Set custom system in global DB Agent info
+    '''
     vd.set_system(system='ALAS')
 
 
 @pytest.fixture
 def modify_feed(test_data, get_configuration, request):
-    """Modify the Amazon Linux feed by setting a test field value."""
+    '''
+    Modify the Amazon Linux feed by setting a test field value.
+    '''
     alas_feed_path = get_configuration['metadata']['alas_custom_feed']
 
     backup_data = read_json_file(alas_feed_path)
@@ -129,9 +184,54 @@ def modify_feed(test_data, get_configuration, request):
     vd.clean_vuln_and_sys_programs_tables()
 
 
-def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration, configure_environment, daemons_handler,
-                         file_monitoring):
-    """Check if the feed is imported successfully by default"""
+def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration,
+                         configure_environment, daemons_handler, file_monitoring):
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - after_execution_clean_vuln_tables_function:
+            type: fixture
+            brief: Clean vulnerabilities tables after execution.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
+          different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if alas_feed_files[get_configuration['metadata']['os']] == custom_alas_json_feed_path:
         vd.check_feed_imported_successfully(wazuh_log_monitor=log_monitor, log_system_name=vd.ALAS_LOG,
                                             expected_vulnerabilities_number=vd.ALAS_NUM_CUSTOM_VULNERABILITIES)
@@ -141,8 +241,61 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
 
 
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
-def test_invalid_syntax_alas_feed(copy_files, modify_feed, daemons_handler, test_data, set_system, get_configuration, configure_environment,
-                                  restart_modulesd_function, file_monitoring):
+def test_invalid_syntax_alas_feed(copy_files, modify_feed, daemons_handler, test_data, set_system, get_configuration,
+                                  configure_environment, restart_modulesd_function, file_monitoring):
+    '''
+    description: Check if the feed is imported successfully by default. To do this, check an error message when
+                 importing the feeds and checks that the vulnerabilities table is empty
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - set_system:
+            type: fixture
+            brief: Set custom system in global DB Agent info.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Perform the restart operation with Wazuh.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
+          different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     """Check if the feed is imported successfully by default"""
     if test_data["description"] == "Add '}}'":
         with pytest.raises(TimeoutError):

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
@@ -221,7 +221,7 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
           VULNERABILITIES table of CVE DB.
 
     input_description:
-        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
           different kinds of vulnerability.
 
     expected_output:
@@ -283,8 +283,9 @@ def test_invalid_syntax_alas_feed(copy_files, modify_feed, daemons_handler, test
           VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. This file contains two
-          different kinds of vulnerability.
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability. Also, there is a test_values list where each item of the list contains a tag
+          and a value. Based on the tag the feed is checked to be imported successful or not.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'
@@ -296,7 +297,6 @@ def test_invalid_syntax_alas_feed(copy_files, modify_feed, daemons_handler, test
         - vulnerability
         - vulnerability_detector
     '''
-    """Check if the feed is imported successfully by default"""
     if test_data["description"] == "Add '}}'":
         with pytest.raises(TimeoutError):
             vd.check_failure_when_importing_feed(wazuh_log_monitor=log_monitor, parser_error=True)

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
@@ -44,7 +44,7 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
 
 tags:
     - vulnerability
@@ -134,9 +134,7 @@ daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'waz
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
@@ -155,17 +153,13 @@ def copy_files(get_configuration):
 
 @pytest.fixture(scope='module')
 def set_system():
-    '''
-    Set custom system in global DB Agent info
-    '''
+    """Set custom system in global DB Agent info."""
     vd.set_system(system='ALAS')
 
 
 @pytest.fixture
 def modify_feed(test_data, get_configuration, request):
-    '''
-    Modify the Amazon Linux feed by setting a test field value.
-    '''
+    """Modify the Amazon Linux feed by setting a test field value."""
     alas_feed_path = get_configuration['metadata']['alas_custom_feed']
 
     backup_data = read_json_file(alas_feed_path)

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
@@ -7,8 +7,8 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct invalid
-       type, strange characters...
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct like invalid
+       type, strange characters.
 
 tier: 2
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+       type, strange characters...
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/alas/
+      test_invalid_values_alas_feed.md#test-invalid-values-alas-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import itertools
 import os
 from tempfile import gettempdir
@@ -57,7 +107,9 @@ daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'waz
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
@@ -78,12 +130,17 @@ def copy_files(get_configuration):
 
 @pytest.fixture(scope='module')
 def set_system():
+    '''
+    Set custom system in global DB Agent info
+    '''
     vd.set_system(system='ALAS')
 
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, get_configuration, request):
-    """Modify the Amazon Linux feed by setting a test field value."""
+    '''
+    Modify the Amazon Linux feed by setting a test field value.
+    '''
     alas_feed_path = get_configuration['metadata']['alas_custom_feed']
 
     data = read_json_file(alas_feed_path)
@@ -106,9 +163,55 @@ def modify_feed(test_data, custom_input, get_configuration, request):
     vd.clean_vuln_and_sys_programs_tables()
 
 
-def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration, configure_environment, daemons_handler,
+def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration,
+                         configure_environment, daemons_handler,
                          file_monitoring):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - after_execution_clean_vuln_tables_function:
+            type: fixture
+            brief: Clean vulnerabilities tables after execution.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if get_configuration['metadata']['alas_custom_feed'] == custom_alas_json_feed_path:
         vd.check_feed_imported_successfully(wazuh_log_monitor=log_monitor, log_system_name=vd.ALAS_LOG,
                                             expected_vulnerabilities_number=vd.ALAS_NUM_CUSTOM_VULNERABILITIES)
@@ -119,10 +222,68 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
 
 @pytest.mark.parametrize('test_data, custom_input', itertools.product(test_data, vd.CUSTOM_INPUT_TEST_VALUES),
                          ids=test_data_ids)
-def test_invalid_values_alas_feed(copy_files, modify_feed, daemons_handler, test_data, custom_input, set_system, get_configuration, configure_environment,
-                                  restart_modulesd_function, file_monitoring):
-    """Check if Vulnerability Detector behaves as expected while importing Amazon Linux feed with syntax errors."""
+def test_invalid_values_alas_feed(copy_files, modify_feed, daemons_handler, test_data, custom_input, set_system,
+                                  get_configuration, configure_environment, restart_modulesd_function, file_monitoring):
+    '''
+    description: Check if Vulnerability Detector behaves as expected while importing Amazon Linux feed with an invalid
+                 value. To do this, fetch in the test_data list the type of information to be analyzed and get the
+                 expected vulnerabilities number of the custom_input list to check if the imported feed has not an
+                 invalid value.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - custom_input:
+            type: list
+            brief: Input list of dict of ids.
+        - set_system:
+            type: fixture
+            brief: Set custom system in global DB Agent info.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Perform the restart operation with Wazuh.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability. Also, there is a test_data that contains fields to be checked and a custom
+          list that contains the number of expected vulnerabilities. Based on the number of expected vulnerabilities,
+          feeds are imported successfully.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     alas_custom_feed_file = get_configuration['metadata']['alas_custom_feed'].split('/')[2]
 
     if vd.CUSTOM_ALAS_JSON_FEED == alas_custom_feed_file:

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
@@ -44,9 +44,7 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/alas/
-      test_invalid_values_alas_feed.md#test-invalid-values-alas-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
 
 tags:
     - vulnerability
@@ -107,9 +105,7 @@ daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'waz
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
@@ -130,17 +126,13 @@ def copy_files(get_configuration):
 
 @pytest.fixture(scope='module')
 def set_system():
-    '''
-    Set custom system in global DB Agent info
-    '''
+    """Set custom system in global DB Agent info."""
     vd.set_system(system='ALAS')
 
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, get_configuration, request):
-    '''
-    Modify the Amazon Linux feed by setting a test field value.
-    '''
+    """Modify the Amazon Linux feed by setting a test field value."""
     alas_feed_path = get_configuration['metadata']['alas_custom_feed']
 
     data = read_json_file(alas_feed_path)
@@ -226,9 +218,8 @@ def test_invalid_values_alas_feed(copy_files, modify_feed, daemons_handler, test
                                   get_configuration, configure_environment, restart_modulesd_function, file_monitoring):
     '''
     description: Check if Vulnerability Detector behaves as expected while importing Amazon Linux feed with an invalid
-                 value. To do this, fetch in the test_data list the type of information to be analyzed and get the
-                 expected vulnerabilities number of the custom_input list to check if the imported feed has not an
-                 invalid value.
+                 tag value. To do this, it fetches in the test_data list the type of information to be analyzed and
+                 modify the feed assigning strange labels and check if the feed can be imported.
 
     wazuh_min_version: 4.2.0
 
@@ -270,8 +261,8 @@ def test_invalid_values_alas_feed(copy_files, modify_feed, daemons_handler, test
 
     input_description:
         - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
-          different kinds of vulnerability. Also, there is a test_data that contains fields to be checked and a custom
-          list that contains the number of expected vulnerabilities. Based on the number of expected vulnerabilities,
+          different kinds of vulnerability. Also, there is a test_data that contains tags to be checked and a
+          custom_input list that contains strange labels. Based on the number of expected vulnerabilities,
           feeds are imported successfully.
 
     expected_output:

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
@@ -7,7 +7,7 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct invalid
        type, strange characters...
 
 tier: 2

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_missing_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_missing_tags_alas_feed.py
@@ -1,7 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when a tag is missing in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 from copy import deepcopy
 from tempfile import gettempdir
@@ -47,7 +94,6 @@ field_ids = [f"missing: {field}" for field in fields]
 configurations = load_wazuh_configurations(
     configurations_path, __name__, params=parameters, metadata=metadata)
 daemons_handler_configuration = {'daemons': ['wazuh-db', 'wazuh-analysisd', 'wazuh-modulesd'], 'ignore_errors': False}
-
 
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
@@ -101,16 +147,55 @@ def remove_field_feed(get_configuration, request):
     vd.clean_vuln_and_sys_programs_tables()
 
 
-def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration, configure_environment, daemons_handler,
+def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vuln_tables_function,  get_configuration,
+                         configure_environment, daemons_handler,
                          file_monitoring):
-    """Check if the feed is imported successfully by default.
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
 
-    Args:
-        clean_vuln_tables (fixture): Clean vulnerabilities tables.
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset the logs file and start a new monitor.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - after_execution_clean_vuln_tables_function:
+            type: fixture
+            brief: Clean vulnerabilities tables after execution.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if alas_feed_files[get_configuration['metadata']['os']] == custom_alas_json_feed_path:
         vd.check_feed_imported_successfully(wazuh_log_monitor=log_monitor, log_system_name=vd.ALAS_LOG,
                                             expected_vulnerabilities_number=vd.ALAS_NUM_CUSTOM_VULNERABILITIES)
@@ -119,16 +204,60 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, after_execution_clean_vu
                                             expected_vulnerabilities_number=vd.ALAS2_NUM_CUSTOM_VULNERABILITIES)
 
 
-def test_missing_tags_alas_feed(copy_files, remove_field_feed, daemons_handler, set_system, get_configuration, configure_environment,
-                                  restart_modulesd_function, file_monitoring):
-    """Check if the feed is imported successfully when certain fields are removed from it.
+def test_missing_tags_alas_feed(copy_files, remove_field_feed, daemons_handler, set_system, get_configuration,
+                                configure_environment, restart_modulesd_function, file_monitoring):
+    '''
+    description: Test to check vulnerability detector behavior when importing Amazon Linux feed with missing tags. To do
+                 this, a tag is removed from the feed and check if the vulnerability can be inserted into the database.
 
-    Args:
-        clean_vuln_tables (fixture): Clean vulnerabilities tables.
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        remove_field_feed (fixture): Modify the feed by removing a certain field and loading the new configuration.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - remove_field_feed:
+            type: fixture
+            brief: Modify the feed by removing a certain field and loading the new configuration.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - set_system:
+            type: fixture
+            brief: Set custom system in global DB Agent info.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Perform the restart operation with Wazuh.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability. 'fields' is the list of tags to be checked and 'field_ids' is the
+          dictionary's list that indicates the missing tag.
+
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if alas_feed_files[get_configuration['metadata']['os']] == custom_alas_json_feed_path:
         if remove_field_feed in ['vulnerabilities', 'fixed_packages']:
             expected_alas_vulnerabilities = 24

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
@@ -43,7 +43,7 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
 
 tags:
     - vulnerability
@@ -82,17 +82,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    '''
-    Modify the Arch Linux JSON feed by setting a test tag value.
-    '''
+    """Modify the Arch Linux JSON feed by setting a test tag value."""
     backup_data = read_json_file(custom_archlinux_json_feed_path)
     modified_data = deepcopy(backup_data)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
@@ -1,6 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when there is an extra tag in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import json
 import os
 from copy import deepcopy
@@ -34,14 +82,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    """Modify the Arch Linux JSON feed by setting a test tag value."""
-
+    '''
+    Modify the Arch Linux JSON feed by setting a test tag value.
+    '''
     backup_data = read_json_file(custom_archlinux_json_feed_path)
     modified_data = deepcopy(backup_data)
 
@@ -70,7 +121,43 @@ def modify_feed(test_values, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default."""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains two different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.ARCH_LOG,
                                         expected_vulnerabilities_number=vd.ARCH_NUM_CUSTOM_VULNERABILITIES)
 
@@ -78,7 +165,50 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
 def test_extra_tags_arch_linux_feed(test_values, clean_vuln_tables, get_configuration, configure_environment,
                                     modify_feed):
-    """Check if Vulnerability Detector behaves as expected while importing Arch Linux JSON feed with extra tags."""
+    '''
+    description: Check if Vulnerability Detector behaves as expected while importing Arch Linux JSON feed with extra
+                 tags. To do this, a vulnerability event is launched and check if the number of vulnerabilities inserted
+                 in the VULNERABILITIES table of CVE DB is the expected and finally check if the process is still
+                 running.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if process is running.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains two different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     inserted_tag = test_values[0]
 
     if type(inserted_tag) in [str]:

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
@@ -195,8 +195,8 @@ def test_extra_tags_arch_linux_feed(test_values, clean_vuln_tables, get_configur
           VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_archlinux_feed.json file. This file contains two different kinds of
-          vulnerability.
+        - Test cases are defined in the test_values list. Each item of the list contains a tag and a value. Based on the
+          tag the feed is checked to be imported successful or not.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
@@ -191,8 +191,8 @@ def test_extra_tags_arch_linux_feed(test_values, clean_vuln_tables, get_configur
             brief: Modify the Amazon Linux JSON feed by setting a test tag value.
 
     assertions:
-        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
-          VULNERABILITIES table of CVE DB and if process is running.
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
         - Test cases are defined in the custom_archlinux_feed.json file. This file contains two different kinds of

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when the feed has some kind of syntactic error
+       such as missing character or closing tag, etc..
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import json
 import os
 
@@ -75,13 +123,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    """Modify the Arch Linux feed by setting a test field value."""
+    '''
+    Modify the Arch Linux feed by setting a test field value.
+    '''
     backup_data = read_json_file(custom_archlinux_json_feed_path)
     modified_data = json.dumps(dict(backup_data[0]), indent=4)
 
@@ -106,7 +158,43 @@ def modify_feed(test_data, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.ARCH_LOG,
                                         expected_vulnerabilities_number=vd.ARCH_NUM_CUSTOM_VULNERABILITIES)
 
@@ -114,7 +202,46 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
 def test_invalid_syntax_arch_linux_feed(test_data, clean_vuln_tables, get_configuration, configure_environment,
                                         modify_feed):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, check an error message when
+                 importing the feeds and checks that the vulnerabilities table is empty
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, parser_error=True)
 
     vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
@@ -44,7 +44,7 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
 
 tags:
     - vulnerability
@@ -123,17 +123,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    '''
-    Modify the Arch Linux feed by setting a test field value.
-    '''
+    """Modify the Arch Linux feed by setting a test field value."""
     backup_data = read_json_file(custom_archlinux_json_feed_path)
     modified_data = json.dumps(dict(backup_data[0]), indent=4)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
@@ -203,8 +203,9 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 def test_invalid_syntax_arch_linux_feed(test_data, clean_vuln_tables, get_configuration, configure_environment,
                                         modify_feed):
     '''
-    description: Check if the feed is imported successfully by default. To do this, check an error message when
-                 importing the feeds and checks that the vulnerabilities table is empty
+    description: Check if vulnerability detector behaves as expected when importing Archlinux feeds with syntax errors.
+                 To do this, check an error message when importing the feeds and checks that the vulnerabilities table
+                 is empty.
 
     wazuh_min_version: 4.2.0
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
@@ -7,8 +7,8 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
-       type, strange characters...
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct like invalid
+       type or strange characters.
 
 tier: 2
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
@@ -44,7 +44,7 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
 
 tags:
     - vulnerability
@@ -90,17 +90,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, request):
-    '''
-    Modify the Arch Linux feed by setting a test field value.
-    '''
+    """Modify the Arch Linux feed by setting a test field value."""
     backup_data = read_json_file(custom_archlinux_json_feed_path)
     data = read_json_file(custom_archlinux_json_feed_path)
 
@@ -168,54 +164,38 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 def test_invalid_values_arch_linux_feed(test_data, custom_input, clean_vuln_tables, get_configuration,
                                         configure_environment, modify_feed):
     '''
-    description: Check if Vulnerability Detector behaves as expected while importing Archlinux feed with an invalid
-                 value. To do this, fetch in the test_data list the type of information to be analyzed and get the
-                 expected vulnerabilities number of the custom_input list to check if the imported feed has not an
-                 invalid value.
+    description: Check if Vulnerability Detector behaves as expected while importing Archlinux feed with an invalid tag
+                 value. To do this, it fetches in the test_data list the type of information to be analyzed and
+                 modify the feed assigning strange labels and check if the feed can be imported.
 
     wazuh_min_version: 4.2.0
 
     parameters:
-        - copy_files:
-            type: fixture
-            brief: Write dict data to JSON file.
-        - modify_feed:
-            type: fixture
-            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
-        - daemons_handler:
-            type: fixture
-            brief: Handler of Wazuh daemons.
         - test_data:
             type: dict's list
             brief: List of tests to be performed.
         - custom_input:
             type: list
             brief: Input list of dict of ids.
-        - set_system:
+        - clean_vuln_tables:
             type: fixture
-            brief: Set custom system in global DB Agent info.
+            brief: Clean vulnerabilities tables.
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-        - restart_modulesd_function:
+        - modify_feed:
             type: fixture
-            brief: Perform the restart operation with Wazuh.
-        - file_monitoring:
-            type: fixture
-            brief: Handle the monitoring of a specified file.
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
 
     assertions:
         - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
           VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
-          different kinds of vulnerability. Also, there is a test_data that contains fields to be checked and a custom
-          list that contains the number of expected vulnerabilities. Based on the number of expected vulnerabilities,
-          feeds are imported successfully.
+        - Test cases are defined in the test_data list and in the custom_input that contain strange labels.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+       type, strange characters...
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import itertools
 import os
 
@@ -42,13 +90,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, request):
-    """Modify the Arch Linux feed by setting a test field value."""
+    '''
+    Modify the Arch Linux feed by setting a test field value.
+    '''
     backup_data = read_json_file(custom_archlinux_json_feed_path)
     data = read_json_file(custom_archlinux_json_feed_path)
 
@@ -70,7 +122,43 @@ def modify_feed(test_data, custom_input, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.ARCH_LOG,
                                         expected_vulnerabilities_number=vd.ARCH_NUM_CUSTOM_VULNERABILITIES)
 
@@ -79,7 +167,66 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
                          ids=test_data_ids)
 def test_invalid_values_arch_linux_feed(test_data, custom_input, clean_vuln_tables, get_configuration,
                                         configure_environment, modify_feed):
-    """Check if Vulnerability Detector behaves as expected while importing Arch Linux feed with syntax errors."""
+    '''
+    description: Check if Vulnerability Detector behaves as expected while importing Archlinux feed with an invalid
+                 value. To do this, fetch in the test_data list the type of information to be analyzed and get the
+                 expected vulnerabilities number of the custom_input list to check if the imported feed has not an
+                 invalid value.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - custom_input:
+            type: list
+            brief: Input list of dict of ids.
+        - set_system:
+            type: fixture
+            brief: Set custom system in global DB Agent info.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Perform the restart operation with Wazuh.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability. Also, there is a test_data that contains fields to be checked and a custom
+          list that contains the number of expected vulnerabilities. Based on the number of expected vulnerabilities,
+          feeds are imported successfully.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if any(isinstance(custom_input, x) for x in test_data['type']):
         expected_vulnerabilities = vd.ARCH_NUM_CUSTOM_VULNERABILITIES
         if test_data['field'] == 'packages' and isinstance(custom_input, list):

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_missing_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_missing_tags_archlinux_feed.py
@@ -1,7 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when a tag is missing in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -69,14 +116,87 @@ def remove_field_feed(request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.ARCH_LOG,
                                         expected_vulnerabilities_number=vd.ARCH_NUM_CUSTOM_VULNERABILITIES)
 
 
-def test_invalid_archlinux_feed(clean_vuln_tables, get_configuration, configure_environment, remove_field_feed):
-    """Check if the feed is imported successfully by default."""
+def test_missing_archlinux_feed(clean_vuln_tables, get_configuration, configure_environment, remove_field_feed):
+    '''
+    description: Test to check vulnerability detector behavior when importing Archlinux feed with missing tags. To do
+                 this, a tag is removed from the feed and check if the vulnerability can be inserted into the database.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - remove_field_feed:
+            type: fixture
+            brief: Modify the feed by removing a certain field and loading the new configuration.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains different kinds of
+          vulnerability. 'fields' is the list of tags to be checked and 'field_ids' is the dictionary's list that
+          indicates the missing tag. 'key_tags' is the list of removed tags.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if remove_field_feed not in key_tags:
         expected_vulnerabilities = vd.ARCH_NUM_CUSTOM_VULNERABILITIES
         if remove_field_feed == 'issues':

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
@@ -94,7 +94,7 @@ def get_configuration(request):
 @pytest.fixture
 def modify_feed(test_values, request):
     '''
-    Modify the Canonical OVAL feed, setting a test tag value
+    Modify the Canonical OVAL feed, setting a test tag value.
     '''
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
@@ -190,12 +190,12 @@ def test_extra_tags_canonical_feed(test_values, clean_vuln_tables, get_configura
             brief: Modify the Amazon Linux JSON feed by setting a test tag value.
 
     assertions:
-        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
-          VULNERABILITIES table of CVE DB and if process is running.
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_archlinux_feed.json file. This file contains two different kinds of
-          vulnerability.
+        - Test cases are defined in the test_values list. Each item of the list contains a tag and a value. Based on the
+          tag the feed is checked to be imported successful or not.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
@@ -43,9 +43,9 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      canonical/test_extra_tags_canonical_feed.md#test-extra-tags-canonical-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #canonical
 
 tags:
     - vulnerability
@@ -85,17 +85,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    '''
-    Modify the Canonical OVAL feed, setting a test tag value.
-    '''
+    """Modify the Canonical OVAL feed, setting a test tag value."""
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     modified_data = insert_xml_tag(pattern=insert_pattern, tag=test_values[0], value=test_values[1],

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when there is an extra tag in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
+      canonical/test_extra_tags_canonical_feed.md#test-extra-tags-canonical-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -36,15 +85,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    """
+    '''
     Modify the Canonical OVAL feed, setting a test tag value
-    """
+    '''
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     modified_data = insert_xml_tag(pattern=insert_pattern, tag=test_values[0], value=test_values[1],
@@ -68,7 +119,43 @@ def modify_feed(test_values, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_canonical_oval_feed.xml file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
                                         expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
 
@@ -77,9 +164,50 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
 def test_extra_tags_canonical_feed(test_values, clean_vuln_tables, get_configuration, configure_environment,
                                    modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing Canonical OVAL feed with extra tags
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Canonical OVAL feed with extra
+                 tags. To do this, a vulnerability event is launched and check if the number of vulnerabilities inserted
+                 in the VULNERABILITIES table of CVE DB is the expected and finally check if the process is still
+                 running.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if process is running.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains two different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     inserted_tag = test_values[0]
 
     if inserted_tag != ' ' and type(inserted_tag) in [str, int]:

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when the feed has some kind of syntactic error
+       such as missing character or closing tag, etc..
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
+      canonical/test_invalid_syntax_canonical_feed.md#test-invalid-syntax-canonical-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -61,15 +111,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 # Fixtures
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    """
-    Modify the Canonical OVAL feeds, setting a test tag value
-    """
+    '''
+    Modify the Canonical OVAL feeds, setting a test tag value.
+    '''
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     modified_data = replace_regex(pattern=test_data['pattern'], new_value=test_data['update'], data=str(backup_data),
@@ -93,7 +145,43 @@ def modify_feed(test_data, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_canonical_oval_feed.xml file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
                                         expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
 
@@ -101,9 +189,48 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
 def test_invalid_syntax_canonical_feed(test_data, clean_vuln_tables, get_configuration, configure_environment,
                                        modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with syntax errors
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Canonical OVAL feeds with syntax
+                 errors. To do this, check an error message when importing the feeds and checks that the vulnerabilities
+                 table is empty.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list. If the expected_fail field is in the list the feed is imported
+          successful.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if test_data['expected_fail']:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
     else:

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.py
@@ -44,9 +44,9 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      canonical/test_invalid_syntax_canonical_feed.md#test-invalid-syntax-canonical-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #canonical
 
 tags:
     - vulnerability
@@ -111,17 +111,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 # Fixtures
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Set configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    '''
-    Modify the Canonical OVAL feeds, setting a test tag value.
-    '''
+    """Modify the Canonical OVAL feeds, setting a test tag value."""
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     modified_data = replace_regex(pattern=test_data['pattern'], new_value=test_data['update'], data=str(backup_data),

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+       type, strange characters...
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #canonical
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import itertools
 import os
 
@@ -101,9 +151,7 @@ def get_configuration(request):
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, request):
-    """
-    Modify the Canonical OVAL feed, setting a test tag value
-    """
+    """Modify the Canonical OVAL feed, setting a test tag value."""
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     modified_data = replace_regex(pattern=test_data['pattern'], new_value=custom_input, data=str(backup_data),
@@ -127,7 +175,43 @@ def modify_feed(test_data, custom_input, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_canonical_oval_feed.xml file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
                                         expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
 
@@ -135,9 +219,50 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_data, custom_input', itertools.product(tags, vd.CUSTOM_INPUT_TEST_VALUES), ids=tags_ids)
 def test_invalid_values_canonical_feed(test_data, custom_input, clean_vuln_tables, get_configuration,
                                        configure_environment, modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing Canonical OVAL feed with wrong tag values
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Canonical OVAL feed with an invalid
+                 tag value. To do this, it fetches in the test_data list the type of information to be analyzed and
+                 modify the feed assigning strange labels and check if the feed can be imported.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - custom_input:
+            type: list
+            brief: Input list of dict of ids.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list and in the custom_input that contain strange labels.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if test_data['name'] == 'dpkginfo_test':
         pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/5275')
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when a tag is missing in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #canonical
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -82,9 +131,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope='module', params=test_data, ids=test_data_ids)
 def remove_tag_feed(request):
-    """
-    It allows to modify the feed by removing a certain tag and loading the new feed configuration
-    """
+    """It allows to modify the feed by removing a certain tag and loading the new feed configuration."""
     backup_data = file.read_xml_file(file_path=custom_canonical_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES)
 
     data_removed_tag = replace_regex(request.param['pattern'], '', str(backup_data))
@@ -107,13 +154,87 @@ def remove_tag_feed(request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_canonical_oval_feed.xml file. This file contains different kinds of
+          vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BIONIC_LOG,
                                         expected_vulnerabilities_number=vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES)
 
 
 def test_missing_canonical_feed(clean_vuln_tables, get_configuration, configure_environment, remove_tag_feed):
-    """Test to check vulnerability detector behavior when importing canonical feed with missing tags"""
+    '''
+    description: Test to check vulnerability detector behavior when importing canonical feed with missing tags. To do
+                 this, a tag is removed from the feed and check if the vulnerability can be inserted into the database.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - remove_tag_feed:
+            type: fixture
+            brief: Modify the feed by removing a certain field and loading the new configuration.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_archlinux_feed.json file. This file contains different kinds of
+          vulnerability. 'key_tags' is the list of tags to be checked and 'test_data_ids' is the dictionary's list that
+          indicates the missing tag. 'xfail_tags' is the list of removed tags.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if remove_tag_feed['name'] in xfail_tags:
         pytest.xfail("Xfailing due https://github.com/wazuh/wazuh/issues/5275")
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
@@ -43,9 +43,9 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      debian/test_extra_tags_debian_feed.md#test-extra-tags-debian-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #debian
 
 tags:
     - vulnerability
@@ -88,17 +88,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    '''
-    Modify the Debian OVAL feed, setting a test tag value.
-    '''
+    """Modify the Debian OVAL feed, setting a test tag value."""
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
@@ -45,7 +45,7 @@ os_version:
 references:
     - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
     - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      canonical/test_extra_tags_canonical_feed.md#test-extra-tags-canonical-feed
+      debian/test_extra_tags_debian_feed.md#test-extra-tags-debian-feed
 
 tags:
     - vulnerability
@@ -97,7 +97,7 @@ def get_configuration(request):
 @pytest.fixture
 def modify_feed(test_values, request):
     '''
-    Modify the Debian OVAL feed, setting a test tag value
+    Modify the Debian OVAL feed, setting a test tag value.
     '''
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
@@ -149,8 +149,8 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
           VULNERABILITIES table of CVE DB.
 
     input_description:
-        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. This file
-          contains different kinds of vulnerability.
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. Those files
+          contain different kinds of vulnerability.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'
@@ -192,12 +192,11 @@ def test_extra_tags_debian_feed(test_values, clean_vuln_tables, get_configuratio
             brief: Modify the Amazon Linux JSON feed by setting a test tag value.
 
     assertions:
-        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
-          VULNERABILITIES table of CVE DB and if process is running.
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. This file
-          contains two different kinds of vulnerability.
+        - Test cases are defined in the test_values list. Each item of the list contains a tag and a value.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when there is an extra tag in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
+      canonical/test_extra_tags_canonical_feed.md#test-extra-tags-canonical-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -39,15 +88,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    """
+    '''
     Modify the Debian OVAL feed, setting a test tag value
-    """
+    '''
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -72,17 +123,90 @@ def modify_feed(test_values, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. This file
+          contains different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BUSTER_LOG,
                                         expected_vulnerabilities_number=vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES)
 
 
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
 def test_extra_tags_debian_feed(test_values, clean_vuln_tables, get_configuration, configure_environment, modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing Debian OVAL feed with extra tags
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Debian OVAL feed with extra tags.
+                 To do this, a vulnerability event is launched and check if the number of vulnerabilities inserted
+                 in the VULNERABILITIES table of CVE DB is the expected and finally check if the process is still
+                 running.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if process is running.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. This file
+          contains two different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BUSTER_LOG,
                                         expected_vulnerabilities_number=vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES,
                                         timeout=vd.DEBIAN_IMPORT_FEED_TIMEOUT,

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when the feed has some kind of syntactic error
+       such as missing character or closing tag, etc..
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
+      debian/test_invalid_syntax_debian_feed.md#test-invalid-syntax-debian-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -62,15 +112,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    """
-    Modify the Debian OVAL feed, setting a test tag value
-    """
+    '''
+    Modify the Debian OVAL feed, setting a test tag value.
+    '''
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -95,7 +147,43 @@ def modify_feed(test_data, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. Those files
+          contain different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BUSTER_LOG,
                                         expected_vulnerabilities_number=vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES)
 
@@ -103,9 +191,48 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
 def test_invalid_syntax_canonical_feed(test_data, clean_vuln_tables, get_configuration, configure_environment,
                                        modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing Debian OVAL feed with syntax errors
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Debian OVAL feeds with syntax
+                 errors. To do this, check an error message when importing the feeds and checks that the vulnerabilities
+                 table is empty.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list. If the expected_fail field is in the list the feed is imported
+          successful.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if test_data['expected_fail']:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, timeout=vd.DEBIAN_IMPORT_FEED_TIMEOUT)
     else:

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
@@ -44,9 +44,9 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      debian/test_invalid_syntax_debian_feed.md#test-invalid-syntax-debian-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #debian
 
 tags:
     - vulnerability
@@ -112,17 +112,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    '''
-    Modify the Debian OVAL feed, setting a test tag value.
-    '''
+    """Modify the Debian OVAL feed, setting a test tag value."""
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+       type, strange characters...
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #debian
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import itertools
 import os
 
@@ -106,9 +156,7 @@ def get_configuration(request):
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, request):
-    """
-    Modify the Debian OVAL feed, setting a test tag value
-    """
+    """Modify the Debian OVAL feed, setting a test tag value."""
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -133,7 +181,43 @@ def modify_feed(test_data, custom_input, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. Those files
+          contain different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BUSTER_LOG,
                                         expected_vulnerabilities_number=vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES)
 
@@ -141,9 +225,50 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_data, custom_input', itertools.product(tags, vd.CUSTOM_INPUT_TEST_VALUES), ids=tags_ids)
 def test_invalid_values_debian_feed(test_data, custom_input, clean_vuln_tables, get_configuration,
                                     configure_environment, restart_modulesd, modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing Debian OVAL feed with wrong tag values
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Debian OVAL feed with an invalid
+                 tag value. To do this, it fetches in the test_data list the type of information to be analyzed and
+                 modify the feed assigning strange labels and check if the feed can be imported.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - custom_input:
+            type: list
+            brief: Input list of dict of ids.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list and in the custom_input that contain strange labels.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if test_data['expected_fail']:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, timeout=vd.DEBIAN_IMPORT_FEED_TIMEOUT)
     else:

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when a tag is missing in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #debian
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -87,9 +136,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope='module', params=test_data, ids=test_data_ids)
 def remove_tag_feed(request):
-    """
-    It allows to modify the feed by removing a certain tag and loading the new feed configuration
-    """
+    """It allows to modify the feed by removing a certain tag and loading the new feed configuration."""
     backup_data = file.read_xml_file(file_path=custom_debian_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -113,13 +160,87 @@ def remove_tag_feed(request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. Those files
+          contain different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.BUSTER_LOG,
                                         expected_vulnerabilities_number=vd.DEBIAN_NUM_CUSTOM_VULNERABILITIES)
 
 
 def test_missing_canonical_feed(clean_vuln_tables, get_configuration, configure_environment, remove_tag_feed):
-    """Test to check vulnerability detector behavior when importing Debian feed with missing tags"""
+    '''
+    description: Test to check vulnerability detector behavior when importing Debian feed with missing tags. To do
+                 this, a tag is removed from the feed and check if the vulnerability can be inserted into the database.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - remove_tag_feed:
+            type: fixture
+            brief: Modify the feed by removing a certain field and loading the new configuration.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. Those files
+          contain different kinds of vulnerability. 'key_tags' is the list of tags to be checked and 'test_data_ids' is
+          the dictionary's list that indicates the missing tag. 'xfail_tags' is the list of removed tags.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if remove_tag_feed['name'] in xfail_list:
         pytest.xfail('Xfailing due to issue: https://github.com/wazuh/wazuh/issues/5322')
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
@@ -43,7 +43,8 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html#msu
 
 tags:
     - vulnerability
@@ -80,17 +81,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    '''
-    Modify the MSU OVAL feed, setting a test field value.
-    '''
+    """Modify the MSU OVAL feed, setting a test field value."""
     backup_data = read_json_file(custom_msu_json_feed_path)
 
     modified_data = dict(backup_data)

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
@@ -1,7 +1,54 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when there is an extra tag in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -33,15 +80,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    """
-    Modify the MSU OVAL feed, setting a test field value
-    """
+    '''
+    Modify the MSU OVAL feed, setting a test field value.
+    '''
     backup_data = read_json_file(custom_msu_json_feed_path)
 
     modified_data = dict(backup_data)
@@ -68,7 +117,42 @@ def modify_feed(test_values, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_msu.json file. This file contains different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.MSU_LOG,
                                         expected_vulnerabilities_number=0)
 
@@ -76,9 +160,48 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
 def test_extra_fields_msu_feed(clean_vuln_tables, test_values, get_configuration, configure_environment,
                                modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing MSU feed with extra fields
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing MSU feed with extra tags. To do
+                 this, a vulnerability event is launched and check if the number of vulnerabilities inserted in the
+                 VULNERABILITIES table of CVE DB is the expected and finally check if the process is still running.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if process is running.
+
+    input_description:
+        - Test cases are defined in the custom_msu.json file. This file contains two different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     field = test_values[0]
 
     if type(field) in [str]:

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
@@ -168,12 +168,12 @@ def test_extra_fields_msu_feed(clean_vuln_tables, test_values, get_configuration
     wazuh_min_version: 4.2.0
 
     parameters:
-        - test_values:
-            type: tuple's list
-            brief: List of tests to be performed.
         - clean_vuln_tables:
             type: fixture
             brief: Clean vulnerabilities tables.
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
@@ -185,11 +185,12 @@ def test_extra_fields_msu_feed(clean_vuln_tables, test_values, get_configuration
             brief: Modify the Amazon Linux JSON feed by setting a test tag value.
 
     assertions:
-        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
-          VULNERABILITIES table of CVE DB and if process is running.
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_msu.json file. This file contains two different kinds of vulnerability.
+        - Test cases are defined in the test_values list. Each item of the list contains a tag and a value. Based on the
+          tag the feed is checked to be imported successful or not.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when the feed has some kind of syntactic error
+       such as missing character or closing tag, etc..
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import json
 import os
 
@@ -78,15 +126,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    """
-    Modify the MSU feed, setting a test field value
-    """
+    '''
+    Modify the MSU feed, setting a test field value.
+    '''
     backup_data = read_json_file(custom_msu_json_feed_path)
 
     modified_data = json.dumps(dict(backup_data))
@@ -114,16 +164,89 @@ def modify_feed(test_data, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_msu.json file. This file contains different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.MSU_LOG,
                                         expected_vulnerabilities_number=0)
 
 
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
 def test_invalid_syntax_msu_feed(test_data, clean_vuln_tables, get_configuration, configure_environment, modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing MSU feed with syntax errors
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing MSU feed with syntax errors. To do
+                 this, check an error message when importing the feeds and checks that the vulnerabilities table is
+                 empty.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list.
+        
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor, parser_error=True)
 
     vd.check_if_modulesd_is_running()

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.py
@@ -44,7 +44,8 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html#msu
 
 tags:
     - vulnerability
@@ -126,17 +127,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    '''
-    Modify the MSU feed, setting a test field value.
-    '''
+    """Modify the MSU feed, setting a test field value."""
     backup_data = read_json_file(custom_msu_json_feed_path)
 
     modified_data = json.dumps(dict(backup_data))
@@ -236,7 +233,7 @@ def test_invalid_syntax_msu_feed(test_data, clean_vuln_tables, get_configuration
 
     input_description:
         - Test cases are defined in the test_data list.
-        
+
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'
         - r'ERROR: The .* feed couldn't be parsed from .* file'

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_values_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_values_msu_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+       type, strange characters...
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html#msu
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import itertools
 import os
 
@@ -53,9 +102,7 @@ def get_configuration(request):
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, request):
-    """
-    Modify the MSU feed, setting a test field value
-    """
+    """Modify the MSU feed, setting a test field value."""
     backup_data = read_json_file(custom_msu_json_feed_path)
 
     data = read_json_file(custom_msu_json_feed_path)
@@ -84,7 +131,42 @@ def modify_feed(test_data, custom_input, request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_msu.json file. This file contains different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.MSU_LOG,
                                         expected_vulnerabilities_number=0)
 
@@ -93,9 +175,50 @@ def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environ
                          ids=test_data_ids)
 def test_invalid_values_msu_feed(test_data, custom_input, clean_vuln_tables, get_configuration, configure_environment,
                                  modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing MSU feed with wrong field values
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing MSU feed with an invalid tag value.
+                 To do this, it fetches in the test_data list the type of information to be analyzed and modify the feed
+                 assigning strange labels and check if the feed can be imported.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - custom_input:
+            type: list
+            brief: Input list of dict of ids.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list and in the custom_input that contain strange labels.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     # If the field is "key" and the input type is not the field type, then look for error messages
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.MSU_LOG,
                                         expected_vulnerabilities_number=0)

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_missing_fields_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_missing_fields_msu_feed.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when a tag is missing in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html#msu
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -44,9 +92,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope='module', params=fields, ids=field_ids)
 def remove_field_feed(request):
-    """
-    It allows to modify the feed by removing a certain field and loading the new feed configuration
-    """
+    """It allows to modify the feed by removing a certain field and loading the new feed configuration."""
     backup_data = read_json_file(custom_msu_json_feed_path)
 
     data = read_json_file(custom_msu_json_feed_path)
@@ -75,15 +121,86 @@ def remove_field_feed(request):
 
 
 def test_no_feed_changes(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_msu.json file. This file contains different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.MSU_LOG,
                                         expected_vulnerabilities_number=0)
 
 
 def test_invalid_msu_feed(clean_vuln_tables, get_configuration, configure_environment, remove_field_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing MSU feed with missing fields
-    """
+    '''
+    description: Test to check vulnerability detector behavior when importing MSU feed with missing tags. To do
+                 this, a tag is removed from the feed and check if the vulnerability can be inserted into the database.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - remove_tag_feed:
+            type: fixture
+            brief: Modify the feed by removing a certain field and loading the new configuration.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_alas_feed.json and custom_alas2_feed.json files. Those files contain two
+          different kinds of vulnerability. 'fields' is the list of tags to be checked and 'field_ids' is the
+          dictionary's list that indicates the missing tag.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor, log_system_name=vd.MSU_LOG,
                                         expected_vulnerabilities_number=0)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
@@ -211,8 +211,8 @@ def test_extra_fields_redhat_feed(copy_files, clean_vuln_tables, test_values, ge
             brief: Modify the Amazon Linux JSON feed by setting a test tag value.
 
     assertions:
-        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
-          VULNERABILITIES table of CVE DB and if process is running.
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
         - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. This file
@@ -229,9 +229,6 @@ def test_extra_fields_redhat_feed(copy_files, clean_vuln_tables, test_values, ge
         - vulnerability
         - vulnerability_detector
     '''
-    """
-    Check if vulnerability detector behaves as expected when importing Red Hat OVAL feed with extra fields
-    """
     inserted_tag = test_values[0]
 
     if inserted_tag != ' ' and type(inserted_tag) in [str, int]:

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
@@ -43,9 +43,9 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      redhat/test_extra_fields_redhat_feed.md#test-extra-fields-red-hat-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #red-hat
 
 tags:
     - vulnerability
@@ -91,17 +91,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture(scope='function')
 def copy_files():
-    '''
-    Copy feed files into a temporal directory.
-    '''
+    """Copy feed files into a temporal directory."""
     shutil.copy(custom_redhat_oval_feed_path, temporal_redhat_oval_feed_path)
     shutil.copy(custom_redhat_json_feed_path, temporal_redhat_json_feed_path)
 
@@ -113,9 +109,7 @@ def copy_files():
 
 @pytest.fixture
 def modify_feed(test_values, request):
-    '''
-    Modify the redhat OVAL feed, setting a test field value.
-    '''
+    """Modify the redhat OVAL feed, setting a test field value."""
     backup_data = file.read_xml_file(file_path=custom_redhat_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
@@ -164,8 +164,8 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, get_configuration, confi
           VULNERABILITIES table of CVE DB.
 
     input_description:
-        - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. This file
-          contains different kinds of vulnerability.
+        - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. Those files
+          contain different kinds of vulnerability.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'
@@ -215,8 +215,9 @@ def test_extra_fields_redhat_feed(copy_files, clean_vuln_tables, test_values, ge
           VULNERABILITIES table of CVE DB and if the process is running.
 
     input_description:
-        - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. This file
-          contains two different kinds of vulnerability.
+        - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. Those files
+          contain two different kinds of vulnerability. Also, there is a test_values list where each item of the list
+          contains a tag and a value. Based on the tag the feed is checked to be imported successful or not.
 
     expected_output:
         - 'Number of inserted vulnerabilities is not the expected.'

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when there is an extra tag in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
+      redhat/test_extra_fields_redhat_feed.md#test-extra-fields-red-hat-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 import shutil
 from tempfile import gettempdir
@@ -42,13 +91,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture(scope='function')
 def copy_files():
-    "Copy feed files into a temporal directory"
+    '''
+    Copy feed files into a temporal directory.
+    '''
     shutil.copy(custom_redhat_oval_feed_path, temporal_redhat_oval_feed_path)
     shutil.copy(custom_redhat_json_feed_path, temporal_redhat_json_feed_path)
 
@@ -57,11 +110,12 @@ def copy_files():
     os.remove(temporal_redhat_oval_feed_path)
     os.remove(temporal_redhat_json_feed_path)
 
+
 @pytest.fixture
 def modify_feed(test_values, request):
-    """
-    Modify the redhat OVAL feed, setting a test field value
-    """
+    '''
+    Modify the redhat OVAL feed, setting a test field value.
+    '''
     backup_data = file.read_xml_file(file_path=custom_redhat_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -78,14 +132,49 @@ def modify_feed(test_values, request):
 
     yield
 
-
     vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 
 
 def test_no_feed_changes(copy_files, clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """Check if the feed is imported successfully by default"""
+    '''
+    description: Check if the feed is imported successfully by default. To do this, a vulnerability event is expected
+                 and check if the number of vulnerabilities inserted in the VULNERABILITIES table of CVE DB is the
+                 expected.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB.
+
+    input_description:
+        - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. This file
+          contains different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     vd.check_feed_imported_successfully(wazuh_log_monitor=wazuh_log_monitor,
                                         log_system_name='Red Hat Enterprise Linux 8',
                                         expected_vulnerabilities_number=vd.REDHAT_NUM_CUSTOM_VULNERABILITIES)
@@ -94,6 +183,52 @@ def test_no_feed_changes(copy_files, clean_vuln_tables, get_configuration, confi
 @pytest.mark.parametrize('test_values', vd.EXTRA_TEST_VALUES, ids=vd.EXTRA_TEST_IDS)
 def test_extra_fields_redhat_feed(copy_files, clean_vuln_tables, test_values, get_configuration, configure_environment,
                                   modify_feed):
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Red Hat OVAL feed with extra tags.
+                 To do this, a vulnerability event is launched and check if the number of vulnerabilities inserted in
+                 the VULNERABILITIES table of CVE DB is the expected and finally check if the process is still running.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - copy_files:
+            type: fixture
+            brief: Write dict data to JSON file.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - test_values:
+            type: tuple's list
+            brief: List of tests to be performed.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equals to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if process is running.
+
+    input_description:
+        - Test cases are defined in the custom_redhat_json_feed.json and custom_redhat_oval_feed.xml files. This file
+          contains two different kinds of vulnerability.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     """
     Check if vulnerability detector behaves as expected when importing Red Hat OVAL feed with extra fields
     """

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
@@ -44,9 +44,9 @@ os_version:
     - Red Hat 6
 
 references:
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
-    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
-      redhat/test_invalid_syntax_redhat_feed.md#test-invalid-syntax-red-hat-feed
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #red-hat
 
 tags:
     - vulnerability
@@ -115,17 +115,13 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    '''
-    Get configurations from the module.
-    '''
+    """Get configurations from the module."""
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    '''
-    Modify the redhat OVAL feed, setting a test field value.
-    '''
+    """Modify the redhat OVAL feed, setting a test field value."""
     backup_data = file.read_xml_file(file_path=custom_redhat_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -152,7 +148,8 @@ def modify_feed(test_data, request):
 
 
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
-def test_invalid_syntax_redhat_feed(test_data, clean_vuln_tables, get_configuration, configure_environment, modify_feed):
+def test_invalid_syntax_redhat_feed(test_data, clean_vuln_tables, get_configuration, configure_environment,
+                                    modify_feed):
     '''
     description: Check if vulnerability detector behaves as expected when importing Redhat OVAL feeds with syntax
                  errors. To do this, check an error message when importing the feeds and checks that the vulnerabilities

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests that check the behavior of Vulnerability Detector when the feed has some kind of syntactic error
+       such as missing character or closing tag, etc..
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/index.md
+    - https://github.com/wazuh/wazuh-qa/blob/master/docs/tests/integration/test_vulnerability_detector/test_feeds/
+      redhat/test_invalid_syntax_redhat_feed.md#test-invalid-syntax-red-hat-feed
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -65,15 +115,17 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 @pytest.fixture(scope='module', params=configurations, ids=ids)
 def get_configuration(request):
-    """Get configurations from the module."""
+    '''
+    Get configurations from the module.
+    '''
     return request.param
 
 
 @pytest.fixture
 def modify_feed(test_data, request):
-    """
-    Modify the redhat OVAL feed, setting a test field value
-    """
+    '''
+    Modify the redhat OVAL feed, setting a test field value.
+    '''
     backup_data = file.read_xml_file(file_path=custom_redhat_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -100,10 +152,49 @@ def modify_feed(test_data, request):
 
 
 @pytest.mark.parametrize('test_data', test_data, ids=test_data_ids)
-def test_extra_fields_redhat_feed(test_data, clean_vuln_tables, get_configuration, configure_environment, modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing redhat OVAL feed with syntax errors
-    """
+def test_invalid_syntax_redhat_feed(test_data, clean_vuln_tables, get_configuration, configure_environment, modify_feed):
+    '''
+    description: Check if vulnerability detector behaves as expected when importing Redhat OVAL feeds with syntax
+                 errors. To do this, check an error message when importing the feeds and checks that the vulnerabilities
+                 table is empty.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list. If the expected_fail field is in the list the feed is imported
+          successful.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if test_data['expected_fail']:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
     else:

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.py
@@ -1,7 +1,57 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when the value of a tag is not correct: invalid
+       type, strange characters...
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #red-hat
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import itertools
 import os
 
@@ -101,9 +151,7 @@ def get_configuration(request):
 
 @pytest.fixture
 def modify_feed(test_data, custom_input, request):
-    """
-    Modify the redhat OVAL feed, setting a test field value
-    """
+    """Modify the redhat OVAL feed, setting a test field value."""
     backup_data = file.read_xml_file(file_path=custom_redhat_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -135,9 +183,50 @@ def modify_feed(test_data, custom_input, request):
                          ids=tags_ids)
 def test_invalid_redhat_feed(test_data, custom_input, clean_vuln_tables, get_configuration, configure_environment,
                              modify_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing redhat OVAL feed with wrong field values
-    """
+    '''
+    description: Check if vulnerability detector behaves as expected when importing redhat OVAL feed with an invalid tag
+                 value. To do this, it fetches in the test_data list the type of information to be analyzed and modify
+                 the feed assigning strange labels and check if the feed can be imported.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - test_data:
+            type: dict's list
+            brief: List of tests to be performed.
+        - custom_input:
+            type: list
+            brief: Input list of dict of ids.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - modify_feed:
+            type: fixture
+            brief: Modify the Amazon Linux JSON feed by setting a test tag value.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the test_data list and in the custom_input that contain strange labels.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if test_data['expected_fail']:
         vd.check_failure_when_importing_feed(wazuh_log_monitor=wazuh_log_monitor)
     else:

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.py
@@ -1,7 +1,56 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Set of tests to check the behavior of Vulnerability Detector when a tag is missing in the feed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/offline-update.html
+      #red-hat
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -78,9 +127,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope='module', params=test_data, ids=test_data_ids)
 def remove_tag_feed(request):
-    """
-    It allows to modify the feed by removing a certain tag and loading the new feed configuration
-    """
+    """It allows to modify the feed by removing a certain tag and loading the new feed configuration."""
     backup_data = file.read_xml_file(file_path=custom_redhat_oval_feed_path, namespaces=vd.XML_FEED_NAMESPACES,
                                      xml_header=True)
 
@@ -106,9 +153,45 @@ def remove_tag_feed(request):
 
 
 def test_invalid_redhat_feed(clean_vuln_tables, get_configuration, configure_environment, remove_tag_feed):
-    """
-    Check if vulnerability detector behaves as expected when importing redhat OVAL feed with missing tags
-    """
+    '''
+    description: Test to check vulnerability detector behavior when importing redhat OVAL feed with missing tags. To do
+                 this, a tag is removed from the feed and check if the vulnerability can be inserted into the database.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - remove_tag_feed:
+            type: fixture
+            brief: Modify the feed by removing a certain field and loading the new configuration.
+
+    assertions:
+        - Assert that the number of vulnerabilities is equal to the expected number of vulnerabilities inserted in the
+          VULNERABILITIES table of CVE DB and if the process is running.
+
+    input_description:
+        - Test cases are defined in the custom_debian_oval_feed.xml and custom_debian_json_feed.json files. Those files
+          contain different kinds of vulnerability. 'key_tags' is the list of tags to be checked and 'test_data_ids' is
+          the dictionary's list that indicates the missing tag. 'xfail_tags' is the list of removed tags.
+
+    expected_output:
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+        - r'Could not find the log event: .*'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     if remove_tag_feed['name'] in xfail_tags:
         pytest.xfail("Xfailing due https://github.com/wazuh/wazuh/issues/5275")
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Tests that download the different feeds (Redhat, Canonical, Debian, Amazon Linux and NVD) and check the
+       confirmation message saying the feeds have been correctly downloaded and imported.
+
+tier: 1
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 from datetime import timedelta
 from time import sleep
@@ -115,10 +163,54 @@ def get_configuration(request):
 
 @pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_download_feeds(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd downloads successfully the feeds from different providers and os.
-    Additionaly, check that the updates are applied only when required. Ex: Outdated local database.
-    """
+    '''
+    description: Check if modulesd downloads successfully the feeds from different providers and os. Additionally, check
+                 that the updates are applied only when required. Ex: Outdated local database.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Check that it starts the feed download
+        - Check Debian Security Tracker feed
+        - Check that the feed is downloaded successfully
+
+    input_description:
+        - The feeds to be downladed are in the provider_info.
+
+    expected_output:
+        - 'Does not apply to this config file.'
+        - r'Starting .* database update'
+        - r'Could not find the provider .* feed download'
+        - 'Indexing vulnerabilities from the Debian Security Tracker.'
+        - 'Could not find the Debian Security Tracker feed download.'
+        - r'The update of the .* feed finished successfully'
+        - r'The provider .* download has taken more than .* minutes'
+        - r'Changing the system clock from .* to .*'
+        - r'End of scheduled scan not detected after .* seconds'
+        - r'The feed .* is outdated. Fetching the last version.'
+        - r'Unexpected outdated feed message for the provider .*'
+        - 'The expected message doesn't exist for Arch Linux. Issue: https://github.com/wazuh/wazuh/issues/8194'
+        - r'The feed .* is in its latest version.'
+        - r'Could not find the provider .* updated feed log after the interval update'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     check_apply_test({'test_download_feeds'}, get_configuration['tags'])
 
     provider = get_configuration['metadata']['provider_name']
@@ -168,7 +260,7 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
             year = get_configuration['metadata']['update_from_year']
             with pytest.raises(TimeoutError):
                 vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor,
-                                   log_event=fr"The feed '{callback_system_log} ({year})' is outdated. Fetching the " 
+                                   log_event=fr"The feed '{callback_system_log} ({year})' is outdated. Fetching the "
                                              fr"last version.",
                                    update_position=False, timeout=15, prefix=MODULESD_PREFIX)
                 raise AttributeError(f'Unexpected outdated feed message for the provider {callback_system_log}')
@@ -179,11 +271,11 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                              "https://github.com/wazuh/wazuh/issues/8194")
             else:
                 wazuh_log_monitor.start(timeout=download_timeout,
-                                    callback=vd.make_vuln_callback(
-                                        f"The feed '{callback_system_log}' is in its latest version."),
-                                    error_message=f"Could not find the provider {callback_system_log} updated feed "
-                                                  f"log after the interval update")
+                                        callback=vd.make_vuln_callback(
+                                                                       f"The feed '{callback_system_log}' is in its "
+                                                                       f"latest version."),
+                                        error_message=f"Could not find the provider {callback_system_log} updated feed "
+                                        f"log after the interval update")
     finally:
         # Clean NVD tables when the download has finished
         vd.clean_vuln_and_sys_programs_tables()
-

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Tests that importing files of several different types (.mp3, .jpg, .pdf ...) as custom feed, and check the
+       response of Vulnerability Detector.
+
+tier: 1
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 import tempfile
 
@@ -109,8 +157,8 @@ debian_ids = [f"Debian_{custom_file}" for custom_file in debian_custom_files]
 
 # JSON Debian configurations
 json_debian_custom_files = custom_files + [custom_debian_json_feed_path]
-json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes', 'ARCH_ENABLED': 'no',
-                               'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
+json_debian_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'yes',
+                               'ARCH_ENABLED': 'no', 'DEBIAN_CUSTOM_FEED': custom_debian_oval_feed_path,
                                'DEBIAN_CUSTOM_JSON_FEED': custom_file, 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
                               for custom_file in json_debian_custom_files]
 json_debian_metadata = [{'feed': 'json debian', 'custom_feed': custom_file, 'log_system_name': 'Debian Buster',
@@ -132,7 +180,8 @@ msu_ids = [f"MSU_{custom_file}" for custom_file in msu_custom_files]
 # NVD configurations
 nvd_custom_files = custom_files + [custom_nvd_json_path + f"{extension}" for extension in custom_correctly_extensions]
 nvd_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no',
-                       'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'yes', 'NVD_CUSTOM_FEED': custom_file} for custom_file in nvd_custom_files]
+                       'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'yes', 'NVD_CUSTOM_FEED': custom_file}
+                      for custom_file in nvd_custom_files]
 nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_file, 'log_system_name': 'National Vulnerability Database',
                  'expected_num_vulnerabilities': vd.NVD_NUM_CUSTOM_VULNERABILITIES}
                 for custom_file in nvd_custom_files]
@@ -151,24 +200,24 @@ archlinux_ids = [f"ArchLinux_{custom_file}" for custom_file in archlinux_custom_
 
 # Amazon Linux 1 configurations
 alas_custom_files = custom_files + [custom_alas_feed_path + f"{extension}" + "$"
-                                         for extension in custom_correctly_extensions]
+                                    for extension in custom_correctly_extensions]
 alas_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no',
-                             'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no', 'ARCH_ENABLED': 'no', 'ALAS_ENABLED': 'yes',
-                             'ALAS_CUSTOM_FEED': custom_file} for custom_file in alas_custom_files]
+                        'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no', 'ARCH_ENABLED': 'no', 'ALAS_ENABLED': 'yes',
+                        'ALAS_CUSTOM_FEED': custom_file} for custom_file in alas_custom_files]
 alas_metadata = [{'feed': 'alas', 'custom_feed': custom_file, 'log_system_name': 'Amazon Linux',
-                       'expected_num_vulnerabilities': vd.ALAS_NUM_CUSTOM_VULNERABILITIES}
-                      for custom_file in alas_custom_files]
+                  'expected_num_vulnerabilities': vd.ALAS_NUM_CUSTOM_VULNERABILITIES}
+                 for custom_file in alas_custom_files]
 alas_ids = [f"ALAS_{custom_file}" for custom_file in alas_custom_files]
 
 # Amazon Linux 2 configurations
 alas2_custom_files = custom_files + [custom_alas2_feed_path + f"{extension}" + "$"
-                                         for extension in custom_correctly_extensions]
+                                     for extension in custom_correctly_extensions]
 alas2_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no',
-                             'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no', 'ARCH_ENABLED': 'no', 'ALAS_ENABLED': 'yes',
-                             'ALAS2_CUSTOM_FEED': custom_file} for custom_file in alas2_custom_files]
+                         'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no', 'ARCH_ENABLED': 'no', 'ALAS_ENABLED': 'yes',
+                         'ALAS2_CUSTOM_FEED': custom_file} for custom_file in alas2_custom_files]
 alas2_metadata = [{'feed': 'alas', 'custom_feed': custom_file, 'log_system_name': 'Amazon Linux',
-                       'expected_num_vulnerabilities': vd.ALAS2_NUM_CUSTOM_VULNERABILITIES}
-                      for custom_file in alas2_custom_files]
+                   'expected_num_vulnerabilities': vd.ALAS2_NUM_CUSTOM_VULNERABILITIES}
+                  for custom_file in alas2_custom_files]
 alas2_ids = [f"ALAS2_{custom_file}" for custom_file in alas2_custom_files]
 
 # Global configuration
@@ -192,7 +241,7 @@ def get_configuration(request):
 
 @pytest.fixture(scope='module')
 def manage_files(request):
-    """Download and clean files used for testing"""
+    """Download and clean files used for testing."""
     file.download_file(source_url=zip_data_url, dest_path=zip_dest_path)
 
     file.decompress_zip(zip_file_path=zip_dest_path, dest_file_path=files_path)
@@ -208,10 +257,52 @@ def manage_files(request):
 @pytest.mark.skip(reason="It will be blocked by #1602, when it was solve we can enable again this test")
 def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configuration, configure_environment,
                                    restart_modulesd):
-    """
-    Check that when importing bad feed files, vulnerability report a log parse error otherwise they are imported
-    correctly
-    """
+    '''
+    description: Check that when importing bad feed files, vulnerability report a log parse error otherwise they are
+                 imported correctly.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - manage_files:
+            type: fixture
+            brief: Download and clean files.
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Check if feed metadata configuration is 'nvd'.
+        - Check if the custom feed has a compression format.
+        - Check if feed metadata configuration is not json debian, msu, or /tmp/dummy.json.
+
+    input_description:
+        - List of custom feeds and list of possible invalid types of custom list.
+
+    expected_output:
+        - 'Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5210'
+        - r'The file|File from URL) .* was successfully uncompressed into .*'
+        - r'Could not find the message: .* was successfully uncompressed'
+        - r'INFO: .* The update of the .* feed finished successfully.'
+        - r'Could not find the message: .* feed finished successfully'
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     custom_feed = get_configuration['metadata']['custom_feed']
     log_system_name = get_configuration['metadata']['log_system_name']
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Tests that importing files of several different types (.mp3, .jpg, .pdf ...) as custom feed from URL, and check
+       the response of Vulnerability Detector.
+
+tier: 1
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 import tempfile
 
@@ -32,6 +80,7 @@ custom_alas_json_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUST
 custom_alas2_json_url = 'file://' + os.path.join(test_data_path, 'feeds', vd.CUSTOM_ALAS2_JSON_FEED)
 
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
 url_feeds = [custom_redhat_oval_feed_url, custom_canonical_oval_feed_url, custom_debian_oval_feed_url,
              custom_nvd_json_url, custom_redhat_json_feed_url, custom_debian_json_feed_url, custom_msu_json_feed_url,
              custom_archlinux_json_url, custom_alas_json_url, custom_alas2_json_url]
@@ -75,7 +124,8 @@ canonical_custom_urls = custom_urls + [custom_canonical_oval_feed_url + f"{exten
                                        for extension in custom_correctly_extensions]
 canonical_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'yes',
                              'CANONICAL_URL_FEED': custom_url, 'DEBIAN_ENABLED': 'no',
-                             'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'} for custom_url in canonical_custom_urls]
+                             'ARCH_ENABLED': 'no', 'MSU_ENABLED': 'no', 'NVD_ENABLED': 'no'}
+                            for custom_url in canonical_custom_urls]
 canonical_metadata = [{'feed': 'canonical', 'custom_feed': custom_url, 'log_system_name': 'Ubuntu Bionic',
                        'expected_num_vulnerabilities': vd.CANONICAL_NUM_CUSTOM_VULNERABILITIES}
                       for custom_url in canonical_custom_urls]
@@ -119,7 +169,8 @@ msu_ids = [f"MSU_{custom_file}" for custom_file in msu_custom_urls]
 nvd_custom_urls = custom_urls + [custom_nvd_json_url + f"{extension}"
                                  for extension in custom_correctly_extensions]
 nvd_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no',
-                       'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'yes', 'NVD_URL_FEED': custom_url} for custom_url in nvd_custom_urls]
+                       'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'yes', 'NVD_URL_FEED': custom_url}
+                      for custom_url in nvd_custom_urls]
 nvd_metadata = [{'feed': 'nvd', 'custom_feed': custom_url, 'log_system_name': 'National Vulnerability Database',
                  'expected_num_vulnerabilities': vd.NVD_NUM_CUSTOM_VULNERABILITIES}
                 for custom_url in nvd_custom_urls]
@@ -127,13 +178,14 @@ nvd_ids = [f"NVD_{custom_url}" for custom_url in nvd_custom_urls]
 
 # Arch Linux configurations
 archlinux_custom_urls = custom_urls + [custom_archlinux_json_url + f"{extension}$"
-                                 for extension in custom_correctly_extensions]
-archlinux_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no',
-                             'ARCH_ENABLED': 'yes', 'NVD_ENABLED': 'no', 'ARCH_CUSTOM_FEED': custom_url}
+                                       for extension in custom_correctly_extensions]
+archlinux_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no',
+                             'MSU_ENABLED': 'no', 'ARCH_ENABLED': 'yes', 'NVD_ENABLED': 'no',
+                             'ARCH_CUSTOM_FEED': custom_url}
                             for custom_url in archlinux_custom_urls]
 archlinux_metadata = [{'feed': 'arch', 'custom_feed': custom_url, 'log_system_name': 'Arch Linux',
-                 'expected_num_vulnerabilities': vd.ARCH_NUM_CUSTOM_VULNERABILITIES}
-                for custom_url in archlinux_custom_urls]
+                       'expected_num_vulnerabilities': vd.ARCH_NUM_CUSTOM_VULNERABILITIES}
+                      for custom_url in archlinux_custom_urls]
 archlinux_ids = [f"ARCH_{custom_url}" for custom_url in archlinux_custom_urls]
 
 # Amazon Linux 1 configurations
@@ -151,8 +203,8 @@ alas_ids = [f"ALAS_{custom_url}" for custom_url in alas_custom_urls]
 alas2_custom_urls = custom_urls + [custom_alas2_json_url + f"{extension}$"
                                    for extension in custom_correctly_extensions]
 alas2_configurations = [{'REDHAT_ENABLED': 'no', 'CANONICAL_ENABLED': 'no', 'DEBIAN_ENABLED': 'no', 'MSU_ENABLED': 'no',
-                        'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'no', 'ALAS_ENABLED': 'yes',
-                        'ALAS2_URL_FEED': custom_url} for custom_url in alas2_custom_urls]
+                         'ARCH_ENABLED': 'no', 'NVD_ENABLED': 'no', 'ALAS_ENABLED': 'yes',
+                         'ALAS2_URL_FEED': custom_url} for custom_url in alas2_custom_urls]
 alas2_metadata = [{'feed': 'alas', 'custom_feed': custom_url, 'log_system_name': 'Amazon Linux',
                   'expected_num_vulnerabilities': vd.ALAS2_NUM_CUSTOM_VULNERABILITIES}
                   for custom_url in alas2_custom_urls]
@@ -179,10 +231,49 @@ def get_configuration(request):
 
 @pytest.mark.skip(reason="It will be blocked by wazuh-qa#2178, when it was solve we can enable again this test")
 def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_environment, restart_modulesd):
-    """
-    Check that when importing bad feed files, vulnerability report a log parse error otherwise they are imported
-    correctly
-    """
+    '''
+    description: Check that when importing bad feed files from url, vulnerability report a log parse error otherwise
+                 they are imported correctly.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - clean_vuln_tables:
+            type: fixture
+            brief: Clean vulnerabilities tables.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Check if feed metadata configuration is 'nvd'.
+        - Check if the custom feed has a compression format.
+        - Check if feed metadata configuration is not json debian, msu or /tmp/dummy.json.
+
+    input_description:
+        - List of custom feeds and list of possible invalid types of custom lists.
+
+    expected_output:
+        - 'Add error messages to this case use. Issue: https://github.com/wazuh/wazuh/issues/5210'
+        - r'The file|File from URL) .* was successfully uncompressed into .*'
+        - r'Could not find the message: .* was successfully uncompressed'
+        - r'INFO: .* The update of the .* feed finished successfully.'
+        - r'Could not find the message: .* feed finished successfully'
+        - 'Number of inserted vulnerabilities is not the expected.'
+        - r'Expected, .*, Got: .*'
+        - r'ERROR: The .* feed couldn't be parsed from .* file'
+        - r'ERROR: CVE database could not be updated.'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     custom_feed = get_configuration['metadata']['custom_feed']
     log_system_name = get_configuration['metadata']['log_system_name']
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -1,7 +1,55 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The tests will download the feeds for all the providers and verify if the format of each feed is the expected and
+       if their content is a valid XML or JSON that can be parsed.
+
+tier: 2
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+'''
 from datetime import datetime
 
 import pytest
@@ -68,10 +116,12 @@ format_feed_data = [
     # Amazon Linux
     {'feed': 'alas', 'os': 'Amazon Linux 1', 'expected_format': 'application/gzip',
      'path': '/tmp/alas.json.gz', 'extension': 'gz',
-     'url': 'https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.json.gz', 'decompressed_file': f'/tmp/alas.json'},
+     'url': 'https://feed.wazuh.com/vulnerability-detector/ALAS/1/alas.json.gz',
+     'decompressed_file': f'/tmp/alas.json'},
     {'feed': 'alas', 'os': 'Amazon Linux 2', 'expected_format': 'application/gzip',
      'path': '/tmp/alas2.json.gz', 'extension': 'gz',
-     'url': 'https://feed.wazuh.com/vulnerability-detector/ALAS/2/alas2.json.gz', 'decompressed_file': f'/tmp/alas2.json'}
+     'url': 'https://feed.wazuh.com/vulnerability-detector/ALAS/2/alas2.json.gz',
+     'decompressed_file': f'/tmp/alas2.json'}
 ]
 
 # NVD
@@ -86,13 +136,10 @@ format_feed_data_ids = [f"{item['feed']}_{item['os']}" for item in format_feed_d
 
 @pytest.fixture
 def manage_file(feed, request):
-    """
-    Download and clean test files
+    """Download and clean test files.
 
-    Parameters
-    ----------
-    feed: dict
-        Feed information which comes from an element of 'format_feed_data' list
+    Args:
+        feed (dict): Feed information which comes from an element of 'format_feed_data' list
     """
     # Download the file
     file.download_file(source_url=feed['url'], dest_path=feed['path'])
@@ -114,9 +161,40 @@ def manage_file(feed, request):
 
 @pytest.mark.parametrize('feed', format_feed_data, ids=format_feed_data_ids)
 def test_validate_feed_content(feed, manage_file):
-    """
-    Check if the downloaded feeds have the expected format
-    """
+    '''
+    description: Check if the downloaded feeds have the expected format. To do this, it downloads the feed from URL and
+                 check if it is parseable to JSON or XML.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - feed:
+            type: dict
+            brief: Feed information which comes from an element of 'format_feed_data' list
+        - manage_file:
+            type: fixture
+            brief: Download and clean test files.
+
+    assertions:
+        - Check if the file is JSON or XML parseable.
+        - Check if the file extension is the expected.
+        - Check if the file mime type is the expected.
+        - Check if the file is JSON or XML parseable.
+
+    input_description:
+        - List of dictionaries that contains feeds.
+
+    expected_output:
+        - 'File extension not expected.'
+        - r'Got .* and expected .*'
+        - 'File mime type not expected.'
+        - r'.* file is not JSON parseable'
+        - r'.* file is not XML parseable'
+
+    tags:
+        - vulnerability
+        - vulnerability_detector
+    '''
     feed_source = feed['feed']
     error_file_extension_message = f"File extension not expected." \
                                    f"Got {file.get_file_info(file_path=feed['path'], info_type='extension')} " \

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `enabled` option of the vulnerability detector module is working correctly. This
-       option is located in its corresponding section of the `ossec.conf` file and allows enabling or disabling this
-       module.
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
 
 tier: 0
 
@@ -95,8 +95,9 @@ def get_configuration(request):
 def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_configuration, configure_environment,
                  restart_modulesd):
     '''
-    description: Check if the `enabled ` option is working correctly. To do this, it checks the `ossec.log` file for the
-                 message indicating that the vulnerability detector is enabled or disabled.
+    description: Check if the `enabled ` option of the vulnerability detector module is working correctly. To do this,
+                 it checks the `ossec.log` file for the message indicating that the vulnerability detector is enabled or
+                 disabled.
 
     wazuh_min_version: 4.2.0
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `enabled` option of the vulnerability detector module
-       is working correctly. This option is located in its corresponding section of
-       the `ossec.conf` file and allows enabling or disabling this module.
+brief: These tests will check if the `enabled` option of the vulnerability detector module is working correctly. This
+       option is located in its corresponding section of the `ossec.conf` file and allows enabling or disabling this
+       module.
 
 tier: 0
 
@@ -19,10 +19,10 @@ modules:
 components:
     - manager
 
-path: tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
-
 daemons:
     - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
 
 os_platform:
     - linux
@@ -52,6 +52,8 @@ references:
 
 tags:
     - settings
+    - vulnerability
+    - vulnerability_detector
 '''
 import os
 
@@ -93,39 +95,43 @@ def get_configuration(request):
 def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_configuration, configure_environment,
                  restart_modulesd):
     '''
-    description: Check if the `enabled ` option is working correctly. To do this,
-                 it checks the `ossec.log` file for the message indicating that the
-                 vulnerability detector is enabled or disabled.
+    description: Check if the `enabled ` option is working correctly. To do this, it checks the `ossec.log` file for the
+                 message indicating that the vulnerability detector is enabled or disabled.
 
-    wazuh_min_version: 4.2
+    wazuh_min_version: 4.2.0
 
     parameters:
-        - configure_environment:
-            type: fixture
-            brief: Configure a custom environment for testing.
-        - get_configuration:
-            type: fixture
-            brief: Get configurations from the module.
-        - restart_modulesd:
-            type: callable
-            brief: Restart the `wazuh-modulesd` daemon.
         - tags_to_apply:
             type: string
             brief: Tags used for use cases.
-        - custom_callback_vulnerability:
+        - custom_callback:
             type: string
             brief: Custom callback for the use case.
+        - custom_error_message:
+            type: string
+            brief: The message shows the vulnerability detector state.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
 
     assertions:
         - Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.
         - Verify that when the `enabled` option is set to `no`, the vulnerability detector module is stopped.
 
-    input_description: Two use cases are found in the test module and include
-                       parameters for `enabled` option (`yes` and `no`).
+    input_description:
+        - Two use cases are found in the test module and include parameters for `enabled` option (`yes` and `no`).
 
     expected_output:
         - r'(.*)wazuh-modulesd:vulnerability-detector(.*)'
         - r'DEBUG: Module disabled. Exiting...'
+        - 'Vulnerability detector is disabled'
+        - 'Vulnerability detector is enabled'
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -7,10 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `ignore_time` option of the vulnerability detector module is working correctly.
-       This option is located in its corresponding section of the `ossec.conf` file and is the time during which
-       vulnerabilities that have already been alerted will be ignored. When this time has not passed yet, only partial
-       scans will be performed.
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
 
 tier: 0
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `ignore_time` option of the vulnerability detector module is working correctly.
+       This option is located in its corresponding section of the `ossec.conf` file and is the time during which
+       vulnerabilities that have already been alerted will be ignored. When this time has not passed yet, only partial
+       scans will be performed.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 from datetime import timedelta
 
@@ -61,14 +115,40 @@ def prepare_agent(mock_agent_module):
 
 
 def test_ignore_time(get_configuration, configure_environment, restart_modulesd, prepare_agent):
-    """Check if an alert is not fired during the ignore time  interval.
+    '''
+    description: Check if an alert is not fired during the ignore time interval. To do this, it inserts a custom
+                 vulnerability and vulnerable package, it checks the initial vulnerability alert, advances the time
+                 clock before the set time, and check that the alert has not been generated. Finally, it advances the
+                 time clock just after the set time and checks that the alert has been generated.
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset the logs file and start a new monitor.
-        prepare_agent (fixture):Add a mock agent, add a package to it and insert a vulnerability for that package.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - prepare_agent:
+            type: fixture
+            brief: Add a mock agent, add a package to it and insert a vulnerability for that package.
+
+    assertions:
+        - Verify that alerts do not appear before ignore time was finished.
+
+    input_description:
+        - Three use cases are found in the test module and include ignore time intervals of 3600s, 60m, and 1h. The file
+          real_nvd_feed.json is used to check for vulnerabilities.
+
+    expected_output:
+        - 'Alert did not appear at the start of the test'
+        - 'Alert appeared before ignore_time was finished'
+        - 'Alert did not appear at the end of the test'
+    '''
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
     vd.update_last_scan(agent=prepare_agent)

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `interval` option of the vulnerability detector module is working correctly.
+       This option is located in its corresponding section of the `ossec.conf` file and is the interval time between
+       vulnerabilities scan.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -46,10 +99,33 @@ def get_configuration(request):
 
 
 def test_interval(get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd waits `interval` between one vulnerability detector scan and another.
-    """
+    '''
+    description: Check if modulesd waits `interval` between one vulnerability detector scan and another. To do this, it
+                 checks in the `ossec.log` file appears the corresponding message.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Verify that the Vulnerability Detector process thread sleeps the time set, checking `ossec.log` message.
+
+    input_description:
+        - Test cases are defined in the list interval_values and interval_units. This test gets their configuration of
+          the wazuh_interval.yaml file.
+
+    expected_output:
+        - 'Missing sleep between scans'
+    '''
     check_apply_test({'interval'}, get_configuration['tags'])
 
     sleeping_interval = wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `interval` option of the vulnerability detector module is working correctly.
-       This option is located in its corresponding section of the `ossec.conf` file and is the interval time between
-       vulnerabilities scan.
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
 
 tier: 0
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the `run_on_start` option of the vulnerability detector module is working correctly.
+       This option is located in its corresponding section of the `ossec.conf` file and allows running this module on
+       start the agent.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#run-on-start
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -46,13 +99,37 @@ def get_configuration(request):
 
 
 def test_run_on_start(get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd detects the vulnerability detector scan after starting.
+    '''
+    description: Check if modulesd detects the vulnerability detector scan after starting. To do this, it checks If the
+                 parameter run_on_start is set to 'yes'. Modulesd will have to report the vulnerability detector scan.
+                 In case of the value 'no', do not report anything.
 
-    If we have set the parameter run_on_start to 'yes', modulesd will have to report the
-    vulnerability detector scan, and in case of the value 'no', do not report anything
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Verify that when the `run_on_start` option is set to `yes`, the vulnerability detector module starts when
+          service starts.
+        - Verify that when the `run_on_start` option is set to `no`, the vulnerability detector module has not started.
+
+    input_description:
+        - Two use cases are found in the test module and include parameters for `run_on_start` option (`yes` and `no`).
+          The test case uses the custom_nvd_feed.json file as input file to start scanning for vulnerabilities.
+
+    expected_output:
+        - 'Could not find vulnerability starting scan log'
+        - 'Found starting scan log when run on start is disabled'
+    '''
     check_apply_test({'run_on_start'}, get_configuration['tags'])
 
     if get_configuration['metadata']['run_on_start'] == 'yes':

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -7,9 +7,9 @@ copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check if the `run_on_start` option of the vulnerability detector module is working correctly.
-       This option is located in its corresponding section of the `ossec.conf` file and allows running this module on
-       start the agent.
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
 
 tier: 0
 


### PR DESCRIPTION
|Related issue|
|---|
|#2325|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 

The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_general_settings_enabled.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `enabled` option of the vulnerability detector module is working correctly. This option is located in its corresponding section of the `ossec.conf` file and allows enabling or disabling this module.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#enabled"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_enabled.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py",
    "tests": [
        {
            "description": "Check if the `enabled ` option is working correctly. To do this, it checks the `ossec.log` file for the message indicating that the vulnerability detector is enabled or disabled.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "string",
                        "brief": "Tags used for use cases."
                    }
                },
                {
                    "custom_callback": {
                        "type": "string",
                        "brief": "Custom callback for the use case."
                    }
                },
                {
                    "custom_error_message": {
                        "type": "string",
                        "brief": "The message shows the vulnerability detector state."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                }
            ],
            "assertions": [
                "Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.",
                "Verify that when the `enabled` option is set to `no`, the vulnerability detector module is stopped."
            ],
            "input_description": [
                "Two use cases are found in the test module and include parameters for `enabled` option (`yes` and `no`)."
            ],
            "expected_output": [
                "r'(.*)wazuh-modulesd:vulnerability-detector(.*)'",
                "r'DEBUG: Module disabled. Exiting...'",
                "Vulnerability detector is disabled",
                "Vulnerability detector is enabled"
            ],
            "name": "test_enabled",
            "inputs": [
                "get_configuration0-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled",
                "get_configuration0-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled",
                "get_configuration1-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled",
                "get_configuration1-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_general_settings_ignore_time.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `ignore_time` option of the vulnerability detector module is working correctly. This option is located in its corresponding section of the `ossec.conf` file and is the time during which vulnerabilities that have already been alerted will be ignored. When this time has not passed yet, only partial scans will be performed.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_ignore_time.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py",
    "tests": [
        {
            "description": "Check if an alert is not fired during the ignore time interval. To do this, it inserts a custom vulnerability and vulnerable package, it checks the initial vulnerability alert, advances the time clock before the set time, and check that the alert has not been generated. Finally, it advances the time clock just after the set time and checks that the alert has been generated.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                },
                {
                    "prepare_agent": {
                        "type": "fixture",
                        "brief": "Add a mock agent, add a package to it and insert a vulnerability for that package."
                    }
                }
            ],
            "assertions": [
                "Verify that alerts do not appear before ignore time was finished."
            ],
            "input_description": [
                "Three use cases are found in the test module and include ignore time intervals of 3600s, 60m, and 1h. The file real_nvd_feed.json is used to check for vulnerabilities."
            ],
            "expected_output": [
                "Alert did not appear at the start of the test",
                "Alert appeared before ignore_time was finished",
                "Alert did not appear at the end of the test"
            ],
            "name": "test_ignore_time",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_general_settings_interval.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `interval` option of the vulnerability detector module is working correctly. This option is located in its corresponding section of the `ossec.conf` file and is the interval time between vulnerabilities scan.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_interval.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py",
    "tests": [
        {
            "description": "Check if modulesd waits `interval` between one vulnerability detector scan and another. To do this, it checks in the `ossec.log` file appears the corresponding message.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                }
            ],
            "assertions": [
                "Verify that the Vulnerability Detector process thread sleeps the time set, checking `ossec.log` message."
            ],
            "input_description": [
                "Test cases are defined in the list interval_values and interval_units. This test gets their configuration of the wazuh_interval.yaml file."
            ],
            "expected_output": [
                "Missing sleep between scans"
            ],
            "name": "test_interval",
            "inputs": [
                "1s",
                "1m",
                "1h",
                "1d",
                "2s",
                "2m",
                "2h",
                "2d",
                "5s",
                "5m",
                "5h",
                "5d"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_general_settings_run_on_start.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "These tests will check if the `run_on_start` option of the vulnerability detector module is working correctly. This option is located in its corresponding section of the `ossec.conf` file and allows running this module on start the agent.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#run-on-start"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_run_on_start.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py",
    "tests": [
        {
            "description": "Check if modulesd detects the vulnerability detector scan after starting. To do this, it checks If the parameter run_on_start is set to 'yes'. Modulesd will have to report the vulnerability detector scan. In case of the value 'no', do not report anything.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                }
            ],
            "assertions": [
                "Verify that when the `run_on_start` option is set to `yes`, the vulnerability detector module starts when service starts.",
                "Verify that when the `run_on_start` option is set to `no`, the vulnerability detector module has not started."
            ],
            "input_description": [
                "Two use cases are found in the test module and include parameters for `run_on_start` option (`yes` and `no`). The test case uses the custom_nvd_feed.json file as input file to start scanning for vulnerabilities."
            ],
            "expected_output": [
                "Could not find vulnerability starting scan log",
                "Found starting scan log when run on start is disabled"
            ],
            "name": "test_run_on_start",
            "inputs": [
                "run_on_start_yes",
                "run_on_start_no"
            ]
        }
    ]
}
```
</p>
</details>

## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The `qa-docs` tool does not raise any error.