### PR TITLE
Vulnerability detector test module refactor: `test_providers_update_interval`

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/event_monitor.py
@@ -245,13 +245,13 @@ def check_vulnerability_scan_remove_alerts(wazuh_alerts_monitor, package, cve):
                                                          f"{package} is no longer vulnerable with {cve}")
 
 
-def check_provider_database_update_start_log(provider_name):
+def check_provider_database_update_start_log(provider_name, timeout=vd.VULN_DETECTOR_FAST_TIMEOUT):
     """Check the provider database update start event in ossec.log
 
     Args:
         provider_name (str): Provider name of the downloaded feed.
     """
-    check_vuln_detector_event(timeout=vd.VULN_DETECTOR_FAST_TIMEOUT,
+    check_vuln_detector_event(timeout=timeout,
                               callback=f"Starting '{provider_name}' database update",
                               error_message=f"Could not find {provider_name} update starting log")
 

--- a/tests/integration/test_vulnerability_detector/test_providers/data/configuration_template/providers_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/configuration_template/providers_update_interval.yaml
@@ -1,0 +1,45 @@
+- sections:
+  - section: vulnerability-detector
+    elements:
+    - enabled:
+        value: 'yes'
+    - run_on_start:
+        value: 'no'
+    - interval:
+        value: '10s'
+    - provider:
+        attributes:
+        - name: PROVIDER
+        elements:
+        - enabled:
+            value: 'yes'
+        - os:
+            value: OS
+        - update_interval:
+            value: UPDATE_INTERVAL
+  - section: sca
+    elements:
+      - enabled:
+          value: 'no'
+  - section: rootcheck
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: syscheck
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: auth
+    elements:
+      - disabled:
+          value: 'yes'
+  - section: rule_test
+    elements:
+      - enabled:
+          value: 'no'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/configuration_template/providers_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/configuration_template/providers_update_interval.yaml
@@ -1,45 +1,47 @@
+---
+
 - sections:
-  - section: vulnerability-detector
-    elements:
-    - enabled:
-        value: 'yes'
-    - run_on_start:
-        value: 'no'
-    - interval:
-        value: '10s'
-    - provider:
-        attributes:
-        - name: PROVIDER
-        elements:
+    - section: vulnerability-detector
+      elements:
         - enabled:
             value: 'yes'
-        - os:
-            value: OS
-        - update_interval:
-            value: UPDATE_INTERVAL
-  - section: sca
-    elements:
-      - enabled:
-          value: 'no'
-  - section: rootcheck
-    elements:
-      - disabled:
-          value: 'yes'
-  - section: syscheck
-    elements:
-      - disabled:
-          value: 'yes'
-  - section: wodle
-    attributes:
-      - name: 'syscollector'
-    elements:
-      - disabled:
-          value: 'yes'
-  - section: auth
-    elements:
-      - disabled:
-          value: 'yes'
-  - section: rule_test
-    elements:
-      - enabled:
-          value: 'no'
+        - run_on_start:
+            value: 'no'
+        - interval:
+            value: '10s'
+        - provider:
+            attributes:
+              - name: PROVIDER
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  value: OS
+              - update_interval:
+                  value: UPDATE_INTERVAL
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: rule_test
+      elements:
+        - enabled:
+            value: 'no'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/configuration_template/providers_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/configuration_template/providers_update_interval.yaml
@@ -1,5 +1,3 @@
----
-
 - sections:
     - section: vulnerability-detector
       elements:
@@ -8,7 +6,7 @@
         - run_on_start:
             value: 'no'
         - interval:
-            value: '10s'
+            value: '30s'
         - provider:
             attributes:
               - name: PROVIDER
@@ -19,24 +17,29 @@
                   value: OS
               - update_interval:
                   value: UPDATE_INTERVAL
+
     - section: sca
       elements:
         - enabled:
             value: 'no'
+
     - section: rootcheck
       elements:
         - disabled:
             value: 'yes'
+
     - section: syscheck
       elements:
         - disabled:
             value: 'yes'
+
     - section: wodle
       attributes:
         - name: 'syscollector'
       elements:
         - disabled:
             value: 'yes'
+
     - section: auth
       elements:
         - disabled:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/test_providers_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/test_providers_update_interval.yaml
@@ -1,0 +1,66 @@
+- name: 'Amazon_Linux_10'
+  description: 'Test update interval 10s Amazon Linux'
+  configuration_parameters:
+    PROVIDER: 'alas'
+    OS: amazon-linux
+    UPDATE_INTERVAL: '10s'
+  metadata:
+    provider: 'alas'
+    update_interval: '10s'
+    feed_path: CUSTOM_ALAS_JSON_FEED_PATH
+
+- name: 'RedHat_10'
+  description: 'Test update interval 10s RedHat'
+  configuration_parameters:
+    PROVIDER: 'redhat'
+    OS: 8
+    UPDATE_INTERVAL: '10s'
+  metadata:
+    provider: 'redhat'
+    update_interval: '10s'
+    feed_path: CUSTOM_REDHAT_JSON_FEED_PATH
+
+- name: 'Canonical_10'
+  description: 'Test update interval 10s Canonical'
+  configuration_parameters:
+    PROVIDER: 'canonical'
+    OS: 'focal'
+    UPDATE_INTERVAL: '10s'
+  metadata:
+    provider: 'canonical'
+    update_interval: '10s'
+    feed_path: CUSTOM_CANONICAL_JSON_FEED_PATH
+  
+- name: 'Debian_10'
+  description: 'Test update interval 10s Debian'
+  configuration_parameters:
+    PROVIDER: 'debian'
+    OS: 'buster'
+    UPDATE_INTERVAL: '10s'
+  metadata:
+    provider: 'debian'
+    update_interval: '10s'
+    feed_path: CUSTOM_DEBIAN_JSON_FEED_PATH
+
+- name: 'NVD_10'
+  description: 'Test update interval 10s NVD'
+  configuration_parameters:
+    PROVIDER: 'redhat'
+    OS: ''
+    UPDATE_INTERVAL: '10s'
+  metadata:
+    provider: 'nvd'
+    update_interval: '10s'
+    feed_path: CUSTOM_NVD_JSON_FEED_PATH
+
+
+- name: 'Arch_Linux_10'
+  description: 'Test update interval 10s Arch Linux'
+  configuration_parameters:
+    PROVIDER: 'arch'
+    OS: ''
+    UPDATE_INTERVAL: '10s'
+  metadata:
+    provider: 'arch'
+    update_interval: '10s'
+    feed_path: CUSTOM_ARCHLINUX_JSON_FEED_PATH

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/test_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/test_update_interval.yaml
@@ -1,66 +1,59 @@
-- name: 'Amazon_Linux_10'
-  description: 'Test update interval 10s Amazon Linux'
+- name: 'Amazon_Linux'
+  description: 'Test update interval 5s Amazon Linux'
   configuration_parameters:
     PROVIDER: 'alas'
     OS: amazon-linux
-    UPDATE_INTERVAL: '10s'
+    UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'Amazon Linux 1'
-    update_interval: '10s'
-    feed_path: CUSTOM_ALAS_JSON_FEED_PATH
+    update_interval: '5s'
 
-- name: 'RedHat_10'
-  description: 'Test update interval 10s RedHat'
+- name: 'RedHat'
+  description: 'Test update interval 5s RedHat'
   configuration_parameters:
     PROVIDER: 'redhat'
     OS: 8
-    UPDATE_INTERVAL: '10s'
+    UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'Red Hat Enterprise Linux 8'
-    update_interval: '10s'
-    feed_path: CUSTOM_REDHAT_JSON_FEED_PATH
+    update_interval: '5s'
 
-- name: 'Canonical_10'
-  description: 'Test update interval 10s Canonical'
+- name: 'Canonical'
+  description: 'Test update interval 5s Canonical'
   configuration_parameters:
     PROVIDER: 'canonical'
     OS: 'focal'
-    UPDATE_INTERVAL: '10s'
+    UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'Ubuntu Focal'
-    update_interval: '10s'
-    feed_path: CUSTOM_CANONICAL_JSON_FEED_PATH
+    update_interval: '5s'
 
-- name: 'Debian_10'
-  description: 'Test update interval 10s Debian'
+- name: 'Debian'
+  description: 'Test update interval 5s Debian'
   configuration_parameters:
     PROVIDER: 'debian'
     OS: 'buster'
-    UPDATE_INTERVAL: '10s'
+    UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'Debian Buster'
-    update_interval: '10s'
-    feed_path: CUSTOM_DEBIAN_JSON_FEED_PATH
+    update_interval: '5s'
 
-- name: 'NVD_10'
-  description: 'Test update interval 10s NVD'
+- name: 'NVD'
+  description: 'Test update interval 5s NVD'
   configuration_parameters:
     PROVIDER: 'nvd'
     OS: ''
-    UPDATE_INTERVAL: '10s'
+    UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'National Vulnerability Database'
-    update_interval: '10s'
-    feed_path: CUSTOM_NVD_JSON_FEED_PATH
+    update_interval: '5s'
 
-
-- name: 'Arch_Linux_10'
-  description: 'Test update interval 10s Arch Linux'
+- name: 'Arch_Linux'
+  description: 'Test update interval 5s Arch Linux'
   configuration_parameters:
     PROVIDER: 'arch'
     OS: ''
-    UPDATE_INTERVAL: '10s'
+    UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'Arch Linux'
-    update_interval: '10s'
-    feed_path: CUSTOM_ARCHLINUX_JSON_FEED_PATH
+    update_interval: '5s'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/test_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/test_update_interval.yaml
@@ -5,7 +5,7 @@
     OS: amazon-linux
     UPDATE_INTERVAL: '10s'
   metadata:
-    provider: 'alas'
+    provider_name: 'Amazon Linux 1'
     update_interval: '10s'
     feed_path: CUSTOM_ALAS_JSON_FEED_PATH
 
@@ -16,7 +16,7 @@
     OS: 8
     UPDATE_INTERVAL: '10s'
   metadata:
-    provider: 'redhat'
+    provider_name: 'Red Hat Enterprise Linux 8'
     update_interval: '10s'
     feed_path: CUSTOM_REDHAT_JSON_FEED_PATH
 
@@ -27,10 +27,10 @@
     OS: 'focal'
     UPDATE_INTERVAL: '10s'
   metadata:
-    provider: 'canonical'
+    provider_name: 'Ubuntu Focal'
     update_interval: '10s'
     feed_path: CUSTOM_CANONICAL_JSON_FEED_PATH
-  
+
 - name: 'Debian_10'
   description: 'Test update interval 10s Debian'
   configuration_parameters:
@@ -38,18 +38,18 @@
     OS: 'buster'
     UPDATE_INTERVAL: '10s'
   metadata:
-    provider: 'debian'
+    provider_name: 'Debian Buster'
     update_interval: '10s'
     feed_path: CUSTOM_DEBIAN_JSON_FEED_PATH
 
 - name: 'NVD_10'
   description: 'Test update interval 10s NVD'
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: 'nvd'
     OS: ''
     UPDATE_INTERVAL: '10s'
   metadata:
-    provider: 'nvd'
+    provider_name: 'National Vulnerability Database'
     update_interval: '10s'
     feed_path: CUSTOM_NVD_JSON_FEED_PATH
 
@@ -61,6 +61,6 @@
     OS: ''
     UPDATE_INTERVAL: '10s'
   metadata:
-    provider: 'arch'
+    provider_name: 'Arch Linux'
     update_interval: '10s'
     feed_path: CUSTOM_ARCHLINUX_JSON_FEED_PATH

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.py
@@ -57,72 +57,43 @@ tags:
     - providers
 '''
 import os
-from datetime import timedelta
-
 import pytest
-from wazuh_testing.fim import check_time_travel
-from wazuh_testing.tools import LOG_FILE_PATH
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
-from wazuh_testing.tools.monitoring import FileMonitor
+
+from wazuh_testing.tools import configuration
 from wazuh_testing.tools.time import time_to_seconds
-from wazuh_testing.modules.vulnerability_detector.event_monitor import make_vuln_callback
-# from wazuh_testing.vulnerability_detector import make_vuln_callback
-# Disabled until refactor
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 # Marks
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=1)]
 
-# Variables
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_providers_update_interval.yaml')
+# Paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+FEEDS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'data')
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'providers_update_interval.yaml')
+test_enabled_cases_path = os.path.join(TEST_CASES_PATH, 'test_providers_update_interval.yaml')
 
-wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+# Configuration
+configuration_parameters, configuration_metadata, test_case_ids = get_test_cases_data(test_enabled_cases_path)
+configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
 
-time_units = ['60s', '60m', '1h', '1d']
-parameters = []
-metadata = []
-ids = []
-
-for item in time_units:
-    parameters.extend([
-        {'PROVIDER_NAME': 'alas', 'OS': 'amazon-linux', 'INTERVAL': item},
-        {'PROVIDER_NAME': 'redhat', 'OS': '8', 'INTERVAL': item},
-        {'PROVIDER_NAME': 'canonical', 'OS': 'bionic', 'INTERVAL': item},
-        {'PROVIDER_NAME': 'debian', 'OS': 'buster', 'INTERVAL': item},
-        {'PROVIDER_NAME': 'nvd', 'OS': '', 'INTERVAL': item},
-        {'PROVIDER_NAME': 'msu', 'OS': '', 'INTERVAL': item},
-        {'PROVIDER_NAME': 'arch', 'OS': '', 'INTERVAL': item}
-    ])
-
-    metadata.extend([
-        {'provider_name': 'alas', 'os': 'amazon-linux', 'interval': item},
-        {'provider_name': 'redhat', 'os': '8', 'interval': item},
-        {'provider_name': 'canonical', 'os': 'bionic', 'interval': item},
-        {'provider_name': 'debian', 'os': 'buster', 'interval': item},
-        {'provider_name': 'nvd', 'os': '', 'interval': item},
-        {'provider_name': 'msu', 'os': '', 'interval': item},
-        {'provider_name': 'arch', 'os': '', 'interval': item}
-    ])
-
-    ids.extend([f"Amazon_{item}", "Redhat_{item}", f"Canonical_{item}", f"Debian_{item}", f"NVD_{item}", f"MSU_{item}",
-                f"Arch_{item}"])
-
-# Configuration data
-configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
-
-# Callbacks
-callback_provider_database_updating = make_vuln_callback('Starting .* database update')
+to_modify = ['CUSTOM_ALAS_JSON_FEED_PATH', 'CUSTOM_REDHAT_JSON_FEED_PATH', 'CUSTOM_CANONICAL_JSON_FEED_PATH',
+             'CUSTOM_DEBIAN_JSON_FEED_PATH', 'CUSTOM_NVD_JSON_FEED_PATH', 'CUSTOM_ARCHLINUX_JSON_FEED_PATH']
+new_values = [os.path.join(FEEDS_PATH, vd.CUSTOM_ALAS_JSON_FEED),
+              os.path.join(FEEDS_PATH, vd.CUSTOM_REDHAT_JSON_FEED),
+              os.path.join(FEEDS_PATH,vd.CUSTOM_CANONICAL_OVAL_FEED),
+              os.path.join(FEEDS_PATH, vd.CUSTOM_DEBIAN_JSON_FEED),
+              os.path.join(FEEDS_PATH, vd.CUSTOM_NVD_FEED),
+              os.path.join(FEEDS_PATH, vd.CUSTOM_ARCHLINUX_JSON_FEED)]
+configuration_metadata = configuration.update_configuration_template(configuration_metadata, to_modify, new_values)
 
 
-# Fixtures
-@pytest.fixture(scope='module', params=configurations, ids=ids)
-def get_configuration(request):
-    """Get configurations from the module."""
-    return request.param
-
-
-@pytest.mark.skip(reason='Temporarily disabled until refactor in https://github.com/wazuh/wazuh-qa/issues/2453')
-def test_update_interval(get_configuration, configure_environment, restart_modulesd):
+@pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=test_case_ids)
+def test_update_interval(configuration, metadata, set_wazuh_configuration, truncate_log_files, clean_cve_tables_func,
+                         restart_modulesd_function):
     '''
     description: Check if the provider database update is triggered after the set interval time has passed. To do this,
                  it checks that the feed update is not started prematurely by checking the log file. It then travels
@@ -157,24 +128,7 @@ def test_update_interval(get_configuration, configure_environment, restart_modul
         - r'Could not find the provider .* updating feed log after the interval update'
         - 'Starting .* database update'
     '''
-    check_apply_test({'test_providers_update_interval'}, get_configuration['tags'])
+    provider = metadata['provider']
+    interval_update_time = time_to_seconds(metadata['update_interval'])
 
-    provider = get_configuration['metadata']['provider_name']
-    interval_update_time = get_configuration['metadata']['interval']
-    seconds_to_travel = time_to_seconds(interval_update_time) + 5
-
-    # Check that the update has not started prematurely
-    with pytest.raises(TimeoutError):
-        wazuh_log_monitor.start(timeout=8,
-                                callback=callback_provider_database_updating)
-        raise AttributeError(f'Unexpected event {provider} database updating')
-
-    # Travels the time set in the update interval parameter
-    check_time_travel(time_travel=True, interval=timedelta(seconds=seconds_to_travel))
-
-    # Check that the feed is downloaded after the set update interval
-    # (10s for vuln thread refresh + 5s to wait callback)
-    wazuh_log_monitor.start(timeout=50,
-                            callback=callback_provider_database_updating,
-                            error_message=f"Could not find the provider {provider} updating feed log after \
-                                            the interval update")
+    evm.check_provider_database_update_start_log(provider, interval_update_time)

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.py
@@ -57,14 +57,10 @@ tags:
     - providers
 '''
 import os
-from time import sleep
 import pytest
-import timeit
 
-from wazuh_testing.tools import configuration
 from wazuh_testing.tools.time import time_to_seconds
 from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
-from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 # Marks
@@ -74,7 +70,6 @@ pytestmark = [pytest.mark.server]
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
 TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
-FEEDS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'data')
 configurations_path = os.path.join(CONFIGURATIONS_PATH, 'providers_update_interval.yaml')
 test_enabled_cases_path = os.path.join(TEST_CASES_PATH, 'test_update_interval.yaml')
 
@@ -82,25 +77,15 @@ test_enabled_cases_path = os.path.join(TEST_CASES_PATH, 'test_update_interval.ya
 configuration_parameters, configuration_metadata, test_case_ids = get_test_cases_data(test_enabled_cases_path)
 configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
 
-to_modify = ['CUSTOM_ALAS_JSON_FEED_PATH', 'CUSTOM_REDHAT_JSON_FEED_PATH', 'CUSTOM_CANONICAL_JSON_FEED_PATH',
-             'CUSTOM_DEBIAN_JSON_FEED_PATH', 'CUSTOM_NVD_JSON_FEED_PATH', 'CUSTOM_ARCHLINUX_JSON_FEED_PATH']
-new_values = [os.path.join(FEEDS_PATH, vd.CUSTOM_ALAS_JSON_FEED),
-              os.path.join(FEEDS_PATH, vd.CUSTOM_REDHAT_JSON_FEED),
-              os.path.join(FEEDS_PATH, vd.CUSTOM_CANONICAL_OVAL_FEED),
-              os.path.join(FEEDS_PATH, vd.CUSTOM_DEBIAN_JSON_FEED),
-              os.path.join(FEEDS_PATH, vd.CUSTOM_NVD_FEED),
-              os.path.join(FEEDS_PATH, vd.CUSTOM_ARCHLINUX_JSON_FEED)]
-configuration_metadata = configuration.update_configuration_template(configuration_metadata, to_modify, new_values)
-
 
 @pytest.mark.tier(level=0)
 @pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=test_case_ids)
 def test_update_interval(configuration, metadata, set_wazuh_configuration, truncate_log_files, clean_cve_tables_func,
                          restart_modulesd_function):
     '''
-    description: Check if the provider feed starts downloading after the interval time set in <interval_update> tag.
-                 To do this, it checks the interval time from the modulesd starts till detect the log event that the
-                 provider feed update has been started.
+    description: Check if the provider feed starts updating the database after the interval time set in
+                 <interval_update> tag. To do this, it sets the interval time and waits till detect the provider feed
+                 update log event
 
     wazuh_min_version: 4.2.0
 
@@ -125,21 +110,17 @@ def test_update_interval(configuration, metadata, set_wazuh_configuration, trunc
             brief: Restart the wazuh-modulesd daemon.
 
     assertions:
-        - The log event arrive.
-        - The interval time till starts update is the expected.
+        - Verify that the update log shows up.
+        - Verify that the interval time till the update starts is the expected.
 
     input_description:
         - The `test_update_interval.yaml` file provides the module configuration for this test.
 
     expected_output:
-        - r'Unexpected event .* database updating'
-        - r'Could not find the provider .* updating feed log after the interval update'
-        - 'Starting .* database update'
+        - 'Starting <provider_name> database update'
     '''
     provider_name = metadata['provider_name']
-    interval_update_time = time_to_seconds(metadata['update_interval'])
+    # update_interval plus a possible delay
+    interval_update_time = time_to_seconds(metadata['update_interval']) * 1.5
 
-    start = timeit.default_timer()
-    evm.check_provider_database_update_start_log(provider_name, interval_update_time * 2)
-    stop = timeit.default_timer()
-    assert stop - start < 1.5 * interval_update_time
+    evm.check_provider_database_update_start_log(provider_name, timeout=interval_update_time)

--- a/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_providers_update_interval.py
@@ -57,7 +57,9 @@ tags:
     - providers
 '''
 import os
+from time import sleep
 import pytest
+import timeit
 
 from wazuh_testing.tools import configuration
 from wazuh_testing.tools.time import time_to_seconds
@@ -66,7 +68,7 @@ from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 # Marks
-pytestmark = [pytest.mark.server, pytest.mark.tier(level=1)]
+pytestmark = [pytest.mark.server]
 
 # Paths
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -74,7 +76,7 @@ CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
 TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
 FEEDS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'data')
 configurations_path = os.path.join(CONFIGURATIONS_PATH, 'providers_update_interval.yaml')
-test_enabled_cases_path = os.path.join(TEST_CASES_PATH, 'test_providers_update_interval.yaml')
+test_enabled_cases_path = os.path.join(TEST_CASES_PATH, 'test_update_interval.yaml')
 
 # Configuration
 configuration_parameters, configuration_metadata, test_case_ids = get_test_cases_data(test_enabled_cases_path)
@@ -84,51 +86,60 @@ to_modify = ['CUSTOM_ALAS_JSON_FEED_PATH', 'CUSTOM_REDHAT_JSON_FEED_PATH', 'CUST
              'CUSTOM_DEBIAN_JSON_FEED_PATH', 'CUSTOM_NVD_JSON_FEED_PATH', 'CUSTOM_ARCHLINUX_JSON_FEED_PATH']
 new_values = [os.path.join(FEEDS_PATH, vd.CUSTOM_ALAS_JSON_FEED),
               os.path.join(FEEDS_PATH, vd.CUSTOM_REDHAT_JSON_FEED),
-              os.path.join(FEEDS_PATH,vd.CUSTOM_CANONICAL_OVAL_FEED),
+              os.path.join(FEEDS_PATH, vd.CUSTOM_CANONICAL_OVAL_FEED),
               os.path.join(FEEDS_PATH, vd.CUSTOM_DEBIAN_JSON_FEED),
               os.path.join(FEEDS_PATH, vd.CUSTOM_NVD_FEED),
               os.path.join(FEEDS_PATH, vd.CUSTOM_ARCHLINUX_JSON_FEED)]
 configuration_metadata = configuration.update_configuration_template(configuration_metadata, to_modify, new_values)
 
 
+@pytest.mark.tier(level=0)
 @pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=test_case_ids)
 def test_update_interval(configuration, metadata, set_wazuh_configuration, truncate_log_files, clean_cve_tables_func,
                          restart_modulesd_function):
     '''
-    description: Check if the provider database update is triggered after the set interval time has passed. To do this,
-                 it checks that the feed update is not started prematurely by checking the log file. It then travels
-                 forward in time, specifically to five seconds after the expiration of the time set in the
-                 update_interval option. Finally, it checks through the log file that the update of the feeds is started
-                 after this period.
+    description: Check if the provider feed starts downloading after the interval time set in <interval_update> tag.
+                 To do this, it checks the interval time from the modulesd starts till detect the log event that the
+                 provider feed update has been started.
 
     wazuh_min_version: 4.2.0
 
     parameters:
-        - get_configuration:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata
+        - set_wazuh_configuration:
             type: fixture
-            brief: Get configurations from the module.
-        - configure_environment:
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_log_files:
             type: fixture
-            brief: Configure a custom environment for testing.
-        - restart_modulesd:
+            brief: Truncate the log files at the end of the testing case.
+        - clean_cve_tables_func:
             type: fixture
-            brief: Reset the logs file and start a new monitor.
+            brief: Clean all the CVE tables before and after running the test.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
 
     assertions:
-        - Verify that the update has not started prematurely.
-        - Verify that the feed is downloaded after the set update interval.
+        - The log event arrive.
+        - The interval time till starts update is the expected.
 
     input_description:
-        - Test cases are found in the test module and include parameters for the `update_interval` tag of the provider
-          option. The `wazuh_providers_update_interval.yaml` file provides the configuration of this module for this
-          test.
+        - The `test_update_interval.yaml` file provides the module configuration for this test.
 
     expected_output:
         - r'Unexpected event .* database updating'
         - r'Could not find the provider .* updating feed log after the interval update'
         - 'Starting .* database update'
     '''
-    provider = metadata['provider']
+    provider_name = metadata['provider_name']
     interval_update_time = time_to_seconds(metadata['update_interval'])
 
-    evm.check_provider_database_update_start_log(provider, interval_update_time)
+    start = timeit.default_timer()
+    evm.check_provider_database_update_start_log(provider_name, interval_update_time * 2)
+    stop = timeit.default_timer()
+    assert stop - start < 1.5 * interval_update_time


### PR DESCRIPTION
|Related issue|
|---|
|Close #2467|

## Description

This PR adds a `test_providers_update_interval` refactor using the new structure of the `wazuh-qa` repository and a configuration utility.

### Added

- Modify monitoring function for database update log event.
- Add testing module: `test_providers_update_interval`, its configuration template and test cases.

### Tests

- [x] `test_providers_update_interval`

### Outputs

<details>
<summary>test_providers_update_interval</summary>

```
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /mnt/qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, testinfra-5.0.0, html-3.1.1
collected 6 items                                                                                                                                                                                             

test_vulnerability_detector/test_providers/test_providers_update_interval.py ......                                                                                                                     [100%]

============================================================================================= 6 passed in 44.70s ==============================================================================================


```
