### PR TITLE
Migrate `test_rids` documentation to `qa-docs`

### DIFF
--- a/tests/integration/test_rids/test_rids.py
+++ b/tests/integration/test_rids/test_rids.py
@@ -22,6 +22,7 @@ components:
 
 daemons:
     - wazuh-remoted
+    - wazuh-agentd
 
 os_platform:
     - linux
@@ -170,14 +171,14 @@ def test_rids(get_configuration, configure_environment, restart_service):
             brief: Get configuration from the module.
         - configure_environment:
             type: fixture
-            brief: Configure a custom environment for testing
+            brief: Configure a custom environment for testing.
         - restart_service:
             type: fixture
             brief: Method to restart the service.
 
     assertions:
-        - Verify that every agent rid is open
-        - Verify that every agent rid is closed
+        - Verify that every agent rid is open.
+        - Verify that every agent rid is closed.
 
     input_description: Some metadata is defined in the module. These include some configurations stored in
                        the 'wazuh_manager_conf.yaml'.

--- a/tests/integration/test_rids/test_rids.py
+++ b/tests/integration/test_rids/test_rids.py
@@ -183,8 +183,8 @@ def test_rids(get_configuration, configure_environment, restart_service):
                        the 'wazuh_manager_conf.yaml'.
 
     expected_output:
-        - `rids_for_agent_open` boolean variable with `True` when RIDS should be `opened`.
-        - `rids_for_agent_open` boolean variable with `False` when RIDS should be `closed`.
+        - The `rids_for_agent_open` boolean variable with `True` when RIDS should be `opened`.
+        - The `rids_for_agent_open` boolean variable with `False` when RIDS should be `closed`.
     '''
     metadata = get_configuration.get('metadata')
     agents_number = metadata['agents_number']

--- a/tests/integration/test_rids/test_rids.py
+++ b/tests/integration/test_rids/test_rids.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The RIDS(Remote Identifiers) are the agent-manager remoted messages counter. Each message is identified by the
+       next possible number(identifier). Only the incoming messages with a valid RID(higher than previous) are allowed.
+       This functionality has a closing time value, which allows removing an agent's file handler when it does not send
+       a message during a period of time(five minutes by default).
+
+tier: 0
+
+modules:
+    - rids
+
+components:
+    - manager
+
+daemons:
+    - wazuh-remoted
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh/blob/master/src/os_crypto/shared/msgs.c
+    - https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#remoted
+    - https://github.com/wazuh/wazuh/blob/master/src/config/remote-config.c
+    - https://github.com/wazuh/wazuh/pull/459
+    - https://github.com/wazuh/wazuh/issues/6112
+    - https://github.com/wazuh/wazuh/pull/7746
+
+tags:
+    - rids
+'''
 import os
 import time
 
@@ -103,6 +157,35 @@ def set_recv_counter_flush(new_recv_counter):
 
 
 def test_rids(get_configuration, configure_environment, restart_service):
+    '''
+    description: Check that RIDS is opened and closed as expected. To do this, it creates injectors(agents and senders)
+                 to be able to communicate with the manager. Then, it stops the agents' listening and checks if RIDS is
+                 closed(when it`s needed).
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing
+        - restart_service:
+            type: fixture
+            brief: Method to restart the service.
+
+    assertions:
+        - Verify that every agent rid is open
+        - Verify that every agent rid is closed
+
+    input_description: Some metadata is defined in the module. These include some configurations stored in
+                       the 'wazuh_manager_conf.yaml'.
+
+    expected_output:
+        - `rids_for_agent_open` boolean variable with `True` when RIDS should be `opened`.
+        - `rids_for_agent_open` boolean variable with `False` when RIDS should be `closed`.
+    '''
     metadata = get_configuration.get('metadata')
     agents_number = metadata['agents_number']
     check_close = metadata['check_close']

