### PR TITLE
Adapt how `qa-ctl` uses `qa-docs` after new changes

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/configuration/config_generator.py
@@ -131,9 +131,9 @@ class QACTLConfigGenerator:
         }
     }
 
-    def __init__(self, tests=None, wazuh_version=None, qa_branch='master',
+    def __init__(self, modules_data=None, wazuh_version=None, qa_branch='master',
                  qa_files_path=join(gettempdir(), 'wazuh_qa_ctl', 'wazuh-qa'), systems=None):
-        self.tests = tests
+        self.modules_data = modules_data
         self.wazuh_version = wazuh_version
         self.systems = systems
         self.qactl_used_ips_file = join(gettempdir(), 'wazuh_qa_ctl', 'qactl_used_ips.txt')
@@ -146,7 +146,7 @@ class QACTLConfigGenerator:
         # Create qa-ctl temporarily files path
         file.recursive_directory_creation(join(gettempdir(), 'wazuh_qa_ctl'))
 
-    def __get_test_info(self, test_name):
+    def __get_module_info(self, type, component, suite, module):
         """Get information from a documented test.
 
         Args:
@@ -155,9 +155,9 @@ class QACTLConfigGenerator:
         Returns:
             dict : return the info of the named test in dict format.
         """
-        qa_docs_command = f"qa-docs -t {test_name} -o {join(gettempdir(), 'wazuh_qa_ctl')} -I " \
-                          f"{join(self.qa_files_path, 'tests')} --no-logging"
-        test_data_file_path = f"{join(gettempdir(), 'wazuh_qa_ctl', test_name)}.json"
+        qa_docs_command = f"qa-docs -p {join(self.qa_files_path, 'tests')} -o {join(gettempdir(), 'wazuh_qa_ctl')} " \
+                          f"-t {type} -c {component} -s {suite} -m {module} --no-logging"
+        test_data_file_path = f"{join(gettempdir(), 'wazuh_qa_ctl', 'output', module)}.json"
 
         run_local_command_returning_output(qa_docs_command)
 
@@ -170,7 +170,7 @@ class QACTLConfigGenerator:
                                QACTLConfigGenerator.LOGGER.error, QACTL_LOGGER)
 
         # Add test name extra info
-        info['test_name'] = test_name
+        info['test_name'] = module
 
         # Delete test data file
         file.delete_file(test_data_file_path)
@@ -183,7 +183,10 @@ class QACTLConfigGenerator:
         Returns:
             dict object : dict containing all the information of the tests given from their documentation.
         """
-        tests_info = [self.__get_test_info(test) for test in self.tests]
+        tests_info = []
+        for type, component, suite, module in zip(self.modules_data['types'], self.modules_data['components'],
+                                                  self.modules_data['suites'], self.modules_data['modules']):
+            tests_info.append(self.__get_module_info(type, component, suite, module))
 
         return tests_info
 
@@ -343,13 +346,13 @@ class QACTLConfigGenerator:
 
         return package_url
 
-    def __add_deployment_config_block(self, test_name, os_version, components, os_platform):
+    def __add_deployment_config_block(self, test_name, os_version, targets, os_platform):
         """Add a configuration block to deploy a test environment in qa-ctl.
 
         Args:
             test_name (string): Test name.
             os_version (string): Host vendor to deploy (e.g: CentOS 8).
