### PR TITLE
Update API configuration integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -125,7 +125,7 @@ def compare_config_api_response(configuration, section):
 
 def get_manager_configuration(section=None, field=None):
     """Get Wazuh manager configuration response from API using GET /manager/configuration
-        
+
     References: https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_configuration
 
     Args:

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -88,6 +88,7 @@ def restart_api(get_configuration, request):
     #    control_service('start', daemon=process_name)
     control_service('start')
 
+
 @pytest.fixture(scope='module')
 def wait_for_start(get_configuration, request):
     # Wait for API to start
@@ -105,6 +106,13 @@ def get_api_details():
 def restart_api_module(request):
     # Stop Wazuh and Wazuh API
     control_service('stop')
+
+    # Reset api.log and start a new monitor
+    truncate_file(API_LOG_FILE_PATH)
+    file_monitor = FileMonitor(API_LOG_FILE_PATH)
+    setattr(request.module, 'wazuh_log_monitor', file_monitor)
+
+    # Start Wazuh API
     control_service('start')
 
 

--- a/tests/integration/test_api/test_config/test_https/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_https/data/conf.yaml
@@ -4,16 +4,8 @@
   configuration:
      https:
       enabled: no
-      key: "/test_cert/server.key"
-      cert: "/test_cert/server.crt"
-      use_ca: no
-      ca: "/test_cert/ca.crt"
 - tags:
   - https_enabled
   configuration:
      https:
       enabled: yes
-      key: "/test_cert/server.key"
-      cert: "/test_cert/server.crt"
-      use_ca: no
-      ca: "/test_cert/ca.crt"

--- a/tests/integration/test_api/test_config/test_https/test_https.py
+++ b/tests/integration/test_api/test_config/test_https/test_https.py
@@ -59,16 +59,12 @@ import os
 
 import pytest
 import requests
-from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import check_apply_test, get_api_conf
 
 # Marks
 
 pytestmark = pytest.mark.server
 
-# Variables
-
-test_directories = [os.path.join(PREFIX, 'test_cert')]
 
 # Configurations
 

--- a/tests/integration/test_api/test_config/test_logs/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_logs/data/conf.yaml
@@ -3,11 +3,9 @@
   - logs_info
   configuration:
     logs:
-      path: /test_logs/test.log
       level: info
 - tags:
   - logs_debug
   configuration:
     logs:
-      path: /test_logs/test.log
       level: debug


### PR DESCRIPTION
|Related issue|
|---|
| closes #2365 |

## Description

After some changes in the API configuration parameters, some of the API configuration integration tests needed an update. Further information in the issue above.

## Configuration options

We removed the following options from the affected tests configuration YAML files:

```yaml
    logs:
      path: /test_logs/test.log

      key: "/test_cert/server.key"
      cert: "/test_cert/server.crt"
      use_ca: no
      ca: "/test_cert/ca.crt"
```

With these changes, these tests must work on v4.2 as well.

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.

```shellsession
root@wazuh-master:/wazuh-qa/tests/integration# python3 -m pytest test_api/test_config/test_logs/ -vv

================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.13.19-100.fc33.x86_64-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'html': '3.1.1', 'testinfra': '5.0.0'}}
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, html-3.1.1, testinfra-5.0.0
collected 4 items                                                                                                                                                                                                                                                                        

test_api/test_config/test_logs/test_logs.py::test_logs[get_configuration0-tags_to_apply0] PASSED                                                                                                                                                                                   [ 25%]
test_api/test_config/test_logs/test_logs.py::test_logs[get_configuration0-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                             [ 50%]
test_api/test_config/test_logs/test_logs.py::test_logs[get_configuration1-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                             [ 75%]
test_api/test_config/test_logs/test_logs.py::test_logs[get_configuration1-tags_to_apply1] PASSED                                                                                                                                                                                   [100%]

============================================================================================================================= 2 passed, 2 skipped in 49.10s ==============================================================================================================================



root@wazuh-master:/wazuh-qa/tests/integration# python3 -m pytest test_api/test_config/test_https/ -vv

================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.13.19-100.fc33.x86_64-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'html': '3.1.1', 'testinfra': '5.0.0'}}
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, html-3.1.1, testinfra-5.0.0
collected 4 items                                                                                                                                                                                                                                                                        

test_api/test_config/test_https/test_https.py::test_https[get_configuration0-tags_to_apply0] PASSED                                                                                                                                                                                [ 25%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration0-tags_to_apply1] SKIPPED (Does not apply to this config file)                                                                                                                                          [ 50%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration1-tags_to_apply0] SKIPPED (Does not apply to this config file)                                                                                                                                          [ 75%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration1-tags_to_apply1] PASSED                                                                                                                                                                                [100%]

============================================================================================================================= 2 passed, 2 skipped in 36.29s ==============================================================================================================================

```