### PR TITLE
Delete unnecessary `CLIENT_KEYS_PATH`

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -100,7 +100,6 @@ _data_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__fil
 LOCAL_RULES_PATH = os.path.join(WAZUH_PATH, 'etc', 'rules', 'local_rules.xml')
 LOCAL_DECODERS_PATH = os.path.join(WAZUH_PATH, 'etc', 'decoders', 'local_decoder.xml')
 
-CLIENT_KEYS_PATH = os.path.join(WAZUH_PATH, 'etc', 'client.keys')
 SERVER_KEY_PATH = os.path.join(WAZUH_PATH, 'etc', 'manager.key')
 SERVER_CERT_PATH = os.path.join(WAZUH_PATH, 'etc', 'manager.cert')
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #2418 |


## Description

After testing some developments, we could see that tests were failing because `CLIENT_KEYS_PATH` is being overwritten in `wazuh_testing.tools`. We have deleted :

https://github.com/wazuh/wazuh-qa/blob/eb32b096457b8fd15678876c97daca77ef20225a/deps/wazuh_testing/wazuh_testing/tools/__init__.py#L103