-            components (string): Test target (manager or agent).
+            targets (string): Test target (manager or agent).
             os_platform (string): host system (e.g: linux).
         """
         # Process deployment data
@@ -357,11 +360,11 @@ class QACTLConfigGenerator:
         vm_name = f"{test_name}_{get_current_timestamp()}".replace('.', '_')
         self.config['deployment'][f"host_{host_number}"] = {
             'provider': {
-                'vagrant': self.__add_instance(os_version, vm_name, components, os_platform)
+                'vagrant': self.__add_instance(os_version, vm_name, targets, os_platform)
             }
         }
         # Add manager if the target is an agent
-        if components == 'agent':
+        if targets == 'agent':
             host_number += 1
             self.config['deployment'][f"host_{host_number}"] = {
                 'provider': {
@@ -397,10 +400,10 @@ class QACTLConfigGenerator:
                         raise QAValueError(f"No valid system was found for {test['name']} test",
                                            QACTLConfigGenerator.LOGGER.error, QACTL_LOGGER)
 
-                    components = 'manager' if 'manager' in test['components'] else 'agent'
+                    targets = 'manager' if 'manager' in test['targets'] else 'agent'
                     os_platform = 'windows' if 'Windows' in os_version else 'linux'
 
-                    self.__add_deployment_config_block(test['test_name'], os_version, components, os_platform)
+                    self.__add_deployment_config_block(test['test_name'], os_version, targets, os_platform)
 
         # If system parameter is specified and have values
         elif isinstance(self.systems, list) and len(self.systems) > 0:
@@ -409,9 +412,9 @@ class QACTLConfigGenerator:
                     if self.__validate_test_info(test):
                         version = self.SYSTEMS[system]['os_version']
                         platform = self.SYSTEMS[system]['os_platform']
-                        component = 'manager' if 'manager' in test['components'] and platform == 'linux' else 'agent'
+                        targets = 'manager' if 'manager' in test['targets'] and platform == 'linux' else 'agent'
 
-                        self.__add_deployment_config_block(test['test_name'], version, component, platform)
+                        self.__add_deployment_config_block(test['test_name'], version, targets, platform)
         else:
             raise QAValueError('Unable to process systems in the automatically generated configuration',
                                QACTLConfigGenerator.LOGGER.error, QACTL_LOGGER)
@@ -521,9 +524,8 @@ class QACTLConfigGenerator:
             system = QACTLConfigGenerator.BOX_INFO[vm_box]['system']
 
             system = 'linux' if system == 'deb' or system == 'rpm' else system
-            modules = copy.deepcopy(test['modules'])
+            modules = copy.deepcopy(test['components'])
             component = self.config['provision']['hosts'][instance]['wazuh_deployment']['target']
-
             # Cut out the full path, and convert it to relative path (tests/integration....)
             test_path = re.sub(r".*wazuh-qa.*(tests.*)", r"\1", test['path'])
             # Convert test path string to the corresponding according to the system

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/doc_generator.py
@@ -13,6 +13,7 @@ from wazuh_testing.qa_docs.lib.utils import clean_folder
 from wazuh_testing.qa_docs import QADOCS_LOGGER
 from wazuh_testing.tools.logging import Logging
 from wazuh_testing.tools.exceptions import QAValueError
+from wazuh_testing.qa_docs.lib.utils import get_file_path_recursively
 
 
 class DocGenerator:
@@ -277,12 +278,14 @@ class DocGenerator:
         complete_module_name = f"{module_name}.py"
         DocGenerator.LOGGER.info(f"Looking for {complete_module_name}")
 
-        for root, dirnames, filenames in os.walk(self.conf.project_path, topdown=True):
-            for filename in filenames:
-                if filename == complete_module_name:
-                    return os.path.join(root, complete_module_name)
+        if self.conf.test_types:
+            path_where_looks_for = os.path.join(self.conf.project_path, self.conf.test_types[0])
+            if self.conf.test_components:
+                path_where_looks_for = os.path.join(path_where_looks_for, self.conf.test_components[0])
+                if self.conf.test_suites:
+                    path_where_looks_for = os.path.join(path_where_looks_for, self.conf.test_suites[0])
 
-        return None
+        return get_file_path_recursively(complete_module_name, path_where_looks_for)
 
     def check_module_exists(self, path):
         """Check that a module exists within the modules path input.

--- a/deps/wazuh_testing/wazuh_testing/qa_docs/lib/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_docs/lib/utils.py
@@ -227,7 +227,12 @@ def get_file_path_recursively(file_to_find, path):
     Returns:
         path (str): File path if exists within the given path, None otherwise.
     """
-    (root, folders, files) = next(os.walk(path))
+    try:
+        (root, folders, files) = next(os.walk(path))
+    except StopIteration:
+        # When iterates over it even after it has been exhausted
+        return
+
     for file in files:
         if file == file_to_find:
             return os.path.join(root, file)

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -155,7 +155,7 @@ def set_environment(parameters):
     # Create the wazuh_qa_ctl temporary folder
     recursive_directory_creation(os.path.join(gettempdir(), 'wazuh_qa_ctl'))
 
-    if parameters.run_test:
+    if parameters.run:
         # Download wazuh-qa repository locally to run qa-docs tool and get the tests info
         local_actions.download_local_wazuh_qa_repository(branch=parameters.qa_branch,
                                                          path=os.path.join(gettempdir(), 'wazuh_qa_ctl'))
@@ -172,10 +172,12 @@ def validate_parameters(parameters):
                       has not been released, or wazuh QA branch does not exist (calculated from wazuh_version).
     """
     def _validate_tests_os(parameters):
-        for test in parameters.run_test:
+        for type, component, suite, module in zip(parameters.test_types, parameters.test_components,
+                                                  parameters.test_suites, parameters.test_modules):
             tests_path = os.path.join(WAZUH_QA_FILES, 'tests')
