### PR TITLE
IT 2532- Test set_agent_groups WDB command

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -155,34 +155,6 @@ def query_wdb(command):
 
     return data
 
-def execute_wazuh_db_query(command, single_response=True):
-    """Function to send a command to the wazuh-db socket.
-
-    Args:
-        command(str): Message to send to the socket.
-        single_response(bool): If set to False, all the 'due' responses
-                               will be appended to a response array
-    Returns:
-        str: A response from the socket
-    """
-    
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.connect(WAZUH_DB_SOCKET_PATH)
-    
-    sock.send(command, size=True)
-    if single_response == True:
-        return sock.receive(size=True).decode()
-    else:
-        response_array = []
-        while True:
-            response = sock.receive(size=True).decode()
-            response_array.append(response)
-            status = response.split()[0]
-            if status != 'due':
-                break
-
-        return response_array[0] if len(response_array) == 1 else response_array
-
 
 def clean_agents_from_db():
     """
@@ -209,13 +181,3 @@ def insert_agent_in_db(id=1, name='TestAgent', ip='any', registration_time=0, co
     except Exception:
         raise Exception(f"Unable to add agent {id}")
 
-
-
-def remove_agent(agent_id):
-    """Function that wraps the needed queries to remove an agent.
-
-    Args:
-        agent_id(int): Unique identifier of an agent
-    """
-    data = execute_wazuh_db_query(f"global delete-agent {agent_id}").split()
-    assert data[0] == 'ok', f"Unable to remove agent {agent_id} - {data[1]}"

--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -155,6 +155,34 @@ def query_wdb(command):
 
     return data
 
+def execute_wazuh_db_query(command, single_response=True):
+    """Function to send a command to the wazuh-db socket.
+
+    Args:
+        command(str): Message to send to the socket.
+        single_response(bool): If set to False, all the 'due' responses
+                               will be appended to a response array
+    Returns:
+        str: A response from the socket
+    """
+    
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(WAZUH_DB_SOCKET_PATH)
+    
+    sock.send(command, size=True)
+    if single_response == True:
+        return sock.receive(size=True).decode()
+    else:
+        response_array = []
+        while True:
+            response = sock.receive(size=True).decode()
+            response_array.append(response)
+            status = response.split()[0]
+            if status != 'due':
+                break
+
+        return response_array[0] if len(response_array) == 1 else response_array
+
 
 def clean_agents_from_db():
     """
@@ -167,7 +195,7 @@ def clean_agents_from_db():
         raise Exception('Unable to clean agents')
 
 
