### PR TITLE
Change callback function used for system tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -847,10 +847,7 @@ def generate_monitoring_callback(regex):
         match = re.search(regex, line)
         logger.debug(line)
         if match:
-            try:
-                return match.group(1)
-            except IndexError:
-                return line
+            return match.group(1)
 
     return new_callback
 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -847,7 +847,10 @@ def generate_monitoring_callback(regex):
         match = re.search(regex, line)
         logger.debug(line)
         if match:
-            return match.group(1)
+            try:
+                return match.group(1)
+            except IndexError:
+                return line
 
     return new_callback
 

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -966,7 +966,7 @@ class HostMonitor:
                 monitor = QueueMonitor(tailer.queue, time_step=self._time_step)
                 try:
                     self._queue.put({host: monitor.start(timeout=case['timeout'],
-                                                         callback=generate_monitoring_callback(case['regex']),
+                                                         callback=make_callback(pattern=case['regex'], prefix=None),
                                                          update_position=False
                                                          ).result().strip('\n')})
                 except TimeoutError:

--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -968,7 +968,7 @@ class HostMonitor:
                     self._queue.put({host: monitor.start(timeout=case['timeout'],
                                                          callback=make_callback(pattern=case['regex'], prefix=None),
                                                          update_position=False
-                                                         ).result().strip('\n')})
+                                                         ).result()})
                 except TimeoutError:
                     try:
                         self._queue.put({host: error_messages_per_host[host]})


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #2509 |


## Description

After the merge of #2417, `generate_monitoring_callback` function is returning `match.group(1)` instead of `line`. This function was being used in `HostMonitor` so this change has affected almost every system test.

We have changed the function used to `make_callback` function.

## Testing
 
We will use `master` as wazuh/wazuh branch.

### System tests

#### test_cluster/test_agent_enrollment

| | Result | Notes|
|:--:|:--:|:--:|
|R1|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087772/R1-test-agent-enrollment.zip) | |
|R2|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087776/R2-test-agent-enrollment.zip) | |
|R3|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087779/R3-test-agent-enrollment.zip)| |
|R4|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087782/R4-test-agent-enrollment.zip) | |
|R5|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087784/R5-test-agent-enrollment.zip)| |
|R6|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087786/R6-test-agent-enrollment.zip) | |
|R7|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087789/R7-test-agent-enrollment.zip)| |
|R8| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8087792/R8-test-agent-enrollment.zip)| |
|R9| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8087793/R9-test-agent-enrollment.zip)| |

These failures will be checked in #2581

#### test_cluster/test_agent_files_deletion

| | Result | Notes|
|:--:|:--:|:--:|
|R1|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087797/R1-test-agent-files-deletion.zip) | This test is failing due to https://github.com/wazuh/wazuh/issues/12108|
|R2|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087798/R2-test-agent-files-deletion.zip)| This test is failing due to https://github.com/wazuh/wazuh/issues/12108 |
|R3|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087802/R3-test-agent-files-deletion.zip)| This test is failing due to https://github.com/wazuh/wazuh/issues/12108|

#### test_cluster/test_agent_info_sync

| | Result | Notes|
|:--:|:--:|:--:|
|R1| [🔴 ](https://github.com/wazuh/wazuh-qa/files/8087804/R1-test-agent-info-sync.zip)| This test is failing due to https://github.com/wazuh/wazuh/issues/12108|
|R2| [🔴 ](https://github.com/wazuh/wazuh-qa/files/8087806/R2-test-agent-info-sync.zip)| This test is failing due to https://github.com/wazuh/wazuh/issues/12108 |
|R3|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087808/R3-test-agent-info-sync.zip)|  This test is failing due to https://github.com/wazuh/wazuh/issues/12108|

#### test_cluster/test_agent_key_polling

| | Result | Notes|
|:--:|:--:|:--:|
|R1|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087810/R1-test-agent-key-polling.zip)| |
|R2| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8087811/R2-test-agent-key-polling.zip)| |
|R3|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8087813/R3-test-agent-key-polling.zip)| |


#### test_active_response_log_format

| | Result | Notes|
|:--:|:--:|:--:|
|R1|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087814/R1-test-active-response-log-format.zip)| This test is failing due to https://github.com/wazuh/wazuh/pull/12328|
|R2|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087816/R2-test-active-response-log-format.zip) |  This test is failing due to https://github.com/wazuh/wazuh/pull/12328|
|R3|[🔴 ](https://github.com/wazuh/wazuh-qa/files/8087817/R3-test-active-response-log-format.zip)|  This test is failing due to https://github.com/wazuh/wazuh/pull/12328|

