### PR TITLE
Adapt `qa-docs` to the new framework terminology

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -18,8 +18,8 @@ from wazuh_testing.tools.exceptions import QAValueError
 class DocGenerator:
     """Main class of DocGenerator tool.
 
-    It is in charge of walk every test file, and every group file to dump the parsed documentation.
-    Every folder is checked so they are ignored when the path matches. Then, every test from folders not ignored
+    It is in charge of walk every module file, and every group file to dump the parsed documentation.
+    Every folder is checked so they are ignored when the path matches. Then, every module from folders not ignored
     that matches a include regex, is parsed.
 
     The included paths are generated using the types and modules from the wazuh-qa framework.
@@ -27,7 +27,7 @@ class DocGenerator:
     Attributes:
         conf (Config): A `Config` instance with the loaded configuration.
         parser (CodeParser): A `CodeParser` instance with parsing utilities.
-        __id_counter (int): An integer that counts the test/group ID when it is created.
+        __id_counter (int): An integer that counts the module/group ID when it is created.
         ignore_regex (list): A list with compiled paths to be ignored.
         include_regex (list): A list with regular expressions used to parse a file or not.
         file_format (str): Generated documentation format.
@@ -123,14 +123,14 @@ class DocGenerator:
 
         return doc_path
 
-    def get_test_doc_path(self, path):
-        """Get the name of the test file in the documentation output based on the original file name.
+    def get_module_doc_path(self, path):
+        """Get the name of the module file in the documentation output based on the original file name.
 
         Args:
             path (str): A string that contains the original file name.
 
         Returns:
-            doc_path (str): A string with the name of the documentation test file.
+            doc_path (str): A string with the name of the documentation module file.
         """
         base_path = os.path.join(self.conf.documentation_path, os.path.basename(self.scan_path))
         relative_path = path.replace(self.scan_path, "")
@@ -144,7 +144,7 @@ class DocGenerator:
         Also, create the containing folder if it does not exist.
 
         Args:
-            content (dict): A dict that contains the parsed content of a test file.
+            content (dict): A dict that contains the parsed content of a module file.
             doc_path (str): A string with the path where the information should be dumped.
 
         Raises:
@@ -182,7 +182,7 @@ class DocGenerator:
 
         Returns:
             __id.counter (int): An integer with the ID of the newly generated group document.
-            None if the test does not have documentation.
+            None if the module does not have documentation.
         """
         self.__id_counter = self.__id_counter + 1
         group = self.parser.parse_group(path, self.__id_counter, group_id)
@@ -196,55 +196,55 @@ class DocGenerator:
             DocGenerator.LOGGER.error(f"Content for {path} is empty, ignoring it")
             raise QAValueError(f"Content for {path} is empty, ignoring it", DocGenerator.LOGGER.error)
 
-    def create_test(self, path, group_id, test_name=None):
-        """Parse the content of a test file and dumps the content into a file.
+    def create_module(self, path, group_id, module_name=None):
+        """Parse the content of a module file and dumps the content into a file.
 
         Modes:
-            Single test:
-                When a single test is going to be parsed, if it has not an output directory, the content is printed.
+            Single module:
+                When a single module is going to be parsed, if it has not an output directory, the content is printed.
                 If it has an output dir, the content is dumped into that dir.
 
             Default:
                 The content is dumped into the corresponding directory.
 
         Args:
-            path (str): A string with the path of the test file to be parsed.
-            group_id (str): A string with the id of the group where the new test belongs.
-            test_name (str): A string with the name of the test that is going to be parsed.
+            path (str): A string with the path of the module file to be parsed.
+            group_id (str): A string with the id of the group where the new module belongs.
+            module_name (str): A string with the name of the module that is going to be parsed.
 
         Returns:
-            __id.counter (int): An integer with the ID of the new generated test document.
-            None if the test does not have documentation.
+            __id.counter (int): An integer with the ID of the new generated module document.
+            None if the module does not have documentation.
         """
         self.__id_counter = self.__id_counter + 1
-        test = self.parser.parse_test(path, self.__id_counter, group_id)
+        tests = self.parser.parse_module(path, self.__id_counter, group_id)
 
-        if test:
+        if tests:
             if self.conf.mode == Mode.DEFAULT:
-                doc_path = self.get_test_doc_path(path)
+                doc_path = self.get_module_doc_path(path)
 
