### PR TITLE
Vulnerability detector test module refactor: test_general_settings_retry_interval 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -24,6 +24,8 @@ QUEUE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
 QUEUE_SOCKETS_PATH = os.path.join(WAZUH_PATH, 'queue', 'sockets')
 WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_DB_PATH, 'wdb')
 CVE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'vulnerabilities', 'cve.db')
+LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'ossec.log')
+
 
 UDP = 'UDP'
 TCP = 'TCP'

--- a/deps/wazuh_testing/wazuh_testing/db_interface/agent_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/agent_db.py
@@ -244,3 +244,12 @@ def check_vulnerability_scan_inventory(agent_id, package, version, arch, cve, co
     result = query_wdb(query)[0]['result']
 
     return result
+
+
+def clean_sys_programs(agent_id='000'):
+    """Clean all the agent packages data from the DB
+
+      Args:
+        agent_id (str): Agent ID.
+    """
+    clean_table(agent_id, 'sys_programs')

--- a/deps/wazuh_testing/wazuh_testing/db_interface/agent_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/agent_db.py
@@ -187,13 +187,26 @@ def modify_agent_scan_timestamp(agent_id='000', timestamp=0, full_scan=True):
     query_wdb(f"agent {agent_id} sql UPDATE vuln_metadata SET {scan_type}={timestamp}")
 
 
-def delete_os_info_data(agent_id='000'):
+def delete_os_info(agent_id='000'):
     """Delete the sys_osinfo data from a specific agent.
 
     Args:
         agent_id (str): Agent ID.
     """
     query_wdb(f"agent {agent_id} sql DELETE FROM sys_osinfo")
+
+
+def update_os_info(agent_id='000', scan_id=int(time()), scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
+                   hostname='centos8', architecture='x86_64', os_name='CentOS Linux', os_version='8.4', os_major='8',
+                   os_minor='4', os_build='', version='', os_release='', os_patch='', release='',
+                   checksum='dummychecksum'):
+    """Update the sys_osinfo data from a specific agent.
+
+    Args:
+        agent_id (str): Agent ID.
+    """
+    delete_os_info(agent_id)
+    insert_os_info(**locals())
 
 
 def check_vulnerability_scan_inventory(agent_id, package, version, arch, cve, condition, severity='-', cvss2=0,

--- a/deps/wazuh_testing/wazuh_testing/db_interface/cve_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/cve_db.py
@@ -41,7 +41,7 @@ def clean_table(table):
     make_sqlite_query(CVE_DB_PATH, [f"DELETE FROM {table}"])
 
 
-def clean_all_tables():
+def clean_all_cve_tables():
     """Clean all tables from CVE database."""
     query = [f"DELETE FROM {table}" for table in get_tables()]
 

--- a/deps/wazuh_testing/wazuh_testing/db_interface/global_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/global_db.py
@@ -85,3 +85,16 @@ def delete_agent(agent_id):
         agent_id (str): Agent ID.
     """
     query_wdb(f"global sql DELETE FROM agent where id={int(agent_id)}")
+
+
+def get_agent_ids(agent_name):
+    """Get the agent ids from a specific name.
+
+    Args:
+        agent_name (str): Agent names to get their ids.
+
+    Returns:
+        list(str): list of ids matching that name. e.g ['001', '005', ...] or [] if there is none.
+    """
+    return [str(item['id']).zfill(3) for item in query_wdb(f"global sql SELECT id FROM agent WHERE "
+                                                           f"name='{agent_name}'")]

--- a/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
@@ -6,6 +6,7 @@ from wazuh_testing.db_interface import global_db
 from wazuh_testing.db_interface import agent_db
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools import client_keys
+from wazuh_testing.tools.file import remove_file
 
 
 SYSTEM_DATA = {
@@ -126,8 +127,47 @@ def delete_mocked_agent(agent_id):
     # Remove from global db
     global_db.delete_agent(agent_id)
 
-    # Remove agent id DB file
-    os.remove(os.path.join(wazuh_testing.DB_PATH, f"{agent_id}.db"))
+    # Remove agent id DB file if exists
+    remove_file(os.path.join(wazuh_testing.DB_PATH, f"{agent_id}.db"))
 
     # Remove entry from client keys
     client_keys.delete_client_keys_entry(agent_id)
+
+
+def insert_mocked_packages(agent_id='000'):
+    """Insert 10 mocked packages in the agent DB (package_1, package2 ...).
+
+    Args:
+        agent_id (str): Agent ID.
+
+    Returns:
+        list(str): List of package names.
+    """
+    package_names = [f"package_{number}" for number in range(1, 11)]
+
+    for package_name in package_names:
+        agent_db.insert_package(agent_id=agent_id, name=package_name, version='1.0.0')
+
+    return package_names
+
+
+def delete_mocked_packages(agent_id='000'):
+    """Delete the mocked packages in the agent DB.
+
+    Args:
+        agent_id (str): Agent ID.
+    """
+    package_names = [f"package_{number}" for number in range(1, 11)]
+
+    for package_name in package_names:
+        agent_db.delete_package(package=package_name, agent_id=agent_id)
+
+
+def delete_all_mocked_agents(name='mocked_agent'):
+    """Delete all mocked agents.
+
+    Args:
+        name (str): Name of mocked agents to delete.
+    """
+    for agent_id in global_db.get_agent_ids(name):
+        delete_mocked_agent(agent_id)

--- a/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
@@ -142,16 +142,17 @@ def delete_mocked_agent(agent_id):
     client_keys.delete_client_keys_entry(agent_id)
 
 
-def insert_mocked_packages(agent_id='000'):
-    """Insert 10 mocked packages in the agent DB (package_1, package2 ...).
+def insert_mocked_packages(agent_id='000', num_packages=10):
+    """Insert a specific number of mocked packages in the agent DB (package_1, package2 ...).
 
     Args:
         agent_id (str): Agent ID.
+        num_packages (int): Number of packages to generate.
 
     Returns:
         list(str): List of package names.
     """
-    package_names = [f"package_{number}" for number in range(1, 11)]
+    package_names = [f"package_{number}" for number in range(1, num_packages + 1)]
 
     for package_name in package_names:
         agent_db.insert_package(agent_id=agent_id, name=package_name, version='1.0.0')

--- a/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
@@ -43,14 +43,19 @@ SYSTEM_DATA = {
 }
 
 
-def set_system(system):
+def set_system(system, agent_id='000'):
     """Set custom system in global DB Agent info.
 
     Args:
         system (str): System to set. Available systems in SYSTEM_DATA variable.
     """
-    global_db.modify_system(os_name=SYSTEM_DATA[system]['os_name'], os_major=SYSTEM_DATA[system]['os_major'],
-                            os_minor=SYSTEM_DATA[system]['os_minor'], name=SYSTEM_DATA[system]['name'])
+    global_db.modify_system(agent_id=agent_id, os_name=SYSTEM_DATA[system]['os_name'],
+                            os_major=SYSTEM_DATA[system]['os_major'],os_minor=SYSTEM_DATA[system]['os_minor'],
+                            name=SYSTEM_DATA[system]['name'])
+
+    agent_db.update_os_info(agent_id=agent_id, os_name=SYSTEM_DATA[system]['os_name'],
+                            os_major=SYSTEM_DATA[system]['os_major'], os_minor=SYSTEM_DATA[system]['os_minor'],
+                            hostname=SYSTEM_DATA[system]['name'])
 
 
 def create_mocked_agent(name='centos8-agent', ip='127.0.0.1', register_ip='127.0.0.1', internal_key='',
@@ -99,8 +104,7 @@ def create_mocked_agent(name='centos8-agent', ip='127.0.0.1', register_ip='127.0
 
     client_keys.add_client_keys_entry(agent_id_str, name, ip, client_key_secret)
 
-    # Delete sys_osinfo data and create the new agent
-    agent_db.delete_os_info_data(agent_id)
+    # Create the new agent
     global_db.create_or_update_agent(agent_id=agent_id_str, name=name, ip=ip, register_ip=register_ip,
                                      internal_key=internal_key, os_name=os_name, os_version=os_version,
                                      os_major=os_major, os_minor=os_minor, os_codename=os_codename, os_build=os_build,
@@ -108,6 +112,10 @@ def create_mocked_agent(name='centos8-agent', ip='127.0.0.1', register_ip='127.0
                                      config_sum=config_sum, merged_sum=merged_sum, manager_host=manager_host,
                                      node_name=node_name, date_add=date_add, last_keepalive=last_keepalive, group=group,
                                      sync_status=sync_status, connection_status=connection_status)
+
+    # Add or update os_info related to the new created agent
+    agent_db.update_os_info(agent_id=agent_id_str, os_name=os_name, os_version=os_version, os_major=os_major,
+                            os_minor=os_minor, os_build=os_build, version=version)
 
     # Restart Wazuh-DB before creating new DB
     control_service('restart', daemon='wazuh-db')

--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/event_monitor.py
@@ -50,9 +50,9 @@ def callback_detect_vulnerability_detector_enabled(line):
     return match1 is not None and match2 is None
 
 
-def check_vuln_detector_event(wazuh_log_monitor=None, callback='', error_message='', update_position=True,
+def check_vuln_detector_event(wazuh_log_monitor=None, callback='', error_message=None, update_position=True,
                               timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT,
-                              prefix=vd.VULNERABILITY_DETECTOR_PREFIX):
+                              prefix=vd.VULNERABILITY_DETECTOR_PREFIX, accum_results=1):
     """Check if a vulnerability event occurs
 
     Args:
@@ -62,10 +62,13 @@ def check_vuln_detector_event(wazuh_log_monitor=None, callback='', error_message
         update_position (boolean): filter configuration parameter to search in Wazuh log
         timeout (str): timeout to check the event in Wazuh log
         prefix (str): log pattern regex
+        accum_results (int): Accumulation of matches.
     """
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH) if wazuh_log_monitor is None else wazuh_log_monitor
+    error_message = f"Could not find this event in {LOG_FILE_PATH}: {callback}" if error_message is None else \
+        error_message
 
-    wazuh_log_monitor.start(timeout=timeout, update_position=update_position,
+    wazuh_log_monitor.start(timeout=timeout, update_position=update_position, accum_results=accum_results,
                             callback=make_vuln_callback(callback, prefix), error_message=error_message)
 
 
@@ -338,3 +341,35 @@ def check_refresh_feed_log(provider_name):
     check_vuln_detector_event(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
                               callback=f"Refresh of '{provider_name}' database finished",
                               error_message=f"Could not find {provider_name} feed refresh log")
+
+
+def check_retry_interval_log(seconds_number, num_expected_events=1):
+    """Check the retry interval event in ossec.log
+
+    Args:
+        seconds_number (int): Number of seconds before retrying the vuln scan.
+    """
+    check_vuln_detector_event(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT, accum_results=num_expected_events,
+                              callback=f"Going to sleep {seconds_number} seconds before retrying pending agents")
+
+
+def check_analyzing_oval_vulnerabilities_log(agent_id='000'):
+    """Check the analyzing oval vulnerabilities event in ossec.log
+
+    Args:
+        agent_id (str): Agent ID.
+    """
+    check_vuln_detector_event(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+                              callback=f"Analyzing OVAL vulnerabilities for agent '{agent_id}'")
+
+
+def check_obtaining_software_failure_log(agent_id='000', num_attemps=5):
+    """Check the obtaining software fail event in ossec.log
+
+    Args:
+        agent_id (str): Agent ID.
+        num_attemps (int): Number of retry interval attemps.
+    """
+    check_vuln_detector_event(timeout=vd.VULN_DETECTOR_GLOBAL_TIMEOUT,
+                              callback=f"The software of the agent '{agent_id}' could not be obtained after "
+                                       f"{num_attemps} attempts. Skipping agent until the next scan.")

--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/utils.py
@@ -1,47 +1,6 @@
 import json
 
-from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.db_interface import agent_db
-from wazuh_testing.db_interface import make_sqlite_query
-from wazuh_testing import CVE_DB_PATH
-
-
-def clean_agent_sys_tables(agent_id='000'):
-    """Clean agent sys tables.
-
-    Args:
-        agent_id (str): id of the agent
-    """
-    for item in vd.AGENT_SYS_TABLES:
-        agent_db.clean_table(agent_id, item)
-
-
-def clean_feed_tables():
-    """Clean provider and NVD feed tables."""
-    # Clean feeds DB
-    query = [f"DELETE FROM {table}" for table in vd.FEED_TABLES] + \
-            [f"DELETE FROM {table}" for table in vd.NVD_TABLES]
-
-    make_sqlite_query(CVE_DB_PATH, query)
-
-
-def clean_vd_tables(agent_id='000'):
-    """Clean the tables involved with vulnerability detector packages and feeds
-
-    Args:
-        agent_id (str): id of the agent
-    """
-    clean_agent_sys_tables(agent_id)
-    clean_feed_tables()
-
-
-def clean_vuln_and_sys_programs_tables(agent_id='000'):
-    """Clean vulnerability detector and sys programs table/s
-
-    Args:
-        agent_id (str): Agent ID.
-    """
-    clean_vd_tables(agent_id)
 
 
 def insert_data_json_feed(data, field_name, field_value, append_data, brackets=True):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,9 @@ from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController, close_sockets
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs
 from wazuh_testing.tools.time import TimeMachine
+from wazuh_testing.mocking import set_system as update_agent_system
+from wazuh_testing import mocking
+
 
 if sys.platform == 'win32':
     from wazuh_testing.fim import KEY_WOW64_64KEY, KEY_WOW64_32KEY, delete_registry, registry_parser, create_registry
@@ -887,3 +890,34 @@ def truncate_log_files():
 
     for log_file in log_files:
         truncate_file(log_file)
+
+
+@pytest.fixture(scope='function')
+def set_system(system):
+    """Update the agent system in the global DB.
+
+    Args:
+        system (str): System to set. Available systems in SYSTEM_DATA variable from mocking module.
+    """
+    update_agent_system(system)
+    yield
+
+
+@pytest.fixture(scope='function')
+def mock_agent_packages():
+    """Add 10 mocked packages to the agent 000 DB"""
+    package_names = mocking.insert_mocked_packages()
+
+    yield package_names
+
+    mocking.delete_mocked_packages()
+
+
+@pytest.fixture(scope='function')
+def clean_mocked_agents():
+    """Clean all mocked agents"""
+    mocking.delete_all_mocked_agents()
+
+    yield
+
+    mocking.delete_all_mocked_agents()

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -148,9 +148,6 @@ def prepare_full_scan_environment(metadata):
     # Mock RedHat system
     set_system('RHEL8')
 
-    # Update sys_osinfo
-    adb.insert_os_info()
-
     for package in metadata['package_names']:
         adb.insert_package(name=package, vendor=metadata['package_vendor'],
                            version=metadata['package_version'], source='NULL')

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -13,12 +13,12 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.services import control_service
-from wazuh_testing.modules.vulnerability_detector.utils import clean_vd_tables
 from wazuh_testing.mocking import create_mocked_agent, delete_mocked_agent
 from wazuh_testing.db_interface import cve_db
 from wazuh_testing.mocking import set_system
 from wazuh_testing import db_interface as dbi
 from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.db_interface import cve_db, agent_db
 
 
 @pytest.fixture(scope='module')
@@ -37,11 +37,13 @@ def restart_modulesd(get_configuration, request):
 @pytest.fixture(scope='module')
 def clean_vuln_tables(request):
     """Clean vulnerabilities tables """
-    clean_vd_tables()
+    agent_db.clean_sys_programs()
+    cve_db.clean_all_cve_tables()
 
     yield
 
-    clean_vd_tables()
+    agent_db.clean_sys_programs()
+    cve_db.clean_all_cve_tables()
 
 
 @pytest.fixture
@@ -108,7 +110,8 @@ def check_cve_db():
 def after_execution_clean_vuln_tables_function():
     """Clean vulnerabilities tables."""
     yield
-    clean_vd_tables()
+    agent_db.clean_sys_programs()
+    cve_db.clean_all_cve_tables()
 
 
 @pytest.fixture(scope='function')
@@ -122,9 +125,9 @@ def restart_modulesd_function():
 @pytest.fixture(scope='function')
 def clean_cve_tables_func():
     """Clean all tables of the CVE database before and after finishing the test"""
-    cve_db.clean_all_tables()
+    cve_db.clean_all_cve_tables()
     yield
-    cve_db.clean_all_tables()
+    cve_db.clean_all_cve_tables()
 
 
 @pytest.fixture(scope='function')
@@ -139,10 +142,12 @@ def prepare_full_scan_environment(metadata):
     Args:
         metadata (dict): Test case metadata.
     """
-    clean_vd_tables()
+    agent_db.clean_sys_programs()
+    cve_db.clean_all_cve_tables()
 
     # Mock RedHat system
     set_system('RHEL8')
+
     # Update sys_osinfo
     adb.insert_os_info()
 
@@ -155,7 +160,5 @@ def prepare_full_scan_environment(metadata):
 
     yield
 
-    for package in metadata['package_names']:
-        adb.delete_package(package)
-
-    clean_vd_tables()
+    agent_db.clean_sys_programs()
+    cve_db.clean_all_cve_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_extra_tags_alas_feed.py
@@ -140,7 +140,7 @@ def modify_feed(test_values, get_configuration, request):
 
     yield
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
 
 @pytest.mark.skip(reason='Temporarily disabled until refactor in https://github.com/wazuh/wazuh-qa/issues/2453')

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_syntax_alas_feed.py
@@ -181,7 +181,7 @@ def modify_feed(test_data, get_configuration, request):
 
     yield
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
 
 @pytest.mark.skip(reason='Temporarily disabled until refactor in https://github.com/wazuh/wazuh-qa/issues/2453')

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_invalid_values_alas_feed.py
@@ -158,7 +158,7 @@ def modify_feed(test_data, custom_input, get_configuration, request):
 
     yield
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
 
 @pytest.mark.skip(reason='Temporarily disabled until refactor in https://github.com/wazuh/wazuh-qa/issues/2453')

--- a/tests/integration/test_vulnerability_detector/test_feeds/alas/test_missing_tags_alas_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/alas/test_missing_tags_alas_feed.py
@@ -151,7 +151,7 @@ def remove_field_feed(get_configuration, request):
 
     yield request.param
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
 
 @pytest.mark.skip(reason='Temporarily disabled until refactor in https://github.com/wazuh/wazuh-qa/issues/2453')

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_extra_tags_archlinux_feed.py
@@ -112,14 +112,14 @@ def modify_feed(test_values, request):
 
     write_file(custom_archlinux_json_feed_path, modified_string)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     control_service('restart', daemon='wazuh-modulesd')
     vd.set_system(system='ARCH')
 
     yield
 
     write_json_file(custom_archlinux_json_feed_path, backup_data)
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     file.truncate_file(LOG_FILE_PATH)
 
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_syntax_archlinux_feed.py
@@ -148,14 +148,14 @@ def modify_feed(test_data, request):
 
     write_file(custom_archlinux_json_feed_path, modified_string_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     control_service('restart', daemon='wazuh-modulesd')
     vd.set_system(system='Windows10')
 
     yield
 
     write_json_file(custom_archlinux_json_feed_path, backup_data)
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     truncate_file(LOG_FILE_PATH)
 
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_invalid_values_archlinux_feed.py
@@ -112,14 +112,14 @@ def modify_feed(test_data, custom_input, request):
     data[0] = modified_data
     write_json_file(custom_archlinux_json_feed_path, data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     control_service('restart', daemon='wazuh-modulesd')
     vd.set_system(system='Windows10')
 
     yield
 
     write_json_file(custom_archlinux_json_feed_path, backup_data)
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     truncate_file(LOG_FILE_PATH)
 
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_missing_tags_archlinux_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/archlinux/test_missing_tags_archlinux_feed.py
@@ -111,14 +111,14 @@ def remove_field_feed(request):
 
     write_json_file(custom_archlinux_json_feed_path, modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     control_service('restart', daemon='wazuh-modulesd')
     vd.set_system(system='Windows10')
 
     yield request.param
 
     write_json_file(custom_archlinux_json_feed_path, backup_data)
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
     truncate_file(LOG_FILE_PATH)
 
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_extra_tags_canonical_feed.py
@@ -105,7 +105,7 @@ def modify_feed(test_values, request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -115,7 +115,7 @@ def modify_feed(test_values, request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_syntax_canonical_feed.py
@@ -130,7 +130,7 @@ def modify_feed(test_data, request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -140,7 +140,7 @@ def modify_feed(test_data, request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_invalid_values_canonical_feed.py
@@ -164,7 +164,7 @@ def modify_feed(test_data, custom_input, request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -174,7 +174,7 @@ def modify_feed(test_data, custom_input, request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/canonical/test_missing_tags_canonical_feed.py
@@ -144,7 +144,7 @@ def remove_tag_feed(request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=data_removed_tag)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -154,7 +154,7 @@ def remove_tag_feed(request):
 
     file.write_file(file_path=custom_canonical_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_extra_tags_debian_feed.py
@@ -109,7 +109,7 @@ def modify_feed(test_values, request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -119,7 +119,7 @@ def modify_feed(test_values, request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_syntax_debian_feed.py
@@ -132,7 +132,7 @@ def modify_feed(test_data, request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -142,7 +142,7 @@ def modify_feed(test_data, request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_invalid_values_debian_feed.py
@@ -170,7 +170,7 @@ def modify_feed(test_data, custom_input, request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -180,7 +180,7 @@ def modify_feed(test_data, custom_input, request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/debian/test_missing_tags_debian_feed.py
@@ -150,7 +150,7 @@ def remove_tag_feed(request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=data_removed_tag)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -160,7 +160,7 @@ def remove_tag_feed(request):
 
     file.write_file(file_path=custom_debian_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_extra_fields_msu_feed.py
@@ -105,7 +105,7 @@ def modify_feed(test_values, request):
 
     write_file(custom_msu_json_feed_path, modified_string_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -115,7 +115,7 @@ def modify_feed(test_values, request):
 
     write_json_file(custom_msu_json_feed_path, backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_syntax_msu_feed.py
@@ -151,7 +151,7 @@ def modify_feed(test_data, request):
 
     write_file(custom_msu_json_feed_path, modified_string_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -161,7 +161,7 @@ def modify_feed(test_data, request):
 
     write_json_file(custom_msu_json_feed_path, backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_values_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_invalid_values_msu_feed.py
@@ -121,7 +121,7 @@ def modify_feed(test_data, custom_input, request):
 
     write_json_file(custom_msu_json_feed_path, data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -131,7 +131,7 @@ def modify_feed(test_data, custom_input, request):
 
     write_json_file(custom_msu_json_feed_path, backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/msu/test_missing_fields_msu_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/msu/test_missing_fields_msu_feed.py
@@ -112,7 +112,7 @@ def remove_field_feed(request):
 
     write_json_file(custom_msu_json_feed_path, data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -122,7 +122,7 @@ def remove_field_feed(request):
 
     write_json_file(custom_msu_json_feed_path, backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_extra_fields_redhat_feed.py
@@ -124,7 +124,7 @@ def modify_feed(test_values, request):
 
     file.write_file(file_path=temporal_redhat_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     control_service('restart', daemon='wazuh-modulesd')
 
@@ -132,7 +132,7 @@ def modify_feed(test_values, request):
 
     yield
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_syntax_redhat_feed.py
@@ -135,7 +135,7 @@ def modify_feed(test_data, request):
 
     file.write_file(file_path=custom_redhat_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 
@@ -147,7 +147,7 @@ def modify_feed(test_data, request):
 
     file.write_file(file_path=custom_redhat_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     file.truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_invalid_values_redhat_feed.py
@@ -167,7 +167,7 @@ def modify_feed(test_data, custom_input, request):
 
     file.write_file(file_path=custom_redhat_oval_feed_path, data=modified_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 
@@ -179,7 +179,7 @@ def modify_feed(test_data, custom_input, request):
 
     file.write_file(file_path=custom_redhat_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/redhat/test_missing_fields_redhat_feed.py
@@ -141,7 +141,7 @@ def remove_tag_feed(request):
 
     file.write_file(file_path=custom_redhat_oval_feed_path, data=data_removed_tag)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 
@@ -153,7 +153,7 @@ def remove_tag_feed(request):
 
     file.write_file(file_path=custom_redhat_oval_feed_path, data=backup_data)
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()
 
     truncate_file(LOG_FILE_PATH)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -277,4 +277,4 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                                         f"log after the interval update")
     finally:
         # Clean NVD tables when the download has finished
-        vd.clean_vuln_and_sys_programs_tables()
+        # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -276,5 +276,6 @@ def test_download_feeds(clean_vuln_tables, get_configuration, configure_environm
                                         error_message=f"Could not find the provider {callback_system_log} updated feed "
                                         f"log after the interval update")
     finally:
+        pass
         # Clean NVD tables when the download has finished
         # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -325,7 +325,7 @@ def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configur
             expected_vulnerabilities_number=get_configuration['metadata']['expected_num_vulnerabilities']
         )
 
-        vd.clean_vuln_and_sys_programs_tables()
+        # vd.clean_vuln_and_sys_programs_tables()
     else:
         expected_vulnerabilities_number = 1 if log_system_name == 'JSON Red Hat Enterprise Linux' else 0
         test_skipped = 1 if get_configuration['metadata']['feed'] == 'msu' and custom_feed == '/tmp/dummy.json' else 0
@@ -341,4 +341,4 @@ def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configur
                                    )
 
         if expected_vulnerabilities_number > 0:
-            vd.clean_vuln_and_sys_programs_tables()
+            # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_custom_feeds.py
@@ -341,4 +341,5 @@ def test_invalid_type_custom_feeds(manage_files, clean_vuln_tables, get_configur
                                    )
 
         if expected_vulnerabilities_number > 0:
+            pass
             # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -315,4 +315,5 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
                                    )
 
         if expected_vulnerabilities_number > 0:
+            pass
             # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_invalid_type_url_feeds.py
@@ -296,7 +296,7 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
             expected_vulnerabilities_number=get_configuration['metadata']['expected_num_vulnerabilities'],
         )
 
-        vd.clean_vuln_and_sys_programs_tables()
+        # vd.clean_vuln_and_sys_programs_tables()
     else:
         timeout = vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT
         expected_vulnerabilities_number = 1 if log_system_name == 'JSON Red Hat Enterprise Linux' else 0
@@ -315,4 +315,4 @@ def test_invalid_type_url_feeds(clean_vuln_tables, get_configuration, configure_
                                    )
 
         if expected_vulnerabilities_number > 0:
-            vd.clean_vuln_and_sys_programs_tables()
+            # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/configuration_template/retry_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/configuration_template/retry_interval.yaml
@@ -1,0 +1,57 @@
+- sections:
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: '20s'
+        - retry_interval:
+            value: RETRY_INTERVAL
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: 'redhat'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: RHEL_OVAL_FEED_PATH
+                  value: '8'
+              - path:
+                  value: RHEL_JSON_FEED_PATH
+              - update_interval:
+                  value: '30d'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: NVD_JSON_FEED_PATH
+              - update_interval:
+                  value: '10s'
+
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_vulnerability_detector/test_general_settings/data/test_cases/test_retry_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/data/test_cases/test_retry_interval.yaml
@@ -1,0 +1,10 @@
+
+- name: '5s'
+  description: 'Retry interval with 5s value'
+  configuration_parameters:
+    RETRY_INTERVAL: '5s'
+    RHEL_OVAL_FEED_PATH: CUSTOM_RHEL_OVAL_FEED_PATH
+    RHEL_JSON_FEED_PATH: CUSTOM_RHEL_JSON_FEED_PATH
+    NVD_JSON_FEED_PATH: CUSTOM_NVD_JSON_FEED_PATH
+  metadata:
+    retry_interval: '5s'

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_general_settings_retry_interval.py
@@ -64,7 +64,7 @@ from wazuh_testing.tools.time import time_to_seconds
 from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.vulnerability_detector.event_monitor import make_vuln_callback
 from wazuh_testing.db_interface import agent_db
-from wazuh_testing.modules.vulnerability_detector.utils import clean_vd_tables
+# from wazuh_testing.modules.vulnerability_detector.utils import clean_vd_tables
 
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_vd_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_vd_retry_interval.py
@@ -1,0 +1,167 @@
+import os
+import pytest
+
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.db_interface import agent_db
+from wazuh_testing.tools.time import time_to_seconds
+from wazuh_testing.tools.configuration import update_configuration_template
+from wazuh_testing import mocking
+from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
+
+
+pytestmark = [pytest.mark.server]
+
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+TEST_FEEDS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'retry_interval.yaml')
+test_cases_path = os.path.join(TEST_CASES_PATH, 'test_retry_interval.yaml')
+
+configuration_parameters, configuration_metadata, test_case_ids = get_test_cases_data(test_cases_path)
+configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
+
+# Offline feeds
+custom_rhel_oval_feed_path = os.path.join(TEST_FEEDS_PATH, vd.CUSTOM_REDHAT_OVAL_FEED)
+custom_rhel_json_feed_path = os.path.join(TEST_FEEDS_PATH, vd.CUSTOM_REDHAT_JSON_FEED)
+custom_nvd_json_feed_path = os.path.join(TEST_FEEDS_PATH, vd.CUSTOM_NVD_FEED)
+
+# Add the custom feeds path in configurations
+tags_to_replace = ['CUSTOM_RHEL_OVAL_FEED_PATH', 'CUSTOM_RHEL_JSON_FEED_PATH', 'CUSTOM_NVD_JSON_FEED_PATH']
+new_tags_values = [custom_rhel_oval_feed_path, custom_rhel_json_feed_path, custom_nvd_json_feed_path]
+configurations = update_configuration_template(configurations, tags_to_replace, new_tags_values)
+
+
+@pytest.fixture(scope='function')
+def restore_sync_info():
+    """Set the update sync info in a valid state after changing it to provoke the retry interval"""
+    yield
+    agent_db.update_sync_info(n_attempts=1, last_attempt=1, last_completion=1)
+
+
+@pytest.mark.tier(level=0)
+@pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=test_case_ids)
+def test_retry_interval(configuration, metadata, set_wazuh_configuration, truncate_log_files, mock_agent_packages,
+                        restart_modulesd_function, restore_sync_info):
+    '''
+    description: Check if the `retry_interval ` option is working correctly. To do this,
+                 it checks the `ossec.log` file for the message indicating that Vulnerability Detector will sleep before
+                 attempting to scan the pending agents (forcing the retry interval action). After this, the DBs are
+                 synchronized and the scan (log) is checked to ensure that it is performed normally.
+
+    wazuh_min_version: 4.3
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_log_files:
+            type: fixture
+            brief: Truncate the log files at the end of the testing case.
+        - mock_agent_packages:
+            type: fixture
+            brief: Add a mocked packages in the agent DB.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
+        - restore_sync_info:
+            type: fixture
+            brief: Re-synchronize after modifying the sync_info agent data.
+
+    assertions:
+        - If the retry interval message is showed.
+        - If the scan occurs after the second retry.
+
+    input_description:
+        - The `test_retry_interval.yaml` file provides the module configuration for this test.
+
+    expected_output:
+        - 'Going to sleep \\d+ seconds before retrying pending agents'
+        - f"Analyzing OVAL vulnerabilities for agent '{agent_id}'"
+    '''
+    # Delete one package from the agent to avoid checksum sync validation
+    agent_db.delete_package(mock_agent_packages[0])
+
+    # Update the sync_info data to force the retry interval scan
+    agent_db.update_sync_info(last_completion=1, last_attempt=2)
+
+    # Check the retry interval event in log
+    evm.check_retry_interval_log(time_to_seconds(metadata['retry_interval']))
+
+    # Add again the package
+    mocking.insert_mocked_packages(num_packages=1)
+
+    # Update the sync_info data to force the retry interval scan
+    agent_db.update_sync_info(last_completion=2, last_attempt=2)
+
+    # Search analyzing OVAL vulnerabilities event
+    evm.check_analyzing_oval_vulnerabilities_log()
+
+
+
+@pytest.mark.tier(level=0)
+@pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=test_case_ids)
+def test_retry_interval_max_retries(configuration, metadata, set_wazuh_configuration, truncate_log_files,
+                                    mock_agent_packages, restart_modulesd_function, restore_sync_info):
+    '''
+    description: Check if after exceeding the maximum number of retries for a scan (`retry_interval`) the
+                 corresponding message is displayed indicating that the software could not be obtained for the agent
+                 and that it will be retried at the next scan (waiting for its time interval).
+
+    wazuh_min_version: 4.3
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_log_files:
+            type: fixture
+            brief: Truncate the log files at the end of the testing case.
+        - mock_agent_packages:
+            type: fixture
+            brief: Add a mocked packages in the agent DB.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
+        - restore_sync_info:
+            type: fixture
+            brief: Re-synchronize after modifying the sync_info agent data.
+
+    assertions:
+        - If the retry interval messages are showed (4 times).
+        - If the message is displayed indicating failure to obtain the agent software, and that it will wait for the
+          next scan.
+
+    input_description:
+        - The `test_retry_interval.yaml` file provides the module configuration for this test.
+
+    expected_output:
+        - 'Going to sleep \\d+ seconds before retrying pending agents'
+        - f"The software of the agent '{agent_id}' could not be obtained after {num_attemps} attempts. Skipping agent
+          until the next scan."
+    '''
+    # Delete one package from the agent to avoid checksum sync validation
+    agent_db.delete_package(mock_agent_packages[0])
+
+    # Update the sync_info data to force the retry interval scan
+    agent_db.update_sync_info(last_completion=1, last_attempt=2)
+
+    # Check the retry interval event in log
+    evm.check_retry_interval_log(time_to_seconds(metadata['retry_interval']), num_expected_events=4)
+
+    # Check the event: could not obtain software for that agent
+    evm.check_obtaining_software_failure_log()

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_from_year.py
@@ -171,4 +171,4 @@ def test_update_from_year(clean_vuln_tables, get_configuration, configure_enviro
         vd.check_log_event(wazuh_log_monitor=wazuh_log_monitor, log_event=log_event, update_position=False,
                            timeout=vd.VULN_DETECTOR_EXTENDED_GLOBAL_TIMEOUT, prefix=MODULESD_PREFIX)
 
-    vd.clean_vd_tables()
+    # vd.clean_vd_tables()

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_alert_vulnerability_removal.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_alert_vulnerability_removal.py
@@ -75,7 +75,7 @@ def mock_system(mock_agent_module):
 
     yield mock_agent_module
 
-    vd.clean_vd_tables()
+    # vd.clean_vd_tables()
 
 
 @pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solved we can enable again this test")

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_duplicate_vulns.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_redhat_duplicate_vulns.py
@@ -159,4 +159,4 @@ def test_redhat_duplicate_vulns(clean_vuln_tables, get_configuration, configure_
 
     assert number_vulns_first == number_vulns_second
 
-    vd.clean_vuln_and_sys_programs_tables()
+    # vd.clean_vuln_and_sys_programs_tables()

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -113,7 +113,7 @@ def mock_system(mock_agent_module):
     yield mock_agent_module
 
     # Clean tables
-    vd.clean_vd_tables(agent=mock_agent_module)
+    # vd.clean_vd_tables(agent=mock_agent_module)
 
 
 @pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solved we can enable again this test")

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
@@ -56,8 +56,7 @@ from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.tools import ALERT_FILE_PATH, LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.db_interface import agent_db
-from wazuh_testing.modules.vulnerability_detector.utils import clean_vd_tables
+from wazuh_testing.db_interface import agent_db, cve_db
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 
@@ -123,7 +122,8 @@ def mock_system(mock_agent_module):
     yield mock_agent_module
 
     # Clean tables
-    clean_vd_tables(agent_id=mock_agent_module)
+    agent_db.clean_sys_programs(agent_id=mock_agent_module)
+    cve_db.clean_all_cve_tables()
 
 
 def test_full_scan_type(get_configuration, configure_environment, restart_modulesd, mock_system):

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -116,7 +116,7 @@ def mock_system(mock_agent_module):
     yield mock_agent_module
 
     # Clean tables
-    vd.clean_vd_tables(agent=mock_agent_module)
+    # vd.clean_vd_tables(agent=mock_agent_module)
 
 
 @pytest.mark.skip(reason="It will be blocked by wazuh#9309, when it was solved we can enable again this test")


### PR DESCRIPTION
|Related issue|
|---|
|close #2517|

## Description

This PR makes the following changes

### Added

- Add new global variable to get the `ossec.log` path
- Add new function to update the `os_info`.
- Add new function to clean only `sys_programs` table
- Add new method to query the `agent_ids` from a specific `agent_name`.
- Add functions to manage the packages mocking
- Add new event monitor functions for vuln detector.
- Add new global fixtures:
  - `set_system`
  - `mock_agent_packages`
  - `clean_mocked_agents`
- Add `test_vd_retry_interval` test module which contains the following test:
  - `test_retry_interval`
  - `test_retry_interval_max_retries`


### Improved

- Renamed function `delete_os_info_data` to `delete_os_info`
- Renamed function `clean_all_tables` to `clean_all_cve_tables`
- Added `update_os_info` when mocking the system.
- Add `os_info` data when creating a mocked agent.
- Add new `accum_results` result parameters to `check_vuln_detector_event` to provide the possibility to make several event matches simultaneously
- Replaced the usage of deprecated utils functions

### Removed

- Deprecated utils functions:
  - `clean_agent_sys_tables`
  - `clean_feed_tables`
  - `clean_vd_tables`
  - `clean_vuln_and_sys_programs_tables`

---

### Checks

- [x] All vulnerability detector tests
- [x] `test_retry_interval`
- [x] `test_retry_interval_max_retries`


<details>
<summary>Test result</summary>

```
========================================= test session starts ==========================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /mnt/qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-3.1.1
collected 2 items                                                                                      

test_vulnerability_detector/test_general_settings/test_vd_retry_interval.py ..                   [100%]

========================================== 2 passed in 26.83s ==========================================

```

</details>