### PR TITLE
Fix version validation in `qa-ctl` config generator

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -231,7 +231,7 @@ class QACTLConfigGenerator:
         # Validate version requirements
         if parse(str(test_info['tests'][0]['wazuh_min_version'])) > parse(str(self.wazuh_version)):
             error_message = f"The minimal version of wazuh to launch the {test_info['test_name']} is " \
-                            f"{test_info['wazuh_min_version']} and you are using {self.wazuh_version}"
+                            f"{test_info['tests'][0]['wazuh_min_version']} and you are using {self.wazuh_version}"
             raise QAValueError(error_message, QACTLConfigGenerator.LOGGER.error, QACTL_LOGGER)
 
         return True


### PR DESCRIPTION
This PR fixes an error when building the error message when the version supported by the test was higher than the one indicated.

<details>
<summary>The error was the following</summary>

```
qa-ctl --dry-run -r test_predecoder_stage --qa-branch jfix-qa-ctl-version -d

2022-01-18 16:01:28,173 - DEBUG - Downloading fix-qa-ctl-version files of wazuh-qa repository in /tmp/wazuh_qa_ctl/wazuh-qa
2022-01-18 16:01:30,232 - INFO - Validating input parameters
2022-01-18 16:01:32,531 - INFO - Input parameters validation has passed successfully
2022-01-18 16:01:32,532 - DEBUG - Generating configuration file
{'description': "Check that the predecoder returns the correct fields when receives different sets of syslog formats. To do this, it receives syslog format and checks that the predecoder JSON responses are the same that the loaded ouput for each test case from the 'syslog_socket_input.yaml' file.", 'wazuh_min_version': '4.3.0', 'parameters': [{'connect_to_sockets_function': {'type': 'fixture', 'brief': "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."}}, {'test_case': {'type': 'list', 'brief': 'List of tests to be performed.'}}], 'assertions': ['Checks that the predecoder gives the expected output.'], 'input_description': ['Different test cases that are contained in an external YAML file (syslog_socket_input.yaml) that includes syslog events data and the expected precoder output.'], 'expected_output': ['Precoder JSON with the correct fields (timestamp, program name, etc) corresponding to each test case.'], 'name': 'test_precoder_supported_formats', 'test_cases': ['Syslog date format 1', 'Syslog date format 2', 'Syslog date format for rsyslog', 'Syslog date format for proftpd 1.3.5', 'Syslog date format for xferlog date format', 'Syslog date format for snort date format', 'Syslog date format for suricata date format', 'Syslog date format for apache log format', 'Syslog date format for macos ULS --syslog output', 'Syslog Umlaut date format']}
dict_keys(['description', 'wazuh_min_version', 'parameters', 'assertions', 'input_description', 'expected_output', 'name', 'test_cases'])
Traceback (most recent call last):
  File "/home/jmv74211/.vscode/venv/bin/qa-ctl", line 11, in <module>
    load_entry_point('wazuh-testing==4.3.0', 'console_scripts', 'qa-ctl')()
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/scripts/qa_ctl.py", line 344, in main
    config_generator.run()
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 585, in run
    self.__process_test_info(info)
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 570, in __process_test_info
    self.__process_deployment_data(tests_info)
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 388, in __process_deployment_data
    if self.__validate_test_info(test):
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 235, in __validate_test_info
    error_message = f"The minimal version of wazuh to launch the {test_info['test_name']} is " \
KeyError: 'wazuh_min_version'
```

</details>


<details>
<summary>After appliying the fix</summary>

```
qa-ctl --dry-run -r test_predecoder_stage --qa-branch fix-qa-ctl-version -d
2022-01-18 16:03:09,860 - DEBUG - Downloading fix-qa-ctl-version files of wazuh-qa repository in /tmp/wazuh_qa_ctl/wazuh-qa
2022-01-18 16:03:11,156 - INFO - Validating input parameters
2022-01-18 16:03:13,329 - INFO - Input parameters validation has passed successfully
2022-01-18 16:03:13,330 - DEBUG - Generating configuration file
{'description': "Check that the predecoder returns the correct fields when receives different sets of syslog formats. To do this, it receives syslog format and checks that the predecoder JSON responses are the same that the loaded ouput for each test case from the 'syslog_socket_input.yaml' file.", 'wazuh_min_version': '4.3.0', 'parameters': [{'connect_to_sockets_function': {'type': 'fixture', 'brief': "Function scope version of 'connect_to_sockets' which connects to the specified sockets for the test."}}, {'test_case': {'type': 'list', 'brief': 'List of tests to be performed.'}}], 'assertions': ['Checks that the predecoder gives the expected output.'], 'input_description': ['Different test cases that are contained in an external YAML file (syslog_socket_input.yaml) that includes syslog events data and the expected precoder output.'], 'expected_output': ['Precoder JSON with the correct fields (timestamp, program name, etc) corresponding to each test case.'], 'name': 'test_precoder_supported_formats', 'test_cases': ['Syslog date format 1', 'Syslog date format 2', 'Syslog date format for rsyslog', 'Syslog date format for proftpd 1.3.5', 'Syslog date format for xferlog date format', 'Syslog date format for snort date format', 'Syslog date format for suricata date format', 'Syslog date format for apache log format', 'Syslog date format for macos ULS --syslog output', 'Syslog Umlaut date format']}
dict_keys(['description', 'wazuh_min_version', 'parameters', 'assertions', 'input_description', 'expected_output', 'name', 'test_cases'])
2022-01-18 16:03:13,951 - ERROR - The minimal version of wazuh to launch the test_predecoder_stage is 4.3.0 and you are using 4.2.5
Traceback (most recent call last):
  File "/home/jmv74211/.vscode/venv/bin/qa-ctl", line 11, in <module>
    load_entry_point('wazuh-testing==4.3.0', 'console_scripts', 'qa-ctl')()
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/scripts/qa_ctl.py", line 344, in main
    config_generator.run()
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 585, in run
    self.__process_test_info(info)
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 570, in __process_test_info
    self.__process_deployment_data(tests_info)
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 388, in __process_deployment_data
    if self.__validate_test_info(test):
  File "/home/jmv74211/.vscode/venv/lib/python3.8/site-packages/wazuh_testing-4.3.0-py3.8.egg/wazuh_testing/qa_ctl/configuration/config_generator.py", line 237, in __validate_test_info
    raise QAValueError(error_message, QACTLConfigGenerator.LOGGER.error, QACTL_LOGGER)
wazuh_testing.tools.exceptions.QAValueError: The minimal version of wazuh to launch the test_predecoder_stage is 4.3.0 and you are using 4.2.5
```

</details>