--- a/tests/integration/test_rids/test_rids_conf.py
+++ b/tests/integration/test_rids/test_rids_conf.py
@@ -1,7 +1,61 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
 
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The RIDS(Remote Identifiers) are the agent-manager remoted messages counter. Each message is identified by the
+       next possible number(identifier). Only the incoming messages with a valid RID(higher than previous) are allowed.
+       This functionality has a closing time value, which allows removing an agent's file handler when it does not send
+       a message during a period of time(five minutes by default).
+
+tier: 0
+
+modules:
+    - rids
+
+components:
+    - manager
+
+daemons:
+    - wazuh-remoted
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://github.com/wazuh/wazuh/blob/master/src/os_crypto/shared/msgs.c
+    - https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#remoted
+    - https://github.com/wazuh/wazuh/blob/master/src/config/remote-config.c
+    - https://github.com/wazuh/wazuh/pull/459
+    - https://github.com/wazuh/wazuh/pull/7746
+    - https://github.com/wazuh/wazuh/issues/6112
+
+tags:
+    - rids
+'''
 import os
 
 import pytest
@@ -66,6 +120,32 @@ def set_internal_options_conf(param, value):
 
 
 def test_rids_conf(get_configuration, configure_environment):
+    '''
+    description: Check that RIDS configuration works as expected for the following fields: `remoted.verify_msg_id` and
+                 `remoted.worker_pool`. To do this, it modifies the local internal options with the test case metadata
+                 and restarts Wazuh to verify that the daemon starts or not. Finally, when a correct configuration has
+                 been tested, it restores the `internal_options.conf` as it was before running the test.
+
+    wazuh_min_version: 4.2.0
+
+    parameters:
+        - get_configuration:
+            type: fixture
+            brief: Get configuration from the module.
+        - configure_environment:
+            type: fixture
+            brief: Configure a custom environment for testing
+
+    assertions:
+        - Verify that the RIDS configuration is applied correctly(or not)
+
+    input_description: Some metadata is defined in the module. These include some configurations stored in
+                       the 'wazuh_manager_conf.yaml'.
+
+    expected_output:
+        - `expected_start` boolean variable with `True` when a defined valid RIDS configuration is loaded.
+        - `expected_start` boolean variable with `False` when a defined wrong RIDS configuration is loaded.
+    '''
     metadata = get_configuration.get('metadata')
     expected_start = metadata['expected_start']
 

--- a/tests/integration/test_rids/test_rids_conf.py
+++ b/tests/integration/test_rids/test_rids_conf.py
@@ -22,6 +22,7 @@ components:
 
 daemons:
     - wazuh-remoted
+    - wazuh-agentd
 
 os_platform:
     - linux
@@ -134,10 +135,10 @@ def test_rids_conf(get_configuration, configure_environment):
             brief: Get configuration from the module.
         - configure_environment:
             type: fixture
-            brief: Configure a custom environment for testing
+            brief: Configure a custom environment for testing.
 
     assertions:
-        - Verify that the RIDS configuration is applied correctly(or not)
+        - Verify that the RIDS configuration is applied correctly(or not).
 
     input_description: Some metadata is defined in the module. These include some configurations stored in
                        the 'wazuh_manager_conf.yaml'.

--- a/tests/integration/test_rids/test_rids_conf.py
+++ b/tests/integration/test_rids/test_rids_conf.py
@@ -121,7 +121,7 @@ def set_internal_options_conf(param, value):
 
 def test_rids_conf(get_configuration, configure_environment):
     '''
-    description: Check that RIDS configuration works as expected for the following fields: `remoted.verify_msg_id` and
+    description: Check that RIDS configuration works as expected for the following fields, `remoted.verify_msg_id` and
                  `remoted.worker_pool`. To do this, it modifies the local internal options with the test case metadata
                  and restarts Wazuh to verify that the daemon starts or not. Finally, when a correct configuration has
                  been tested, it restores the `internal_options.conf` as it was before running the test.
@@ -143,8 +143,8 @@ def test_rids_conf(get_configuration, configure_environment):
                        the 'wazuh_manager_conf.yaml'.
 
     expected_output:
-        - `expected_start` boolean variable with `True` when a defined valid RIDS configuration is loaded.
-        - `expected_start` boolean variable with `False` when a defined wrong RIDS configuration is loaded.
+        - The `expected_start` boolean variable with `True` when a defined valid RIDS configuration is loaded.
+        - The `expected_start` boolean variable with `False` when a defined wrong RIDS configuration is loaded.
     '''
     metadata = get_configuration.get('metadata')
     expected_start = metadata['expected_start']


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1817|

# Description
As part of epic #1796, this PR adds the missing documentation and migrates the current documentation to the new format used by **qa-docs**. 

The schema used is the one defined in issue #1694

## Tests
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] The `qa-docs` tool does not raise any error.