### PR TITLE
Remoted IT - Fix imports, fixtures and warnings

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -612,7 +612,7 @@ def check_push_shared_config(agent, sender, injector=None):
         sender.send_event(agent.keep_alive_event)
 
         # Check up file (push start) message
-        check_agent_received_message(agent, r'#!-up file \w+ merged.mg', timeout=10,
+        check_agent_received_message(agent, r'#!-up file .+ merged.mg', timeout=10,
                                      error_message="initial up file message not received")
 
         # Check agent.conf message

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -6,7 +6,7 @@ import re
 import socket
 import subprocess as sb
 import time
-
+import multiprocessing
 import pytest
 import wazuh_testing.tools.agent_simulator as ag
 from wazuh_testing import UDP, TCP
@@ -536,7 +536,7 @@ def check_queue_socket_event(raw_events=EXAMPLE_MESSAGE_PATTERN, timeout=30, upd
 
     # Intercept queue sockets events
     mitm = ManInTheMiddle(address=QUEUE_SOCKET_PATH, family='AF_UNIX', connection_protocol=UDP,
-                                     func=intercept_socket_data)
+                          func=intercept_socket_data)
     mitm.start()
 
     # Monitor MITM queue
@@ -570,7 +570,6 @@ def check_agent_received_message(agent, search_pattern, timeout=5, update_positi
 
     """
     queue_monitor = QueueMonitor(agent.rcv_msg_queue)
-
     queue_monitor.start(timeout=timeout, callback=make_callback(search_pattern, '.*', escape),
                         update_position=update_position, error_message=error_message)
 
@@ -591,6 +590,11 @@ def check_push_shared_config(agent, sender, injector=None):
     """
 
     # Activate receives_messages modules in simulated agent.
+    def keep_alive_until_group_configuration_sent(sender, interval=1, timeout=20):
+        for i in range(timeout):
+            sender.send_event(agent.keep_alive_event)
+            time.sleep(interval)
+
     agent.set_module_status('receive_messages', 'enabled')
 
     # Run injector with only receive messages module enabled
@@ -632,14 +636,18 @@ def check_push_shared_config(agent, sender, injector=None):
         # Add agent to group and check if the configuration is pushed.
         add_agent_to_group(DEFAULT_TESTING_GROUP_NAME, agent.id)
 
-        for _ in range(5):
-            # send some keep alive messages until manager push the new group configuration
-            sender.send_event(agent.keep_alive_event)
-            time.sleep(1)
+        keep_alive_agent = multiprocessing.Process(target=keep_alive_until_group_configuration_sent,
+                                                   args=(sender,))
+        keep_alive_agent.start()
 
-        check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=10,
+        log_callback = make_callback(pattern=".*End sending file '.+' to agent '\d+'\.", prefix='.*wazuh-remoted.*')
+        log_monitor = FileMonitor(LOG_FILE_PATH)
+        log_monitor.start(timeout=REMOTED_GLOBAL_TIMEOUT, callback=log_callback,
+                          error_message="New shared configuration was not sent")
+        check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=5,
                                      error_message="New group shared config not received")
 
     finally:
         if stop_injector:
             injector.stop_receive()
+            keep_alive_agent.terminate()

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -616,7 +616,7 @@ def check_push_shared_config(agent, sender, injector=None):
         sender.send_event(agent.keep_alive_event)
 
         # Check up file (push start) message
-        check_agent_received_message(agent, r'#!-up file .+ merged.mg', timeout=10,
+        check_agent_received_message(agent, r'#!-up file \w+ merged.mg', timeout=10,
                                      error_message="initial up file message not received")
 
         # Check agent.conf message
@@ -644,7 +644,7 @@ def check_push_shared_config(agent, sender, injector=None):
         log_monitor = FileMonitor(LOG_FILE_PATH)
         log_monitor.start(timeout=REMOTED_GLOBAL_TIMEOUT, callback=log_callback,
                           error_message="New shared configuration was not sent")
-        check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=5,
+        check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=REMOTED_GLOBAL_TIMEOUT,
                                      error_message="New group shared config not received")
 
     finally:

--- a/tests/integration/test_remoted/conftest.py
+++ b/tests/integration/test_remoted/conftest.py
@@ -5,7 +5,8 @@ import shutil
 import subprocess as sb
 import os
 import pytest
-from wazuh_testing.remote import remove_agent_group, new_agent_group
+from wazuh_testing.remote import callback_detect_remoted_started, new_agent_group, REMOTED_GLOBAL_TIMEOUT, \
+                                 remove_agent_group
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -60,3 +61,12 @@ def remove_shared_files():
             shutil.move(os.path.join(target_dir, file_name), source_dir)
 
     os.removedirs(target_dir)
+
+
+@pytest.fixture(scope="module")
+def wait_for_remoted_start_log(get_configuration):
+    """Checks if remoted start callback appears"""
+    remoted_start_monitor = FileMonitor(LOG_FILE_PATH)
+    remoted_start_monitor.start(timeout=REMOTED_GLOBAL_TIMEOUT,
+                                callback=callback_detect_remoted_started('.*', '.*', '.*'),
+                                error_message="The 'Started (pid...' remoted log didn't appear")

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -178,15 +178,15 @@ def get_configuration(request):
     return request.param
 
 
-def test_multi_agents_protocols_communication(get_configuration, configure_environment, restart_remoted):
+def test_multi_agents_protocols_communication(get_configuration, configure_environment, restart_wazuh):
     '''
     description: Check agent-manager communication with several agents simultaneously via TCP, UDP or both.
                  For this purpose, the test will create all the agents and select the protocol using Round-Robin. Then,
                  an event and a message will be created for each agent created. Finally, it will search for
                  those events within the messages sent to the manager.
-    
+
     wazuh_min_version: 4.2.0
-    
+
     parameters:
         - get_configuration:
             type: fixture
@@ -197,19 +197,19 @@ def test_multi_agents_protocols_communication(get_configuration, configure_envir
         - restart_wazuh:
             type: fixture
             brief: Stop Wazuh, reset ossec.log and start a new monitor. Then start Wazuh.
-    
+
     assertions:
         - Verify that the custom events created has been logged correctly.
-    
+
     input_description: A configuration template (test_multi_agent_protocols_communication) is contained in an external
                        YAML file, (wazuh_multi_agent_protocols_communication.yaml). That template is combined with
                        different test cases defined in the module. Those include configuration settings for the
                        'wazuh-remoted' daemon and agents info.
-                        
+
     expected_output:
         - r".* test message from agent .*"
         - Agent message was not received or took too much time.
-    
+
     tags:
         - simulator
         - remoted

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
@@ -108,10 +108,10 @@ def test_invalid_protocol(get_configuration, configure_environment, restart_remo
                  of them is invalid, it should be used the valid protocol. Otherwise, if none of them is valid, TCP
                  should be used(For a syslog connection if more than one protocol is provided only TCP should be used).
                  For this purpose, it selects a valid protocol(within a proper checking), checks if remoted is properly
-                 started and if the configuration is the same as the API reponse. 
-    
+                 started and if the configuration is the same as the API reponse.
+
     wazuh_min_version: 4.2.0
-    
+
     parameters:
         - get_configuration:
             type: fixture
@@ -122,27 +122,28 @@ def test_invalid_protocol(get_configuration, configure_environment, restart_remo
         - restart_remoted:
             type: fixture
             brief: Clear the 'ossec.log' file and start a new monitor.
-    
+
     assertions:
         - Verify that invalid procotol selection warning message appears in ossec.log.
         - Verify that no valid protocol selection warning message appears in ossec.log.
         - Verify that remoted starts correctly.
         - Verify that the selected configuration is the same that API response.
-    
+
     input_description: A configuration template (test_basic_configuration_connection) is contained in an external YAML
                        file, (wazuh_basic_configuration.yaml). That template is combined with different test cases
                        defined in the module. Those include configuration settings for the 'wazuh-remoted' daemon and
                        agents info.
-    
+
     expected_output:
         - The expected error output has not been produced
         - r'WARNING: .* Ignored invalid value .* for protocol field.'
         - r'WARNING: .* Error getting protocol. Default value TCP will be used.'
         - r'Started <pid>: .* Listening on port .*'
-    
+
     tags:
         - simulator
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
     protocol_field = cfg['protocol'].split(',')
 

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_invalid_protocol.py
@@ -101,7 +101,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_invalid_protocol(get_configuration, configure_environment, restart_remoted):
+def test_invalid_protocol(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check if 'wazuh-remoted' sets properly prococol values.
                  First of all, it selects a valid protocol to be used. If a pair of protocols is provided, in case one

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_valid.py
@@ -106,10 +106,10 @@ def test_connection_valid(get_configuration, configure_environment, restart_remo
     description: Check if 'wazuh-remoted' sets 'connection' as 'secure' or 'syslog' properly.
                  For this purpose, it loads the configuration from test cases cfg(For a syslog connection if more than
                  one protocol is provided, only TCP should be used), checks if remoted is properly started and if the
-                 configuration is the same as the API reponse. 
-    
+                 configuration is the same as the API reponse.
+
     wazuh_min_version: 4.2.0
-    
+
     parameters:
         - get_configuration:
             type: fixture
@@ -120,27 +120,28 @@ def test_connection_valid(get_configuration, configure_environment, restart_remo
         - restart_remoted:
             type: fixture
             brief: Clear the 'ossec.log' file and start a new monitor.
-    
+
     assertions:
         - Verify that a proper protocol is used.
         - Verify that invalid procotol selection warning message appears in ossec.log.
         - Verify that remoted starts correctly.
         - Verify that the selected configuration is the same that API response.
-    
+
     input_description: A configuration template (test_basic_configuration_connection) is contained in an external YAML
                        file, (wazuh_basic_configuration.yaml). That template is combined with different test cases
                        defined in the module. Those include configuration settings for the 'wazuh-remoted' daemon and
                        agents info.
-    
+
     expected_output:
         - The expected error output has not been produced
         - r'WARNING: .* Only secure connection supports TCP and UDP at the same time.'
         - Default value TCP will be used.
         - r'Started <pid>: .* Listening on port .*'
-    
+
     tags:
         - simulator
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     used_protocol = cfg['protocol']

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_connection_valid.py
@@ -101,7 +101,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_connection_valid(get_configuration, configure_environment, restart_remoted):
+def test_connection_valid(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check if 'wazuh-remoted' sets 'connection' as 'secure' or 'syslog' properly.
                  For this purpose, it loads the configuration from test cases cfg(For a syslog connection if more than

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
@@ -127,6 +127,7 @@ def test_ipv6_secure(get_configuration, configure_environment, restart_remoted):
     tags:
         - simulator
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     if cfg['connection'] == 'secure':

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_ipv6.py
@@ -89,7 +89,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_ipv6_secure(get_configuration, configure_environment, restart_remoted):
+def test_ipv6_secure(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check if 'wazuh-remoted' correctly starts using ipv6 values.
                  For this purpose, it loads the configuration from test cases cfg(when the connection is secure, ipv4 is

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
@@ -137,6 +137,7 @@ def test_local_ip_valid(get_configuration, configure_environment, restart_remote
     tags:
         - simulator
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     # Check that API query return the selected configuration

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_local_ip_valid.py
@@ -99,7 +99,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_local_ip_valid(get_configuration, configure_environment, restart_remoted):
+def test_local_ip_valid(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check if 'wazuh-remoted' can set 'local_ip' using different IPs without errors.
                  For this purpose, it uses the configuration from test cases and check if the cfg in ossec.conf matches

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
@@ -90,7 +90,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_big_queue_size(get_configuration, configure_environment, restart_remoted):
+def test_big_queue_size(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check that when 'wazuh-remoted' sets the queue size too big(greater than 262144), a warning message
                  appears. For this purpose, it uses the configuration from test cases, check if the warning has been

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_too_big.py
@@ -92,12 +92,12 @@ def get_configuration(request):
 
 def test_big_queue_size(get_configuration, configure_environment, restart_remoted):
     '''
-    description: Check that when 'wazuh-remoted' sets the queue size too big(greater than 262144), a warning message 
+    description: Check that when 'wazuh-remoted' sets the queue size too big(greater than 262144), a warning message
                  appears. For this purpose, it uses the configuration from test cases, check if the warning has been
                  logged and the configuration is the same as the API respnse.
-    
+
     wazuh_min_version: 4.2.0
-    
+
     parameters:
         - get_configuration:
             type: fixture
@@ -108,28 +108,29 @@ def test_big_queue_size(get_configuration, configure_environment, restart_remote
         - restart_remoted:
             type: fixture
             brief: Clear the 'ossec.log' file and start a new monitor.
-    
+
     assertions:
         - Verify that remoted starts correctly.
         - Verify that the API query matches correctly with the configuration that ossec.conf contains.
         - Verify that the warning is logged when the queue size is too big.
         - Verify that the selected configuration is the same as the API response.
-    
+
     input_description: A configuration template (test_basic_configuration_queue_size) is contained in an external YAML
                        file, (wazuh_basic_configuration.yaml). That template is combined with different test cases
                        defined in the module. Those include configuration settings for the 'wazuh-remoted' daemon and
                        agents info.
-    
+
     expected_output:
         - r'Started <pid>: .* Listening on port .*'
-        - r'API query '{protocol}://{host}:{port}/manager/configuration?section=remote' doesn't match the 
+        - r'API query '{protocol}://{host}:{port}/manager/configuration?section=remote' doesn't match the
           introduced configuration on ossec.conf.'
         - The expected error output has not been produced
         - 'WARNING: Queue size is very high. The application may run out of memory'
-    
+
     tags:
         - simulator
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     log_callback = remote.callback_queue_size_too_big()

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
@@ -128,6 +128,7 @@ def test_queue_size_valid(get_configuration, configure_environment, restart_remo
     tags:
         - simulator
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     compare_config_api_response([cfg], 'remote')

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_queue_size_valid.py
@@ -91,7 +91,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_queue_size_valid(get_configuration, configure_environment, restart_remoted):
+def test_queue_size_valid(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check that when 'wazuh-remoted' sets a valid queue size. For this purpose, it uses the configuration 
                  from test cases, check if the warning has been logged and the configuration is the same as the API

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py
@@ -101,7 +101,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_rids_closing_time_valid(get_configuration, configure_environment, restart_remoted):
+def test_rids_closing_time_valid(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check that 'rids_closing_time' can be set with no errors. For this purpose, 
                  it uses the configuration from test cases and check if the selected cfg matches with the API response.

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_rids_closing_time_valid.py
@@ -138,6 +138,7 @@ def test_rids_closing_time_valid(get_configuration, configure_environment, resta
         - simulator
         - rids
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     # Check that API query return the selected configuration

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
@@ -101,9 +101,9 @@ def test_allowed_denied_ips_syslog(get_configuration, configure_environment, res
     description: Check that 'allowed-ips' and 'denied-ips' could be configured without errors for syslog connection.
                  For this purpose, it uses the configuration from test cases, check if the warning has been logged and
                  the configuration is the same as the API reponse.
-    
+
     wazuh_min_version: 4.2.0
-    
+
     parameters:
         - get_configuration:
             type: fixture
@@ -114,27 +114,28 @@ def test_allowed_denied_ips_syslog(get_configuration, configure_environment, res
         - restart_remoted:
             type: fixture
             brief: Clear the 'ossec.log' file and start a new monitor.
-    
+
     assertions:
         - Verify that remoted starts correctly.
         - Verify that the API query matches correctly with the configuration that ossec.conf contains.
         - Verify that the selected configuration is the same as the API response.
-    
+
     input_description: A configuration template (test_basic_configuration_allowed_denied_ips) is contained in an
                        external YAML file, (wazuh_basic_configuration.yaml). That template is combined with different
                        test cases defined in the module. Those include configuration settings for the 'wazuh-remoted'
                        daemon and agents info.
-    
+
     expected_output:
         - r'Started <pid>: .* Listening on port .*'
-        - r'API query '{protocol}://{host}:{port}/manager/configuration?section=remote' doesn't match the 
+        - r'API query '{protocol}://{host}:{port}/manager/configuration?section=remote' doesn't match the
           introduced configuration on ossec.conf.'
         - Wazuh remoted didn't start as expected.
         - r'Remote syslog allowed from: .*'
-    
+
     tags:
         - remoted
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     log_callback = remote.callback_detect_syslog_allowed_ips(cfg['allowed-ips'])

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_allowed_denied_ips_valid.py
@@ -96,7 +96,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_allowed_denied_ips_syslog(get_configuration, configure_environment, restart_remoted):
+def test_allowed_denied_ips_syslog(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check that 'allowed-ips' and 'denied-ips' could be configured without errors for syslog connection.
                  For this purpose, it uses the configuration from test cases, check if the warning has been logged and

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
@@ -87,7 +87,7 @@ def get_configuration(request):
     return request.param
 
 
-def test_denied_ips_syslog(get_configuration, configure_environment, restart_remoted):
+def test_denied_ips_syslog(get_configuration, configure_environment, restart_remoted, wait_for_remoted_start_log):
     '''
     description: Check that 'wazuh-remoted' denied connection to the specified 'denied-ips'.
                  For this purpose, it uses the configuration from test cases, check if the different errors are

--- a/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
+++ b/tests/integration/test_remoted/test_configuration/test_basic_configuration_syslog_denied_ips.py
@@ -7,7 +7,7 @@ type: integration
 
 brief: The 'wazuh-remoted' program is the server side daemon that communicates with the agents.
        Specifically, this test will check that specified 'denied-ips' connection is denied and
-       syslog produces a 'not allowed' message. 
+       syslog produces a 'not allowed' message.
 
 tier: 0
 
@@ -92,9 +92,9 @@ def test_denied_ips_syslog(get_configuration, configure_environment, restart_rem
     description: Check that 'wazuh-remoted' denied connection to the specified 'denied-ips'.
                  For this purpose, it uses the configuration from test cases, check if the different errors are
                  logged correctly and check if the API retrieves the expected configuration.
-    
+
     wazuh_min_version: 4.2.0
-    
+
     parameters:
         - get_configuration:
             type: fixture
@@ -105,7 +105,7 @@ def test_denied_ips_syslog(get_configuration, configure_environment, restart_rem
         - restart_remoted:
             type: fixture
             brief: Clear the 'ossec.log' file and start a new monitor.
-    
+
     assertions:
         - Verify that remoted starts correctly.
         - Verify that the warning is logged correctly in ossec.log when receives a message from blocked ip.
@@ -113,24 +113,25 @@ def test_denied_ips_syslog(get_configuration, configure_environment, restart_rem
         - Verify that the critical error is logged correctly in ossec.log when receives a message from blocked ip.
         - Verify that the API query matches correctly with the configuration that ossec.conf contains.
         - Verify that the selected configuration is the same as the API response.
-    
+
     input_description: A configuration template (test_basic_configuration_allowed_denied_ips) is contained in an
                        external YAML file, (wazuh_basic_configuration.yaml). That template is combined with different
                        test cases defined in the module. Those include configuration settings for the 'wazuh-remoted'
                        daemon and agents info.
-    
+
     expected_output:
         - r'Started <pid>: .* Listening on port .*'
         - Wazuh remoted did not start as expected.
         - r'Remote syslog allowed from: .*'
         - The expected output for denied-ips has not been produced.
         - r'Message from .* not allowed. Cannot find the ID of the agent'
-        - r'API query '{protocol}://{host}:{port}/manager/configuration?section=remote' doesn't match the 
+        - r'API query '{protocol}://{host}:{port}/manager/configuration?section=remote' doesn't match the
           introduced configuration on ossec.conf.'
-    
+
     tags:
         - remoted
     '''
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
     cfg = get_configuration['metadata']
 
     log_callback = remote.callback_detect_syslog_allowed_ips(cfg['allowed-ips'])


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2562 |

## Description


After the merge of #1496, remoted tests started failing on nightly runs. The imports in `remote.py` have changed but the code didn't. We need to change the code in order to use the correct imports.

We have fixed imports in `remote.py`, warnings about unverified HTTPs requests, and changed `restart_remoted` to `restart_wazuh`.

## Testing

### Packages

| Version | Revision | Link |
|:--:|:--:|:--:|
| v4.4.0 | 40400 | https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/var/wazuh-manager-4.4.0-2562.remoted.tests.x86_64.rpm

**test_remoted**

|CentOS Manager| Local| Jenkins | Notes |
|:--:|:--:|:--:|:--:|
|R1| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8048287/R1-2564-centos-manager.tar.gz)  | [🟢   ](https://ci.wazuh.info/view/Tests/job/Test_integration/20527/)
|R2 | [🔴 ](https://github.com/wazuh/wazuh-qa/files/8048288/R2-2564-centos-manager.tar.gz)  | [🟢 ](https://ci.wazuh.info/view/Tests/job/Test_integration/20528/)
|R3 | [🔴 ](https://github.com/wazuh/wazuh-qa/files/8048290/R3-2564-centos-manager.tar.gz)  | [🟢  ](https://ci.wazuh.info/view/Tests/job/Test_integration/20529/)

***


- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :orange_circle:: Jenkins problem
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress 