### PR TITLE
Migrate test_general_setting documentation to qa-docs

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/schema.yaml
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/schema.yaml
@@ -236,6 +236,7 @@ predefined_values:
     - fim_registry_restrict
     - fim_synchronization
     - gcloud
+    - general_settings
     - github
     - integrity
     - keys

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -51,6 +51,7 @@ references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#enabled
 
 tags:
+    - general_settings
     - settings
     - vulnerability
     - vulnerability_detector

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py
@@ -1,20 +1,32 @@
 '''
 copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
            Created by Wazuh, Inc. <info@wazuh.com>.
+
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 type: integration
-brief: These tests will check if the 'enabled' option of the vulnerability detector module
-       is working correctly. This option is located in its corresponding section of
-       the 'ossec.conf' file and allows enabling or disabling this module.
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
 tier: 0
+
 modules:
     - vulnerability_detector
+
 components:
     - manager
+
 daemons:
     - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
 os_platform:
     - linux
+
 os_version:
     - Arch Linux
     - Amazon Linux 2
@@ -33,13 +45,18 @@ os_version:
     - Red Hat 8
     - Red Hat 7
     - Red Hat 6
+
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#enabled
+
 tags:
     - settings
+    - vulnerability
+    - vulnerability_detector
 '''
 import os
+
 import pytest
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
@@ -54,16 +71,23 @@ pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 # variables
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_enabled.yaml')
+
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+
 parameters = [{'ENABLED': 'yes', 'TAG': 'enabled'}, {'ENABLED': 'no', 'TAG': 'disabled'}]
 metadata = [{'enabled': 'yes'}, {'enabled': 'no'}]
+
 # Configuration data
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
+
+
 # fixtures
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
+
+
 @pytest.mark.parametrize('tags_to_apply, custom_callback, custom_error_message', [
     ({'enabled'}, callback_detect_vulnerability_detector_enabled, 'Vulnerability detector is disabled'),
     ({'disabled'}, callback_detect_vulnerability_detector_disabled, 'Vulnerability detector is enabled')
@@ -71,34 +95,44 @@ def get_configuration(request):
 def test_enabled(tags_to_apply, custom_callback, custom_error_message, get_configuration, configure_environment,
                  restart_modulesd):
     '''
-    description: Check if the 'enabled' option is working correctly. To do this,
-                 it checks the 'ossec.log' file for the message indicating that the
-                 vulnerability detector is enabled or disabled.
+    description: Check if the `enabled ` option of the vulnerability detector module is working correctly. To do this,
+                 it checks the `ossec.log` file for the message indicating that the vulnerability detector is enabled or
+                 disabled.
+
     wazuh_min_version: 4.2.0
+
     parameters:
-        - configure_environment:
-            type: fixture
-            brief: Configure a custom environment for testing.
-        - get_configuration:
-            type: fixture
-            brief: Get configurations from the module.
-        - restart_modulesd:
-            type: callable
-            brief: Restart the 'wazuh-modulesd' daemon.
         - tags_to_apply:
             type: string
             brief: Tags used for use cases.
-        - custom_callback_vulnerability:
+        - custom_callback:
             type: string
             brief: Custom callback for the use case.
+        - custom_error_message:
+            type: string
+            brief: The message shows the vulnerability detector state.
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
     assertions:
-        - Verify that when the 'enabled' option is set to 'yes', the vulnerability detector module is running.
-        - Verify that when the 'enabled' option is set to 'no', the vulnerability detector module is stopped.
-    input_description: Two use cases are found in the test module and include
-                       parameters for 'enabled' option ('yes' and 'no').
+        - Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.
+        - Verify that when the `enabled` option is set to `no`, the vulnerability detector module is stopped.
+
+    input_description:
+        - Two use cases are found in the test module and include parameters for `enabled` option (`yes` and `no`).
+
     expected_output:
         - r'(.*)wazuh-modulesd:vulnerability-detector(.*)'
         - r'DEBUG: Module disabled. Exiting...'
+        - 'Vulnerability detector is disabled'
+        - 'Vulnerability detector is enabled'
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 from datetime import timedelta
 
@@ -61,14 +114,40 @@ def prepare_agent(mock_agent_module):
 
 
 def test_ignore_time(get_configuration, configure_environment, restart_modulesd, prepare_agent):
-    """Check if an alert is not fired during the ignore time  interval.
+    '''
+    description: Check if an alert is not fired during the ignore time interval. To do this, it inserts a custom
+                 vulnerability and vulnerable package, it checks the initial vulnerability alert, advances the time
+                 clock before the set time, and check that the alert has not been generated. Finally, it advances the
+                 time clock just after the set time and checks that the alert has been generated.
 
-    Args:
-        get_configuration (fixture): Get configurations from the module.
-        configure_environment (fixture): Configure a custom environment for testing.
-        restart_modulesd (fixture): Reset the logs file and start a new monitor.
-        prepare_agent (fixture):Add a mock agent, add a package to it and insert a vulnerability for that package.
-    """
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+        - prepare_agent:
+            type: fixture
+            brief: Add a mock agent, add a package to it and insert a vulnerability for that package.
+
+    assertions:
+        - Verify that alerts do not appear before ignore time was finished.
+
+    input_description:
+        - Three use cases are found in the test module and include ignore time intervals of 3600s, 60m, and 1h. The file
+          real_nvd_feed.json is used to check for vulnerabilities.
+
+    expected_output:
+        - 'Alert did not appear at the start of the test'
+        - 'Alert appeared before ignore_time was finished'
+        - 'Alert did not appear at the end of the test'
+    '''
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')
     vd.update_last_scan(agent=prepare_agent)

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -146,6 +146,7 @@ def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
 
     expected_output:
         - r''.* is vulnerable to .*'
+        - r'.*Sending FIM event (.+)$'
     '''
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -146,7 +146,7 @@ def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
 
     expected_output:
         - r''.* is vulnerable to .*'
-        - r'.*Sending FIM event (.+)$'
+        - r'.*Sending FIM event: (.+)$'
     '''
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -51,6 +51,7 @@ references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time
 
 tags:
+    - general_settings
     - settings
     - vulnerability
     - vulnerability_detector

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py
@@ -144,9 +144,7 @@ def test_ignore_time(get_configuration, configure_environment, restart_modulesd,
           real_nvd_feed.json is used to check for vulnerabilities.
 
     expected_output:
-        - 'Alert did not appear at the start of the test'
-        - 'Alert appeared before ignore_time was finished'
-        - 'Alert did not appear at the end of the test'
+        - r''.* is vulnerable to .*'
     '''
     control_service('stop', daemon='wazuh-modulesd')
     control_service('stop', daemon='wazuh-db')

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -48,7 +48,7 @@ os_version:
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
-    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#interval
 
 tags:
     - settings
@@ -124,7 +124,7 @@ def test_interval(get_configuration, configure_environment, restart_modulesd):
           the wazuh_interval.yaml file.
 
     expected_output:
-        - 'Missing sleep between scans'
+        - r'.* Sleeping for (.*)...'
     '''
     check_apply_test({'interval'}, get_configuration['tags'])
 

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -51,6 +51,7 @@ references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#interval
 
 tags:
+    - general_settings
     - settings
     - vulnerability
     - vulnerability_detector

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -46,10 +99,33 @@ def get_configuration(request):
 
 
 def test_interval(get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd waits `interval` between one vulnerability detector scan and another.
-    """
+    '''
+    description: Check if modulesd waits `interval` between one vulnerability detector scan and another. To do this, it
+                 checks in the `ossec.log` file appears the corresponding message.
 
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Verify that the Vulnerability Detector process thread sleeps the time set, checking `ossec.log` message.
+
+    input_description:
+        - Test cases are defined in the list interval_values and interval_units. This test gets their configuration of
+          the wazuh_interval.yaml file.
+
+    expected_output:
+        - 'Missing sleep between scans'
+    '''
     check_apply_test({'interval'}, get_configuration['tags'])
 
     sleeping_interval = wazuh_log_monitor.start(timeout=VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -51,6 +51,7 @@ references:
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#run-on-start
 
 tags:
+    - general_settings
     - settings
     - vulnerability
     - vulnerability_detector

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -1,7 +1,60 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
+tier: 0
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#run-on-start
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+'''
 import os
 
 import pytest
@@ -46,13 +99,37 @@ def get_configuration(request):
 
 
 def test_run_on_start(get_configuration, configure_environment, restart_modulesd):
-    """
-    Check if modulesd detects the vulnerability detector scan after starting.
+    '''
+    description: Check if modulesd detects the vulnerability detector scan after starting. To do this, it checks If the
+                 parameter run_on_start is set to 'yes'. Modulesd will have to report the vulnerability detector scan.
+                 In case of the value 'no', do not report anything.
 
-    If we have set the parameter run_on_start to 'yes', modulesd will have to report the
-    vulnerability detector scan, and in case of the value 'no', do not report anything
-    """
+    wazuh_min_version: 4.2.0
 
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - restart_modulesd:
+            type: callable
+            brief: Restart the `wazuh-modulesd` daemon.
+
+    assertions:
+        - Verify that when the `run_on_start` option is set to `yes`, the vulnerability detector module starts when
+          service starts.
+        - Verify that when the `run_on_start` option is set to `no`, the vulnerability detector module has not started.
+
+    input_description:
+        - Two use cases are found in the test module and include parameters for `run_on_start` option (`yes` and `no`).
+          The test case uses the custom_nvd_feed.json file as input file to start scanning for vulnerabilities.
+
+    expected_output:
+        - 'Could not find vulnerability starting scan log'
+        - 'Found starting scan log when run on start is disabled'
+    '''
     check_apply_test({'run_on_start'}, get_configuration['tags'])
 
     if get_configuration['metadata']['run_on_start'] == 'yes':

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py
@@ -127,8 +127,8 @@ def test_run_on_start(get_configuration, configure_environment, restart_modulesd
           The test case uses the custom_nvd_feed.json file as input file to start scanning for vulnerabilities.
 
     expected_output:
-        - 'Could not find vulnerability starting scan log'
-        - 'Found starting scan log when run on start is disabled'
+        - 'Starting vulnerability scan'
+        - 'Vulnerability scan finished'
     '''
     check_apply_test({'run_on_start'}, get_configuration['tags'])
 


### PR DESCRIPTION
|Related issue|
|---|
|#2325|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 

The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_general_settings_enabled.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat, Canonical, Debian, Amazon Linux and NVD Database.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#enabled"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_enabled.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_enabled.py",
    "tests": [
        {
            "description": "Check if the `enabled ` option of the vulnerability detector module is working correctly. To do this, it checks the `ossec.log` file for the message indicating that the vulnerability detector is enabled or disabled.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "tags_to_apply": {
                        "type": "string",
                        "brief": "Tags used for use cases."
                    }
                },
                {
                    "custom_callback": {
                        "type": "string",
                        "brief": "Custom callback for the use case."
                    }
                },
                {
                    "custom_error_message": {
                        "type": "string",
                        "brief": "The message shows the vulnerability detector state."
                    }
                },
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                }
            ],
            "assertions": [
                "Verify that when the `enabled` option is set to `yes`, the vulnerability detector module is running.",
                "Verify that when the `enabled` option is set to `no`, the vulnerability detector module is stopped."
            ],
            "input_description": [
                "Two use cases are found in the test module and include parameters for `enabled` option (`yes` and `no`)."
            ],
            "expected_output": [
                "r'(.*)wazuh-modulesd:vulnerability-detector(.*)'",
                "r'DEBUG: Module disabled. Exiting...'",
                "Vulnerability detector is disabled",
                "Vulnerability detector is enabled"
            ],
            "name": "test_enabled",
            "inputs": [
                "get_configuration0-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled",
                "get_configuration0-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled",
                "get_configuration1-tags_to_apply0-callback_detect_vulnerability_detector_enabled-Vulnerability detector is disabled",
                "get_configuration1-tags_to_apply1-callback_detect_vulnerability_detector_disabled-Vulnerability detector is enabled"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_general_settings_ignore_time.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat, Canonical, Debian, Amazon Linux and NVD Database.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_ignore_time.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_ignore_time.py",
    "tests": [
        {
            "description": "Check if an alert is not fired during the ignore time interval. To do this, it inserts a custom vulnerability and vulnerable package, it checks the initial vulnerability alert, advances the time clock before the set time, and check that the alert has not been generated. Finally, it advances the time clock just after the set time and checks that the alert has been generated.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                },
                {
                    "prepare_agent": {
                        "type": "fixture",
                        "brief": "Add a mock agent, add a package to it and insert a vulnerability for that package."
                    }
                }
            ],
            "assertions": [
                "Verify that alerts do not appear before ignore time was finished."
            ],
            "input_description": [
                "Three use cases are found in the test module and include ignore time intervals of 3600s, 60m, and 1h. The file real_nvd_feed.json is used to check for vulnerabilities."
            ],
            "expected_output": [
                "Alert did not appear at the start of the test",
                "Alert appeared before ignore_time was finished",
                "Alert did not appear at the end of the test"
            ],
            "name": "test_ignore_time",
            "inputs": [
                "get_configuration0",
                "get_configuration1",
                "get_configuration2"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_general_settings_interval.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat, Canonical, Debian, Amazon Linux and NVD Database.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#ignore-time"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_interval.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_interval.py",
    "tests": [
        {
            "description": "Check if modulesd waits `interval` between one vulnerability detector scan and another. To do this, it checks in the `ossec.log` file appears the corresponding message.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                }
            ],
            "assertions": [
                "Verify that the Vulnerability Detector process thread sleeps the time set, checking `ossec.log` message."
            ],
            "input_description": [
                "Test cases are defined in the list interval_values and interval_units. This test gets their configuration of the wazuh_interval.yaml file."
            ],
            "expected_output": [
                "Missing sleep between scans"
            ],
            "name": "test_interval",
            "inputs": [
                "1s",
                "1m",
                "1h",
                "1d",
                "2s",
                "2m",
                "2h",
                "2d",
                "5s",
                "5m",
                "5h",
                "5d"
            ]
        }
    ]
}
```
</p>
</details>

<details><summary>test_general_settings_run_on_start.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat, Canonical, Debian, Amazon Linux and NVD Database.",
    "tier": 0,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#run-on-start"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_general_settings_run_on_start.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_run_on_start.py",
    "tests": [
        {
            "description": "Check if modulesd detects the vulnerability detector scan after starting. To do this, it checks If the parameter run_on_start is set to 'yes'. Modulesd will have to report the vulnerability detector scan. In case of the value 'no', do not report anything.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "callable",
                        "brief": "Restart the `wazuh-modulesd` daemon."
                    }
                }
            ],
            "assertions": [
                "Verify that when the `run_on_start` option is set to `yes`, the vulnerability detector module starts when service starts.",
                "Verify that when the `run_on_start` option is set to `no`, the vulnerability detector module has not started."
            ],
            "input_description": [
                "Two use cases are found in the test module and include parameters for `run_on_start` option (`yes` and `no`). The test case uses the custom_nvd_feed.json file as input file to start scanning for vulnerabilities."
            ],
            "expected_output": [
                "Could not find vulnerability starting scan log",
                "Found starting scan log when run on start is disabled"
            ],
            "name": "test_run_on_start",
            "inputs": [
                "run_on_start_yes",
                "run_on_start_no"
            ]
        }
    ]
}
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The `qa-docs` tool does not raise any error.