### PR TITLE
rf: modify alert ID of fired rule

### DIFF
--- a/tests/system/provisioning/manager_agent/roles/manager-role/files/ossec.conf
+++ b/tests/system/provisioning/manager_agent/roles/manager-role/files/ossec.conf
@@ -166,7 +166,7 @@
     <disabled>no</disabled>
     <command>firewall-drop</command>
     <location>local</location>
-    <rules_id>5710</rules_id>
+    <rules_id>5760</rules_id>
     <timeout>30</timeout>
   </active-response>
   
@@ -174,7 +174,7 @@
     <disabled>no</disabled>
     <command>firewall-drop-sh</command>
     <location>local</location>
-    <rules_id>5710</rules_id>
+    <rules_id>5760</rules_id>
     <timeout>30</timeout>
   </active-response>
 

--- a/tests/system/test_active_response_log_format/data/messages_415_or_lower.yml
+++ b/tests/system/test_active_response_log_format/data/messages_415_or_lower.yml
@@ -3,6 +3,6 @@ wazuh-agent1:
   - regex: (wazuh-agent1).*(\\\"\\'\\\$token\\'\\\" \\\[01\\\]\\\(02\\\)\\{symbols\\:\\'\\\|\\!\\#\\\*\\\\\\'\\&\\})
     path: "/var/ossec/logs/ossec.log"
     timeout: 60
-  - regex: "(\/var\/ossec\/active-response\/bin\/firewall-drop.sh add).*(5710)"
+  - regex: "(\/var\/ossec\/active-response\/bin\/firewall-drop.sh add).*(5760)"
     path: "/var/ossec/logs/active-responses.log"
     timeout: 60


### PR DESCRIPTION
|Related issue|
|---|
|[#2566|](https://github.com/wazuh/wazuh-qa/issues/2566)

## Description

During research for PR https://github.com/wazuh/wazuh-qa/pull/2557 it was found that the test test_active_response_log_format was failing. It was found that the Rule that was activated by the log passed in by the test, changed from 5710 to 5760 causing no active response to be fired and no logs to be shown.

The changes done in this PR were:
- Changes in manager's ossec.conf: both active responses from 5710 a 5760
- Changes to messages_415_or_lower.yml file: the regex value for active_response.log from 5710 to 5760


## Configuration options
### Wazuh Branch: Master


## Tests
| Test |  Results | Date | By |
|--|--|--|--|
| test_active_response_log_format.py  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8080548/R3.zip) |  2022/02/16 | @Deblintrake09  |  
| test_active_response_log_format.py  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8080549/R2.zip) |  2022/02/16 | @Deblintrake09  |  
| test_active_response_log_format.py  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8080550/R1.zip) |  2022/02/16 | @Deblintrake09  |  


- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.