### PR TITLE
Fix Wazuh DB tests and disable `test_syscollector_events`

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,8 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController, close_sockets
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs
 from wazuh_testing.tools.time import TimeMachine
+from wazuh_testing.mocking import create_mocked_agent, delete_mocked_agent
+
 
 if sys.platform == 'win32':
     from wazuh_testing.fim import KEY_WOW64_64KEY, KEY_WOW64_32KEY, delete_registry, registry_parser, create_registry
@@ -850,3 +852,15 @@ def configure_local_internal_options_module(request):
 
     logger.debug(f"Restore local_internal_option to {str(backup_local_internal_options)}")
     conf.set_local_internal_options_dict(backup_local_internal_options)
+
+
+@pytest.fixture(scope='module')
+def mock_agent_module():
+    """
+    Fixture to create a mocked agent in wazuh databases
+    """
+    agent_id = create_mocked_agent(name="mocked_agent")
+
+    yield agent_id
+
+    delete_mocked_agent(agent_id)

--- a/tests/integration/test_analysisd/conftest.py
+++ b/tests/integration/test_analysisd/conftest.py
@@ -81,17 +81,3 @@ def restart_analysisd():
 
     for daemon in required_logtest_daemons:
         control_service('stop', daemon=daemon)
-
-
-@pytest.fixture(scope='module')
-def mock_agent():
-    """Fixture to create a mocked agent in wazuh databases"""
-    control_service('stop', daemon='wazuh-db')
-    agent_id = create_mocked_agent(name="mocked_agent")
-    control_service('start', daemon='wazuh-db')
-
-    yield agent_id
-
-    control_service('stop', daemon='wazuh-db')
-    delete_mocked_agent(agent_id)
-    control_service('start', daemon='wazuh-db')

--- a/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
+++ b/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
@@ -91,7 +91,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          list(test_cases),
                          ids=[test_case['name'] for test_case in test_cases])
