### PR TITLE
Migrate test_cpe_indexing documentation to qa-docs

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/schema.yaml
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/schema.yaml
@@ -269,5 +269,6 @@ predefined_values:
     - wazuh_db
     - wdb_socket
     - who_data
+    - windows
     - worker
     - wpk

--- a/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py
@@ -1,7 +1,62 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
+tier: 1
+
+modules:
+    - vulnerability_detector
+
+components:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://wazuh.com/blog/using-wazuh-for-windows-vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/cpe-helper.html
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+    - windows
+'''
 import os
 from time import sleep
 
@@ -34,23 +89,26 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 common_system_data = {'name': 'windows', 'os_major': '10', 'os_minor': '0', 'os_release': '1000'}
 # Architecture with associate name extension
-architecture_name_extension = {'x86_64': '', 'x86' : '_I386'}
+architecture_name_extension = {'x86_64': '', 'x86': '_I386'}
 system_data = []
 target_name_index_system_data = [
     {'target': 'WINDOWS_SERVER_2013', 'os_name': "Microsoft Windows Server 2003", 'index_name': 'windows_server_2003'},
-    {'target': 'WINDOWS_SERVER_2013_R2', 'os_name': "Microsoft Windows Server 2003 R2", 'index_name': 'windows_server_2003'},
+    {'target': 'WINDOWS_SERVER_2013_R2', 'os_name': "Microsoft Windows Server 2003 R2",
+     'index_name': 'windows_server_2003'},
     {'target': 'WINDOWS_XP', 'os_name': "Microsoft Windows XP", 'index_name': 'windows_xp'},
-    {'target': 'WINDOWS_VISTA', 'os_name': "Microsoft Windows Vista",'index_name': 'windows_vista'},
-    {'target': 'WINDOWS_7', 'os_name': "Microsoft Windows 7",'index_name': 'windows_7'},
-    {'target': 'WINDOWS_8', 'os_name': "Microsoft Windows 8",'index_name': 'windows_8'},
-    {'target': 'WINDOWS_8.1', 'os_name': "Microsoft Windows 8.1",'index_name': 'windows_8.1',},
-    {'target': 'WINDOWS_10', 'os_name': "Microsoft Windows 10",'index_name': 'windows_10'},
-    {'target': 'WINDOWS_SERVER_2008', 'os_name': "Microsoft Windows Server 2008",'index_name': 'windows_server_2008'},
-    {'target': 'WINDOWS_SERVER_2008_R2', 'os_name': "Microsoft Windows Server 2008 R2",'index_name': 'windows_server_2008'},
-    {'target': 'WINDOWS_SERVER_2012', 'os_name': "Microsoft Windows Server 2012",'index_name': 'windows_server_2012'},
-    {'target': 'WINDOWS_SERVER_2012_R2', 'os_name': "Microsoft Windows Server 2012 R2",'index_name': 'windows_server_2012'},
-    {'target': 'WINDOWS_SERVER_2016', 'os_name': "Microsoft Windows Server 2016",'index_name': 'windows_server_2016'},
-    {'target': 'WINDOWS_SERVER_2019', 'os_name': "Microsoft Windows Server 2019",'index_name': 'windows_server_2019',},
+    {'target': 'WINDOWS_VISTA', 'os_name': "Microsoft Windows Vista", 'index_name': 'windows_vista'},
+    {'target': 'WINDOWS_7', 'os_name': "Microsoft Windows 7", 'index_name': 'windows_7'},
+    {'target': 'WINDOWS_8', 'os_name': "Microsoft Windows 8", 'index_name': 'windows_8'},
+    {'target': 'WINDOWS_8.1', 'os_name': "Microsoft Windows 8.1", 'index_name': 'windows_8.1'},
+    {'target': 'WINDOWS_10', 'os_name': "Microsoft Windows 10", 'index_name': 'windows_10'},
+    {'target': 'WINDOWS_SERVER_2008', 'os_name': "Microsoft Windows Server 2008", 'index_name': 'windows_server_2008'},
+    {'target': 'WINDOWS_SERVER_2008_R2', 'os_name': "Microsoft Windows Server 2008 R2",
+     'index_name': 'windows_server_2008'},
+    {'target': 'WINDOWS_SERVER_2012', 'os_name': "Microsoft Windows Server 2012", 'index_name': 'windows_server_2012'},
+    {'target': 'WINDOWS_SERVER_2012_R2', 'os_name': "Microsoft Windows Server 2012 R2",
+     'index_name': 'windows_server_2012'},
+    {'target': 'WINDOWS_SERVER_2016', 'os_name': "Microsoft Windows Server 2016", 'index_name': 'windows_server_2016'},
+    {'target': 'WINDOWS_SERVER_2019', 'os_name': "Microsoft Windows Server 2019", 'index_name': 'windows_server_2019'},
 ]
 for architecture, architecture_extension in architecture_name_extension.items():
     for system_data_case in target_name_index_system_data:
@@ -95,7 +153,7 @@ def mock_system(request, mock_agent):
     vd.make_query(vd.CVE_DB_PATH, [query_string])
 
     truncate_file(LOG_FILE_PATH)
-    
+
     vd.update_last_scan(agent=mock_agent)
 
     control_service('start', daemon='wazuh-db')
@@ -110,9 +168,52 @@ def mock_system(request, mock_agent):
     control_service('start', daemon='wazuh-db')
 
 
-def test_window_version_indexing(get_configuration, configure_environment,
-                                 configure_local_internal_options_module, restart_modulesd,
-                                 check_cve_db, mock_system, file_monitoring):
+def test_window_version_indexing(get_configuration, configure_environment, configure_local_internal_options_module,
+                                 restart_modulesd, check_cve_db, mock_system, file_monitoring):
+    '''
+    description: Check if inserted vulnerable packages are reported by the vulnerability detector. To do this, an
+                 auxiliary dictionary is generated in order to translate the gathered program names, (emulated by an
+                 entry list), into the standard format used by the NVD, which is called CPE. This allows the
+                 vulnerability detector to scan the NVD looking for vulnerabilities of these applications. So, is
+                 inserted a vulnerability in the NVD_CVE table since this is needed for the vulnerability detector to
+                 generate the required log.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configurations from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Configure the local internal options file.
+        - restart_modulesd:
+            type: fixture
+            brief: Reset the logs file and start a new monitor.
+        - check_cve_db:
+            type: fixture
+            brief: Check if the CVE database exists and its tables are created.
+        - mock_system:
+            type: fixture
+            brief: It allows to insert a vulnerability in the NVD_CVE table.
+        - file_monitoring:
+            type: fixture
+            brief: Handle the monitoring of a specified file.
+
+    assertions:
+        - Verify that the monitor gets the expected message.
+
+    input_description:
+        - Test cases are found in the test module. The `cpe_indexing.yaml` file provides the configuration of
+          this module for this test. Feeds are got from custom_nvd_feed.json file.
+          Vulnerabilities are got from custom_msu.json file.
+
+    expected_output:
+        - r'The CPE `o:microsoft:.*:(-|r2|.*):(.*)?:::::.*:` from the agent `.*` was indexed'
+    '''
     log_monitor.start(
         timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
         update_position=False,


### PR DESCRIPTION
|Related issue|
|---|
|#2328|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 

The schema used is the one defined in issue #1694


# Generated documentation


<details><summary>test_cpe_indexing.json</summary>
<p>

```json
{
    "copyright": "Copyright (C) 2015-2021, Wazuh Inc.\nCreated by Wazuh, Inc. <info@wazuh.com>.\nThis program is free software; you can redistribute it and/or modify it under the terms of GPLv2",
    "type": "integration",
    "brief": "Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat, Canonical, Debian, Amazon Linux and NVD Database.",
    "tier": 1,
    "modules": [
        "vulnerability_detector"
    ],
    "components": [
        "manager"
    ],
    "daemons": [
        "wazuh-modulesd",
        "wazuh-db",
        "wazuh-analysisd"
    ],
    "os_platform": [
        "linux"
    ],
    "os_version": [
        "Arch Linux",
        "Amazon Linux 2",
        "Amazon Linux 1",
        "CentOS 8",
        "CentOS 7",
        "CentOS 6",
        "Ubuntu Focal",
        "Ubuntu Bionic",
        "Ubuntu Xenial",
        "Ubuntu Trusty",
        "Debian Buster",
        "Debian Stretch",
        "Debian Jessie",
        "Debian Wheezy",
        "Red Hat 8",
        "Red Hat 7",
        "Red Hat 6"
    ],
    "references": [
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html",
        "https://wazuh.com/blog/using-wazuh-for-windows-vulnerability-detection/",
        "https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/cpe-helper.html"
    ],
    "tags": [
        "settings",
        "vulnerability",
        "vulnerability_detector"
    ],
    "name": "test_cpe_indexing.py",
    "id": 1,
    "group_id": 0,
    "path": "tests/integration/test_vulnerability_detector/test_windows/test_cpe_indexing.py",
    "tests": [
        {
            "description": "Check if inserted vulnerable packages are reported by the vulnerability detector. To do this, an auxiliary dictionary is generated in order to translate the gathered program names, (emulated by an entry list), into the standard format used by the NVD, which is called CPE. This allows the vulnerability detector to scan the NVD looking for vulnerabilities of these applications. So, is inserted a vulnerability in the NVD_CVE table since this is needed for the vulnerability detector to generate the required log.",
            "wazuh_min_version": "4.2.0",
            "parameters": [
                {
                    "get_configuration": {
                        "type": "fixture",
                        "brief": "Get configurations from the module."
                    }
                },
                {
                    "configure_environment": {
                        "type": "fixture",
                        "brief": "Configure a custom environment for testing."
                    }
                },
                {
                    "configure_local_internal_options_module": {
                        "type": "fixture",
                        "brief": "Configure the local internal options file."
                    }
                },
                {
                    "restart_modulesd": {
                        "type": "fixture",
                        "brief": "Reset the logs file and start a new monitor."
                    }
                },
                {
                    "check_cve_db": {
                        "type": "fixture",
                        "brief": "Check if the CVE database exists and its tables are created."
                    }
                },
                {
                    "mock_system": {
                        "type": "fixture",
                        "brief": "It allows to insert a vulnerability in the NVD_CVE table."
                    }
                },
                {
                    "file_monitoring": {
                        "type": "fixture",
                        "brief": "Handle the monitoring of a specified file."
                    }
                }
            ],
            "assertions": [
                "Verify that the monitor gets the expected message."
            ],
            "input_description": [
                "Test cases are found in the test module. The `cpe_indexing.yaml` file provides the configuration of this module for this test. Feeds are got from custom_nvd_feed.json file. Vulnerabilities are got from custom_msu.json file."
            ],
            "expected_output": [
                "r'The CPE `o:microsoft:.*:(-|r2|.*):(.*)?:::::.*:` from the agent `.*` was indexed'"
            ],
            "name": "test_window_version_indexing",
            "inputs": [
                "cpe_index_configuration-WINDOWS_SERVER_2013",
                "cpe_index_configuration-WINDOWS_SERVER_2013_R2",
                "cpe_index_configuration-WINDOWS_XP",
                "cpe_index_configuration-WINDOWS_VISTA",
                "cpe_index_configuration-WINDOWS_7",
                "cpe_index_configuration-WINDOWS_8",
                "cpe_index_configuration-WINDOWS_8.1",
                "cpe_index_configuration-WINDOWS_10",
                "cpe_index_configuration-WINDOWS_SERVER_2008",
                "cpe_index_configuration-WINDOWS_SERVER_2008_R2",
                "cpe_index_configuration-WINDOWS_SERVER_2012",
                "cpe_index_configuration-WINDOWS_SERVER_2012_R2",
                "cpe_index_configuration-WINDOWS_SERVER_2016",
                "cpe_index_configuration-WINDOWS_SERVER_2019",
                "cpe_index_configuration-WINDOWS_SERVER_2013_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2013_R2_I386",
                "cpe_index_configuration-WINDOWS_XP_I386",
                "cpe_index_configuration-WINDOWS_VISTA_I386",
                "cpe_index_configuration-WINDOWS_7_I386",
                "cpe_index_configuration-WINDOWS_8_I386",
                "cpe_index_configuration-WINDOWS_8.1_I386",
                "cpe_index_configuration-WINDOWS_10_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2008_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2008_R2_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2012_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2012_R2_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2016_I386",
                "cpe_index_configuration-WINDOWS_SERVER_2019_I386"
            ]
        }
    ]
}
```
</p>
</details>


## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The `qa-docs` tool does not raise any error.