### PR TITLE
Fix Logcollector IT: test_command_execution_dbg

### DIFF
--- a/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_dbg.py
+++ b/tests/integration/test_logcollector/test_command_monitoring/test_command_execution_dbg.py
@@ -261,7 +261,7 @@ def test_command_execution_dbg(get_files_list, create_file_structure_module, con
 
     if config['info'] == 'does not end':
         with open(not_ending_command_file_full_path, 'a') as command_file:
-            for line in range(int(local_internal_options['logcollector.max_lines']) + 1):
+            for line in range(int(local_internal_options['logcollector.max_lines']) + 5):
                 command_file.write(f"Testing not ending command.Line {line}\n")
 
     # Command with known output to test "Reading command message: ..."


### PR DESCRIPTION
|Related issue|
|---|
|close #2672|


## Description

Fix `test_command_execution_dbg`, replacing `tail -f` with never-ending bash for iteration.

<!--
## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.