-            test_documentation_command = f"qa-docs -I {tests_path} -t {test} -o {gettempdir()} --no-logging"
-            test_documentation_file_path = os.path.join(gettempdir(), f"{test}.json")
+            test_documentation_command = f"qa-docs -p {tests_path} -t {type} -c {component} -s {suite} -m {module} " \
+                                         f"-o {gettempdir()} --no-logging"
+            test_documentation_file_path = os.path.join(gettempdir(), f"{module}.json")
             local_actions.run_local_command_returning_output(test_documentation_command)
 
             test_data = json.loads(file.read_file(test_documentation_file_path))
@@ -185,27 +187,39 @@ def validate_parameters(parameters):
                 platform = QACTLConfigGenerator.SYSTEMS[op_system]['os_platform'] if op_system in \
                     QACTLConfigGenerator.SYSTEMS.keys() else op_system
                 if platform not in test_data['os_platform']:
-                    raise QAValueError(f"The {test} test does not support the {op_system} system. Allowed platforms: "
-                                       f"{test_data['os_platform']} (ubuntu and centos are from linux platform)")
+                    raise QAValueError(f"The {module} module does not support the {op_system} system. Allowed platforms:"
+                                       f" {test_data['os_platform']} (ubuntu and centos are from linux platform)")
                 # Check os version
                 if len([os_version.lower() for os_version in test_data['os_version'] if op_system in os_version]) > 0:
-                    raise QAValueError(f"The {test} test does not support the {op_system} system. Allowed operating "
-                                       f"system versions: {test_data['os_version']}")
+                    raise QAValueError(f"The {module} module does not support the {op_system} system. Allowed operating"
+                                       f" system versions: {test_data['os_version']}")
             # Clean the temporary files
             for extension in ['.json', '.yaml']:
-                file.remove_file(os.path.join(gettempdir(), f"{test}{extension}"))
+                file.remove_file(os.path.join(gettempdir(), f"{module}{extension}"))
 
     qactl_logger.info('Validating input parameters')
 
     # Check incompatible parameters
-    if parameters.config and parameters.run_test:
+    if parameters.config and parameters.run:
         raise QAValueError('The --run parameter is incompatible with --config. --run will autogenerate the '
                            'configuration', qactl_logger.error, QACTL_LOGGER)
 
-    if parameters.user_version and parameters.run_test is None:
+    if parameters.run and not (parameters.test_components and parameters.test_suites and parameters.test_modules):
+        raise QAValueError('The --run parameter needs the component, suite and module to run a test. You can specify '
+                           'them with --test-components, --test-suites and --test-modules.',
+                           qactl_logger.error, QACTL_LOGGER)
+
+    if len(parameters.test_types) != len(parameters.test_components) or  \
+       len(parameters.test_types) != len(parameters.test_suites) or \
+       len(parameters.test_types) != len(parameters.test_modules):
+        raise QAValueError('The parameters that specify the modules, suites, components, and types must have the same '
+                           'length: --test-types, --test-components, --test-suites and --test_modules.',
+                           qactl_logger.error, QACTL_LOGGER)
+
+    if parameters.user_version and parameters.run is None:
         raise QAValueError('The -v, --version parameter can only be used with -r, --run', qactl_logger.error)
 
-    if parameters.dry_run and parameters.run_test is None:
+    if parameters.dry_run and parameters.run is None:
         raise QAValueError('The --dry-run parameter can only be used with -r, --run', qactl_logger.error, QACTL_LOGGER)
 
     if (parameters.skip_deployment or parameters.skip_provisioning or parameters.skip_testing) \
@@ -229,23 +243,25 @@ def validate_parameters(parameters):
                            qactl_logger.error, QACTL_LOGGER)
 
     # Check if specified tests exist. Wazuh-qa repository needs to be downloaded locally before.
-    if parameters.run_test:
-        for test in parameters.run_test:
+    if parameters.run:
+        # cambiar el for para iterar sobre los 4 arrays
+        for type, component, suite, module in zip(parameters.test_types, parameters.test_components,
+                                                  parameters.test_suites, parameters.test_modules):
             tests_path = os.path.join(WAZUH_QA_FILES, 'tests')
             # Validate if the specified tests exist
