### PR TITLE
 Prevent Analysisd from failing on missing rule dependencies - Backport to 4.3

### DIFF
--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_11.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_11.xml
@@ -1,7 +1,7 @@
 <!-- Test: non existing group in if_group -->
 <group name="testing">
 
-    <rule id="100001" level="3">
+    <rule id="100002" level="3">
     <if_group>non_existing_group</if_group>
     <description>Non existing group description</description>
     </rule>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_8.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_rule_8.xml
@@ -1,11 +1,6 @@
 <!-- Test:  if_matched_sid attribute without frequency and timeframe -->
 <group name="testing">
 
-    <rule id="100001" level="3">
-    <program_name>example</program_name>
-    <description>example_description</description>
-    </rule>
-
     <rule id="100002" level="5">
     <if_matched_sid>100005</if_matched_sid>
     <description>example if_matched_sid without existig rule and frequency/timeframe</description>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
@@ -32,8 +32,8 @@
   rules: "custom_rule_4.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "Overwrite rule '123123' not found."
-  output_data_codemsg: -1
+  output_data_msg: "Rule ID '123123' does not exist but 'overwrite' is set to 'yes'. Still, the rule will be loaded."
+  output_data_codemsg: 1
 -
   name: "Invalid rules syntax: same_* attribute without frequency and timeframe"
   rules: "custom_rule_5.xml"
@@ -53,15 +53,15 @@
   rules: "custom_rule_7.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "rules_list: Signature ID '123123' not found. Invalid 'if_sid'."
-  output_data_codemsg: -1
+  output_data_msg: "Signature ID '123123' was not found. Invalid 'if_sid'. Rule '100001' will be ignored."
+  output_data_codemsg: 1
 -
   name: "Invalid rules syntax: no existing if_matched_sid rule number attribute without frequency and timeframe"
   rules: "custom_rule_8.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "rules_list: Signature ID '100005' not found. Invalid 'if_sid'."
-  output_data_codemsg: -1
+  output_data_msg: "Signature ID '100005' was not found. Invalid 'if_matched_sid'. Rule '100002' will be ignored."
+  output_data_codemsg: 1
 -
   name: "Invalid rules syntax: non existing/invalid attribute"
   rules: "custom_rule_9.xml"
@@ -81,8 +81,8 @@
   rules: "custom_rule_11.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "rules_list: Group 'non_existing_group' not found. Invalid 'if_group'."
-  output_data_codemsg: -1
+  output_data_msg: "Group 'non_existing_group' was not found. Invalid 'if_group'. Rule '100002' will be ignored."
+  output_data_codemsg: 1
 -
   name: "Invalid rules syntax: invalid values on option attribute"
   rules: "custom_rule_12.xml"


### PR DESCRIPTION
Related issue|
|---|
|close #2655|


### Wazuh version
| Branch| Commit |
|---|---|
| https://github.com/wazuh/wazuh/tree/12641-backport-refactor-rules-loading-when-error | https://github.com/wazuh/wazuh/commit/be73ac7a9faa4b7470bed8fda7ca7e3bcefabcda|


## Testing

### Module 1

|  OS  | Local | Notes
|---    |---    |---|
| R1   | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/23081/console)   | 

* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress






## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.