### PR TITLE
System Test: Module (WAZUH-DB) - Agent registered with group Y (agent_authd - disconnected)

### DIFF
--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -31,7 +31,7 @@ def remove_cluster_agents(wazuh_master, agents_list, host_manager):
     agent_id = get_agent_id(host_manager)
     while (agent_id != ''):
         host_manager.get_host(wazuh_master).ansible("command", f'{WAZUH_PATH}/bin/manage_agents -r {agent_id}',
-                                                  check=False)
+                                                    check=False)
         agent_id = get_agent_id(host_manager)
     for agent in agents_list:
         host_manager.control_service(host=agent, service='wazuh', state="stopped")
@@ -70,5 +70,5 @@ def check_agent_groups(agent_id, group_to_check, hosts_list, host_manager):
 def check_agent_status(agent_id, agent_name, agent_ip, status, host_manager, hosts_list):
     # Check the agent has the expected status (never_connected, pending, active, disconnected)
     for host in hosts_list:
-        data= get_agents_in_cluster(host, host_manager)
+        data = get_agents_in_cluster(host, host_manager)
         assert f"{agent_id}  {agent_name}  {agent_ip}  {status}" in data

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -14,6 +14,8 @@ AGENT_STATUS_DISCONNECTED = 'disconnected'
 AGENT_NO_GROUPS = 'Null'
 
 
+# Error Messages
+ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND = f'Did not find the expected keys generated in the master node.'
 
 
 

--- a/tests/system/test_cluster/test_agent_groups/common.py
+++ b/tests/system/test_cluster/test_agent_groups/common.py
@@ -7,7 +7,8 @@ import time
 from wazuh_testing.tools import WAZUH_PATH
 from system import get_agent_id
 
-def register_agent(agent, agent_manager, host_manager):
+
+def register_agent(agent, agent_manager, host_manager, id_group=''):
     agent_ip = host_manager.run_command(agent, f'hostname -i')
     agent_name = "Agent-" + str(time.time())
 
@@ -16,10 +17,14 @@ def register_agent(agent, agent_manager, host_manager):
     host_manager.add_block_to_file(host=agent, path=f"{WAZUH_PATH}/etc/ossec.conf",
                                    after="<address>", before="</address>", replace=manager_ip)
 
-    # Add agent to Master/Worker using agent-auth tool  
-    host_manager.run_command(agent, 
-                             f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip}')
+    # Add agent to Master/Worker using agent-auth tool
+    if(id_group == ''):
+        host_manager.run_command(agent,
+                                 f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip}')
+    else:
+        host_manager.run_command(agent,
+                                 f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip} -G {id_group}')
 
     agent_id = get_agent_id(host_manager)
-    
+
     return [agent_ip, agent_id, agent_name, manager_ip]

--- a/tests/system/test_cluster/test_agent_groups/common.py
+++ b/tests/system/test_cluster/test_agent_groups/common.py
@@ -25,7 +25,6 @@ def register_agent(agent, agent_manager, host_manager, id_group=''):
         host_manager.run_command(agent,
                                  f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip} -G {id_group}')
 
-
     agent_id = get_id_from_agent(agent, host_manager)
 
     return [agent_ip, agent_id, agent_name, manager_ip]

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -114,4 +114,4 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
 
     finally:
         # Delete group of agent