-                self.dump_output(test, doc_path)
+                self.dump_output(tests, doc_path)
                 DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' "
                                           f"was created with ID:{self.__id_counter}")
                 return self.__id_counter
 
-            elif self.conf.mode == Mode.PARSE_TESTS:
+            elif self.conf.mode == Mode.PARSE_MODULES:
                 # If qa-docs is run with --check-doc flag then the output files wont be generated
                 if self.conf.check_doc:
                     return
 
                 if self.conf.documentation_path:
                     doc_path = self.conf.documentation_path
-                    doc_path = os.path.join(doc_path, test_name)
+                    doc_path = os.path.join(doc_path, module_name)
 
-                    self.dump_output(test, doc_path)
+                    self.dump_output(tests, doc_path)
                     DocGenerator.LOGGER.debug(f"New documentation file '{doc_path}' was created.")
         else:
             DocGenerator.LOGGER.error(f"Content for {path} is empty, ignoring it")
             raise QAValueError(f"Content for {path} is empty, ignoring it", DocGenerator.LOGGER.error)
 
     def parse_folder(self, path, group_id):
-        """Search in a specific folder to parse possible group files and each test file.
+        """Search in a specific folder to parse possible group files and each module file.
 
         Args:
             path (str): A string with the path of the folder to be parsed.
@@ -267,86 +267,86 @@ class DocGenerator:
 
         for file in files:
             if self.is_valid_file(file):
-                self.create_test(os.path.join(root, file), group_id)
+                self.create_module(os.path.join(root, file), group_id)
 
         for folder in folders:
             self.parse_folder(os.path.join(root, folder), group_id)
 
-    def parse_test_list(self):
-        """Parse the tests that the user has specified."""
-        for test_name in self.conf.test_names:
-            self.test_path = self.locate_test(test_name)
+    def parse_module_list(self):
+        """Parse the modules that the user has specified."""
+        for module in self.conf.test_modules:
+            self.module_path = self.locate_module(module)
 
-            if self.test_path:
-                self.create_test(self.test_path, 0, test_name)
+            if self.module_path:
+                self.create_module(self.module_path, 0, module)
             else:
-                DocGenerator.LOGGER.error(f"'{test_name}' could not be found")
-                raise QAValueError(f"'{test_name}' could not be found", DocGenerator.LOGGER.error)
+                DocGenerator.LOGGER.error(f"'{module}' could not be found")
+                raise QAValueError(f"'{module}' could not be found", DocGenerator.LOGGER.error)
 
-    def locate_test(self, test_name):
-        """Get the test path when a test is specified by the user.
+    def locate_module(self, module_name):
+        """Get the module path when a module is specified by the user.
 
         Returns:
-            str: A string with the test path.
+            str: A string with the module path.
         """
-        complete_test_name = f"{test_name}.py"
-        DocGenerator.LOGGER.info(f"Looking for {complete_test_name}")
+        complete_module_name = f"{module_name}.py"
+        DocGenerator.LOGGER.info(f"Looking for {complete_module_name}")
 
         for root, dirnames, filenames in os.walk(self.conf.project_path, topdown=True):
             for filename in filenames:
-                if filename == complete_test_name:
-                    return os.path.join(root, complete_test_name)
+                if filename == complete_module_name:
+                    return os.path.join(root, complete_module_name)
 
         return None
 
-    def check_test_exists(self, path):
-        """Check that a test exists within the tests path input.
+    def check_module_exists(self, path):
+        """Check that a module exists within the modules path input.
 
         Args:
-            path (str): A string with the tests path.
+            path (str): A string with the modules path.
         """
-        for test_name in self.conf.test_names:
-            if self.locate_test(test_name):
-                print(f'{test_name} exists in {path}')
+        for module in self.conf.test_modules:
+            if self.locate_module(module):
+                print(f'{module} exists in {path}')
             else:
-                print(f'{test_name} does not exist in {path}')
+                print(f'{module} does not exist in {path}')
 
     def check_documentation(self):
-        for test_name in self.conf.test_names:
-            test_path = self.locate_test(test_name)
+        for module in self.conf.test_modules:
+            module_path = self.locate_module(module)
             try:
