### PR TITLE
Enrollment IT: IPV6 fix

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -113,7 +113,7 @@ def check_client_keys_file():
     log_monitor = monitoring.FileMonitor(LOG_FILE_PATH)
     try:
         log_monitor.start(timeout=6, callback=wait_key_changes)
-    except:
+    except Exception:
         pass
     try:
         with open(CLIENT_KEYS_PATH) as client_file:
@@ -316,10 +316,10 @@ def callback_invalid_server_address(server_ip):
 
 
 def callback_unable_to_connect(server_ip, port='1515'):
-    msg = fr"ERROR: \(\d+\): Unable to connect to enrollment service at '\[{server_ip}\]:{port}'"
+    msg = f"ERROR: \(\d+\): Unable to connect to enrollment service at '\[{server_ip}\]:{port}'"
     return monitoring.make_callback(pattern=msg, prefix=monitoring.AGENT_DETECTOR_PREFIX)
 
 
 def callback_connected_to_manager_ip(server_ip, port='1515'):
-    msg = f"Connected to enrollment service at '[{server_ip}]:{port}'"
+    msg = f"Connected to enrollment service at '\[{server_ip}\]:{port}'"
     return monitoring.make_callback(pattern=msg, prefix=monitoring.AGENT_DETECTOR_PREFIX)


### PR DESCRIPTION
|Related issue|
|---|
|close #2551 |

## Description

Fix errors in ipv6 enrollment tests callbacks and pep8 style in the agent module.

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.