### PR TITLE
Added specific version of libcst to install in python lower than 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ bandit==1.7.0
 git-repo==1.10.3
 pywinrm>=0.4.2 ; platform_system == "Linux" or platform_system=='Windows'
 wmi>=1.5.1; platform_system=='Windows'
+libcst==0.3.23 ; python_version <= '3.6'


### PR DESCRIPTION
Hello team,

We have added a little modification to allow requirements to install in old python distributions 3.6 or lower.
This will fix our problem with CentOS 6

Regards.