-        delete_group_of_agents('wazuh-master', 'group_test', host_manager)
+        delete_group_of_agents('wazuh-master', id_group, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -1,0 +1,115 @@
+"""
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+type: system
+brief: Check that when an agent with status never_connected, pointing to a master/worker node is
+       registered using agent-auth with a group the change is sync with the cluster.
+tier: 0
+modules:
+    - cluster
+components:
+    - manager
+    - agent
+path: /tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+daemons:
+    - wazuh-db
+    - wazuh-clusterd
+os_platform:
+    - linux
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+references:
+    - https://github.com/wazuh/wazuh-qa/issues/2508
+tags:
+    - cluster
+"""
+
+
+import os
+
+import pytest
+from wazuh_testing.tools.system import HostManager
+from system import (check_agent_groups, check_agent_status, clean_cluster_logs,
+                    check_keys_file, delete_group_of_agents,
+                    remove_cluster_agents)
+from common import register_agent
+
+
+# Hosts
+test_infra_managers = ["wazuh-master", "wazuh-worker1", "wazuh-worker2"]
+test_infra_agents = ["wazuh-agent1"]
+
+inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                              'provisioning', 'enrollment_cluster', 'inventory.yml')
+host_manager = HostManager(inventory_path)
+local_path = os.path.dirname(os.path.abspath(__file__))
+tmp_path = os.path.join(local_path, 'tmp')
+id_group = 'group_test'
+
+
+@pytest.fixture(scope='function')
+def clean_environment():
+
+    clean_cluster_logs(test_infra_agents + test_infra_managers, host_manager)
+
+    yield
+    # Remove the agent once the test has finished
+    remove_cluster_agents(test_infra_managers[0], test_infra_agents, host_manager)
+
+
+@pytest.mark.parametrize("agent_target", ['wazuh-master', 'wazuh-worker1'])
+def test_assign_agent_to_a_group(agent_target, clean_environment):
+    '''
+    description: Check that when an agent with status never_connected, pointing to a master/worker node is
+                 registered using agent-auth with a group the change is sync with the cluster.
+    wazuh_min_version: 4.4.0
+    parameters:
+        - agent_target:
+            type: string
+            brief: name of the host where the agent will register
+        - clean_enviroment:
+            type: fixture
+            brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
+    assertions:
+        - Verify that after registering the agent key file exists in all nodes.
+        - Verify that after registering the agent appears as never_connected in all nodes.
+        - Verify that after registering it has the 'group_test' group assigned.
+    expected_output:
+        - The agent 'Agent_name' with ID 'Agent_id' belongs to groups: group_test."
+    '''
+
+    # Create group with agent_groups
+    host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -a -g {id_group}")
+
+    # Register agent with agent-auth
+    agent_ip, agent_id, agent_name, manager_ip = register_agent(test_infra_agents[0], agent_target,
+                                                                host_manager, id_group)
+
+    # Check that agent status is never_connected in cluster
+    check_agent_status(agent_id, agent_name, agent_ip, 'never_connected', host_manager, test_infra_managers)
+
+    # Check that agent has group set to group_test on Managers
+    check_agent_groups(agent_id, id_group, test_infra_managers, host_manager)
+
+    # Check that agent has client key file
+    assert check_keys_file(test_infra_agents[0], host_manager)
+
+    # Delete group of agent
+    delete_group_of_agents('wazuh-master', 'group_test', host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -95,21 +95,23 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
         - The agent 'Agent_name' with ID 'Agent_id' belongs to groups: group_test."
     '''
 
-    # Create group with agent_groups
-    host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -a -g {id_group}")
+    try:
+        # Create group with agent_groups
+        host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -a -g {id_group}")
 
-    # Register agent with agent-auth
-    agent_ip, agent_id, agent_name, manager_ip = register_agent(test_infra_agents[0], agent_target,
-                                                                host_manager, id_group)
+        # Register agent with agent-auth
+        agent_ip, agent_id, agent_name, manager_ip = register_agent(test_infra_agents[0], agent_target,
+                                                                    host_manager, id_group)
 
-    # Check that agent status is never_connected in cluster
-    check_agent_status(agent_id, agent_name, agent_ip, 'never_connected', host_manager, test_infra_managers)
+        # Check that agent status is never_connected in cluster
+        check_agent_status(agent_id, agent_name, agent_ip, 'never_connected', host_manager, test_infra_managers)
 
-    # Check that agent has group set to group_test on Managers
-    check_agent_groups(agent_id, id_group, test_infra_managers, host_manager)
+        # Check that agent has group set to group_test on Managers
+        check_agent_groups(agent_id, id_group, test_infra_managers, host_manager)
 
-    # Check that agent has client key file
-    assert check_keys_file(test_infra_agents[0], host_manager)
+        # Check that agent has client key file
+        assert check_keys_file(test_infra_agents[0], host_manager)
 
-    # Delete group of agent
-    delete_group_of_agents('wazuh-master', 'group_test', host_manager)
+    finally:
+        # Delete group of agent
+        delete_group_of_agents('wazuh-master', 'group_test', host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -45,7 +45,7 @@ import pytest
 
 from common import register_agent
 from system import (check_agent_groups, check_agent_status, check_keys_file, delete_group_of_agents,
-                    AGENT_STATUS_NEVER_CONNECTED)
+                    AGENT_STATUS_NEVER_CONNECTED, ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND)
 from wazuh_testing.tools.system import HostManager
 
 
@@ -110,7 +110,7 @@ def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_man
         check_agent_groups(agent_id, id_group, test_infra_managers, host_manager)
 
         # Check that agent has client key file
-        assert check_keys_file(test_infra_agents[0], host_manager), f'Did not find the expected keys generated in the master node.'
+        assert check_keys_file(test_infra_agents[0], host_manager), ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND
 
     finally:
         # Delete group of agent

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -40,16 +40,13 @@ references:
 tags:
     - cluster
 """
-
-
 import os
 
 import pytest
-from wazuh_testing.tools.system import HostManager
-from system import (check_agent_groups, check_agent_status, clean_cluster_logs,
-                    check_keys_file, delete_group_of_agents,
-                    remove_cluster_agents)
+
 from common import register_agent
+from system import check_agent_groups, check_agent_status, check_keys_file, delete_group_of_agents
+from wazuh_testing.tools.system import HostManager
 
 
 # Hosts
@@ -64,18 +61,12 @@ tmp_path = os.path.join(local_path, 'tmp')
 id_group = 'group_test'
 
 
-@pytest.fixture(scope='function')
-def clean_environment():
-
-    clean_cluster_logs(test_infra_agents + test_infra_managers, host_manager)
-
-    yield
-    # Remove the agent once the test has finished
-    remove_cluster_agents(test_infra_managers[0], test_infra_agents, host_manager)
-
-
+# Tests
+@pytest.mark.parametrize("test_infra_managers",[test_infra_managers])
+@pytest.mark.parametrize("test_infra_agents",[test_infra_agents])
+@pytest.mark.parametrize("host_manager",[host_manager])
 @pytest.mark.parametrize("agent_target", ['wazuh-master', 'wazuh-worker1'])
-def test_assign_agent_to_a_group(agent_target, clean_environment):
+def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_managers, test_infra_agents, host_manager):
     '''
     description: Check that when an agent with status never_connected, pointing to a master/worker node is
                  registered using agent-auth with a group the change is sync with the cluster.
@@ -87,6 +78,15 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
         - clean_enviroment:
             type: fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
+        - test_infra_managers
+            type: List
+            brief: list of manager hosts in enviroment
+        - test_infra_managers
+            type: List
+            brief: list of agent hosts in enviroment
+        - host_manager
+            type: HostManager object
+            brief: handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering the agent appears as never_connected in all nodes.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -41,11 +41,11 @@ tags:
     - cluster
 """
 import os
-
 import pytest
 
 from common import register_agent
-from system import check_agent_groups, check_agent_status, check_keys_file, delete_group_of_agents
+from system import (check_agent_groups, check_agent_status, check_keys_file, delete_group_of_agents,
+                    AGENT_STATUS_NEVER_CONNECTED)
 from wazuh_testing.tools.system import HostManager
 
 
@@ -104,13 +104,13 @@ def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_man
                                                                     host_manager, id_group)
 
         # Check that agent status is never_connected in cluster
-        check_agent_status(agent_id, agent_name, agent_ip, 'never_connected', host_manager, test_infra_managers)
+        check_agent_status(agent_id, agent_name, agent_ip, AGENT_STATUS_NEVER_CONNECTED, host_manager, test_infra_managers)
 
         # Check that agent has group set to group_test on Managers
         check_agent_groups(agent_id, id_group, test_infra_managers, host_manager)
 
         # Check that agent has client key file
-        assert check_keys_file(test_infra_agents[0], host_manager)
+        assert check_keys_file(test_infra_agents[0], host_manager), f'Did not find the expected keys generated in the master node.'
 
     finally:
         # Delete group of agent

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -81,7 +81,7 @@ def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_man
         - test_infra_managers
             type: List
             brief: list of manager hosts in enviroment
-        - test_infra_managers
+        - test_infra_agents
             type: List
             brief: list of agent hosts in enviroment
         - host_manager


### PR DESCRIPTION
In this PR the test suite for `Agent registered with group Y (agent_authd - disconnected)`  is added. A total of 2 new test cases covering different modes and combinations of options.

<table>
  <tr>
    <th>Related issues</th>
    <th><a href="[url](https://github.com/wazuh/wazuh-qa/issues/2507)">#2508</a></th>
    <th><a href="[url](https://github.com/wazuh/wazuh/issues/10771)">#10771</a></th>
  </tr>
</table>

## Cases:

- [x] Agent registered with group Y (agent_authd - disconnected):
        - The agent is never_connected and registers with group  to the master node using agent-auth
        - The agent is never_connected and registers with group  to the worker node using agent-auth

--- 

## Configuration options
In order to run the test, first the environment located in `/test/system/provisioning/enrollment_cluster` must be enabled with:
`sudo ansible-playbook -i inventory.yml playbook.yml --extra-vars='{"wazuh_branch": "dev-10771-agent-groups-files-to-wazuh-db"}'`

**Local Internal Options:** No Local Internal Options used

---

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
| test/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py  | CentOS - Manager | Local | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8215151/R1.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/8215152/R2.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/8215154/R3.zip)| 09/03/2022 |  @CamiRomero  | 

---
## Required
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