-            check_test_exist = local_actions.run_local_command_returning_output(f"qa-docs -e {test} -I {tests_path} "
-                                                                                '--no-logging')
-            if f"{test} exists" not in check_test_exist:
-                raise QAValueError(f"{test} does not exist in {tests_path}", qactl_logger.error, QACTL_LOGGER)
+            exist_cmd = f"qa-docs -p {tests_path} -t {type} -c {component} -s {suite} -e {module} --no-logging"
+            check_test_exist = local_actions.run_local_command_returning_output(exist_cmd)
+            if f"{module} exists" not in check_test_exist:
+                raise QAValueError(f"{module} does not exist in {tests_path}", qactl_logger.error, QACTL_LOGGER)
 
             # Validate if the selected tests are documented
-            test_documentation_check = local_actions.run_local_command_returning_output(f"qa-docs -t {test} -I "
-                                                                                        f"{tests_path} "
-                                                                                        '--check-documentation '
-                                                                                        '--no-logging')
-            if f'{test} is not documented' in test_documentation_check:
-                raise QAValueError(f"{test} is not documented using qa-docs current schema", qactl_logger.error,
+            check_doc_cmd = f"qa-docs -p {tests_path} -t {type} -c {component} -s {suite} -m {module} --no-logging " \
+                            '--check-documentation'
+            test_documentation_check = local_actions.run_local_command_returning_output(check_doc_cmd)
+            if f'{module} is not documented' in test_documentation_check:
+                raise QAValueError(f"{module} is not documented using qa-docs current schema", qactl_logger.error,
                                    QACTL_LOGGER)
+
     # Validate the tests operating system compatibility if specified
     if parameters.operating_systems:
         _validate_tests_os(parameters)
@@ -282,7 +298,26 @@ def get_script_parameters():
                         help='Config generation mode. The test data will be processed and the configuration will be '
                              'generated without running anything.')
 
