### PR TITLE
IT Test: Module (FIM) - Replace callback_generator to generate_monitoring_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Release report: TBD
 - Migrate several test groups of test_logcollector documentation to qa-docs ([#2180](https://github.com/wazuh/wazuh-qa/pull/2180))
 - Add wpk test documentation ([#2409](https://github.com/wazuh/wazuh-qa/pull/2409))
 - Migrate test_remoted documentation to schema 2.0 ([#2426](https://github.com/wazuh/wazuh-qa/pull/2426))
+- Fix FIM test: Replace callback_generator function to generate_monitoring_callback ([#2535](https://github.com/wazuh/wazuh-qa/pull/2535))
 
 
 ### Deleted

--- a/deps/wazuh_testing/wazuh_testing/fim_module/fim_synchronization.py
+++ b/deps/wazuh_testing/wazuh_testing/fim_module/fim_synchronization.py
@@ -5,7 +5,7 @@
 from wazuh_testing.fim import LOG_FILE_PATH, callback_detect_registry_integrity_state_event
 from wazuh_testing import global_parameters
 from wazuh_testing.fim_module.fim_variables import MAX_EVENTS_VALUE, CB_REGISTRY_DBSYNC_NO_DATA
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 
 
 def get_sync_msgs(tout, new_data=True):
@@ -24,7 +24,7 @@ def get_sync_msgs(tout, new_data=True):
     events = []
     if new_data:
         wazuh_log_monitor.start(timeout=tout,
-                                callback=callback_generator(CB_REGISTRY_DBSYNC_NO_DATA),
+                                callback=generate_monitoring_callback(CB_REGISTRY_DBSYNC_NO_DATA),
                                 error_message='Did not receive expected '
                                               '"db sync no data" event')
     for _ in range(0, MAX_EVENTS_VALUE):

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py
@@ -92,7 +92,7 @@ from wazuh_testing.fim_module.fim_variables import (TEST_DIR_1, YAML_CONF_DIFF, 
                                                     REPORT_CHANGES, TEST_DIRECTORIES, ERR_MSG_MAXIMUM_FILE_SIZE,
                                                     ERR_MSG_WRONG_VALUE_MAXIMUM_FILE_SIZE)
 from wazuh_testing.wazuh_variables import DATA, SYSCHECK_DEBUG, VERBOSE_DEBUG_OUTPUT
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 
 
 # Marks
@@ -178,7 +178,7 @@ def test_diff_size_limit_configured(configure_local_internal_options_module, get
 
     diff_size_value = wazuh_log_monitor.start(
         timeout=global_parameters.default_timeout,
-        callback=callback_generator(CB_MAXIMUM_FILE_SIZE),
+        callback=generate_monitoring_callback(CB_MAXIMUM_FILE_SIZE),
         error_message=ERR_MSG_MAXIMUM_FILE_SIZE).result()
 
     assert diff_size_value == str(DIFF_LIMIT_VALUE), ERR_MSG_WRONG_VALUE_MAXIMUM_FILE_SIZE

--- a/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_diff_size_limit_default.py
@@ -87,7 +87,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 from wazuh_testing.wazuh_variables import DATA
 from wazuh_testing.fim_module.fim_variables import (DIFF_DEFAULT_LIMIT_VALUE, CB_MAXIMUM_FILE_SIZE,
                                                     REPORT_CHANGES, TEST_DIR_1, TEST_DIRECTORIES,
@@ -173,7 +173,7 @@ def test_diff_size_limit_default(configure_local_internal_options_module, get_co
 
     diff_size_value = wazuh_log_monitor.start(
         timeout=global_parameters.default_timeout,
-        callback=callback_generator(CB_MAXIMUM_FILE_SIZE),
+        callback=generate_monitoring_callback(CB_MAXIMUM_FILE_SIZE),
         error_message=ERR_MSG_MAXIMUM_FILE_SIZE
                                               ).result()
 

--- a/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
+++ b/tests/integration/test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py
@@ -62,7 +62,7 @@ from wazuh_testing.fim import LOG_FILE_PATH, KEY_WOW64_32KEY, KEY_WOW64_64KEY, g
     check_time_travel, validate_registry_value_event, callback_value_event, REG_SZ
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.fim_module.fim_variables import CB_MAXIMUM_FILE_SIZE
 
@@ -178,7 +178,7 @@ def test_file_size_default(key, subkey, arch, value_name, tags_to_apply,
     mode = get_configuration['metadata']['fim_mode']
 
     file_size_values = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                               callback=callback_generator(CB_MAXIMUM_FILE_SIZE),
+                                               callback=generate_monitoring_callback(CB_MAXIMUM_FILE_SIZE),
                                                accum_results=3,
                                                error_message='Did not receive expected '
                                                              '"Maximum file size limit to generate diff information '

--- a/tests/integration/test_fim/test_synchronization/test_sync_disabled_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_disabled_win32.py
@@ -61,7 +61,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 from wazuh_testing.wazuh_variables import DATA
 from wazuh_testing.fim_module.fim_variables import (TEST_DIR_1, WINDOWS_HKEY_LOCAL_MACHINE, MONITORED_KEY,
                                                     YAML_CONF_SYNC_WIN32, TEST_DIRECTORIES, TEST_REGISTRIES,
@@ -143,5 +143,5 @@ def test_sync_disabled(get_configuration, configure_environment, restart_syschec
     # The file synchronization event shouldn't be triggered
     with pytest.raises(TimeoutError):
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                        callback=callback_generator(CB_INTEGRITY_CONTROL_MESSAGE),
+                                        callback=generate_monitoring_callback(CB_INTEGRITY_CONTROL_MESSAGE),
                                         update_position=True).result()

--- a/tests/integration/test_fim/test_synchronization/test_sync_registry_disabled_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_registry_disabled_win32.py
@@ -62,7 +62,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params, callback_detect_integrity_event
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 from wazuh_testing.wazuh_variables import DATA
 from wazuh_testing.fim_module.fim_variables import (TEST_DIR_1, WINDOWS_HKEY_LOCAL_MACHINE, MONITORED_KEY,
                                                     YAML_CONF_SYNC_WIN32, TEST_DIRECTORIES, TEST_REGISTRIES,
@@ -150,4 +150,4 @@ def test_sync_disabled(get_configuration, configure_environment, restart_syschec
     # The registry synchronization event shouldn't be triggered
     with pytest.raises(TimeoutError):
         event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout, update_position=True,
-                                        callback=callback_generator(CB_INTEGRITY_CONTROL_MESSAGE)).result()
+                                        callback=generate_monitoring_callback(CB_INTEGRITY_CONTROL_MESSAGE)).result()

--- a/tests/integration/test_fim/test_synchronization/test_sync_registry_enabled_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_registry_enabled_win32.py
@@ -62,7 +62,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import LOG_FILE_PATH, generate_params
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import FileMonitor, callback_generator
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 from wazuh_testing.wazuh_variables import DATA
 from wazuh_testing.fim_module.fim_variables import (TEST_DIR_1, WINDOWS_HKEY_LOCAL_MACHINE, MONITORED_KEY,
                                                     YAML_CONF_SYNC_WIN32, TEST_DIRECTORIES, TEST_REGISTRIES,
@@ -145,5 +145,5 @@ def test_sync_disabled(get_configuration, configure_environment, restart_syschec
     # The file synchronization event shouldn't be triggered
     with pytest.raises(TimeoutError):
         event = (wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
-                                         callback=callback_generator(CB_INTEGRITY_CONTROL_MESSAGE),
+                                         callback=generate_monitoring_callback(CB_INTEGRITY_CONTROL_MESSAGE),
                                          update_position=True).result())


### PR DESCRIPTION
|Related issue|
|---|
[2345](https://github.com/wazuh/wazuh-qa/issues/2534)

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
When PR 2345 was merged, we replace the name of a function callback_generator for generate_monitoring_callback. But some tests were affected by this change.

test affected:

    test_fim/test_files/test_report_changes/test_diff_size_limit_configured.py

    test_fim/test_files/test_report_changes/test_diff_size_limit_default.py

    test_fim/test_registry/test_registry_report_changes/test_registry_file_size_default.py

    test_fim/test_synchronization/test_registry_responses_win32.py

    test_fim/test_synchronization/test_sync_disabled_win32.py

    test_fim/test_synchronization/test_sync_registry_disabled_win32.py

    test_fim/test_synchronization/test_sync_registry_enabled_win32.py

Changes to do:
Replace calbback_generator with generate_monitoring_callback


<!--
When proceed, this section should include new configuration parameters.
-->

## Logs example

<!--
Paste here related logs and alerts
-->
### test_fim/

| Test path | Execution |OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |---
| test_fim/ | Jenkins | Windows   | Agent  | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19695/) | Camila |
| test_fim/ | Jenkins | Windows  | Agent | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19706/) | Camila |
| test_fim/ | Jenkins| Windows   | Agent | 4.3.0 | 01/02/2022| [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19707/) | Camila |

| Test path | Execution |OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |---
| test_fim/ | Jenkins | MacOS   | Agent  | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19693/) | Camila |
| test_fim/ | Jenkins | MacOS  | Agent | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19702/) | Camila |
| test_fim/ | Jenkins| MacOS   | Agent | 4.3.0 | 01/02/2022| [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19703/) | Camila |

| Test path | Execution |OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |---
| test_fim/ | Jenkins | Centos   | Agent  | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19700/) | Camila |
| test_fim/ | Jenkins | Centos  | Agent | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19701/) | Camila |
| test_fim/ | Jenkins| Centos   | Agent | 4.3.0 | 01/02/2022| [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19718/) | Camila |

| Test path | Execution |OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |---
| test_fim/ | Jenkins | Centos   | Manager  | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19694/) | Camila |
| test_fim/ | Jenkins | Centos  | Manager | 4.3.0 | 01/02/2022 | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19704/) | Camila |
| test_fim/ | Jenkins| Centos   | Manager | 4.3.0 | 01/02/2022| [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/19705/) | Camila |

| Test path | Execution |OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |---
| test_fim/ | Jenkins | Solaris   | Agente  | 4.3.0 | 02/02/2022 | [:green_circle:  ](https://ci.wazuh.info/view/Tests/job/Test_integration/19820/) | Camila |
| test_fim/ | Jenkins | Solaris  | Agente | 4.3.0 | 02/02/2022 | [:green_circle: ](https://ci.wazuh.info/view/Tests/job/Test_integration/19821/) | Camila |
| test_fim/ | Jenkins| Solaris   | Agente | 4.3.0 | 02/02/2022| [:green_circle: ](https://ci.wazuh.info/view/Tests/job/Test_integration/19822/) | Camila |

### test affected - local
| Test path | Execution |OS  | Type  | Version  | Date | Status | Executed by | 
|---   |---    |---    |--- |--- |--- |--- |---
| test affected | Local | Centos   | Agente  | 4.3.0 | 02/02/2022 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7988926/R1.zip)| Camila |
| test affected| Local | Centos  | Agente | 4.3.0 | 02/02/2022 | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7986668/R2.zip)| Camila |
| test affected | Local| Centos   | Agente | 4.3.0 | 02/02/2022| [:green_circle:](https://github.com/wazuh/wazuh-qa/files/7986669/R3.zip) | Camila |
## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
