### PR TITLE
IPv6 integration tests: Remoted syslog no allowed IPs

### DIFF
--- a/tests/integration/test_remoted/test_configuration/data/wazuh_basic_configuration.yaml
+++ b/tests/integration/test_remoted/test_configuration/data/wazuh_basic_configuration.yaml
@@ -75,6 +75,8 @@
     elements:
     - connection:
         value: CONNECTION
+    - ipv6:
+        value: IPV6
     - port:
         value: 514
     - protocol:

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_no_allowed_ips.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_no_allowed_ips.py
@@ -16,10 +16,12 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 configurations_path = os.path.join(test_data_path, 'wazuh_basic_configuration.yaml')
 
 parameters = [
-    {'CONNECTION': 'syslog'}
+    {'CONNECTION': 'syslog', 'IPV6': 'no'},
+    {'CONNECTION': 'syslog', 'IPV6': 'yes'}
 ]
 metadata = [
-    {'connection': 'syslog'}
+    {'connection': 'syslog', 'ipv6': 'no'},
+    {'connection': 'syslog', 'ipv6': 'yes'}
 ]
 
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)


### PR DESCRIPTION
|Related issue|
|---|
|#2396|

## Description
Following issue #2396, it is needed to add IPv6 cases to Remoted `test_basic_configuration_syslog_no_allowed_ips.py`. We have added an IPv6 case, which consists of trying to initialize remoted without `<allowed-ips>`, with both IPv6 possible values.

## Tests
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the [QA-Docs Schema 2.0](https://github.com/wazuh/wazuh-qa/wiki/QA-Documentation---How-to-document-a-test-using-Schema-2.0).