-    parser.add_argument('--run', '-r', type=str, action='store', required=False, nargs='+', dest='run_test',
+    # parser.add_argument('--run', '-r', type=str, action='store', required=False, nargs='+', dest='run_test',
+    #                     help='Independent run method. Specify a test or a list of tests to be run.')
+ 
+    parser.add_argument('--run', '-r', action='store_true',
+                        help='Independent run method. The tests that the use specified will be run.')
+
+    parser.add_argument('--test-types', type=str, action='store', required=False, nargs='+', dest='test_types',
+                        default=['integration'],
+                        help='Independent run method. Specify a test or a list of tests to be run.')
+
+    parser.add_argument('--test-components', type=str, action='store', required=False, nargs='+',
+                        dest='test_components', default=[],
+                        help='Independent run method. Specify a test or a list of tests to be run.')
+
+    parser.add_argument('--test-suites', type=str, action='store', required=False, nargs='+', dest='test_suites',
+                        default=[],
+                        help='Independent run method. Specify a test or a list of tests to be run.')
+
+    parser.add_argument('--test-modules', type=str, action='store', required=False, nargs='+', dest='test_modules',
+                        default=[],
                         help='Independent run method. Specify a test or a list of tests to be run.')
 
     parser.add_argument('--version', '-v', type=str, action='store', required=False, dest='version',
@@ -334,12 +369,23 @@ def main():
     if not arguments.no_validation:
         validate_parameters(arguments)
 
-    qa_ctl_mode = AUTOMATIC_MODE if arguments.run_test else MANUAL_MODE
+    qa_ctl_mode = AUTOMATIC_MODE if arguments.run else MANUAL_MODE
 
     # Generate or get the qactl configuration file
     if qa_ctl_mode == AUTOMATIC_MODE:
         qactl_logger.debug('Generating configuration file')
-        config_generator = QACTLConfigGenerator(arguments.run_test, arguments.version, arguments.qa_branch,
+        # cambiar run_test de config generator
+        # args = ['types', 'components', 'suites', 'modules']
+        modules_data = {'types': [], 'components': [], 'suites': [], 'modules': []}
+        # modules_data = dict(zip(args,[[] for x in range(0,len(args))]))
+        for type, component, suite, module in zip(arguments.test_types, arguments.test_components,
+                                                  arguments.test_suites, arguments.test_modules):
+            modules_data['types'].append(type)
+            modules_data['components'].append(component)
+            modules_data['suites'].append(suite)
+            modules_data['modules'].append(module)
+
+        config_generator = QACTLConfigGenerator(modules_data, arguments.version, arguments.qa_branch,
                                                 WAZUH_QA_FILES, arguments.operating_systems)
         config_generator.run()
         launched['config_generator'] = True
@@ -406,10 +452,10 @@ def main():
             if TEST_KEY in configuration_data and launched['test_runner']:
                 tests_runner.destroy()
 
-            if arguments.run_test and launched['config_generator']:
+            if arguments.run and launched['config_generator']:
                 config_generator.destroy()
         else:
-            if not RUNNING_ON_DOCKER_CONTAINER and arguments.run_test:
+            if not RUNNING_ON_DOCKER_CONTAINER and arguments.run:
                 qactl_logger.info(f"Configuration file saved in {config_generator.config_file_path}")
 
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_docs.py
@@ -190,28 +190,16 @@ def check_incompatible_parameters(parameters):
                                'using --tests-path',
                                qadocs_logger.error)
 
-        if parameters.test_exist:
-            raise QAValueError('The --types option is not compatible with -e(--exist)',
-                               qadocs_logger.error)
-
     if parameters.test_components:
         if parameters.tests_path is None and not parameters.run_with_docker:
             raise QAValueError('The --components option needs the path to the tests to be parsed. You must specify it '
                                'by using --tests-path',
                                qadocs_logger.error)
 
-        if parameters.test_exist:
-            raise QAValueError('The --components option is not compatible with -e(--exist)',
-                               qadocs_logger.error)
-
     if parameters.test_suites:
         if not parameters.test_components:
             raise QAValueError('The --suites option needs the suite module to be parsed. You must specify it '
                                'using --components',
-                               qadocs_logger.error)
-
-        if parameters.test_exist:
-            raise QAValueError('The --suites option is not compatible with -e(--exist)',
                                qadocs_logger.error)
 
     if parameters.test_modules:
@@ -341,7 +329,7 @@ def validate_parameters(parameters, parser):
                                        '--components with just one type if you want to parse some components within a '
                                        'test type.', qadocs_logger.error)
 
-        if parameters.test_modules:
+        if parameters.test_modules or parameters.test_exist:
             # If at least one module is specified
             if len(parameters.test_components) != 1:
                 raise QAValueError('The --modules option work swhen is only parsing a single test component. Use '
@@ -366,15 +354,16 @@ def validate_parameters(parameters, parser):
                         raise QAValueError(f"The given suite: {suite} has not been found in {component_path}",
                                            qadocs_logger.error)
 
-                suite_path = '' if not parameters.test_suites else parameters.test_suites[0]
+        if parameters.test_modules:
+            suite_path = '' if not parameters.test_suites else parameters.test_suites[0]
 
-                for module in parameters.test_modules:
-                    suite_path = os.path.join(component_path, suite_path)
-                    module_file = f"{module}.py"
-                    if module_file not in os.listdir(suite_path):
-                        if utils.get_file_path_recursively(module_file, suite_path) is None:
-                            raise QAValueError(f"The given module: {module_file} has not been found in {suite_path}",
-                                               qadocs_logger.error)
+            for module in parameters.test_modules:
+                suite_path = os.path.join(component_path, suite_path)
+                module_file = f"{module}.py"
+                if module_file not in os.listdir(suite_path):
+                    if utils.get_file_path_recursively(module_file, suite_path) is None:
+                        raise QAValueError(f"The given module: {module_file} has not been found in {suite_path}",
+                                           qadocs_logger.error)
 
     qadocs_logger.debug('Input parameters validation completed')
 
@@ -398,7 +387,18 @@ def run_searchui(index):
 def parse_data(args):
     """Parse the tests and collect the data."""
     if args.test_exist:
-        doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, '', test_modules=args.test_exist))
+
+        if args.test_suites:
+
+            # Looking for specified modules
+            doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types,
+                                            args.test_components, args.test_suites, args.test_exist),
+                                     OUTPUT_FORMAT)
+        else:
+
+            # Parse specified components
+            doc_check = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH, args.test_types,
+                                            args.test_components, test_modules=args.test_exist), OUTPUT_FORMAT)
 
         doc_check.check_module_exists(args.tests_path)
 
@@ -446,7 +446,7 @@ def parse_data(args):
             docs = DocGenerator(Config(SCHEMA_PATH, args.tests_path, OUTPUT_PATH), OUTPUT_FORMAT)
             docs.run()
 
-    if args.test_types or args.test_components or args.test_modules and not args.check_doc:
+    if (args.test_types or args.test_components or args.test_modules) and not (args.check_doc or args.test_exist):
         qadocs_logger.info('Running QADOCS')
         docs.run()
     elif args.test_modules and args.check_doc:


### PR DESCRIPTION
|Related issue|
|---|
|#2589|

## Description
This PR aims to update how `qa-ctl` uses `qa-docs` after the changes made in #2605 and #2633

This update has made the following changes:

### Changed

- Change the `-e, --exist` behavior using the new required parameters.
- Update the `qa-docs` command in `qa-ctl`

---

## Checks

- [x] `qa-ctl` creates the configuration file correctly
- [x] `qa-ctl` runs the module as expected