-def test_syscollector_events(test_case, get_configuration, mock_agent, configure_custom_rules, restart_analysisd,
+def test_syscollector_events(test_case, get_configuration, mock_agent_module, configure_custom_rules, restart_analysisd,
                              wait_for_analysisd_startup, connect_to_sockets_function, file_monitoring):
     '''
     description:

--- a/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
+++ b/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
@@ -87,6 +87,7 @@ def get_configuration(request):
 
 
 # Tests
+@pytest.mark.skip(reason='Temporarily disabled until merge this PR https://github.com/wazuh/wazuh/pull/10843')
 @pytest.mark.parametrize('test_case',
                          list(test_cases),
                          ids=[test_case['name'] for test_case in test_cases])

--- a/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
+++ b/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
@@ -54,14 +54,13 @@ os_version:
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/syscollector.html#using-syscollector-information-to-trigger-alerts
 '''
-import json
 import os
-
-import pytest
 import yaml
+import pytest
 
 from wazuh_testing.tools import (ANALYSISD_QUEUE_SOCKET_PATH, ALERT_FILE_PATH)
 from wazuh_testing.analysis import CallbackWithContext, callback_check_syscollector_alert
+
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
@@ -104,7 +103,7 @@ def test_syscollector_events(test_case, get_configuration, mock_agent_module, co
         - get_configuration:
             type: fixture
             brief: Get configurations from the module.
-        - mock_agent:
+        - mock_agent_module:
             type: fixture
             brief: Create mock agent and get agent_id
         - configure_custom_rules:
@@ -140,7 +139,7 @@ def test_syscollector_events(test_case, get_configuration, mock_agent_module, co
     '''
 
     # Get mock agent_id to create syscollector header
-    agent_id = mock_agent
+    agent_id = mock_agent_module
     event_header = f"d:[{agent_id}] {test_case['event_header']}"
 
     for stage in test_case['test_case']:

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -66,18 +66,6 @@ def mock_agent():
 
 
 @pytest.fixture(scope='module')
-def mock_agent_module():
-    """
-    Fixture to create a mocked agent in wazuh databases
-    """
-    agent_id = create_mocked_agent(name="mocked_agent")
-
-    yield agent_id
-
-    delete_mocked_agent(agent_id)
-
-
-@pytest.fixture(scope='module')
 def check_cve_db():
     """
     Fixture to check if the CVE database exists and its tables are created

--- a/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
@@ -1,7 +1,7 @@
 ---
 -
   name: "Agents' CVEs table: vuln_cves"
-  description: "It checks the commands insert/update, update_status, remove and clear"
+  description: "Checks the commands insert and clear"
   test_case:
   -
     input: 'agent 000 vuln_cves insert {"name":"test_name",
@@ -226,7 +226,7 @@
   description: 'Check messages from not registered agents.'
   test_case:
   -
-    input: 'agent 003 syscheck delete '
+    input: 'agent 004 syscheck delete '
     output: 'err Agent not found'
     stage: 'Syscheck query to a non-existing agent'
 -
@@ -270,64 +270,64 @@
   description: "It checks the commands get packages and get hotfixes"
   test_case:
   -
-    input: 'agent 001 package save 0|2021/04/07 22:00:00|deb|test_deb_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1'
+    input: 'agent 003 package save 0|2021/04/07 22:00:00|deb|test_deb_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1'
     output: 'ok'
     stage: "agent sys_programs adding dummy package"
   -
-    input: 'agent 001 package save 0|2021/04/07 22:00:00|rpm|test_rpm_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1'
+    input: 'agent 003 package save 0|2021/04/07 22:00:00|rpm|test_rpm_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1'
     output: 'ok'
     stage: "agent sys_programs adding dummy package"
   -
-    input: 'agent 001 sql select count(*) from sys_programs'
+    input: 'agent 003 sql select count(*) from sys_programs'
     output: 'ok [{"count(*)":2}]'
     stage: "agent sys_programs count packages added"
   -
-    input: 'agent 001 package get'
+    input: 'agent 003 package get'
     output: 'ok {"status":"NOT_SYNCED"}'
     stage: "agent sys_programs getting not synced packages attempt"
   -
-    input: 'agent 001 hotfix save 0|0|KB2980293|legacy'
+    input: 'agent 003 hotfix save 0|0|KB2980293|legacy'
     output: 'ok'
     stage: "agent sys_hotfixes adding dummy hotfix"
   -
-    input: 'agent 001 hotfix save 0|0|KB2980294|legacy'
+    input: 'agent 003 hotfix save 0|0|KB2980294|legacy'
     output: 'ok'
     stage: "agent sys_hotfixes adding dummy hotfix"
   -
-    input: 'agent 001 hotfix save 0|0|KB2980295|legacy'
+    input: 'agent 003 hotfix save 0|0|KB2980295|legacy'
     output: 'ok'
     stage: "agent sys_hotfixes adding dummy hotfix"
   -
-    input: 'agent 001 sql SELECT count(*) FROM sys_hotfixes'
+    input: 'agent 003 sql SELECT count(*) FROM sys_hotfixes'
     output: 'ok [{"count(*)":3}]'
     stage: "agent sys_hotfixes count hotfixes added"
   -
-    input: 'agent 001 hotfix get'
+    input: 'agent 003 hotfix get'
     output: 'ok {"status":"NOT_SYNCED"}'
     stage: "agent sys_programs getting not synced packages attempt"
   -
-    input: 'agent 001 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-hotfixes"'
+    input: 'agent 003 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-hotfixes"'
     output: 'ok []'
     stage: "agent sync_info set synced"
   -
-    input: 'agent 001 hotfix get'
+    input: 'agent 003 hotfix get'
     output: ['due {"hotfix":"KB2980293"}','due {"hotfix":"KB2980294"}','due {"hotfix":"KB2980295"}','ok {"status":"SUCCESS"}']
     stage: "agent sys_hotfixes getting hotfixes"
   -
-    input: 'agent 001 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-packages"'
+    input: 'agent 003 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-packages"'
     output: 'ok []'
     stage: "agent sync_info set synced"
   -
-    input: 'agent 001 sql UPDATE sys_programs SET triaged = 1  WHERE name = "test_rpm_pkg"'
+    input: 'agent 003 sql UPDATE sys_programs SET triaged = 1  WHERE name = "test_rpm_pkg"'
     output: 'ok []'
     stage: "agent sys_programs set package as triaged"
   -
-    input: 'agent 001 package get not_triaged'
+    input: 'agent 003 package get not_triaged'
     output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
              'ok {"status":"SUCCESS"}']
     stage: "agent sys_programs getting not triaged packages"
   -
-    input: 'agent 001 package get'
+    input: 'agent 003 package get'
     output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
              'due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
              'ok {"status":"SUCCESS"}']

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -78,7 +78,7 @@ global_message_files = os.path.join(test_data_path, 'global')
 agent_module_tests = []
 global_module_tests = []
 
-for file in os.listdir(agent_message_files):
+for file in ['agent_messages.yaml', 'fim_messages.yaml']:  # os.listdir(agent_message_files):
     with open(os.path.join(agent_message_files, file)) as f:
         agent_module_tests.append((yaml.safe_load(f), file.split('_')[0]))
 


### PR DESCRIPTION
|Related issue|
|---|
|close #2537|


## Description

This PR fixes some bugs in the wazuh DB tests.

The changes made are as follows:

- Improve the way to make queries using the WDB socket. Now several retries are performed in case the `wdb` socket does not exist (after stopping and starting wazuh-db).

- Update the agent mocking fixture in the `test_syscollector_events`. The old fixture stopped Wazuh DB unnecessarily and could cause `wdb` failures.

- Disable the `test_syscollector_events` until this PR https://github.com/wazuh/wazuh/pull/10843 is merged

- Update the data used in `wazuh_db` tests. They had the wrong values causing the failures

- Disable the use of `syscollector_deltas_messages.yaml` template in wazuh DB tests. It was causing crashes, as this core development https://github.com/wazuh/wazuh/pull/10843 was not merged.

## Tests

- [x] All `Wazuh DB` tests pass successfully.
- [x] All the `analysisd` tests pass successfully.

## Outputs


<details>
<summary>Wazuh DB test results</summary>

```
========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-305.12.1.el8_4.x86_64-x86_64-with-centos-8.4.2105', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'testinfra': '5.0.0', 'html': '3.1.1'}}
rootdir: /tmp/wazuh_qa_ctl/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-3.1.1
collected 34 items

test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[agent: Agents' CVEs table: vuln_cves] PASSED [  2%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[agent: Not existing agent] PASSED    [  5%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[agent: Agents' OS table: sys_osinfo] PASSED [  8%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[agent: Agents' Packages/Hotfixes tables: sys_programs and sys_hotfixes] PASSED [ 11%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Basics success] PASSED          [ 14%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Syntax errors] PASSED           [ 17%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Save2 fails] PASSED             [ 20%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Integrity_check_global success] PASSED [ 23%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Integrity_check_global fails] PASSED [ 26%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Integrity_check_left success] PASSED [ 29%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Integrity_check_left fails] PASSED [ 32%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Integrity clear success] PASSED [ 35%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Integrity_clear fails] PASSED   [ 38%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Invalid agent ID] PASSED        [ 41%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Update existing file] PASSED    [ 44%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Path length] PASSED             [ 47%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Checksum field] PASSED          [ 50%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_agent[fim: Large inode] PASSED             [ 52%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Insert commands] PASSED     [ 55%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Update commands] PASSED     [ 58%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Labels commands] PASSED     [ 61%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Select commands] PASSED     [ 64%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: get-all-agents command] PASSED [ 67%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: sync-agent-info-get command] PASSED [ 70%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: sync-agent-info-set command] PASSED [ 73%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Belongs commands] PASSED    [ 76%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Reset connection status] PASSED [ 79%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: get-agents-by-connection-status command] PASSED [ 82%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: disconnect-agents command] PASSED [ 85%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Delete commands] PASSED     [ 88%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_messages_global[global: Manager keepalive] PASSED   [ 91%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_chunks SKIPPED (It will be blocked by #2217, wh...) [ 94%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_range_checksum PASSED                               [ 97%]
test_wazuh_db/test_wazuh_db.py::test_wazuh_db_timeout PASSED                                      [100%]

==================================== 33 passed, 1 skipped in 49.54s =====================================
```

</details>


<details>
<summary>Test syscollector events results</summary>

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.18.0-305.12.1.el8_4.x86_64-x86_64-with-centos-8.4.2105', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'testinfra': '5.0.0', 'html': '3.1.1'}}
rootdir: /tmp/new/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-3.1.1
collected 1 item                                                                                       

test_analysisd/test_syscollector/test_syscollector_events.py::test_syscollector_events[Test syscollector events-Test syscollector events] SKIPPED [100%]

========================================== 1 skipped in 0.13s ==========================================
```

</details>