-def insert_agent_in_db(id=1, name='TestAgent', ip='any', registration_time=0, connection_status=0,
+def insert_agent_in_db(id=1, name='TestAgent', ip='any', registration_time=0, connection_status="never_connected",
                        disconnection_time=0):
     """
     Write agent in global.db
@@ -176,7 +204,19 @@ def insert_agent_in_db(id=1, name='TestAgent', ip='any', registration_time=0, co
     update_command = f'global sql UPDATE agent SET connection_status = "{connection_status}",\
                        disconnection_time = "{disconnection_time}" WHERE id = {id};'
     try:
-        query_wdb(insert_command)
-        query_wdb(update_command)
+        r1 = query_wdb(insert_command)
+        r2 = query_wdb(update_command)
+        return [r1, r2]
     except Exception:
         raise Exception(f"Unable to add agent {id}")
+
+
+
+def remove_agent(agent_id):
+    """Function that wraps the needed queries to remove an agent.
+
+    Args:
+        agent_id(int): Unique identifier of an agent
+    """
+    data = execute_wazuh_db_query(f"global delete-agent {agent_id}").split()
+    assert data[0] == 'ok', f"Unable to remove agent {agent_id} - {data[1]}"

--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -204,9 +204,8 @@ def insert_agent_in_db(id=1, name='TestAgent', ip='any', registration_time=0, co
     update_command = f'global sql UPDATE agent SET connection_status = "{connection_status}",\
                        disconnection_time = "{disconnection_time}" WHERE id = {id};'
     try:
-        r1 = query_wdb(insert_command)
-        r2 = query_wdb(update_command)
-        return [r1, r2]
+        query_wdb(insert_command)
+        query_wdb(update_command)
     except Exception:
         raise Exception(f"Unable to add agent {id}")
 

--- a/tests/integration/test_wazuh_db/test_set_agent_groups/data/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups/data/set_agent_groups.yaml
@@ -3,7 +3,7 @@
   name: "Group Append - Add TestGroup1"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 1
     expected_group: "TestGroup1"
@@ -11,7 +11,7 @@
   name: "Group Append Empty groups - Agent has no groups - No groups added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":002,\"groups\":[]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 2
     expected_group: "None"
@@ -19,8 +19,8 @@
   name: "Group Append Empty groups - Agent has default group - No groups affected"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":002,\"groups\":[\"default\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":002,\"groups\":[]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[\"default\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
     output: "ok"
     agent_id: 2
     expected_group: "default"
@@ -28,8 +28,8 @@
   name: "Group Append Add same group twice - Has only one group"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 3
     expected_group: "TestGroup1"
@@ -37,8 +37,8 @@
   name: "Group Append Two groups - Agent Has two groups"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup2\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup2\"]}]}"
     output: "ok"
     agent_id: 4
     expected_group: "TestGroup1,TestGroup2"
@@ -46,7 +46,7 @@
   name: "Group Empty-Only - Agent Has no groups. One Group is Added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 5
     expected_group: "TestGroup1"
@@ -54,8 +54,8 @@
   name: "Group Empty-Only - Agent Has no groups. No new groups added"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup2\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup2\"]}]}"
     output: "ok"
     agent_id: 6
     expected_group: "TestGroup1"
@@ -63,8 +63,8 @@
   name: "Group Override - Agent Has one group.  New group replaces old group"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
     output: "ok"
     agent_id: 7
     expected_group: "TestGroup2"
@@ -72,8 +72,8 @@
   name: "Group Override - Agent has Group - Pass no new group.  Error - groups not affected"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":008,\"groups\":[]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[]}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 8
     expected_group: "TestGroup1"
@@ -81,8 +81,8 @@
   name: "Group Remove - Agent has one Group - Remove the group.  Agent has default assigned"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 9
     expected_group: "default"
@@ -90,8 +90,8 @@
   name: "Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 10
     expected_group: "TestGroup2"
@@ -99,7 +99,7 @@
   name: "Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned "
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 11
     expected_group: "default"
@@ -107,7 +107,7 @@
   name: "Invalid Mode - use an Invalid mode - no groups added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid mode 'wrong_mode' in set_agent_groups command"
     agent_id: 12
     expected_group: "None"
@@ -115,7 +115,7 @@
   name: "No Mode - No mode is passed - no groups affected"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid mode '' in set_agent_groups command"
     agent_id: 13
     expected_group: "None"
@@ -123,7 +123,7 @@
   name: "sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"source\":\"remote\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 14
     expected_group: "TestGroup1"
@@ -131,7 +131,7 @@
   name: "Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"source\":\"remote\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 15
     expected_group: "None"
@@ -139,7 +139,7 @@
   name: "No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 16
     expected_group: "None"
@@ -147,7 +147,7 @@
   name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\"}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 16
     expected_group: "None"
@@ -155,7 +155,7 @@
   name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":016}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":016}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 16
     expected_group: "None"
@@ -163,23 +163,15 @@
   name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 16
     expected_group: "None"
 -
-  name: "Missing Fields - Assign a group using without source field - agent has TestGroup1 assigned"
-  test_case:
-  -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
-    agent_id: 16
-    expected_group: "TestGroup1"
--
   name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
     expected_group: "None"
@@ -187,7 +179,7 @@
   name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"source\":\"remote\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 18
     expected_group: "TestGroup1"

--- a/tests/integration/test_wazuh_db/test_set_agent_groups/data/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups/data/set_agent_groups.yaml
@@ -147,7 +147,7 @@
   name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\"}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\"}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 16
     expected_group: "None"
@@ -155,7 +155,7 @@
   name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"id\":016}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":016}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 16
     expected_group: "None"
@@ -163,31 +163,31 @@
   name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
     agent_id: 16
     expected_group: "None"
 -
-  name: "Missing Fields - Assign a group using without source field - agent has no group assigned"
+  name: "Missing Fields - Assign a group using without source field - agent has TestGroup1 assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
     agent_id: 16
-    expected_group: "None"
+    expected_group: "TestGroup1"
 -
   name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid JSON data, missing required fields"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
 -
   name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"source\":\"remote\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"source\":\"remote\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 16
+    agent_id: 18
     expected_group: "TestGroup1"

--- a/tests/integration/test_wazuh_db/test_set_agent_groups/data/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups/data/set_agent_groups.yaml
@@ -1,0 +1,193 @@
+---
+-
+  name: "Group Append - Add TestGroup1"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 1
+    expected_group: "TestGroup1"
+-
+  name: "Group Append Empty groups - Agent has no groups - No groups added"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":002,\"groups\":[]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 2
+    expected_group: "None"
+-
+  name: "Group Append Empty groups - Agent has default group - No groups affected"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":002,\"groups\":[\"default\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":002,\"groups\":[]}]}"
+    output: "ok"
+    agent_id: 2
+    expected_group: "default"
+-
+  name: "Group Append Add same group twice - Has only one group"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 3
+    expected_group: "TestGroup1"
+-
+  name: "Group Append Two groups - Agent Has two groups"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 4
+    expected_group: "TestGroup1,TestGroup2"
+-
+  name: "Group Empty-Only - Agent Has no groups. One Group is Added"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 5
+    expected_group: "TestGroup1"
+-
+  name: "Group Empty-Only - Agent Has no groups. No new groups added"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 6
+    expected_group: "TestGroup1"
+-
+  name: "Group Override - Agent Has one group.  New group replaces old group"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 7
+    expected_group: "TestGroup2"
+-
+  name: "Group Override - Agent has Group - Pass no new group.  Error - groups not affected"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":008,\"groups\":[]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 8
+    expected_group: "TestGroup1"
+-
+  name: "Group Remove - Agent has one Group - Remove the group.  Agent has default assigned"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 9
+    expected_group: "default"
+-
+  name: "Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 10
+    expected_group: "TestGroup2"
+-
+  name: "Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned "
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 11
+    expected_group: "default"
+-
+  name: "Invalid Mode - use an Invalid mode - no groups added"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
+    output: "err Invalid mode 'wrong_mode' in set_agent_groups command"
+    agent_id: 12
+    expected_group: "None"
+-
+  name: "No Mode - No mode is passed - no groups affected"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"source\":\"remote\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
+    output: "err Invalid mode '' in set_agent_groups command"
+    agent_id: 13
+    expected_group: "None"
+-
+  name: "sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"source\":\"remote\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 14
+    expected_group: "TestGroup1"
+-
+  name: "Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"source\":\"remote\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 15
+    expected_group: "None"
+-
+  name: "No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 16
+    expected_group: "None"
+-
+  name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\"}"
+    output: "err Invalid JSON data, missing required fields"
+    agent_id: 16
+    expected_group: "None"
+-
+  name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"id\":016}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 16
+    expected_group: "None"
+-
+  name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 16
+    expected_group: "None"
+-
+  name: "Missing Fields - Assign a group using without source field - agent has no group assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 16
+    expected_group: "None"
+-
+  name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"sync_status\":\"\",\"source\":\"remote\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    output: "err Invalid JSON data, missing required fields"
+    agent_id: 16
+    expected_group: "None"
+-
+  name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"source\":\"remote\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    output: "ok"
+    agent_id: 16
+    expected_group: "TestGroup1"

--- a/tests/integration/test_wazuh_db/test_set_agent_groups/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups/test_set_agent_groups.py
@@ -155,4 +155,4 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
     if case_data["expected_group"] == 'None' and 'err' in output:
         assert 'group' not in response[0], "Agent has groups data and it was expecting no group data"
     else:
-        assert case_data["expected_group"] == response[0]['group'], "did not recieve expected groups in Agent."
+        assert case_data["expected_group"] == response[0]['group'], "Did not receive the expected groups in the agent."

--- a/tests/integration/test_wazuh_db/test_set_agent_groups/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups/test_set_agent_groups.py
@@ -1,0 +1,158 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh-db is the daemon in charge of the databases with all the Wazuh persistent information, exposing a socket
+       to receive requests and provide information. The Wazuh core uses list-based databases to store information
+       related to agent keys, and FIM/Rootcheck event data.
+       This test checks the usage of the set_agent_groups command used for changing the agent's group data and for the
+       cluster's database sync procedures.
+
+tier: 0
+
+modules:
+    - wazuh_db
+
+components:
+    - manager
+
+daemons:
+    - wazuh-db
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-db.html
+
+tags:
+    - wazuh_db
+'''
+import os
+import time
+import pytest
+import yaml
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db
+from wazuh_testing.tools.services import delete_dbs
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+messages_file = os.path.join(test_data_path, 'set_agent_groups.yaml')
+module_tests = []
+with open(messages_file) as f:
+    module_tests.append((yaml.safe_load(f), messages_file.split('_')[0]))
+
+log_monitor_paths = []
+wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
+receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
+monitored_sockets_params = [('wazuh-db', None, True)]
+receiver_sockets= None  # Set in the fixtures
+
+
+#Fixtures
+@pytest.fixture(scope='module')
+def remove_database(request):
+    yield
+    delete_dbs()
+
+
+# Tests
+@pytest.mark.parametrize('test_case',
+                         [case['test_case'] for module_data in module_tests for case in module_data[0]],
+                         ids=[f"{module_name}: {case['name']}"
+                              for module_data, module_name in module_tests
+                              for case in module_data]
+                         )
+def test_set_agent_groups(remove_database, configure_sockets_environment, connect_to_sockets_module, test_case):
+    '''
+    description: Check that every input message using the 'set_agent_groups' command in wazuh-db socket generates 
+                 the proper output to wazuh-db socket. To do this, it performs a query to the socket with a command 
+                 taken from the list of test_cases's 'input' field, and compare the result with the test_case's
+                 'output' and 'expected_group' fields.
+
+    wazuh_min_version: 4.4.0
+
+    parameters:
+        - restart_wazuh:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of 'connect_to_sockets' fixture.
+        - test_case:
+            type: fixture
+            brief: List of test_case stages (dicts with input, output and agent_id and expected_groups keys).
+
+    assertions:
+        - Verify that the socket response matches the expected output.
+        - Verify that the agent has the expected_group assigned.
+
+    input_description:
+        - Test cases are defined in the set_agent_groups.yaml file. This file contains the command to insert the agentes
+          groups, with different modes and combinations, as well as the expected outputs and results.
+
+    expected_output:
+        - f"Assertion Error - expected {output}, but got {response}"
+        - 'Unable to add agent'
+        - 'did not recieve expected groups in Agent.'
+
+    tags:
+        - wazuh_db
+        - wdb_socket
+    '''
+
+    case_data = test_case[0]
+    output = case_data["output"]
+    agent_id= case_data["agent_id"]
+
+    # Insert test Agent
+    response = insert_agent_in_db(id=agent_id, connection_status="disconnected", registration_time=str(time.time()))
+    
+    # Apply preconditions
+    if 'pre_input' in case_data:
+        query_wdb(case_data['pre_input'])
+    
+    # Add tested group
+    response = query_wdb(case_data["input"])
+
+    # validate output
+    assert response == output, f"Assertion Error - expected {output}, but got {response}"
+
+    # get agent data and validate agent's groups
+    response = query_wdb(f'global get-agent-info {agent_id}')
+
+    if case_data["expected_group"] == 'None' and 'err' in output:
+        assert 'group' not in response[0], "Agent has groups data and it was expecting no group data"
+    else:
+        assert case_data["expected_group"] == response[0]['group'], "did not recieve expected groups in Agent."


### PR DESCRIPTION
# Description
In this PR the test suite for `set_agent_groups` command is added.  A total of 23 new test cases covering different modes and combinations of options.

<table>
  <tr>
    <th>Related issues</th>
    <th><a href="[url](https://github.com/wazuh/wazuh-qa/issues/2532)">#2532</a></th>
    <th><a href="[url](https://github.com/wazuh/wazuh/issues/10771)">#10771 (Wazuh)</a></th>
  </tr>
</table>

## Cases for `set_agent_groups` command:

- [x] Append
        - Add TestGroup1
        - Empty groups - Agent has no groups - No groups added
        - Empty groups - Agent has default group - No groups affected
        - Add same group twice - Has only one group
        - Two groups - Agent Has two groups
- [x] Empty-Only
        - Agent Has no groups. One Group is Added
        - Agent Has no groups. No new groups added
- [x] Override
        - Agent Has one group.  New group replaces old group
        - Agent has Group - Pass no new group.  Error - groups not affected
- [x] Remove  
        - Agent has one Group - Remove the group.  Agent has default assigned
        - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
        - Agent has no groups - Try remove a group.  Agent has default assigned
- [x] Invalid Mode - use an Invalid mode - no groups added
- [x] No Mode - No mode is passed - no groups affected
- [x] sync_status
        - sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
        - Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
        - No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
- [x] Missing Fields 
        - Assign a group using without data field - agent has no group assigned
        - Assign a group using without data groups field - agent has no group assigned
        - Assign a group using without data id field - agent has no group assigned
        - Assign a group using without source field - agent has TestGroup1 assigned
        - Assign a group using without mode field - agent has no group assigned
        - Assign a group using without sync_status field - agent has TestGroup1 assigned

**Note:** Form more case details, it can be checked in `set_agent_groups.yaml` file.



--- 

## Configuration options
|OS | Version | Branch | Type |
|--|--|--|--|
| Centos | 4.4.0 | dev-10771-agent-groups-files-to-wazuh-db | Manager|

**Local Internal Options:** No Local Internal Options used

---

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
| test_wazuh_db/test_set_agent_groups  | Manager | Local | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8127239/R1.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8127240/R2.zip)  [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8127242/R3.zip) |2022/02/23 | @Deblintrake09  |  
| test_wazuh_db/test_set_agent_groups  | Manager | Jenkins | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/21763/)  [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/21764/)  [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/21765/) |2022/02/23 | @Deblintrake09  |

---
## Required
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.