### PR TITLE
Fix `wazuh-metrics` CLI bug when child processes restart

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/scripts/wazuh_metrics.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/wazuh_metrics.py
@@ -1,23 +1,31 @@
 import argparse
 import logging
+from collections import defaultdict
 from datetime import datetime
 from os import makedirs
 from os.path import join
 from signal import signal, SIGTERM, SIGINT
 from tempfile import gettempdir
-from time import time
+from time import time, sleep
 
 from wazuh_testing.tools.performance.binary import Monitor, logger
 
 METRICS_FOLDER = join(gettempdir(), 'process_metrics')
 CURRENT_SESSION = join(METRICS_FOLDER, datetime.now().strftime('%d-%m-%Y'), str(int(time())))
-MONITOR_LIST = []
+ACTIVE_MONITORS = defaultdict(list)
+SESSION_ACTIVE = True
 
 
 def shutdown_threads(signal_number, frame):
     logger.info('Attempting to shutdown all monitor threads')
-    for monitor in MONITOR_LIST:
+
+    global SESSION_ACTIVE
+    SESSION_ACTIVE = False
+
+    # Shutdown all possible monitors
+    for monitor in sum(ACTIVE_MONITORS.values(), []):
         monitor.shutdown()
+
     logger.info('Process finished')
 
 
@@ -37,6 +45,52 @@ def get_script_arguments():
                         help=f"Path to store the CSVs with the data. Default {gettempdir()}.")
 
     return parser.parse_args()
+
+
+def check_monitors_health(options, errors=0):
+    for process, monitors in ACTIVE_MONITORS.items():
+        # Check if there is any unhealthy monitor
+        if any(filter(lambda m: m.event.is_set(), monitors)):
+            logger.warning(f'Monitoring of {process} failed. Attempting to create new monitor instances')
+
+            try:
+                # Try to get new PIDs
+                process_pids = Monitor.get_process_pids(process)
+                # Shutdown all the related monitors to the failed process (necessary for multiprocessing)
+                for monitor in monitors:
+                    monitor.shutdown()
+            except ValueError as e:
+                errors_allowed = 5 * len(ACTIVE_MONITORS)
+                errors += 1
+                logger.warning(f'Could not create new monitor instances for {process}. Error {errors}/{errors_allowed}')
+                if errors >= errors_allowed:
+                    logger.error('Reached maximum number of retries. Aborting')
+                    raise e
+                continue
+
+            for i, pid in enumerate(process_pids):
+                # Attempt to create new monitor instances for the process
+                p_name = process if i == 0 else f'{process}_child_{i}'
+                monitor = Monitor(process_name=p_name, pid=pid, value_unit=options.data_unit,
+                                  time_step=options.sleep_time,
+                                  version=options.version, dst_dir=options.store_path)
+                monitor.start()
+
+                try:
+                    # Replace old monitors for new ones
+                    ACTIVE_MONITORS[process][i] = monitor
+                except IndexError:
+                    ACTIVE_MONITORS[process].append(monitor)
+
+    return errors
+
+
+def monitor_healthcheck(options):
+    errors = 0
+    while SESSION_ACTIVE:
+        monitoring_errors = check_monitors_health(options, errors)
+        errors = 0 if monitoring_errors == errors else monitoring_errors
+        sleep(5)
 
 
 def main():
@@ -59,7 +113,9 @@ def main():
             monitor = Monitor(process_name=p_name, pid=pid, value_unit=options.data_unit, time_step=options.sleep_time,
                               version=options.version, dst_dir=options.store_path)
             monitor.start()
-            MONITOR_LIST.append(monitor)
+            ACTIVE_MONITORS[process].append(monitor)
+
+    monitor_healthcheck(options)
 
 
 if __name__ == '__main__':

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py
@@ -40,7 +40,6 @@ class Monitor:
         pid (int): PID of the process.
         event (thread.Event): thread Event used to control the scans.
         thread (thread): thread to scan the data.
