### PR TITLE
IPv6 integration tests: Remoted local IP valid test

### DIFF
--- a/tests/integration/test_remoted/test_configuration/data/wazuh_basic_configuration.yaml
+++ b/tests/integration/test_remoted/test_configuration/data/wazuh_basic_configuration.yaml
@@ -61,6 +61,8 @@
         value: secure
     - port:
         value: 1514
+    - ipv6:
+        value: IPV6
     - local_ip:
         value: LOCAL_IP
     - protocol:

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
@@ -30,13 +30,20 @@ network_interfaces = netifaces.interfaces()
 for interface in network_interfaces:
     try:
         ip = netifaces.ifaddresses(interface)[netifaces.AF_INET][0]['addr']
+        ip6 = netifaces.ifaddresses(interface)[netifaces.AF_INET6][0]['addr']
+        contains_interface = ip6.find('%')
+        if contains_interface != -1:
+            ip6 = ip6[:contains_interface]
         array_interfaces_ip.append(ip)
+        array_interfaces_ip.append(ip6)
     except KeyError:
         pass
 
 for local_ip in array_interfaces_ip:
-    parameters.append({'LOCAL_IP': local_ip})
-    metadata.append({'local_ip': local_ip})
+    parameters.append({'LOCAL_IP': local_ip, 'IPV6': 'yes'})
+    metadata.append({'local_ip': local_ip, 'ipv6': 'yes'})
+    parameters.append({'LOCAL_IP': local_ip, 'IPV6': 'no'})
+    metadata.append({'local_ip': local_ip, 'ipv6': 'no'})
 
 configurations = load_wazuh_configurations(configurations_path, "test_basic_configuration_local_ip",
                                            params=parameters, metadata=metadata)


### PR DESCRIPTION
|Related issue|
|---|
|#2373|

## Description
Following issue #2373, it is needed to add IPv6 cases to Remoted `test_basic_configuration_local_ip_valid.py`. We need to add the IPv6 parameter to the configuration file so we can test IPv4 and IPv6 by specifying the parameter to 'no' and 'yes'. In addition, we added the IPv6 address from all interfaces. There are test cases for every IPv4 and IPv6 address in each interface, with the ipv6 value to 'no' and 'yes' to test all possible scenarios.
```
- section: remote
    ...
    - ipv6:
        value: IPV6
    ...
```

## Tests
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the [QA-Docs Schema 2.0](https://github.com/wazuh/wazuh-qa/wiki/QA-Documentation---How-to-document-a-test-using-Schema-2.0).