### PR TITLE
System Test: Module (WAZUH-DB) - Adds a new node to a synchronized environment

### DIFF
--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -32,7 +32,7 @@ def remove_cluster_agents(wazuh_master, agents_list, host_manager):
     while (agent_id != ''):
         host_manager.get_host(wazuh_master).ansible("command", f'{WAZUH_PATH}/bin/manage_agents -r {agent_id}',
                                                   check=False)
-    agent_id = get_agent_id(host_manager)
+        agent_id = get_agent_id(host_manager)
     for agent in agents_list:
         host_manager.control_service(host=agent, service='wazuh', state="stopped")
         host_manager.clear_file(agent, file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -66,6 +66,8 @@ def check_agent_groups(agent_id, group_to_check, hosts_list, host_manager):
     # Check the expected group is in the group data for the agent
     for host in hosts_list:
         group_data = host_manager.run_command(host, f'{WAZUH_PATH}/bin/agent_groups -s -i {agent_id}')
+        print("------GROUP DATA----------" + host)
+        print(group_data)
         assert group_to_check in group_data
 
 
@@ -73,4 +75,6 @@ def check_agent_status(agent_id, agent_name, agent_ip, status, host_manager, hos
     # Check the agent has the expected status (never_connected, pending, active, disconnected)
     for host in hosts_list:
         data= get_agents_in_cluster(host, host_manager)
+        print("-------------------")
+        print(data)
         assert f"{agent_id}  {agent_name}  {agent_ip}  {status}" in data

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -74,8 +74,6 @@ def check_agent_groups(agent_id, group_to_check, hosts_list, host_manager):
     # Check the expected group is in the group data for the agent
     for host in hosts_list:
         group_data = host_manager.run_command(host, f'{WAZUH_PATH}/bin/agent_groups -s -i {agent_id}')
-        print("------GROUP DATA----------" + host)
-        print(group_data)
         assert group_to_check in group_data
 
 
@@ -83,8 +81,6 @@ def check_agent_status(agent_id, agent_name, agent_ip, status, host_manager, hos
     # Check the agent has the expected status (never_connected, pending, active, disconnected)
     for host in hosts_list:
         data= get_agents_in_cluster(host, host_manager)
-        print("-------------------")
-        print(data)
         assert f"{agent_id}  {agent_name}  {agent_ip}  {status}" in data
 
 

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -10,6 +10,8 @@ from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH
 def get_agent_id(host_manager):
     return host_manager.run_command('wazuh-master', f'cut -c 1-3 {WAZUH_PATH}/etc/client.keys')
 
+def get_id_from_agent(agent, host_manager):
+    return host_manager.run_command(agent, f'cut -c 1-3 {WAZUH_PATH}/etc/client.keys')
 
 def restart_cluster(hosts_list, host_manager):
     # Restart the cluster's hosts

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -7,6 +7,10 @@ import os
 from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH
 
 
+def get_agent_id(host_manager):
+    return host_manager.run_command('wazuh-master', f'cut -c 1-3 {WAZUH_PATH}/etc/client.keys')
+
+
 def restart_cluster(hosts_list, host_manager):
     # Restart the cluster's hosts
     for host in hosts_list:
@@ -23,8 +27,15 @@ def clean_cluster_logs(hosts_list, host_manager):
             host_manager.clear_file(host=host, file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
 
 
-def get_agent_id(host_manager):
-    return host_manager.run_command('wazuh-master', f'cut -c 1-3 {WAZUH_PATH}/etc/client.keys')
+def remove_cluster_agents(wazuh_master, agents_list, host_manager):
+    agent_id = get_agent_id(host_manager)
+    while (agent_id != ''):
+        host_manager.get_host(wazuh_master).ansible("command", f'{WAZUH_PATH}/bin/manage_agents -r {agent_id}',
+                                                  check=False)
+    agent_id = get_agent_id(host_manager)
+    for agent in agents_list:
+        host_manager.control_service(host=agent, service='wazuh', state="stopped")
+        host_manager.clear_file(agent, file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
 
 
 def get_agents_in_cluster(host, host_manager):
@@ -47,3 +58,17 @@ def assign_agent_to_new_group(host, id_group, id_agent, host_manager):
 def delete_group_of_agents(host, id_group, host_manager):
     # Delete group
     host_manager.run_command(host, f"/var/ossec/bin/agent_groups -q -r -g {id_group}")
+
+
+def check_agent_groups(agent_id, group_to_check, hosts_list, host_manager):
+    # Check the expected group is in the group data for the agent
+    for host in hosts_list:
+        group_data = host_manager.run_command(host, f'{WAZUH_PATH}/bin/agent_groups -s -i {agent_id}')
+        assert group_to_check in group_data
+
+
+def check_agent_status(agent_id, agent_name, agent_ip, status, host_manager, hosts_list):
+    # Check the agent has the expected status (never_connected, pending, active, disconnected)
+    for host in hosts_list:
+        data= get_agents_in_cluster(host, host_manager)
+        assert f"{agent_id}  {agent_name}  {agent_ip}  {status}" in data

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -105,7 +105,7 @@ def check_agents_status_in_node(agent_expected_status_list, host, host_manager):
     # List format: [f"{agent_id}  {agent_name}  {agent_ip}  {status}",...]
     data = get_agents_in_cluster(host, host_manager)
     for status in agent_expected_status_list:
-        assert status in data
+        assert status in data, f"Didn't recieve the agent status: {status} in the node's data: {data}"
 
 
 def change_agent_group_with_wdb(agent_id, new_group, host, host_manager):

--- a/tests/system/provisioning/four_manager_disconnected_node/README.md
+++ b/tests/system/provisioning/four_manager_disconnected_node/README.md
@@ -1,0 +1,93 @@
+# wazuh-qa
+
+Wazuh - Cluster provisioning
+
+## Setting up the provisioning
+
+To run this provisioning we need to use a **Linux** machine and install the following tools:
+
+- [Docker](https://docs.docker.com/install/)
+- [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+
+## Structure
+
+```bash
+four_manager_disconnected_node
+├── ansible.cfg
+├── destroy.yml
+├── inventory.yml
+├── playbook.yml
+├── README.md
+├── roles
+│   ├── agent-role
+│   │   ├── files
+│   │   │   └── ossec.conf
+│   │   └── tasks
+│   │       └── main.yml
+│   ├── master-role
+│   │   ├── files
+│   │   │   └── ossec.conf
+│   │   └── tasks
+│   │       └── main.yml
+│   └── worker-role
+│       ├── files
+│       │   └── ossec.conf
+│       └── tasks
+│           └── main.yml
+└── vars
+    ├── configurations.yml
+    └── main.yml
+```
+
+#### ansible.cfg
+
+Ansible configuration file in the current directory. In this file, we setup the configuration of Ansible for this
+provisioning.
+
+#### destroy.yml
+
+In this file we will specify that we want to shut down the docker machines in our environment.
+
+##### inventory.yml
+
+File containing the inventory of machines in our environment. In this file we will set the connection method and its
+python interpreter
+
+##### playbook.yml
+
+Here we will write the commands to be executed in order to use our environment
+
+##### roles
+
+Folder with all the general roles that could be used for start our environment. Within each role we can find the
+following structure:
+
+- **files**: Configuration files to be applied when the environment is setting up.
+- **tasks**: Main tasks to be performed for each role
+
+#### Vars
+
+This folder contains the variables used to configure our environment. Variables like the cluster key or the agent key.
+
+## Environment
+
+The base environment defined for Docker provisioning is
+
+- A master node
+- Two workers nodes
+- Three agents, all connected to master manager.
+- A fourth manager is created that can be later connected to the cluster.
+
+## Environment management
+
+For running the docker provisioning we must execute the following command:
+
+```shell script
+ansible-playbook -i inventory.yml playbook.yml --extra-vars='{"wazuh_branch": "PUT YOUT wazuh/wazuh BRANCH HERE"}'
+```
+
+To destroy it, the command is:
+
+```shell script
+ansible-playbook -i inventory.yml destroy.yml
+```

--- a/tests/system/provisioning/four_manager_disconnected_node/README.md
+++ b/tests/system/provisioning/four_manager_disconnected_node/README.md
@@ -51,11 +51,11 @@ In this file we will specify that we want to shut down the docker machines in ou
 ##### inventory.yml
 
 File containing the inventory of machines in our environment. In this file we will set the connection method and its
-python interpreter
+python interpreter.
 
 ##### playbook.yml
 
-Here we will write the commands to be executed in order to use our environment
+Here we will write the commands to be executed in order to use our environment.
 
 ##### roles
 
@@ -63,7 +63,7 @@ Folder with all the general roles that could be used for start our environment. 
 following structure:
 
 - **files**: Configuration files to be applied when the environment is setting up.
-- **tasks**: Main tasks to be performed for each role
+- **tasks**: Main tasks to be performed for each role.
 
 #### Vars
 
@@ -71,10 +71,10 @@ This folder contains the variables used to configure our environment. Variables 
 
 ## Environment
 
-The base environment defined for Docker provisioning is
+The base environment defined for Docker provisioning is:
 
-- A master node
-- Two workers nodes
+- A master node.
+- Two workers nodes.
 - Three agents, all connected to master manager.
 - A fourth manager is created that can be later connected to the cluster.
 
@@ -86,7 +86,7 @@ For running the docker provisioning we must execute the following command:
 ansible-playbook -i inventory.yml playbook.yml --extra-vars='{"wazuh_branch": "PUT YOUT wazuh/wazuh BRANCH HERE"}'
 ```
 
-To destroy it, the command is:
+To destroy it,  we must execute the following command:
 
 ```shell script
 ansible-playbook -i inventory.yml destroy.yml

--- a/tests/system/provisioning/four_manager_disconnected_node/ansible.cfg
+++ b/tests/system/provisioning/four_manager_disconnected_node/ansible.cfg
@@ -1,0 +1,12 @@
+[defaults]
+hash_behaviour = merge
+gather_timeout = 300
+stdout_callback = yaml
+callback_whitelist = profile_tasks, timer, mail
+timeout = 60
+log_path = ./ansible.log
+
+[ssh_connection]
+ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+pipelining = True
+retries = 10

--- a/tests/system/provisioning/four_manager_disconnected_node/destroy.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/destroy.yml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  tasks:
+  - docker_container:
+      name: wazuh-master
+      state: absent
+      force_kill: yes
+  - docker_container:
+      name: wazuh-worker1
+      state: absent
+      force_kill: yes
+  - docker_container:
+      name: wazuh-worker2
+      state: absent
+      force_kill: yes
+  - docker_container:
+      name: wazuh-worker2
+      state: absent
+      force_kill: yes
+  - docker_container:
+      name: wazuh-agent1
+      state: absent
+      force_kill: yes
+  - docker_container:
+      name: wazuh-agent2
+      state: absent
+      force_kill: yes
+  - docker_container:
+      name: wazuh-agent3
+      state: absent
+      force_kill: yes

--- a/tests/system/provisioning/four_manager_disconnected_node/destroy.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/destroy.yml
@@ -14,7 +14,7 @@
       state: absent
       force_kill: yes
   - docker_container:
-      name: wazuh-worker2
+      name: wazuh-worker3
       state: absent
       force_kill: yes
   - docker_container:

--- a/tests/system/provisioning/four_manager_disconnected_node/inventory.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/inventory.yml
@@ -1,0 +1,64 @@
+all:
+  hosts:
+    wazuh-master:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker1:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker2:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker3:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-agent1:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-agent2:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-agent3:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+managers:
+  hosts:
+    wazuh-master:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker1:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker2:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker3:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+master:
+  hosts:
+    wazuh-master:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+workers:
+  hosts:
+    wazuh-worker1:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker2:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-worker3:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+agents:
+  hosts:
+    wazuh-agent1:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-agent2:
+      ansible_connection: docker
+      ansible_python_interpreter: python
+    wazuh-agent3:
+      ansible_connection: docker
+      ansible_python_interpreter: python

--- a/tests/system/provisioning/four_manager_disconnected_node/playbook.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/playbook.yml
@@ -1,0 +1,162 @@
+---
+- name: Create our container (Master)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - name: Create a network
+      docker_network:
+        name: "{{ docker_network }}"
+    - docker_container:
+        name: "{{ master_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ master_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Create our container (Worker1)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - docker_container:
+        name: "{{ worker1_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ worker1_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Create our container (Worker2)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - docker_container:
+        name: "{{ worker2_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ worker2_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Create our container (Worker3)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - docker_container:
+        name: "{{ worker3_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ worker3_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Create our container (Agent1)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - docker_container:
+        name: "{{ agent1_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ agent1_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Create our container (Agent2)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - docker_container:
+        name: "{{ agent2_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ agent2_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Create our container (Agent3)
+  hosts: localhost
+  vars_files:
+    - ./vars/configurations.yml
+  tasks:
+    - docker_container:
+        name: "{{ agent3_hostname }}"
+        image: "{{ image }}"
+        hostname: "{{ agent3_hostname }}"
+        networks:
+          - name: "{{ docker_network }}"
+
+- name: Wazuh Master
+  hosts: wazuh-master
+  vars:
+    master_hostname: "wazuh-master"
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/master-role"
+
+- name: Wazuh Worker1
+  hosts: wazuh-worker1
+  vars:
+    worker_name: wazuh-worker1
+    restart_command: "{{restart_command}}"
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/worker-role"
+
+- name: Wazuh Worker2
+  hosts: wazuh-worker2
+  vars:
+    worker_name: wazuh-worker2
+    restart_command: "{{restart_command}}"
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/worker-role"
+
+- name: Wazuh Worker3
+  hosts: wazuh-worker3
+  vars:
+    worker_name: wazuh-worker3
+    restart_command: ""
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/worker-role"
+
+- name: Wazuh Agent1
+  hosts: wazuh-agent1
+  vars:
+    manager_hostname: wazuh-master
+    agent_id: "{{ agent1_id }}"
+    agent_hostname: "{{ agent1_hostname }}"
+    agent_key: "{{ agent1_key }}"
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/agent-role"
+
+- name: Wazuh Agent2
+  hosts: wazuh-agent2
+  vars:
+    manager_hostname: wazuh-master
+    agent_id: "{{ agent2_id }}"
+    agent_hostname: "{{ agent2_hostname }}"
+    agent_key: "{{ agent2_key }}"
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/agent-role"
+
+- name: Wazuh Agent3
+  hosts: wazuh-agent3
+  vars:
+    manager_hostname: wazuh-master
+    agent_id: "{{ agent3_id }}"
+    agent_hostname: "{{ agent3_hostname }}"
+    agent_key: "{{ agent3_key }}"
+  vars_files:
+    - ./vars/configurations.yml
+  roles:
+    - name: "roles/agent-role"

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/agent-role/files/ossec.conf
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/agent-role/files/ossec.conf
@@ -1,0 +1,170 @@
+<!--
+  Wazuh - Agent - Default configuration for debian 10
+  More info at: https://documentation.wazuh.com
+  Mailing list: https://groups.google.com/forum/#!forum/wazuh
+-->
+
+<ossec_config>
+  <client>
+    <server>
+      <address>MANAGER_IP</address>
+      <port>1514</port>
+      <protocol>tcp</protocol>
+    </server>
+    <config-profile>debian, debian10</config-profile>
+    <notify_time>10</notify_time>
+    <time-reconnect>60</time-reconnect>
+    <auto_restart>yes</auto_restart>
+    <crypto_method>aes</crypto_method>
+  </client>
+
+  <client_buffer>
+    <!-- Agent buffer options -->
+    <disabled>no</disabled>
+    <queue_size>5000</queue_size>
+    <events_per_second>500</events_per_second>
+  </client_buffer>
+
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+    <check_files>yes</check_files>
+    <check_trojans>yes</check_trojans>
+    <check_dev>yes</check_dev>
+    <check_sys>yes</check_sys>
+    <check_pids>yes</check_pids>
+    <check_ports>yes</check_ports>
+    <check_if>yes</check_if>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>
+
+  <wodle name="cis-cat">
+    <disabled>yes</disabled>
+    <timeout>1800</timeout>
+    <interval>1d</interval>
+    <scan-on-start>yes</scan-on-start>
+
+    <java_path>wodles/java</java_path>
+    <ciscat_path>wodles/ciscat</ciscat_path>
+  </wodle>
+
+  <!-- Osquery integration -->
+  <wodle name="osquery">
+    <disabled>yes</disabled>
+    <run_daemon>yes</run_daemon>
+    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
+    <config_path>/etc/osquery/osquery.conf</config_path>
+    <add_labels>yes</add_labels>
+  </wodle>
+
+  <!-- System inventory -->
+  <wodle name="syscollector">
+    <disabled>no</disabled>
+    <interval>1h</interval>
+    <scan_on_start>yes</scan_on_start>
+    <hardware>yes</hardware>
+    <os>yes</os>
+    <network>yes</network>
+    <packages>yes</packages>
+    <ports all="no">yes</ports>
+    <processes>yes</processes>
+  </wodle>
+
+  <sca>
+    <enabled>yes</enabled>
+    <scan_on_start>yes</scan_on_start>
+    <interval>12h</interval>
+    <skip_nfs>yes</skip_nfs>
+  </sca>
+
+
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <scan_on_start>yes</scan_on_start>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+    <ignore>/sys/kernel/security</ignore>
+    <ignore>/sys/kernel/debug</ignore>
+    <ignore>/dev/core</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">^/proc</ignore>
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+  </syscheck>
+
+  <!-- Log analysis -->
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/ossec/logs/active-responses.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/dpkg.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>command</log_format>
+    <command>df -P</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>netstat -tulpn | sed "s/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/" | sort -k 4 -g | sed "s/ == \(.*\) ==/:\1/" | sed 1,2d</command>
+    <alias>netstat listening ports</alias>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>last -n 20</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <!-- Active response -->
+  <active-response>
+    <disabled>no</disabled>
+    <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
+    <ca_verification>yes</ca_verification>
+  </active-response>
+
+  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
+  <logging>
+    <log_format>plain</log_format>
+  </logging>
+
+</ossec_config>

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/agent-role/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
+- name: "Installing dependencies using apt"
+  apt:
+    pkg:
+      - git
+      - gcc
+      - make
+      - cmake
+      - libc6-dev
+      - curl
+      - policycoreutils
+      - automake
+      - autoconf
+      - libtool
+      - python3-pytest
+    force_apt_get: yes
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: "Clone wazuh repository"
+  git:
+    repo: "https://github.com/wazuh/wazuh"
+    dest: /wazuh
+    version: "{{ wazuh_branch }}"
+
+- name: Install agent
+  args:
+    chdir: /wazuh
+    creates: /var/ossec
+  environment:
+    USER_LANGUAGE: "en"
+    USER_NO_STOP: "y"
+    USER_INSTALL_TYPE: "agent"
+    USER_DIR: "/var/ossec"
+    USER_ENABLE_EMAIL: "n"
+    USER_ENABLE_SYSCHECK: "y"
+    USER_ENABLE_ROOTCHECK: "y"
+    USER_ENABLE_OPENSCAP: "y"
+    USER_WHITE_LIST: "n"
+    USER_ENABLE_SYSLOG: "y"
+    USER_ENABLE_AUTHD: "y"
+    USER_AUTO_START: "y"
+  shell: "./install.sh"
+
+- name: Copy ossec.conf file
+  copy:
+    src: ../files/ossec.conf
+    dest: /var/ossec/etc/ossec.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Remove client.keys
+  file:
+    path: /var/ossec/etc/client.keys
+    state: absent
+
+- name: Set Wazuh Manager IP
+  lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<address>(.*)</address>'
+    line: "<address>{{ manager_hostname }}</address>"
+    backrefs: yes
+
+- name: Restart Wazuh
+  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/agent-role/tasks/main.yml
@@ -66,6 +66,3 @@
     regexp: '<address>(.*)</address>'
     line: "<address>{{ manager_hostname }}</address>"
     backrefs: yes
-
-- name: Restart Wazuh
-  command: /var/ossec/bin/wazuh-control restart

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/master-role/files/ossec.conf
@@ -1,0 +1,280 @@
+<!--
+  Wazuh - Manager - Default configuration for debian 10
+  More info at: https://documentation.wazuh.com
+  Mailing list: https://groups.google.com/forum/#!forum/wazuh
+-->
+
+<ossec_config>
+  <global>
+    <jsonout_output>yes</jsonout_output>
+    <alerts_log>yes</alerts_log>
+    <logall>no</logall>
+    <logall_json>no</logall_json>
+    <email_notification>no</email_notification>
+    <smtp_server>smtp.example.wazuh.com</smtp_server>
+    <email_from>wazuh@example.wazuh.com</email_from>
+    <email_to>recipient@example.wazuh.com</email_to>
+    <email_maxperhour>12</email_maxperhour>
+    <email_log_source>alerts.log</email_log_source>
+  </global>
+
+  <alerts>
+    <log_alert_level>3</log_alert_level>
+    <email_alert_level>12</email_alert_level>
+  </alerts>
+
+  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
+  <logging>
+    <log_format>plain</log_format>
+  </logging>
+
+  <remote>
+    <connection>secure</connection>
+    <port>1514</port>
+    <protocol>tcp</protocol>
+    <queue_size>131072</queue_size>
+  </remote>
+
+  <rootcheck>
+    <disabled>yes</disabled>
+  </rootcheck>
+
+  <wodle name="cis-cat">
+    <disabled>yes</disabled>
+    <timeout>1800</timeout>
+    <interval>1d</interval>
+    <scan-on-start>yes</scan-on-start>
+
+    <java_path>wodles/java</java_path>
+    <ciscat_path>wodles/ciscat</ciscat_path>
+  </wodle>
+
+  <!-- Osquery integration -->
+  <wodle name="osquery">
+    <disabled>yes</disabled>
+    <run_daemon>yes</run_daemon>
+    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
+    <config_path>/etc/osquery/osquery.conf</config_path>
+    <add_labels>yes</add_labels>
+  </wodle>
+
+  <!-- System inventory -->
+  <wodle name="syscollector">
+    <disabled>no</disabled>
+    <interval>1h</interval>
+    <scan_on_start>yes</scan_on_start>
+    <hardware>yes</hardware>
+    <os>yes</os>
+    <network>yes</network>
+    <packages>yes</packages>
+    <ports all="no">yes</ports>
+    <processes>yes</processes>
+  </wodle>
+
+  <sca>
+    <enabled>yes</enabled>
+    <scan_on_start>yes</scan_on_start>
+    <interval>12h</interval>
+    <skip_nfs>yes</skip_nfs>
+  </sca>
+
+
+  <vulnerability-detector>
+    <enabled>no</enabled>
+    <interval>5m</interval>
+    <ignore_time>6h</ignore_time>
+    <run_on_start>yes</run_on_start>
+
+    <provider name="canonical">
+      <enabled>no</enabled>
+      <os>precise</os>
+      <os>trusty</os>
+      <os>xenial</os>
+      <os>bionic</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <provider name="debian">
+      <enabled>no</enabled>
+      <os>wheezy</os>
+      <os>stretch</os>
+      <os>jessie</os>
+      <os>buster</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <provider name="redhat">
+      <enabled>no</enabled>
+      <update_from_year>2010</update_from_year>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <provider name="nvd">
+      <enabled>no</enabled>
+      <update_from_year>2010</update_from_year>
+      <update_interval>1h</update_interval>
+    </provider>
+
+  </vulnerability-detector>
+
+  <syscheck>
+    <disabled>yes</disabled>
+
+    <scan_on_start>yes</scan_on_start>
+
+    <!-- Generate alert when new file detected -->
+    <alert_new_files>yes</alert_new_files>
+
+  </syscheck>
+
+  <!-- Active response -->
+  <global>
+    <white_list>127.0.0.1</white_list>
+    <white_list>^localhost.localdomain$</white_list>
+    <white_list>80.58.0.33</white_list>
+    <white_list>80.58.32.97</white_list>
+  </global>
+
+  <command>
+    <name>disable-account</name>
+    <executable>disable-account.sh</executable>
+    <expect>user</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>restart-ossec</name>
+    <executable>restart-ossec.sh</executable>
+    <expect></expect>
+  </command>
+
+  <command>
+    <name>firewall-drop</name>
+    <executable>firewall-drop.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>host-deny</name>
+    <executable>host-deny.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>route-null</name>
+    <executable>route-null.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>win_route-null</name>
+    <executable>route-null.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>win_route-null-2012</name>
+    <executable>route-null-2012.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>netsh</name>
+    <executable>netsh.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>netsh-win-2016</name>
+    <executable>netsh-win-2016.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <!--
+  <active-response>
+    active-response options here
+  </active-response>
+  -->
+
+  <!-- Log analysis -->
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/ossec/logs/active-responses.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/dpkg.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>command</log_format>
+    <command>df -P</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>netstat -tulpn | sed "s/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/" | sort -k 4 -g | sed "s/ == \(.*\) ==/:\1/" | sed 1,2d</command>
+    <alias>netstat listening ports</alias>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>last -n 20</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <ruleset>
+    <!-- Default ruleset -->
+    <decoder_dir>ruleset/decoders</decoder_dir>
+    <rule_dir>ruleset/rules</rule_dir>
+    <rule_exclude>0215-policy_rules.xml</rule_exclude>
+    <list>etc/lists/audit-keys</list>
+    <list>etc/lists/amazon/aws-eventnames</list>
+    <list>etc/lists/security-eventchannel</list>
+
+    <!-- User-defined ruleset -->
+    <decoder_dir>etc/decoders</decoder_dir>
+    <rule_dir>etc/rules</rule_dir>
+  </ruleset>
+
+  <!-- Configuration for wazuh-authd -->
+  <auth>
+    <disabled>no</disabled>
+    <port>1515</port>
+    <use_source_ip>no</use_source_ip>
+    <purge>yes</purge>
+    <use_password>no</use_password>
+    <limit_maxagents>yes</limit_maxagents>
+    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
+    <!-- <ssl_agent_ca></ssl_agent_ca> -->
+    <ssl_verify_host>no</ssl_verify_host>
+    <ssl_manager_cert>/var/ossec/etc/sslmanager.cert</ssl_manager_cert>
+    <ssl_manager_key>/var/ossec/etc/sslmanager.key</ssl_manager_key>
+    <ssl_auto_negotiate>no</ssl_auto_negotiate>
+  </auth>
+
+  <cluster>
+    <name>wazuh</name>
+    <node_name>wazuh-master</node_name>
+    <node_type>master</node_type>
+    <key>KEY</key>
+    <port>1516</port>
+    <bind_addr>0.0.0.0</bind_addr>
+    <nodes>
+        <node>MASTER_IP</node>
+    </nodes>
+    <hidden>no</hidden>
+    <disabled>no</disabled>
+  </cluster>
+
+</ossec_config>

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/master-role/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
+- name: "Installing dependencies using apt"
+  apt:
+    pkg:
+      - git
+      - gcc
+      - make
+      - cmake
+      - libc6-dev
+      - curl
+      - policycoreutils
+      - automake
+      - autoconf
+      - libtool
+      - sqlite3
+    force_apt_get: yes
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: "Clone wazuh repository"
+  git:
+    repo: "https://github.com/wazuh/wazuh"
+    dest: /wazuh
+    version: "{{ wazuh_branch }}"
+
+- name: Install master
+  args:
+    chdir: /wazuh
+    creates: /var/ossec
+  environment:
+    USER_LANGUAGE: "en"
+    USER_NO_STOP: "y"
+    USER_INSTALL_TYPE: "server"
+    USER_DIR: "/var/ossec"
+    USER_ENABLE_EMAIL: "n"
+    USER_ENABLE_SYSCHECK: "n"
+    USER_ENABLE_ROOTCHECK: "n"
+    USER_ENABLE_OPENSCAP: "n"
+    USER_WHITE_LIST: "n"
+    USER_ENABLE_SYSLOG: "y"
+    USER_ENABLE_AUTHD: "y"
+    USER_AUTO_START: "y"
+    USER_UPDATE: "n"
+  shell: "./install.sh"
+
+- name: Copy ossec.conf file
+  copy:
+    src: ../files/ossec.conf
+    dest: /var/ossec/etc/ossec.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Set cluster key
+  lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<key>(KEY)</key>'
+    line: "<key>{{ cluster_key }}</key>"
+    backrefs: yes
+
+- name: Set Wazuh Master IP
+  lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<node>(.*)</node>'
+    line: "<node>{{ master_hostname }}</node>"
+    backrefs: yes
+
+- name: Stop Wazuh
+  command: /var/ossec/bin/wazuh-control stop
+
+- name: Remove client.keys
+  file:
+    path: /var/ossec/etc/client.keys
+    state: absent
+
+- name: enable authd and clusterd debug mode
+  blockinfile:
+    path: /var/ossec/etc/local_internal_options.conf
+    block: |
+      authd.debug=2
+      wazuh_clusterd.debug=2
+      wazuh_db.debug=2
+      wazuh_modules.debug=2
+
+- name: Start Wazuh
+  command: /var/ossec/bin/wazuh-control restart
+
+- name: "Install necessary dependencies"
+  command: /var/ossec/framework/python/bin/python3.9 -m pip install lockfile filetype certifi testinfra

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/files/ossec.conf
@@ -1,0 +1,280 @@
+<!--
+  Wazuh - Manager - Default configuration for debian 10
+  More info at: https://documentation.wazuh.com
+  Mailing list: https://groups.google.com/forum/#!forum/wazuh
+-->
+
+<ossec_config>
+  <global>
+    <jsonout_output>yes</jsonout_output>
+    <alerts_log>yes</alerts_log>
+    <logall>no</logall>
+    <logall_json>no</logall_json>
+    <email_notification>no</email_notification>
+    <smtp_server>smtp.example.wazuh.com</smtp_server>
+    <email_from>wazuh@example.wazuh.com</email_from>
+    <email_to>recipient@example.wazuh.com</email_to>
+    <email_maxperhour>12</email_maxperhour>
+    <email_log_source>alerts.log</email_log_source>
+  </global>
+
+  <alerts>
+    <log_alert_level>3</log_alert_level>
+    <email_alert_level>12</email_alert_level>
+  </alerts>
+
+  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
+  <logging>
+    <log_format>plain</log_format>
+  </logging>
+
+  <remote>
+    <connection>secure</connection>
+    <port>1514</port>
+    <protocol>tcp</protocol>
+    <queue_size>131072</queue_size>
+  </remote>
+
+  <rootcheck>
+    <disabled>yes</disabled>
+  </rootcheck>
+
+  <wodle name="cis-cat">
+    <disabled>yes</disabled>
+    <timeout>1800</timeout>
+    <interval>1d</interval>
+    <scan-on-start>yes</scan-on-start>
+
+    <java_path>wodles/java</java_path>
+    <ciscat_path>wodles/ciscat</ciscat_path>
+  </wodle>
+
+  <!-- Osquery integration -->
+  <wodle name="osquery">
+    <disabled>yes</disabled>
+    <run_daemon>yes</run_daemon>
+    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
+    <config_path>/etc/osquery/osquery.conf</config_path>
+    <add_labels>yes</add_labels>
+  </wodle>
+
+  <!-- System inventory -->
+  <wodle name="syscollector">
+    <disabled>no</disabled>
+    <interval>1h</interval>
+    <scan_on_start>yes</scan_on_start>
+    <hardware>yes</hardware>
+    <os>yes</os>
+    <network>yes</network>
+    <packages>yes</packages>
+    <ports all="no">yes</ports>
+    <processes>yes</processes>
+  </wodle>
+
+  <sca>
+    <enabled>yes</enabled>
+    <scan_on_start>yes</scan_on_start>
+    <interval>12h</interval>
+    <skip_nfs>yes</skip_nfs>
+  </sca>
+
+
+  <vulnerability-detector>
+    <enabled>no</enabled>
+    <interval>5m</interval>
+    <ignore_time>6h</ignore_time>
+    <run_on_start>yes</run_on_start>
+
+    <provider name="canonical">
+      <enabled>no</enabled>
+      <os>precise</os>
+      <os>trusty</os>
+      <os>xenial</os>
+      <os>bionic</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <provider name="debian">
+      <enabled>no</enabled>
+      <os>wheezy</os>
+      <os>stretch</os>
+      <os>jessie</os>
+      <os>buster</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <provider name="redhat">
+      <enabled>no</enabled>
+      <update_from_year>2010</update_from_year>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <provider name="nvd">
+      <enabled>no</enabled>
+      <update_from_year>2010</update_from_year>
+      <update_interval>1h</update_interval>
+    </provider>
+
+  </vulnerability-detector>
+
+  <syscheck>
+    <disabled>yes</disabled>
+
+    <scan_on_start>yes</scan_on_start>
+
+    <!-- Generate alert when new file detected -->
+    <alert_new_files>yes</alert_new_files>
+
+  </syscheck>
+
+  <!-- Active response -->
+  <global>
+    <white_list>127.0.0.1</white_list>
+    <white_list>^localhost.localdomain$</white_list>
+    <white_list>80.58.0.33</white_list>
+    <white_list>80.58.32.97</white_list>
+  </global>
+
+  <command>
+    <name>disable-account</name>
+    <executable>disable-account.sh</executable>
+    <expect>user</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>restart-ossec</name>
+    <executable>restart-ossec.sh</executable>
+    <expect></expect>
+  </command>
+
+  <command>
+    <name>firewall-drop</name>
+    <executable>firewall-drop.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>host-deny</name>
+    <executable>host-deny.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>route-null</name>
+    <executable>route-null.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>win_route-null</name>
+    <executable>route-null.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>win_route-null-2012</name>
+    <executable>route-null-2012.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>netsh</name>
+    <executable>netsh.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>netsh-win-2016</name>
+    <executable>netsh-win-2016.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <!--
+  <active-response>
+    active-response options here
+  </active-response>
+  -->
+
+  <!-- Log analysis -->
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/ossec/logs/active-responses.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/dpkg.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>command</log_format>
+    <command>df -P</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>netstat -tulpn | sed "s/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/" | sort -k 4 -g | sed "s/ == \(.*\) ==/:\1/" | sed 1,2d</command>
+    <alias>netstat listening ports</alias>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>last -n 20</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <ruleset>
+    <!-- Default ruleset -->
+    <decoder_dir>ruleset/decoders</decoder_dir>
+    <rule_dir>ruleset/rules</rule_dir>
+    <rule_exclude>0215-policy_rules.xml</rule_exclude>
+    <list>etc/lists/audit-keys</list>
+    <list>etc/lists/amazon/aws-eventnames</list>
+    <list>etc/lists/security-eventchannel</list>
+
+    <!-- User-defined ruleset -->
+    <decoder_dir>etc/decoders</decoder_dir>
+    <rule_dir>etc/rules</rule_dir>
+  </ruleset>
+
+  <!-- Configuration for wazuh-authd -->
+  <auth>
+    <disabled>no</disabled>
+    <port>1515</port>
+    <use_source_ip>no</use_source_ip>
+    <purge>yes</purge>
+    <use_password>no</use_password>
+    <limit_maxagents>yes</limit_maxagents>
+    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
+    <!-- <ssl_agent_ca></ssl_agent_ca> -->
+    <ssl_verify_host>no</ssl_verify_host>
+    <ssl_manager_cert>/var/ossec/etc/sslmanager.cert</ssl_manager_cert>
+    <ssl_manager_key>/var/ossec/etc/sslmanager.key</ssl_manager_key>
+    <ssl_auto_negotiate>no</ssl_auto_negotiate>
+  </auth>
+
+  <cluster>
+    <name>wazuh</name>
+    <node_name>node01</node_name>
+    <node_type>worker</node_type>
+    <key>KEY</key>
+    <port>1516</port>
+    <bind_addr>0.0.0.0</bind_addr>
+    <nodes>
+        <node>MASTER_IP</node>
+    </nodes>
+    <hidden>no</hidden>
+    <disabled>no</disabled>
+  </cluster>
+
+</ossec_config>

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/tasks/main.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+- name: "Check and update debian repositories"
+  shell:
+    cmd: apt-get update --allow-releaseinfo-change
+
+- name: "Installing dependencies using apt"
+  apt:
+    pkg:
+      - git
+      - gcc
+      - make
+      - cmake
+      - libc6-dev
+      - curl
+      - policycoreutils
+      - automake
+      - autoconf
+      - libtool
+      - python3-pytest
+      - sqlite3
+    force_apt_get: yes
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: "Clone wazuh repository"
+  git:
+    repo: "https://github.com/wazuh/wazuh"
+    dest: /wazuh
+    version: "{{ wazuh_branch }}"
+
+- name: Install worker
+  args:
+    chdir: /wazuh
+    creates: /var/ossec
+  environment:
+    USER_LANGUAGE: "en"
+    USER_NO_STOP: "y"
+    USER_INSTALL_TYPE: "server"
+    USER_DIR: "/var/ossec"
+    USER_ENABLE_EMAIL: "n"
+    USER_ENABLE_SYSCHECK: "y"
+    USER_ENABLE_ROOTCHECK: "y"
+    USER_ENABLE_OPENSCAP: "y"
+    USER_WHITE_LIST: "n"
+    USER_ENABLE_SYSLOG: "y"
+    USER_ENABLE_AUTHD: "y"
+    USER_AUTO_START: "y"
+    USER_UPDATE: "n"
+  shell: "./install.sh"
+
+- name: Copy ossec.conf file
+  copy:
+    src: ../files/ossec.conf
+    dest: /var/ossec/etc/ossec.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Set cluster key
+  lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<key>(KEY)</key>'
+    line: "<key>{{ cluster_key }}</key>"
+    backrefs: yes
+
+- name: Set Wazuh Worker name
+  lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<node_name>(.*)</node_name>'
+    line: "<node_name>{{ worker_name }}</node_name>"
+    backrefs: yes
+
+- name: Set Wazuh Worker IP
+  lineinfile:
+    path: /var/ossec/etc/ossec.conf
+    regexp: '<node>(.*)</node>'
+    line: "<node>{{ master_hostname }}</node>"
+    backrefs: yes
+
+- name: enable authd and clusterd debug mode
+  blockinfile:
+    path: /var/ossec/etc/local_internal_options.conf
+    block: |
+      authd.debug=2
+      wazuh_clusterd.debug=2
+      wazuh_db.debug=2
+      wazuh_modules.debug=2
+
+- name: Restart Wazuh
+  command: "{{restart_command}}"
+
+- name: "Install necessary dependencies"
+  command: /var/ossec/framework/python/bin/python3.9 -m pip install lockfile filetype certifi testinfra

--- a/tests/system/provisioning/four_manager_disconnected_node/vars/configurations.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/vars/configurations.yml
@@ -1,0 +1,23 @@
+cluster_key: "00000000000000000000000000000000"
+
+master_hostname: "wazuh-master"
+
+worker1_hostname: "wazuh-worker1"
+worker2_hostname: "wazuh-worker2"
+worker3_hostname: "wazuh-worker3"
+
+agent1_id: "001"
+agent2_id: "002"
+agent3_id: "003"
+agent1_hostname: "wazuh-agent1"
+agent2_hostname: "wazuh-agent2"
+agent3_hostname: "wazuh-agent3"
+agent1_key: "1111111111111111111111111111111111111111111111111111111111111111"
+agent2_key: "2222222222222222222222222222222222222222222222222222222222222222"
+agent3_key: "3333333333333333333333333333333333333333333333333333333333333333"
+
+restart_command: /var/ossec/bin/wazuh-control restart
+
+docker_network: "cluster_net"
+
+image: "dontpanicat/debian:buster"

--- a/tests/system/provisioning/four_manager_disconnected_node/vars/main.yml
+++ b/tests/system/provisioning/four_manager_disconnected_node/vars/main.yml
@@ -1,0 +1,2 @@
+---
+include_vars: "configurations.yml"

--- a/tests/system/test_cluster/test_agent_groups/common.py
+++ b/tests/system/test_cluster/test_agent_groups/common.py
@@ -10,7 +10,7 @@ from system import get_id_from_agent
 
 def register_agent(agent, agent_manager, host_manager, id_group=''):
     agent_ip = host_manager.run_command(agent, f'hostname -i')
-    agent_name = "Agent-" + str(time.time())
+    agent_name = "Agent-" + str(round(time.time()))
 
     # Set the IP for the agent to point to host where enrollment will be done
     manager_ip = host_manager.run_command(agent_manager, f'hostname -i')

--- a/tests/system/test_cluster/test_agent_groups/common.py
+++ b/tests/system/test_cluster/test_agent_groups/common.py
@@ -20,6 +20,6 @@ def register_agent(agent, agent_manager, host_manager):
     host_manager.run_command(agent, 
                              f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip}')
 
-    agent_id = get_id_from_agent(host_manager)
+    agent_id = get_id_from_agent(agent, host_manager)
     
     return [agent_ip, agent_id, agent_name, manager_ip]

--- a/tests/system/test_cluster/test_agent_groups/common.py
+++ b/tests/system/test_cluster/test_agent_groups/common.py
@@ -5,7 +5,7 @@
 import time
 
 from wazuh_testing.tools import WAZUH_PATH
-from system import get_agent_id
+from system import get_agent_id, get_id_from_agent
 
 def register_agent(agent, agent_manager, host_manager):
     agent_ip = host_manager.run_command(agent, f'hostname -i')
@@ -20,6 +20,6 @@ def register_agent(agent, agent_manager, host_manager):
     host_manager.run_command(agent, 
                              f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip}')
 
-    agent_id = get_agent_id(host_manager)
+    agent_id = get_id_from_agent(host_manager)
     
     return [agent_ip, agent_id, agent_name, manager_ip]

--- a/tests/system/test_cluster/test_agent_groups/common.py
+++ b/tests/system/test_cluster/test_agent_groups/common.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2015-2022, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import time
+
+from wazuh_testing.tools import WAZUH_PATH
+from system import get_agent_id
+
+def register_agent(agent, agent_manager, host_manager):
+    agent_ip = host_manager.run_command(agent, f'hostname -i')
+    agent_name = "Agent-" + str(time.time())
+
+    # Set the IP for the agent to point to host where enrollment will be done
+    manager_ip = host_manager.run_command(agent_manager, f'hostname -i')
+    host_manager.add_block_to_file(host=agent, path=f"{WAZUH_PATH}/etc/ossec.conf",
+                                   after="<address>", before="</address>", replace=manager_ip)
+
+    # Add agent to Master/Worker using agent-auth tool  
+    host_manager.run_command(agent, 
+                             f'{WAZUH_PATH}/bin/agent-auth -m {manager_ip} -A {agent_name} -I {agent_ip}')
+
+    agent_id = get_agent_id(host_manager)
+    
+    return [agent_ip, agent_id, agent_name, manager_ip]

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -43,10 +43,8 @@ tags:
     - wazuh-db
 '''
 import os
-import time
 
 import pytest
-from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.system import HostManager
 from system import (create_new_agent_group, check_agent_groups, check_agent_status,
                     remove_cluster_agents, restart_cluster, clean_cluster_logs, delete_group_of_agents)
@@ -62,7 +60,6 @@ inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os
                               'provisioning', 'four_manager_disconnected_node', 'inventory.yml')
 host_manager = HostManager(inventory_path)
 local_path = os.path.dirname(os.path.abspath(__file__))
-tmp_path = os.path.join(local_path, 'tmp')
 
 
 @pytest.fixture(scope='function')

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -4,7 +4,8 @@ copyright: Copyright (C) 2015-2022, Wazuh Inc.
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 type: system
-brief: 
+brief: This tests check that when a cluster has a series of agents with groups assigned, when a new node is
+       added to the cluster, that new node the agent's status and groups are synchronized.
 tier: 0
 modules:
     - cluster
@@ -124,3 +125,50 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
     check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
     check_agent_groups(agent3_data[1], agent_groups[2], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
+
+
+def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
+    '''
+    description: Having two agents assined to different workers and different groups, check that when an new node
+    is added to the cluster, the group data is synchronized to the new node.
+    wazuh_min_version: 4.4.0
+    parameters:
+        - clean_enviroment:
+            type: fixture
+            brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
+    assertions:
+        - Verify that after registering the agents appear as active in all nodes.
+        - Verify that after registering and after starting the agent, the indicated group is synchronized.
+        - Verify that after after adding a new node to the cluster, the agent's group data is synchronized.
+    expected_output:
+        - The 'Agent_name' with ID 'Agent_id' belongs to groups: 'group_name'.
+    '''
+    for group in ["Group1", "Group2"]:
+        create_new_agent_group(test_infra_managers[0], group, host_manager)
+
+    agent1_data = register_agent(test_infra_agents[0], test_infra_managers[1], host_manager, agent_groups[0])
+    agent2_data = register_agent(test_infra_agents[1], test_infra_managers[2], host_manager, agent_groups[1])
+    
+    restart_cluster(test_infra_agents[0:2], host_manager)
+    time.sleep(10)
+    # Check that agent status is active in cluster
+    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_managers)
+    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_managers)
+
+
+    # Check that agent has the expected group assigned in all nodes
+    check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+    check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+    
+
+    restart_cluster(test_infra_new_nodes, host_manager)
+    time.sleep(10)
+
+    # Check that agent status is active in new node
+    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_new_nodes)
+    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_new_nodes)
+    
+    
+    # Check that agent has group set to default in new node
+    check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
+    check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -116,7 +116,7 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_new_nodes)
     check_agent_status(agent3_data[1], agent3_data[2], agent3_data[0], "active", host_manager, test_infra_new_nodes)
     
-    # Check that agent has group set to default in new node
+    # Check that agent has the correct group set in new node
     check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
     check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
     check_agent_groups(agent3_data[1], agent_groups[2], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
@@ -162,6 +162,6 @@ def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
     check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_new_nodes)
     
     
-    # Check that agent has group set to default in new node
+    # Check that agent has the correct group set in new node
     check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
     check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -46,7 +46,7 @@ import os
 
 import pytest
 from wazuh_testing.tools.system import HostManager
-from system import (create_new_agent_group, check_agent_groups, check_agent_status,
+from system import (create_new_agent_group, check_agent_groups, check_agents_status_in_node,
                     remove_cluster_agents, restart_cluster, clean_cluster_logs, delete_group_of_agents)
 from system.test_cluster.test_agent_groups.common import register_agent
 
@@ -96,13 +96,14 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     agent2_data = register_agent(test_infra_agents[1], test_infra_managers[0], host_manager, agent_groups[1])
     agent3_data = register_agent(test_infra_agents[2], test_infra_managers[0], host_manager, agent_groups[2])
     
-
+    agent_status_list = [f"{agent1_data[1]}  {agent1_data[2]}  {agent1_data[0]}  active",
+                         f"{agent2_data[1]}  {agent2_data[2]}  {agent2_data[0]}  active",
+                         f"{agent3_data[1]}  {agent3_data[2]}  {agent3_data[0]}  active"]
     restart_cluster(test_infra_agents, host_manager)
+    
     # Check that agent status is active in cluster
-    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_managers)
-    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_managers)
-    check_agent_status(agent3_data[1], agent3_data[2], agent3_data[0], "active", host_manager, test_infra_managers)
-
+    for host in test_infra_managers:
+        check_agents_status_in_node(agent_status_list, host, host_manager)
 
     # Check that agent has the expected group assigned in all nodes
     check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
@@ -112,10 +113,9 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     restart_cluster(test_infra_new_nodes, host_manager)
 
     # Check that agent status is active in new node
-    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_new_nodes)
-    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_new_nodes)
-    check_agent_status(agent3_data[1], agent3_data[2], agent3_data[0], "active", host_manager, test_infra_new_nodes)
-    
+    check_agents_status_in_node(agent_status_list, test_infra_new_nodes[0], host_manager)
+
+
     # Check that agent has the correct group set in new node
     check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
     check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
@@ -144,10 +144,13 @@ def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
     agent1_data = register_agent(test_infra_agents[0], test_infra_managers[1], host_manager, agent_groups[0])
     agent2_data = register_agent(test_infra_agents[1], test_infra_managers[2], host_manager, agent_groups[1])
     
+    agent_status_list = [f"{agent1_data[1]}  {agent1_data[2]}  {agent1_data[0]}  active",
+                         f"{agent2_data[1]}  {agent2_data[2]}  {agent2_data[0]}  active"]
+
     restart_cluster(test_infra_agents[0:2], host_manager)
     # Check that agent status is active in cluster
-    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_managers)
-    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_managers)
+    for host in test_infra_managers:
+        check_agents_status_in_node(agent_status_list, host, host_manager)
 
 
     # Check that agent has the expected group assigned in all nodes
@@ -158,9 +161,7 @@ def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
     restart_cluster(test_infra_new_nodes, host_manager)
 
     # Check that agent status is active in new node
-    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_new_nodes)
-    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_new_nodes)
-    
+    check_agents_status_in_node(agent_status_list, test_infra_new_nodes[0], host_manager)    
     
     # Check that agent has the correct group set in new node
     check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -1,0 +1,117 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: system
+brief: 
+tier: 0
+modules:
+    - cluster
+components:
+    - manager
+    - agent
+daemons:
+    - wazuh-db
+    - wazuh-clusterd
+os_platform:
+    - linux
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/tools/agent-auth.html
+    - https://documentation.wazuh.com/current/user-manual/registering/command-line-registration.html
+    - https://documentation.wazuh.com/current/user-manual/registering/agent-enrollment.html
+tags:
+    - wazuh-db
+'''
+import os
+import time
+
+import pytest
+from wazuh_testing.tools import WAZUH_PATH
+from wazuh_testing.tools.system import HostManager
+from system import (assign_agent_to_new_group, check_agent_groups, check_agent_status, get_id_from_agent,
+                    remove_cluster_agents, restart_cluster, clean_cluster_logs, check_keys_file)
+from system.test_cluster.test_agent_groups.common import register_agent
+
+# Hosts
+test_infra_managers = ["wazuh-master", "wazuh-worker1", "wazuh-worker2"]
+test_infra_new_nodes = ["wazuh-worker3"]
+test_infra_agents = ["wazuh-agent1","wazuh-agent2","wazuh-agent3"]
+agent_groups = ["Group1", "Group2", "Group3"]
+
+inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                              'provisioning', 'enrollment_cluster', 'inventory.yml')
+host_manager = HostManager(inventory_path)
+local_path = os.path.dirname(os.path.abspath(__file__))
+tmp_path = os.path.join(local_path, 'tmp')
+
+
+@pytest.fixture(scope='function')
+def clean_cluster_environment():
+    clean_cluster_logs(test_infra_managers + test_infra_agents, host_manager)
+    yield
+    # Remove the agent once the test has finished
+    remove_cluster_agents(test_infra_managers[0], test_infra_agents, host_manager)
+
+
+def test_agent_groups_new_cluster_node(clean_cluster_environment):
+    '''
+    description: Check that having a series of agents assigned with different groups, when an new node is added to
+    the cluster, the group data is synchronized to the new node.
+    wazuh_min_version: 4.4.0
+    parameters:
+        - clean_enviroment:
+            type: fixture
+            brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
+    assertions:
+        - Verify that after registering the agents appear as active in all nodes.
+        - Verify that after registering and after starting the agent, the indicated group is synchronized.
+        - Verify that after after adding a new node to the cluster, the agent's group data is synchronized.
+    expected_output:
+        - The 'Agent_name' with ID 'Agent_id' belongs to groups: 'group_name'.
+    '''
+
+    agent1_data = register_agent(test_infra_agents[0], test_infra_managers[0], host_manager)
+    agent2_data = register_agent(test_infra_agents[1], test_infra_managers[0], host_manager)
+    agent3_data = register_agent(test_infra_agents[3], test_infra_managers[0], host_manager)
+    
+    for agent in test_infra_agents:
+        assign_agent_to_new_group(test_infra_managers[0], agent, "Group_1", host_manager)
+    
+    # Start the enrollment process by restarting cluster
+    restart_cluster(test_infra_agents, host_manager)
+
+    # Check that agent status is active in cluster
+    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_managers)
+    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_managers)
+    check_agent_status(agent3_data[1], agent3_data[2], agent3_data[0], "active", host_manager, test_infra_managers)
+
+
+    # Check that agent has the expected group assigned in all nodes
+    for index, agent in enumerate(test_infra_agents):
+        check_agent_groups(agent, agent_groups[index], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+
+    restart_cluster(test_infra_new_nodes, host_manager)
+    time.sleep(10)
+
+    # Check that agent has group set to default
+    for index, agent in enumerate(test_infra_agents):
+        check_agent_groups(agent, agent_groups[index], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -47,8 +47,8 @@ import time
 import pytest
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.system import HostManager
-from system import (assign_agent_to_new_group, check_agent_groups, check_agent_status, get_id_from_agent,
-                    remove_cluster_agents, restart_cluster, clean_cluster_logs, check_keys_file)
+from system import (create_new_agent_group, check_agent_groups, check_agent_status,
+                    remove_cluster_agents, restart_cluster, clean_cluster_logs, delete_group_of_agents)
 from system.test_cluster.test_agent_groups.common import register_agent
 
 # Hosts
@@ -70,6 +70,8 @@ def clean_cluster_environment():
     yield
     # Remove the agent once the test has finished
     remove_cluster_agents(test_infra_managers[0], test_infra_agents, host_manager)
+    for group in agent_groups:
+        delete_group_of_agents(test_infra_managers[0], group, host_manager)
     host_manager.control_service(host=test_infra_new_nodes[0], service='wazuh', state="stopped")
 
 
@@ -89,15 +91,14 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     expected_output:
         - The 'Agent_name' with ID 'Agent_id' belongs to groups: 'group_name'.
     '''
+    for group in agent_groups:
+        create_new_agent_group(test_infra_managers[0], group, host_manager)
 
-    agent1_data = register_agent(test_infra_agents[0], test_infra_managers[0], host_manager)
-    agent2_data = register_agent(test_infra_agents[1], test_infra_managers[0], host_manager)
-    agent3_data = register_agent(test_infra_agents[2], test_infra_managers[0], host_manager)
+    agent1_data = register_agent(test_infra_agents[0], test_infra_managers[0], host_manager, agent_groups[0])
+    agent2_data = register_agent(test_infra_agents[1], test_infra_managers[0], host_manager, agent_groups[1])
+    agent3_data = register_agent(test_infra_agents[2], test_infra_managers[0], host_manager, agent_groups[2])
     
-    for index, agent in enumerate(test_infra_agents):
-        assign_agent_to_new_group(test_infra_managers[0], agent_groups[index], agent, host_manager)
-    
-    # Start the enrollment process by restarting cluster
+
     restart_cluster(test_infra_agents, host_manager)
     time.sleep(10)
     # Check that agent status is active in cluster
@@ -107,12 +108,19 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
 
 
     # Check that agent has the expected group assigned in all nodes
-    for index, agent in enumerate(test_infra_agents):
-        check_agent_groups(agent, agent_groups[index], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+    check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+    check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+    check_agent_groups(agent3_data[1], agent_groups[2], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
 
     restart_cluster(test_infra_new_nodes, host_manager)
     time.sleep(10)
 
-    # Check that agent has group set to default
-    for index, agent in enumerate(test_infra_agents):
-        check_agent_groups(agent, agent_groups[index], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
+    # Check that agent status is active in new node
+    check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_new_nodes)
+    check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_new_nodes)
+    check_agent_status(agent3_data[1], agent3_data[2], agent3_data[0], "active", host_manager, test_infra_new_nodes)
+    
+    # Check that agent has group set to default in new node
+    check_agent_groups(agent1_data[1], agent_groups[0], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
+    check_agent_groups(agent2_data[1], agent_groups[1], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes
+    check_agent_groups(agent3_data[1], agent_groups[2], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_new_nodes

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -148,6 +148,7 @@ def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
                          f"{agent2_data[1]}  {agent2_data[2]}  {agent2_data[0]}  active"]
 
     restart_cluster(test_infra_agents[0:2], host_manager)
+
     # Check that agent status is active in cluster
     for host in test_infra_managers:
         check_agents_status_in_node(agent_status_list, host, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -101,7 +101,6 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     
 
     restart_cluster(test_infra_agents, host_manager)
-    time.sleep(10)
     # Check that agent status is active in cluster
     check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_managers)
     check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_managers)
@@ -114,7 +113,6 @@ def test_agent_groups_new_cluster_node(clean_cluster_environment):
     check_agent_groups(agent3_data[1], agent_groups[2], ["wazuh-master"], host_manager) # replace wazuh-master for test_infra_managers
 
     restart_cluster(test_infra_new_nodes, host_manager)
-    time.sleep(10)
 
     # Check that agent status is active in new node
     check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_new_nodes)
@@ -150,7 +148,6 @@ def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
     agent2_data = register_agent(test_infra_agents[1], test_infra_managers[2], host_manager, agent_groups[1])
     
     restart_cluster(test_infra_agents[0:2], host_manager)
-    time.sleep(10)
     # Check that agent status is active in cluster
     check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_managers)
     check_agent_status(agent2_data[1], agent2_data[2], agent2_data[0], "active", host_manager, test_infra_managers)
@@ -162,7 +159,6 @@ def test_agent_groups_sync_from_worker_new_node(clean_cluster_environment):
     
 
     restart_cluster(test_infra_new_nodes, host_manager)
-    time.sleep(10)
 
     # Check that agent status is active in new node
     check_agent_status(agent1_data[1], agent1_data[2], agent1_data[0], "active", host_manager, test_infra_new_nodes)

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -132,7 +132,7 @@ def test_agent_groups_sync_when_add_a_new_cluster_node(clean_environment, test_i
 @pytest.mark.parametrize("host_manager",[host_manager])
 def test_agent_groups_sync_worker_new_node(clean_environment, test_infra_managers, test_infra_agents, host_manager):
     '''
-    description: Having two agents assined to different workers and different groups, check that when an new node
+    description: Having two agents assigned to different workers and different groups, check that when an new node
     is added to the cluster, the group data is synchronized to the new node.
     wazuh_min_version: 4.4.0
     parameters:

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -62,6 +62,7 @@ inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os
                               'provisioning', 'four_manager_disconnected_node', 'inventory.yml')
 host_manager = HostManager(inventory_path)
 local_path = os.path.dirname(os.path.abspath(__file__))
+timeout = 10
 
 
 #Tests
@@ -118,7 +119,6 @@ def test_agent_groups_new_cluster_node(clean_environment, test_infra_managers, t
     restart_cluster(test_infra_new_nodes, host_manager)
 
     # Check that agent status is active in new node
-
     check_agents_status_in_node(agent_status_list, test_infra_new_nodes[0], host_manager)
 
 
@@ -178,9 +178,9 @@ def test_agent_groups_sync_worker_new_node(clean_environment, test_infra_manager
     check_agent_groups(agent2_data[1], agent_groups[1], test_infra_managers, host_manager)
 
     restart_cluster(test_infra_new_nodes, host_manager)
-    time.sleep(10)
-    # Check that agent status is active in new node
+    time.sleep(timeout)
 
+    # Check that agent status is active in new node
     check_agents_status_in_node(agent_status_list, test_infra_new_nodes[0], host_manager)    
     
     # Check that agent has the correct group set in new node

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -44,7 +44,6 @@ tags:
 '''
 import os
 import time
-
 import pytest
 
 from wazuh_testing.tools.system import HostManager
@@ -69,7 +68,7 @@ timeout = 10
 @pytest.mark.parametrize("test_infra_managers",[test_infra_managers])
 @pytest.mark.parametrize("test_infra_agents",[test_infra_agents])
 @pytest.mark.parametrize("host_manager",[host_manager])
-def test_agent_groups_new_cluster_node(clean_environment, test_infra_managers, test_infra_agents, host_manager):
+def test_agent_groups_sync_when_add_a_new_cluster_node(clean_environment, test_infra_managers, test_infra_agents, host_manager):
     '''
     description: Check that having a series of agents assigned with different groups, when an new node is added to
     the cluster, the group data is synchronized to the new node.

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -137,7 +137,7 @@ def test_agent_groups_sync_worker_new_node(clean_environment, test_infra_manager
     is added to the cluster, the group data is synchronized to the new node.
     wazuh_min_version: 4.4.0
     parameters:
-        - clean_cluster_enviroment:
+        - clean_enviroment:
             type: fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
         - test_infra_managers


### PR DESCRIPTION
In this PR the test suite for `Adds a new node to a synchronized environment`  is added. A total of 2 new test cases covering different modes and combinations of options.

<table>
  <tr>
    <th>Related issues</th>
    <th><a href="[url](https://github.com/wazuh/wazuh-qa/issues/2511)">#2511</a></th>
    <th><a href="[url](https://github.com/wazuh/wazuh/issues/10771)">#10771</a></th>
  </tr>
</table>

## Cases:

- [x]  Adds a new node to a synchronized environment:
        - The agent  on active status and connect to `master` node has the default group
        - The agent  on active status and connect to `worker` node has the default group

--- 

## Configuration options
In order to run the test, first the environment located in `/test/system/provisioning/four_manager_disconnected_node)` must be enabled with:
`sudo ansible-playbook -i inventory.yml playbook.yml --extra-vars='{"wazuh_branch": "dev-10771-agent-groups-files-to-wazuh-db"}'`

**Local Internal Options:** No Local Internal Options used

---

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
| test/system/test_cluster/test_agent_groups/test_agent_groups_default.py  | CentOS - Manager | Local | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8233800/R1.zip)[:large_blue_circle:])[:large_blue_circle:]| 11/03/2022 |  @CamiRomero  | 

---

## Required
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
