### PR TITLE
Modify default empty value to avoid an empty severity in Vulnerability Detector

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
@@ -103,14 +103,14 @@
                                         "type":"PACKAGE",
                                         "status":"VALID",
                                         "check_pkg_existence":false,
-                                        "severity":"-",
+                                        "severity":"Untriaged",
                                         "cvss2_score":0,
                                         "cvss3_score":0}'
     output: 'ok {"action":"INSERT","status":"SUCCESS"}'
     stage: "agent vuln_cves insert package with same CVE without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2"'
-    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"-","cvss2_score":0,"cvss3_score":0,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
+    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"Untriaged","cvss2_score":0,"cvss3_score":0,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
     stage: "agent vuln_cves checking package insertion with same CVE"
     use_regex: "yes"
   -


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12675|

## Description

Following the change implemented in the following PR https://github.com/wazuh/wazuh/pull/12695, it has been necessary to modify the value of the `severity` variable in the wazuh_db IT, so that it works correctly and does not fail: 

https://github.com/wazuh/wazuh-qa/blob/7eada9983d28ca0a094187bf9b3e526c4a0dfcf8/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml#L106

The only change has been to modify both the inserted value of `severity` and the result of the same, to obtain the new value `Untriaged`, instead of `-`.

## Logs example

```
Successfully installed wazuh-testing-4.3.0
======================================== test session starts ========================================
platform linux -- Python 3.8.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: testinfra-6.3.0, html-2.0.1, metadata-1.11.0
collected 33 items                                                                                  

tests/integration/test_wazuh_db/test_wazuh_db.py .................................            [100%]

======================================== 33 passed in 40.47s ========================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.