### PR TITLE
Remove deprecated configurations

### DIFF
--- a/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
@@ -252,8 +252,6 @@
     <disabled>no</disabled>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
-    <force_insert>yes</force_insert>
-    <force_time>0</force_time>
     <purge>yes</purge>
     <use_password>no</use_password>
     <limit_maxagents>yes</limit_maxagents>

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
@@ -252,8 +252,6 @@
     <disabled>no</disabled>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
-    <force_insert>yes</force_insert>
-    <force_time>0</force_time>
     <purge>yes</purge>
     <use_password>no</use_password>
     <limit_maxagents>yes</limit_maxagents>

--- a/tests/system/provisioning/basic_cluster/roles/agent-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/agent-role/files/ossec.conf
@@ -45,13 +45,6 @@
     <skip_nfs>yes</skip_nfs>
   </rootcheck>
 
-  <wodle name="open-scap">
-    <disabled>yes</disabled>
-    <timeout>1800</timeout>
-    <interval>1d</interval>
-    <scan-on-start>yes</scan-on-start>
-  </wodle>
-
   <wodle name="cis-cat">
     <disabled>yes</disabled>
     <timeout>1800</timeout>

--- a/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
@@ -252,8 +252,6 @@
     <disabled>no</disabled>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
-    <force_insert>yes</force_insert>
-    <force_time>0</force_time>
     <purge>yes</purge>
     <use_password>no</use_password>
     <limit_maxagents>yes</limit_maxagents>

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
@@ -252,8 +252,6 @@
     <disabled>no</disabled>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
-    <force_insert>yes</force_insert>
-    <force_time>0</force_time>
     <purge>yes</purge>
     <use_password>no</use_password>
     <limit_maxagents>yes</limit_maxagents>

--- a/tests/system/provisioning/enrollment_cluster/roles/agent-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/agent-role/files/ossec.conf
@@ -45,13 +45,6 @@
     <skip_nfs>yes</skip_nfs>
   </rootcheck>
 
-  <wodle name="open-scap">
-    <disabled>yes</disabled>
-    <timeout>1800</timeout>
-    <interval>1d</interval>
-    <scan-on-start>yes</scan-on-start>
-  </wodle>
-
   <wodle name="cis-cat">
     <disabled>yes</disabled>
     <timeout>1800</timeout>

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
@@ -252,8 +252,6 @@
     <disabled>no</disabled>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
-    <force_insert>yes</force_insert>
-    <force_time>0</force_time>
     <purge>yes</purge>
     <use_password>no</use_password>
     <limit_maxagents>yes</limit_maxagents>

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
@@ -252,8 +252,6 @@
     <disabled>no</disabled>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
-    <force_insert>yes</force_insert>
-    <force_time>0</force_time>
     <purge>yes</purge>
     <use_password>no</use_password>
     <limit_maxagents>yes</limit_maxagents>


### PR DESCRIPTION
|Related issue|
|---|
|#2297|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This closes #2297. In this PR we remove two options that were deprecated: 
- The OpenSCAP module, which was deprecated in v4.0.0. Further information [here](https://documentation.wazuh.com/current/release-notes/release-4-0-0.html).
- The `force_insert` and `force_time` options, deprecated in v4.3.0. Further information [here](https://github.com/wazuh/wazuh/issues/9550).