-                test = self.parser.parse_test(test_path, self.__id_counter, 0)
+                test = self.parser.parse_module(module_path, self.__id_counter, 0)
             except Exception as qaerror:
                 test = None
-                print(f"{test_name} is not documented using qa-docs current schema")
+                print(f"{module} is not documented using qa-docs current schema")
 
             if test:
-                print(f"{test_name} is documented using qa-docs current schema")
+                print(f"{module} is documented using qa-docs current schema")
 
-    def print_test_info(self, test):
-        """Print the test info to standard output.
+    def print_module_info(self, module):
+        """Print the module info to standard output.
 
         Args:
-            test: A dict with the parsed test data
+            module: A dict with the parsed module data
         """
-        relative_path = re.sub(r'.*wazuh-qa\/', '', self.test_path)
-        test['path'] = relative_path
+        relative_path = re.sub(r'.*wazuh-qa\/', '', self.module_path)
+        module['path'] = relative_path
 
-        print(json.dumps(test, indent=4))
+        print(json.dumps(module, indent=4))
 
     def run(self):
-        """Run a complete scan of each included path to parse every test and group found.
+        """Run a complete scan of each included path to parse every module and group found.
 
         Default mode: parse the files within the included paths.
-        Single test mode: found the test required and parse it.
+        Single module mode: found the module required and parse it.
 
             For example:
             qa-docs -I ../../tests/ -> It would be running as `default mode`.
 
-            qa-docs -I ../../tests/ -T test_cache -> It would be running as `single test mode`
+            qa-docs -I ../../tests/ -m test_cache -> It would be running as `single module mode`
             using the standard output
 
-            qa-docs -I ../../tests/ -T test_cache -o /tmp -> It would be running as `single test mode`
+            qa-docs -I ../../tests/ -m test_cache -o /tmp -> It would be running as `single module mode`
             creating `/tmp/test_cache.json`
         """
         if self.conf.mode == Mode.DEFAULT:
@@ -357,8 +357,8 @@ class DocGenerator:
                 DocGenerator.LOGGER.debug(f"Going to parse files on '{path}'")
                 self.parse_folder(path, self.__id_counter)
 
-        elif self.conf.mode == Mode.PARSE_TESTS:
-            self.parse_test_list()
+        elif self.conf.mode == Mode.PARSE_MODULES:
+            self.parse_module_list()
 
         if not self.conf.check_doc:
             DocGenerator.LOGGER.info(f"Run completed, documentation location: {self.conf.documentation_path}")

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/code_parser.py
@@ -18,7 +18,7 @@ STOP_FIELDS = ['tests', 'test_cases']
 
 
 class CodeParser:
-    """Class that parses the content of the test files.
+    """Class that parses the content of the module files.
 
     Attributes:
         conf (Config): A `Config` instance with the loaded configuration.
@@ -56,7 +56,7 @@ class CodeParser:
         return False
 
     def remove_ignored_fields(self, doc):
-        """Remove the fields from a parsed test file to delete the fields that are not mandatory or optional.
+        """Remove the fields from a parsed module file to delete the fields that are not mandatory or optional.
 
         It may disappear because the fields that are parsed and not specified in the `qa-docs` schema raise an error.
 
@@ -181,18 +181,18 @@ class CodeParser:
 
         return doc
 
-    def parse_test(self, path, id, group_id):
-        """Parse the content of a test file.
+    def parse_module(self, path, id, group_id):
+        """Parse the content of a module file.
 
         Args:
-            path (str): A string with the path of the test file to be parsed.
-            id (str): An integer with the ID of the new test document.
-            group_id (int): An integer with the ID of the group where the new test document belongs.
+            path (str): A string with the path of the module file to be parsed.
+            id (str): An integer with the ID of the new module document.
+            group_id (int): An integer with the ID of the group where the new module document belongs.
 
         Returns:
             module_doc (dict): A dictionary with the documentation block parsed with module and tests fields.
         """
-        CodeParser.LOGGER.debug(f"Parsing test file '{path}'")
+        CodeParser.LOGGER.debug(f"Parsing module file '{path}'")
         self.scan_file = path
         with open(path) as fd:
             file_content = fd.read()
@@ -253,8 +253,8 @@ class CodeParser:
 
         Args:
             group_file (str): A string with the path of the group file to be parsed.
-            id (int): An integer with the ID of the new test document.
-            group_id (int): An integer with the ID of the group where the new test document belongs.
+            id (int): An integer with the ID of the new module document.
+            group_id (int): An integer with the ID of the group where the new module document belongs.
 
         Returns:
             group_doc (dict): A dictionary with the parsed information from `group_file`.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/config.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/config.py
@@ -32,32 +32,31 @@ class Config():
         module_fields (_fields): A struct that contains the module documentation data.
         test_fields (_fields): A struct that contains the test documentation data.
         test_types (list): A list with the types to be parsed.
-        test_modules (list): A list with the modules to be parsed.
-        test_names (list): A list with the tests to be parsed.
+        test_components (list): A list with the modules to be parsed.
+        test_modules (list): A list with the tests to be parsed.
         LOGGER (_fields): A custom qa-docs logger.
     """
     LOGGER = Logging.get_logger(QADOCS_LOGGER)
 
