### PR TITLE
Move flaw regarding use of MD5 functions to false positives

### DIFF
--- a/tests/scans/code_analysis/known_flaws/known_flaws_framework.json
+++ b/tests/scans/code_analysis/known_flaws/known_flaws_framework.json
@@ -1,6 +1,20 @@
 {
     "false_positives": [
         {
+            "code": " def md5(fname):\n     hash_md5 = hashlib.md5()\n     with open(fname, \"rb\") as f:\n",
+            "filename": "framework/wazuh/core/utils.py",
+            "issue_confidence": "HIGH",
+            "issue_severity": "MEDIUM",
+            "issue_text": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+            "line_number": 649,
+            "line_range": [
+                649
+            ],
+            "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md5",
+            "test_id": "B303",
+            "test_name": "blacklist"
+        },
+        {
             "code": "         try:\n             proc = subprocess.Popen([wazuh_control, \"info\"], stdout=subprocess.PIPE)\n             (stdout, stderr) = proc.communicate()\n",
             "filename": "framework/scripts/wazuh-logtest.py",
             "issue_confidence": "HIGH",
@@ -200,20 +214,6 @@
             ],
             "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b405-import-xml-etree",
             "test_id": "B405",
-            "test_name": "blacklist"
-        },
-        {
-            "code": " def md5(fname):\n     hash_md5 = hashlib.md5()\n     with open(fname, \"rb\") as f:\n",
-            "filename": "framework/wazuh/core/utils.py",
-            "issue_confidence": "HIGH",
-            "issue_severity": "MEDIUM",
-            "issue_text": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
-            "line_number": 619,
-            "line_range": [
-                619
-            ],
-            "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md5",
-            "test_id": "B303",
             "test_name": "blacklist"
         },
         {


### PR DESCRIPTION
|Related issue|
|---|
|#2330|



## Description

After the investigation done in the issue https://github.com/wazuh/wazuh/issues/10114, we have proposed the possible vulnerability regarding the use of MD5 functions in framework to be a **false positive**.

This pull request changes the flaw's respective dictionary entry from to_fix to false_positives in the known_flaws_framework.json file.


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