-        healthy (thread.Event): thread Event used to control the monitor health status.
         csv_file (str): path to the CSV file.
     """
     def __init__(self, process_name, pid, value_unit='KB', time_step=1, version=None, dst_dir=gettempdir()):
@@ -55,7 +54,6 @@ class Monitor:
         self.proc = None
         self.event = None
         self.thread = None
-        self.healthy = None
         self.previous_read = None
         self.previous_write = None
         self.set_process()
@@ -177,7 +175,6 @@ class Monitor:
         except psutil.NoSuchProcess:
             logger.warning(f'Lost PID for {self.process_name}')
             self.shutdown()
-            self.healthy.set()
         finally:
             info.update({key: round(value, 2) for key, value in info.items() if isinstance(value, (int, float))})
             logger.debug(f'Recollected data for process {self.pid}')
@@ -216,7 +213,6 @@ class Monitor:
         self.event = Event()
         self.thread = Thread(target=self._monitor_process)
         self.thread.start()
-        self.healthy = Event()
 
     def start(self):
         """Start the monitoring threads."""


### PR DESCRIPTION
|Related issue|
|---|
|closes #2401 |


## Description

As reported, the `wazuh-metrics` CLI would not monitor child processes that could restart. Currently, this issue only happens with the Wazuh cluster and API, as they use multiprocessing. An example of this bug can be seen in #2401 .

To fix this, the CLI has been reworked to add a monitor healthcheck that is able to shutdown unused monitors and launch new ones when processes restart. They key for this to work is that we retrieve child PIDs using the following line:

https://github.com/wazuh/wazuh-qa/blob/e1e36219fb52726295066e086efb334cc45da6c9/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py#L95

This will always return a list of PIDs ordered from oldest (parent process) to most recent if there are any child processes. In addition, both the cluster and API processes always spawn their child in the same order, asserting that although the PIDs may change, the process name will remain the same in the CSV file.

Another key change is this block:

https://github.com/wazuh/wazuh-qa/blob/e1e36219fb52726295066e086efb334cc45da6c9/deps/wazuh_testing/wazuh_testing/scripts/wazuh_metrics.py#L80-L92

As this CLI is used for the first time after outer healthchecks confirm that everything is working as intended, the first monitor list that we retrieve will have the exact number of expected processes. Thus, replacing each monitor with a new one after scanning the PIDs instead of simply removing and adding new monitor instances will leave failed monitors that will be checked again. This mechanism will keep failing until all the expected child processes are being monitored again.

## Configuration options

After the rework, two new options have been added to the CLI:

- Healthcheck time (`-H`, `--healthcheck-time`): Time in seconds between each health check. Default value 10 seconds.
- Retries (`-r`, `--retries`): Number of reconnection retries before aborting the monitoring process. Default value 5 retries.

## Logs example

- Launching the CLI with the following parameters: `wazuh-metrics -p wazuh-apid wazuh-clusterd`
- There is a script constantly adding agents to the environment using the API.
- A `service wazuh-manager restart` was executed shortly after beginning the monitoring task.

![image](https://user-images.githubusercontent.com/37274979/147580380-2781934f-dfd4-4bd0-b38e-70a920d58815.png)

<details>

<summary>wazuh-metrics log</summary>

```
2021/12/28 15:08:22 INFO: Started new session: /tmp/process_metrics/28-12-2021/1640704102
2021/12/28 15:08:22 INFO: Started monitoring process wazuh-apid (441500)
2021/12/28 15:08:22 INFO: Started monitoring process wazuh-apid_child_1 (441523)
2021/12/28 15:08:22 INFO: Started monitoring process wazuh-apid_child_2 (441526)
2021/12/28 15:08:22 INFO: Started monitoring process wazuh-clusterd (442354)
2021/12/28 15:08:22 INFO: Started monitoring process wazuh-clusterd_child_1 (442708)
2021/12/28 15:08:22 INFO: Started monitoring process wazuh-clusterd_child_2 (442711)
2021/12/28 15:08:34 WARNING: Lost PID for wazuh-clusterd_child_2
2021/12/28 15:08:34 WARNING: Lost PID for wazuh-clusterd
2021/12/28 15:08:34 WARNING: Lost PID for wazuh-clusterd_child_1
2021/12/28 15:08:36 WARNING: Lost PID for wazuh-apid_child_2
2021/12/28 15:08:36 WARNING: Lost PID for wazuh-apid_child_1
2021/12/28 15:08:37 WARNING: Lost PID for wazuh-apid
2021/12/28 15:08:42 WARNING: Monitoring of wazuh-apid failed. Attempting to create new monitor instances
2021/12/28 15:08:42 INFO: Started monitoring process wazuh-apid (496700)
2021/12/28 15:08:42 INFO: Started monitoring process wazuh-apid_child_1 (496723)
2021/12/28 15:08:42 INFO: Started monitoring process wazuh-apid_child_2 (496726)
2021/12/28 15:08:42 WARNING: Monitoring of wazuh-clusterd failed. Attempting to create new monitor instances
2021/12/28 15:08:42 WARNING: Could not create new monitor instances for wazuh-clusterd
2021/12/28 15:08:52 WARNING: Monitoring of wazuh-clusterd failed. Attempting to create new monitor instances
2021/12/28 15:08:52 INFO: Started monitoring process wazuh-clusterd (497470)
2021/12/28 15:08:52 INFO: Started monitoring process wazuh-clusterd_child_1 (499336)
2021/12/28 15:08:52 INFO: Started monitoring process wazuh-clusterd_child_2 (499347)
2021/12/28 15:09:05 INFO: Attempting to shutdown all monitor threads
2021/12/28 15:09:08 INFO: Process finished gracefully
```

</details>

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.