### PR TITLE
IT - WDB - 2532- Test wazuh-DB getconfig WDB command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Wazuh commit: TBD \
 Release report: TBD
 
 ### Added
-
+- Test `wazuhdb getconfig` WDB command ([2627#](https://github.com/wazuh/wazuh-qa/pull/2627))
 - Test `get-groups-integrity` WDB command ([#2607](https://github.com/wazuh/wazuh-qa/pull/2607))
 - Test `set-agent-groups` WDB command ([#2602](https://github.com/wazuh/wazuh-qa/pull/2602))
 - Add test fim with file currently open ([#2300](https://github.com/wazuh/wazuh-qa/pull/2300))

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -61,7 +61,7 @@ def get_list_of_content_yml(file_path, filter, list=[]):
         list: a list with previous information
 
     Returns:
-       list
+       list with elements that match with the filter
     """
     list.append((read_yaml(file_path), file_path + filter))
     return list

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -61,7 +61,7 @@ def get_list_of_content_yml(file_path, filter, list=[]):
         list: a list with previous information
 
     Returns:
-       list with elements that match with the filter
+       list: Yaml structure.
     """
     list.append((read_yaml(file_path), file_path + filter))
     return list

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -501,6 +501,4 @@ def download_text_file(file_url, local_destination_path):
         raise ValueError(f"The remote url {file_url} does not have text/plain content type to download it")
 
     open(local_destination_path, 'wb').write(request.content)
-
-
-def get_content_yml():
+ 

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -51,6 +51,22 @@ def read_yaml(file_path):
         return yaml.safe_load(f)
 
 
+def get_list_of_content_yml(file_path, filter, list=[]):
+    """Read a YAML file from a given path, return a list with the YAML data
+    after apply filter
+
+    Args:
+        file_path (str): Path of the YAML file to be readed
+        filter (str): filder to extract some part of yaml
+        list: a list with previous information
+
+    Returns:
+       list
+    """
+    list.append((read_yaml(file_path), file_path + filter))
+    return list
+
+
 def truncate_file(file_path):
     """
     Truncate a file to reset its content.
@@ -485,3 +501,6 @@ def download_text_file(file_url, local_destination_path):
         raise ValueError(f"The remote url {file_url} does not have text/plain content type to download it")
 
     open(local_destination_path, 'wb').write(request.content)
+
+
+def get_content_yml():

--- a/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
+++ b/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
@@ -1,0 +1,31 @@
+---
+-
+  name: 'Get config missing parameter'
+  test_case:
+  -
+    input: 'wazuhdb getconfig'
+    output: "err Invalid DB query syntax, near 'getconfig'"
+-
+  name: 'Get config empty parameter'
+  test_case:
+  -
+    input: 'wazuhdb getconfig '
+    output: 'err Failed reading wazuh-db config'
+-
+  name: 'Get config wrong parameter'
+  test_case:
+  -
+    input: 'wazuhdb getconfig wrong_parameter'
+    output: 'err Failed reading wazuh-db config'
+-
+  name: 'Get internal config'
+  test_case:
+  -
+    input: 'wazuhdb getconfig internal'
+    output: "{'wazuh_db': {'commit_time_max': 60, 'commit_time_min': 10, 'open_db_limit': 64, 'sock_queue_size': 128, 'worker_pool_size': 8}}"
+-
+  name: 'Get wdb config'
+  test_case:
+  -
+    input: 'wazuhdb getconfig wdb'
+    output: "{'wdb':{ 'backup_settings_nodes':[{'node_name':'global','enabled':true,'interval':86400,'max_files':3}]}}"

--- a/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
+++ b/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
@@ -28,4 +28,4 @@
   test_case:
   -
     input: 'wazuhdb getconfig wdb'
-    output: "{'wdb':{ 'backup_settings_nodes':[{'node_name':'global','enabled':true,'interval':86400,'max_files':3}]}}"
+    output: "{'wdb': {'backup': [{'database': 'global', 'enabled': True, 'interval': 86400, 'max_files': 3}]}}"

--- a/tests/integration/test_wazuh_db/test_wazuhdb_getconfig.py
+++ b/tests/integration/test_wazuh_db/test_wazuhdb_getconfig.py
@@ -94,10 +94,11 @@ def test_sync_agent_groups(configure_sockets_environment, connect_to_sockets_mod
         - wazuh_db
         - wdb_socket
     '''
+     # Set each case
     case_data = test_case[0]
     output = case_data["output"]
 
     response = query_wdb(case_data["input"])
 
-    # validate response
+    # Validate response
     assert str(response) == output

--- a/tests/integration/test_wazuh_db/test_wazuhdb_getconfig.py
+++ b/tests/integration/test_wazuh_db/test_wazuhdb_getconfig.py
@@ -44,6 +44,7 @@ import pytest
 import yaml
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb
+from wazuh_testing.tools.file import get_list_of_content_yml
 
 
 # Marks
@@ -52,9 +53,7 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
 # Configurations
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_file = os.path.join(os.path.join(test_data_path, 'global'), 'wazuhdb_getconfig.yaml')
-module_tests = []
-with open(messages_file) as f:
-    module_tests.append((yaml.safe_load(f), messages_file.split('_')[0]))
+module_tests = get_list_of_content_yml(messages_file, ".split('_')[0]")
 
 log_monitor_paths = []
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))

--- a/tests/integration/test_wazuh_db/test_wazuhdb_getconfig.py
+++ b/tests/integration/test_wazuh_db/test_wazuhdb_getconfig.py
@@ -1,0 +1,103 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+type: integration
+brief: Wazuh-db is the daemon in charge of the databases with all the Wazuh persistent information, exposing a socket
+       to receive requests and provide information. The Wazuh core uses list-based databases to store information
+       related to agent keys, and FIM/Rootcheck event data.
+       This test checks the usage of the wazuhdb getconfig command used to get the current configuration
+tier: 0
+modules:
+    - wazuh_db
+components:
+    - manager
+daemons:
+    - wazuh-db
+os_platform:
+    - linux
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-db.html
+tags:
+    - wazuh_db
+'''
+import os
+import pytest
+import yaml
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.wazuh_db import query_wdb
+
+
+# Marks
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
+
+# Configurations
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+messages_file = os.path.join(os.path.join(test_data_path, 'global'), 'wazuhdb_getconfig.yaml')
+module_tests = []
+with open(messages_file) as f:
+    module_tests.append((yaml.safe_load(f), messages_file.split('_')[0]))
+
+log_monitor_paths = []
+wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
+receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
+monitored_sockets_params = [('wazuh-db', None, True)]
+receiver_sockets = None  # Set in the fixtures
+
+
+# Tests
+@pytest.mark.parametrize('test_case',
+                         [case['test_case'] for module_data in module_tests for case in module_data[0]],
+                         ids=[f"{module_name}: {case['name']}"
+                              for module_data, module_name in module_tests
+                              for case in module_data]
+                         )
+def test_sync_agent_groups(configure_sockets_environment, connect_to_sockets_module, test_case):
+    '''
+    description: Check that commands about wazuhdb getconfig works properly.
+    wazuh_min_version: 4.4.0
+    parameters:
+        - configure_sockets_environment:
+            type: fixture
+            brief: Configure environment for sockets and MITM.
+        - connect_to_sockets_module:
+            type: fixture
+            brief: Module scope version of 'connect_to_sockets' fixture.
+        - test_case:
+            type: fixture
+            brief: List of test_case stages (dicts with input, output and agent_id and expected_groups keys).
+    assertions:
+        - Verify that the socket response matches the expected output.
+    input_description:
+        - Test cases are defined in the wazuhdb_getconfig.yaml file.
+    expected_output:
+        - an array with the configuration of DB.
+    tags:
+        - wazuh_db
+        - wdb_socket
+    '''
+    case_data = test_case[0]
+    output = case_data["output"]
+
+    response = query_wdb(case_data["input"])
+
+    # validate response
+    assert str(response) == output


### PR DESCRIPTION
In this PR the test suite for `wazuhdb getconfig` command is added. A total of 5 new test cases covering different modes and combinations of options.

<table>
  <tr>
    <th>Related issues</th>
    <th><a href="[url](https://github.com/wazuh/wazuh-qa/issues/2532)">#2532</a></th>
    <th><a href="[url](https://github.com/wazuh/wazuh/issues/10771)">#10771 (Wazuh)</a></th>
  </tr>
</table>

## Cases for `wazuh-DB getconfig` command:

- [x] Wazuh-DB getconfig commands
        - Get config missing parameter
        - Get config empty parameter
        - Get config wrong parameter
        - Get internal config
        - Get wdb config

--- 

## Configuration options
|OS | Version | Branch | Type |
|--|--|--|--|
| CentOS | 4.4.0 | dev-10771-agent-groups-files-to-wazuh-db | Manager|

**Local Internal Options:** No Local Internal Options used

---

---

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
| test_wazuh_db/test_wazuhdb_getconfig  | CentOS - Manager | Local | [:green_circle:]((https://github.com/wazuh/wazuh-qa/files/8173375/r1.zip))[:green_circle:](https://github.com/wazuh/wazuh-qa/files/8173376/R2.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/8173377/R3.zip)| 02/03/2022 |  @CamiRomero  |  
| test_wazuh_db/test_wazuhdb_getconfig   | CentOS - Manager | Jenkins | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/22206/)  [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/22207/)  [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/22208/) |02/03/2022 |  @CamiRomero |



---
## Required
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.