### PR TITLE
System Test: Module (WAZUH-DB) - Agent never_connected is added to a group with tool after the sync completes

### DIFF
--- a/tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
@@ -1,0 +1,127 @@
+"""
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+type: system
+brief: Check that when an agent with status never_connected, pointing to a master/worker node is
+       registered using agent-auth and when aasing to a group with agent-group, the change is sync
+       with the cluster.
+tier: 1
+modules:
+    - cluster
+components:
+    - manager
+    - agent
+path: /tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
+daemons:
+    - wazuh-db
+    - wazuh-clusterd
+os_platform:
+    - linux
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+references:
+    - https://github.com/wazuh/wazuh-qa/issues/2508
+tags:
+    - cluster
+"""
+
+
+import os
+
+import pytest
+from wazuh_testing.tools.system import HostManager
+from system import (check_agent_groups, check_agent_status, clean_cluster_logs,
+                    check_keys_file, delete_group_of_agents,
+                    remove_cluster_agents, assign_agent_to_new_group)
+from common import register_agent
+import time
+
+
+# Hosts
+test_infra_managers = ["wazuh-master", "wazuh-worker1", "wazuh-worker2"]
+test_infra_agents = ["wazuh-agent1"]
+
+inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                              'provisioning', 'enrollment_cluster', 'inventory.yml')
+host_manager = HostManager(inventory_path)
+local_path = os.path.dirname(os.path.abspath(__file__))
+tmp_path = os.path.join(local_path, 'tmp')
+group_id = 'group_test'
+
+
+@pytest.fixture(scope='function')
+def clean_environment():
+
+    clean_cluster_logs(test_infra_agents + test_infra_managers, host_manager)
+
+    yield
+    # Remove the agent once the test has finished
+    remove_cluster_agents(test_infra_managers[0], test_infra_agents, host_manager)
+
+
+@pytest.mark.parametrize("agent_target", ['wazuh-worker1'])
+def test_assign_agent_to_a_group(agent_target, clean_environment):
+    '''
+    description: Check that when an agent with status never_connected, pointing to a master/worker node is
+                 registered using agent-auth and when aasing to a group with agent-group, the change is sync
+                with the cluster.
+    wazuh_min_version: 4.4.0
+    parameters:
+        - agent_target:
+            type: string
+            brief: name of the host where the agent will register
+        - clean_enviroment:
+            type: fixture
+            brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
+    assertions:
+        - Verify that after registering the agent key file exists in all nodes.
+        - Verify that after registering the agent appears as never_connected in all nodes.
+        - Verify that after registering it has the 'Null' group assigned.
+        - Verify that after assign group with agent-groups the change is sync with the cluster.
+    expected_output:
+        - The agent 'Agent_name' with ID 'Agent_id' belongs to groups: group_test."
+    '''
+
+    # Register agent with agent-auth
+    agent_ip, agent_id, agent_name, manager_ip = register_agent(test_infra_agents[0], agent_target,
+                                                                host_manager)
+
+    # Check that agent has client key file
+    assert check_keys_file(test_infra_agents[0], host_manager)
+
+    # Check that agent status is never_connected in cluster
+    check_agent_status(agent_id, agent_name, agent_ip, 'never_connected', host_manager, test_infra_managers)
+
+    
+    # Check that agent has group set to Null on Managers
+    check_agent_groups(agent_id, 'Null', test_infra_managers, host_manager)
+
+    try:
+        # Add group to agent1
+        assign_agent_to_new_group(test_infra_managers[0], group_id, agent_id, host_manager)
+
+        time.sleep(10)
+        # Check that agent has group set to group_test on Managers
+        check_agent_groups(agent_id, group_id, test_infra_managers, host_manager)
+
+
+    finally:
+        # Delete group of agent
+        delete_group_of_agents(test_infra_managers[0], group_id, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
@@ -109,7 +109,6 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
     # Check that agent status is never_connected in cluster
     check_agent_status(agent_id, agent_name, agent_ip, 'never_connected', host_manager, test_infra_managers)
 
-    
     # Check that agent has group set to Null on Managers
     check_agent_groups(agent_id, 'Null', test_infra_managers, host_manager)
 
@@ -120,7 +119,6 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
         time.sleep(10)
         # Check that agent has group set to group_test on Managers
         check_agent_groups(agent_id, group_id, test_infra_managers, host_manager)
-
 
     finally:
         # Delete group of agent

--- a/tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_never_connected_change_groups.py
@@ -37,7 +37,7 @@ os_version:
     - Red Hat 7
     - Red Hat 6
 references:
-    - https://github.com/wazuh/wazuh-qa/issues/2508
+    - https://github.com/wazuh/wazuh-qa/issues/2513
 tags:
     - cluster
 """
@@ -76,7 +76,7 @@ def clean_environment():
     remove_cluster_agents(test_infra_managers[0], test_infra_agents, host_manager)
 
 
-@pytest.mark.parametrize("agent_target", ['wazuh-worker1'])
+@pytest.mark.parametrize("agent_target", ['wazuh-master', 'wazuh-worker1'])
 def test_assign_agent_to_a_group(agent_target, clean_environment):
     '''
     description: Check that when an agent with status never_connected, pointing to a master/worker node is


### PR DESCRIPTION
In this PR the test suite for `Agent never_connected is added to a group with tool after the sync completes`  is added. A total of 2 new test cases covering different modes and combinations of options.

<table>
  <tr>
    <th>Related issues</th>
    <th><a href="[url](https://github.com/wazuh/wazuh-qa/issues/2513)">#2513</a></th>
    <th><a href="[url](https://github.com/wazuh/wazuh/issues/10771)">#10771</a></th>
  </tr>
</table>

## Cases:

- [x] Agent registered with group Y (agent_authd - disconnected):
        - The agent is never_connected and registers with group  to the master node using CLI
        - The agent is never_connected and registers with group  to the worker node using CLI

--- 

## Configuration options
In order to run the test, first the environment located in `/test/system/provisioning/enrollment_cluster` must be enabled with:
`sudo ansible-playbook -i inventory.yml playbook.yml --extra-vars='{"wazuh_branch": "dev-10771-agent-groups-files-to-wazuh-db"}'`

**Local Internal Options:** No Local Internal Options used

---

---

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
| test/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py  | CentOS - Manager | Local | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8216948/R1.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/8216952/R2.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/8216964/R3.zip)| 09/03/2022 |  @CamiRomero  | 

---
## Required
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.