-    def __init__(self, schema_path, test_dir, output_path='', test_types=None, test_modules=None, test_names=None,
-                 check_doc=False):
+    def __init__(self, schema_path, test_dir, output_path='', test_types=None, test_components=None, test_suites=None,
+                 test_modules=None, check_doc=False):
         """Constructor that loads the schema file and set the `qa-docs` configuration.
 
-        If a test name is passed, it would be run in `single test mode`.
-        And if an output path is not received, when is running in single test mode, it will be printed using the
+        If a module name is passed, it would be run in `single module mode`.
+        And if an output path is not received, when is running in single module mode, it will be printed using the
         standard output. But if an output path is passed, there will be generated a JSON file with the same data that
-        would be printed in `single test` mode.
+        would be printed in `single module` mode.
 
         The default output path for `default mode` is `qa_docs_installation/output`, it cannot be changed.
 
         Args:
             schema_path (str): A string that contains the schema file path.
-            test_dir (str): A string that contains the path of the tests.
+            module_dir (str): A string that contains the path of the modules.
             output_path (str): A string that contains the doc output path.
-            test_types (list): A list that contains the tests type(s) to be parsed.
             test_types (list): A list that contains the test type(s) that the user specifies.
-            test_modules (list): A list that contains the test module(s) that the user specifies.
-            test_names (list): A list that contains the test name(s) that the user specifies.
-            check_dock (boolean): Flag to indicate if the test specified (with -t parameter) is documented.
+            test_components (list): A list that contains the test component(s) that the user specifies.
+            test_modules (list): A list that contains the test name(s) that the user specifies.
+            check_dock (boolean): Flag to indicate if the test specified (with -m parameter) is documented.
         """
         self.mode = Mode.DEFAULT
         self.project_path = test_dir
@@ -69,7 +68,8 @@ class Config():
         self.module_fields = _fields()
         self.test_fields = _fields()
         self.test_types = []
-        self.test_modules = []
+        self.test_components = []
+        self.test_suites = []
         self.predefined_values = {}
         self.check_doc = check_doc
 
@@ -78,18 +78,21 @@ class Config():
         self.__set_documentation_path(output_path.replace('\\', '/'))
         self.__read_predefined_values()
 
-        if test_names is not None:
-            # When a name is passed, it is using just a single test.
-            self.mode = Mode.PARSE_TESTS
-            self.test_names = test_names
+        if test_modules is not None:
+            # When a name is passed, it is using just a single module.
+            self.mode = Mode.PARSE_MODULES
+            self.test_modules = test_modules
 
         if test_types is None:
             self.__get_test_types()
         else:
             self.test_types = test_types
 
-            if test_modules:
-                self.test_modules = test_modules
+            if test_components:
+                self.test_components = test_components
+
+                if test_suites:
+                    self.test_suites = test_suites
 
         # Get the paths to parse
         self.__get_include_paths()
@@ -106,19 +109,21 @@ class Config():
                 self.test_types.append(name)
 
     def __get_include_paths(self):
-        """Get all the modules to include within all the specified types.
-
-        The paths to be included are generated using this info.
-        """
+        """Get all the components and suites to include within all the specified types."""
         dir_regex = re.compile("test_.")
         self.include_paths = []
 
         for type in self.test_types:
             subset_tests = os.path.join(self.project_path, type)
 
-            if self.test_modules:
-                for name in self.test_modules:
-                    self.include_paths.append(os.path.join(subset_tests, name))
+            if self.test_components:
+                if self.test_suites:
+                    for component in self.test_components:
+                        for suite in self.test_suites:
+                            self.include_paths.append(os.path.join(subset_tests, component, suite))
+                else:
+                    for component in self.test_components:
+                        self.include_paths.append(os.path.join(subset_tests, component))
             else:
                 for name in os.listdir(subset_tests):
                     if os.path.isdir(os.path.join(subset_tests, name)) and dir_regex.match(name):
@@ -242,8 +247,8 @@ class Mode(Enum):
     The current modes that `doc_generator` has are these:
 
         Modes:
-            DEFAULT: `default mode` parses all tests within tests directory.
-            PARSE_TESTS: `single tests mode` parses a list of tests.
+            DEFAULT: `default mode` parses all modules within tests directory.
+            PARSE_MODULES: `single modules mode` parses a list of modules.
 
             For example, if you want to declare that it is running thru all tests directory, you must specify it by:
 
@@ -253,4 +258,4 @@ class Mode(Enum):
         Enum (Class): Base class for creating enumerated constants.
     """
     DEFAULT = 1
-    PARSE_TESTS = 2
+    PARSE_MODULES = 2

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/config.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/config.py
@@ -70,6 +70,7 @@ class Config():
         self.test_types = []
         self.test_components = []
         self.test_suites = []
+        self.test_modules = []
         self.predefined_values = {}
         self.check_doc = check_doc
 
@@ -77,11 +78,6 @@ class Config():
         self.__read_output_fields()
         self.__set_documentation_path(output_path.replace('\\', '/'))
         self.__read_predefined_values()
-
-        if test_modules is not None:
-            # When a name is passed, it is using just a single module.
-            self.mode = Mode.PARSE_MODULES
-            self.test_modules = test_modules
 
         if test_types is None:
             self.__get_test_types()
@@ -93,6 +89,10 @@ class Config():
 
                 if test_suites:
                     self.test_suites = test_suites
+
+        if test_modules:
+            self.mode = Mode.PARSE_MODULES
+            self.test_modules = test_modules
 
         # Get the paths to parse
         self.__get_include_paths()
@@ -118,9 +118,16 @@ class Config():
 
             if self.test_components:
                 if self.test_suites:
-                    for component in self.test_components:
-                        for suite in self.test_suites:
-                            self.include_paths.append(os.path.join(subset_tests, component, suite))
+                    if self.test_modules:
+                        for component in self.test_components:
+                            for suite in self.test_suites:
+                                for module in self.test_modules:
+                                    self.include_paths.append(os.path.join(subset_tests, component, suite,
+                                                              f"{module}.py"))
+                    else:
+                        for component in self.test_components:
+                            for suite in self.test_suites:
+                                self.include_paths.append(os.path.join(subset_tests, component, suite))
                 else:
                     for component in self.test_components:
                         self.include_paths.append(os.path.join(subset_tests, component))

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/index_data.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/index_data.py
@@ -83,13 +83,13 @@ class IndexData:
         """
         if self.files_format == 'json':
             for file in files:
-                with open(file, 'r') as test_file:
-                    lines = json.load(test_file)
+                with open(file, 'r') as module_file:
+                    lines = json.load(module_file)
                     self.output.append(lines)
         else:
             for file in files:
-                with open(file, 'r') as test_file:
-                    lines = yaml.load(test_file, Loader=yaml.FullLoader)
+                with open(file, 'r') as module_file:
+                    lines = yaml.load(module_file, Loader=yaml.FullLoader)
                     self.output.append(lines)
 
     def remove_index(self):

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/pytest_wrap.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/pytest_wrap.py
@@ -41,10 +41,10 @@ class PytestWrap:
         self.plugin = PytestPlugin()
 
     def collect_test_cases(self, path):
-        """Execute pytest in 'collect-only' mode to extract all the test cases found for a test file.
+        """Execute pytest in 'collect-only' mode to extract all the test cases found for a module file.
 
         Args:
-            path (str): A string with the path of the test file to extract the test cases.
+            path (str): A string with the path of the module file to extract the test cases.
 
         Returns:
             outpout (dict): A dictionary that contains the pytest parsed output.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/utils.py
@@ -301,13 +301,18 @@ def get_qa_docs_run_options(args):
         command += ' --types'
         for type in args.test_types:
             command += f" {type}"
-            if args.test_modules:
-                command += ' --modules'
-                for modules in args.test_modules:
-                    command += f" {modules} "
-    elif args.test_names:
-        command += ' -t'
-        for test_name in args.test_names:
-            command += f" {test_name} "
+            if args.test_components:
+                command += ' --components'
+                for components in args.test_components:
+                    command += f" {components} "
+                if args.test_suites:
+                    command += ' --suites'
+                    for suite in args.test_suites:
+                        command += f" {suite} "
+
+    elif args.test_modules:
+        command += ' -m'
+        for module in args.test_modules:
+            command += f" {module} "
 
     return command

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -92,7 +92,7 @@ def get_parameters():
     parser.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                         help='Show this help message and exit.')
 
-    parser.add_argument('-s', '--sanity-check', action='store_true', dest='sanity',
+    parser.add_argument('--sanity-check', action='store_true', dest='sanity',
                         help="Run a sanity check.")
 
     parser.add_argument('--no-logging', action='store_true', dest='no_logging',
@@ -104,17 +104,20 @@ def get_parameters():
     parser.add_argument('-d', '--debug', action='count', dest='debug_level',
                         help="Enable debug messages.")
 
-    parser.add_argument('--tests-path', dest='tests_path',
+    parser.add_argument('-p', '--tests-path', dest='tests_path',
                         help="Path where tests are located.")
 
-    parser.add_argument('-t', '--tests', nargs='+', default=[], dest='test_names',
-                        help="Parse the test(s) that you pass as argument.")
-
-    parser.add_argument('--types', nargs='+', default=[], dest='test_types',
+    parser.add_argument('-t', '--types', nargs='+', default=[], dest='test_types',
                         help="Parse the tests from type(s) that you pass as argument.")
 
-    parser.add_argument('--modules', nargs='+', default=[], dest='test_modules',
-                        help="Parse the tests from modules(s) that you pass as argument.")
+    parser.add_argument('-c', '--components', nargs='+', default=[], dest='test_components',
+                        help="Parse the tests from components(s) that you pass as argument.")
+
+    parser.add_argument('-s', '--suites', nargs='+', default=[], dest='test_suites',
+                        help="Parse the tests from suite(s) that you pass as argument.")
+
+    parser.add_argument('-m', '--modules', nargs='+', default=[], dest='test_modules',
+                        help="Parse the test(s) that you pass as argument.")
 
     parser.add_argument('-i', '--index-data', dest='index_name',
                         help="Indexes the data named as you specify as argument to elasticsearch.")
@@ -158,9 +161,9 @@ def check_incompatible_parameters(parameters):
     Args:
         parameters (argparse.Namespace): The parameters that the tool receives.
     """
-    default_run = parameters.test_types or parameters.test_modules
+    default_run = parameters.test_types or parameters.test_components or parameters.test_suites
     api_run = parameters.index_name or parameters.app_index_name or parameters.launching_index_name
-    test_run = parameters.test_names or parameters.test_exist
+    test_run = parameters.test_modules or parameters.test_exist
 
     qadocs_logger.debug('Checking parameters incompatibilities.')
 
@@ -175,53 +178,63 @@ def check_incompatible_parameters(parameters):
 
         if parameters.tests_path is None:
             raise QAValueError('The -s(--sanity-check) option needs the path to the tests to be parsed. You must '
-                               'specify it by using -I, --tests-path',
+                               'specify it by using --tests-path',
                                qadocs_logger.error)
 
     if parameters.test_types:
         if parameters.tests_path is None and not parameters.run_with_docker:
             raise QAValueError('The --types option needs the path to the tests to be parsed. You must specify it by '
-                               'using -I, --tests-path',
+                               'using --tests-path',
                                qadocs_logger.error)
 
-        if parameters.test_names:
-            raise QAValueError('The --types option is not compatible with -t(--test)',
+        if parameters.test_modules:
+            raise QAValueError('The --types option is not compatible with -t(--modules)',
                                qadocs_logger.error)
 
         if parameters.test_exist:
             raise QAValueError('The --types option is not compatible with -e(--exist)',
                                qadocs_logger.error)
 
-    if parameters.test_modules:
+    if parameters.test_components:
         if parameters.tests_path is None and not parameters.run_with_docker:
-            raise QAValueError('The --modules option needs the path to the tests to be parsed. You must specify it by '
-                               'using -I, --tests-path',
+            raise QAValueError('The --components option needs the path to the tests to be parsed. You must specify it by '
+                               'using --tests-path',
                                qadocs_logger.error)
 
-        if parameters.test_names:
-            raise QAValueError('The --modules option is not compatible with -t(--test)',
+        if parameters.test_modules:
+            raise QAValueError('The --components option is not compatible with -m(--modules)',
                                qadocs_logger.error)
 
         if parameters.test_exist:
-            raise QAValueError('The --modules option is not compatible with -e(--exist)',
+            raise QAValueError('The --components option is not compatible with -e(--exist)',
                                qadocs_logger.error)
 
-    if parameters.test_names:
+    if parameters.test_suites:
+        if not parameters.test_components:
+            raise QAValueError('The --suites option needs the suite module to be parsed. You must specify it '
+                                'using --components',
+                                qadocs_logger.error)
+
+        if parameters.test_exist:
+                raise QAValueError('The --suites option is not compatible with -e(--exist)',
+                                qadocs_logger.error)
+
+    if parameters.test_modules:
         if parameters.tests_path is None and not parameters.run_with_docker:
-            raise QAValueError('The -t(--test) option needs the path to the tests to be parsed. You must specify it by'
-                               ' using -I, --tests-path',
+            raise QAValueError('The -m(--modules) option needs the path to the tests to be parsed. You must specify it '
+                               'using --tests-path',
                                qadocs_logger.error)
 
         if parameters.index_name:
-            raise QAValueError('The -t(--test) option is not compatible with -i option',
+            raise QAValueError('The -m(--modules) option is not compatible with -i option',
                                qadocs_logger.error)
 
         if parameters.app_index_name:
-            raise QAValueError('The -t(--test) option is not compatible with -l option',
+            raise QAValueError('The -m(--modules) option is not compatible with -l option',
                                qadocs_logger.error)
 
         if parameters.launching_index_name:
-            raise QAValueError('The -t(--test) option is not compatible with -il option',
+            raise QAValueError('The -m(--modules) option is not compatible with -il option',
                                qadocs_logger.error)
 
     if parameters.test_exist:
@@ -307,11 +320,11 @@ def validate_parameters(parameters, parser):
                                    qadocs_logger.error)
 
         # Check that test_input name exists
-        if parameters.test_names:
-            doc_check = DocGenerator(Config(SCHEMA_PATH, parameters.tests_path, test_names=parameters.test_names))
+        if parameters.test_modules:
+            doc_check = DocGenerator(Config(SCHEMA_PATH, parameters.tests_path, test_modules=parameters.test_modules))
 
-            for test_name in parameters.test_names:
-                if doc_check.locate_test(test_name) is None:
+            for test_name in parameters.test_modules:
+                if doc_check.locate_module(test_name) is None:
                     raise QAValueError(f"{test_name} has not been not found in "
                                        f"{parameters.tests_path}.", qadocs_logger.error)
 
@@ -329,18 +342,30 @@ def validate_parameters(parameters, parser):
                     raise QAValueError(f"The given type: {type}, not found in {parameters.tests_path}",
                                        qadocs_logger.error)
 
-        # Check that modules selection is done within a test type
-        if parameters.test_modules:
+        # Check that components selection is done within a test type
+        if parameters.test_components:
             if len(parameters.test_types) != 1:
-                raise QAValueError('The --modules option work when is only parsing a single test type. Use --types with'
-                                   ' just one type if you want to parse some modules within a test type.',
+                raise QAValueError('The --components option work when is only parsing a single test type. Use --types with'
+                                   ' just one type if you want to parse some components within a test type.',
                                    qadocs_logger.error)
 
-            for module in parameters.test_modules:
+            if parameters.test_suites:
+                if len(parameters.test_components) != 1:
+                    raise QAValueError('The --suites option work when is only parsing a single test module. Use '
+                                       '--components with just one type if you want to parse some components within a test '
+                                       'type.', qadocs_logger.error)
+
+            for module in parameters.test_components:
                 type_path = os.path.join(parameters.tests_path, parameters.test_types[0])
                 if module not in os.listdir(type_path):
                     raise QAValueError(f"The given module: {module}, not found in {type_path}",
                                        qadocs_logger.error)
+                    
+                for suite in parameters.test_suites:
+                    module_path = os.path.join(parameters.tests_path, parameters.test_types[0], module)
+                    if suite not in os.listdir(module_path):
+                        raise QAValueError(f"The given suite: {suite}, not found in {module_path}",
+                                           qadocs_logger.error)
 
     qadocs_logger.debug('Input parameters validation completed')
 
@@ -348,7 +373,7 @@ def validate_parameters(parameters, parser):
 def install_searchui_deps():
     """Install SearchUI dependencies if needed"""
     os.chdir(SEARCH_UI_PATH)
-    if not os.path.exists(os.path.join(SEARCH_UI_PATH, 'node_modules')):
+    if not os.path.exists(os.path.join(SEARCH_UI_PATH, 'node_components')):
         qadocs_logger.info('Installing SearchUI dependencies')
         run_local_command("npm install")
 
@@ -364,26 +389,33 @@ def run_searchui(index):
 def parse_data(args):
     """Parse the tests and collect the data."""
     if args.test_exist:
-        doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_names=args.test_exist))
+        doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_modules=args.test_exist))
 
-        doc_check.check_test_exists(args.tests_path)
+        doc_check.check_module_exists(args.tests_path)
 
-    # Parse a list of tests
-    elif args.test_names:
-        qadocs_logger.info(f"Parsing the following test(s) {args.test_names}")
+    # Parse a list of modules
+    elif args.test_modules:
+        qadocs_logger.info(f"Parsing the following test(s) {args.test_modules}")
 
-        docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, test_names=args.test_names,
+        docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, test_modules=args.test_modules,
                             check_doc=args.check_doc), OUTPUT_FORMAT)
 
     # Parse a list of test types
     elif args.test_types:
         qadocs_logger.info(f"Parsing the following test(s) type(s): {args.test_types}")
 
-        # Parse a list of test modules
-        if args.test_modules:
-            qadocs_logger.info(f"Parsing the following test(s) modules(s): {args.test_modules}")
-            docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types,
-                                args.test_modules), OUTPUT_FORMAT)
+        # Parse a list of test components
+        if args.test_components:
+            qadocs_logger.info(f"Parsing the following test(s) components(s): {args.test_components}")
+
+            if args.test_suites:
+                qadocs_logger.info(f"Parsing the following suite(s): {args.test_suites}")
+                docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types,
+                                    args.test_components, args.test_suites), OUTPUT_FORMAT)
+            else:
+                docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types,
+                                args.test_components), OUTPUT_FORMAT)
+
         else:
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types), OUTPUT_FORMAT)
 
@@ -394,10 +426,10 @@ def parse_data(args):
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH), OUTPUT_FORMAT)
             docs.run()
 
-    if args.test_types or args.test_modules or args.test_names and not args.check_doc:
+    if args.test_types or args.test_components or args.test_modules and not args.check_doc:
         qadocs_logger.info('Running QADOCS')
         docs.run()
-    elif args.test_names and args.check_doc:
+    elif args.test_modules and args.check_doc:
         docs.check_documentation()
 
 
@@ -432,6 +464,7 @@ def main():
 
     if args.run_with_docker:
         command = get_qa_docs_run_options(args)
+        qadocs_logger.info(f"Running {command} in a docker container.")
         qa_docs_docker_run(args.qa_branch, command, OUTPUT_PATH)
     elif args.version:
         with open(VERSION_PATH, 'r') as version_file:


### PR DESCRIPTION
|Related issue|
|---|
|#2588|

## Description
This PR aims to refactor the `qa-docs` tool to be able to parse the modules correctly since the new framework changes. Now we identify each item like this:

- **type**: `integration`, `system`, etc.
- **component**: `test_vulnerability_detector`, `test_fim`, etc.
- **suite**: `test_general_settings`, `test_scan_results`, etc
- **module**: `test_enabled`, `test_min_full_scan_interval`
- **test**: test within a module

This refactor has made the following changes:

### Added

- Added `--suites` parameter which parses a list of suites

### Changed

- Renamed `--modules` parameter as `--components`
- Renamed `--tests` parameter as `--modules`
- Updated the tool code and documentation to follow the new terminology

---

## Checks

- [x] The tool keep parsing the documentation as expected
