### PR TITLE
Fix Agentd IT:  `test_agentd_multi_server`

### DIFF
--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -244,17 +244,17 @@ metadata = [
         'LOG_MONITOR_STR': [
             [
                 f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
-                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
+                f"Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}",
                 f"Received message: '#!-agent ack '",
             ],
             [
                 f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
-                f"Unable to connect to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
+                f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}",
             ],
             [
                 f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
-                f"Unable to connect to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
-                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
+                f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}",
+                f"Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}",
                 f'Server responded. Releasing lock.',
                 f"Received message: '#!-agent ack '"
             ]

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -61,6 +61,7 @@ from wazuh_testing.agent import CLIENT_KEYS_PATH, SERVER_CERT_PATH, SERVER_KEY_P
 
 SERVER_ADDRESS = '127.0.0.1'
 REMOTED_PORTS = [1514, 1516, 1517]
+AUTHD_PORT = 1515
 SERVER_HOSTS = ['testServer1', 'testServer2', 'testServer3']
 
 pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0), pytest.mark.agent]
@@ -96,11 +97,11 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [  # Stage 1
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
                 f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
-                f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
-                f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
                 f'Requesting a key from server: {SERVER_HOSTS[2]}/{SERVER_ADDRESS}'
             ]
         ]
@@ -121,16 +122,17 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [  # Stage 1 - Enroll to first server
-                f'Requesting a key from server: {SERVER_HOSTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
                 f'Valid key received',
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
             ],
             [  # Stage 2 - Pass second server and connect to third
-                f'Requesting a key from server: {SERVER_HOSTS[0]}',
-                f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
+                #f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
-                f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
-                f'Connected to the server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
+                f'Connected to the server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
                 f"Received message: '#!-agent ack '"
             ]
         ]
@@ -151,16 +153,17 @@ metadata = [
         'LOG_MONITOR_STR': [
             [  # Stage 1 - Enroll and connect to first server
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
+                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f'Valid key received',
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
             ],
             [
-                # f'Lost connection with manager. Setting lock.',
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f'Connected to the server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
+                f'Lost connection with manager. Setting lock.',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f'Connected to the server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f"Received message: '#!-agent ack '",
             ]
         ]
@@ -182,16 +185,17 @@ metadata = [
         'LOG_MONITOR_STR': [
             [  # Stage 1 - Enroll and connect to first server
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
+                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f'Valid key received',
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
             ],  # Stage 2 - Enroll and connect to second server after failed attempts to connect with server 1
             [
                 f'Server unavailable. Setting lock.',
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
-                f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f'Connected to the server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f'Connected to the server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f"Received message: '#!-agent ack '",
             ]
         ]
@@ -211,15 +215,15 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f"Unable to connect to '{SERVER_ADDRESS}:{REMOTED_PORTS[0]}",
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}",
             ],
             [
-                f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f"Unable to connect to '{SERVER_ADDRESS}:{REMOTED_PORTS[1]}",
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}",
             ],
             [
-                f'Connected to the server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
+                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f"Received message: '#!-agent ack '"
             ]
         ]
@@ -239,18 +243,18 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [
-                f'Trying to connect to server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
-                f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f"Received message: '#!-agent ack '",
             ],
             [
-                f'Trying to connect to server ({SERVER_HOSTS[1]}/{SERVER_ADDRESS}:{REMOTED_PORTS[1]}',
-                f"Unable to connect to '{SERVER_ADDRESS}:{REMOTED_PORTS[1]}",
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f"Unable to connect to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
             ],
             [
-                f'Trying to connect to server ({SERVER_HOSTS[2]}/{SERVER_ADDRESS}:{REMOTED_PORTS[2]}',
-                f"Unable to connect to '{SERVER_ADDRESS}:{REMOTED_PORTS[2]}",
-                f'Connected to the server ({SERVER_HOSTS[0]}/{SERVER_ADDRESS}:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
+                f"Unable to connect to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
+                f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f'Server responded. Releasing lock.',
                 f"Received message: '#!-agent ack '"
             ]
@@ -435,10 +439,10 @@ def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id
         - r'Requesting a key from server'
         - r'Valid key received'
         - r'Trying to connect to server'
-        - r'Connected to the server'
+        - r'Connected to enrollment service'
         - r'Received message'
         - r'Server responded. Releasing lock.'
-        - r'Unable to connect to'
+        - r'Unable to connect to enrollment service at'
 
     tags:
         - simulator

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -371,6 +371,7 @@ def clean_keys(request, get_configuration):
 def restart_agentd():
     """Restart agentd daemon with debug mode active."""
     control_service('stop', daemon="wazuh-agentd")
+    truncate_file(LOG_FILE_PATH)
     control_service('start', daemon="wazuh-agentd", debug_mode=True)
 
 

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -128,7 +128,7 @@ metadata = [
                 f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
             ],
             [  # Stage 2 - Pass second server and connect to third
-                #f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
@@ -160,7 +160,7 @@ metadata = [
                 f"Received message: '#!-agent ack '"
             ],
             [
-                f'Lost connection with manager. Setting lock.',
+                #f'Lost connection with manager. Setting lock.',
                 f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
                 f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f'Connected to the server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -128,7 +128,6 @@ metadata = [
                 f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
             ],
             [  # Stage 2 - Pass second server and connect to third
-                f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
                 f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
                 f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -365,7 +365,6 @@ def clean_keys(request, get_configuration):
 def restart_agentd():
     """Restart agentd daemon with debug mode active."""
     control_service('stop', daemon="wazuh-agentd")
-    truncate_file(LOG_FILE_PATH)
     control_service('start', daemon="wazuh-agentd", debug_mode=True)
 
 

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -290,6 +290,8 @@ receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in t
 authd_server = AuthdSimulator(SERVER_ADDRESS, key_path=SERVER_KEY_PATH, cert_path=SERVER_CERT_PATH)
 remoted_servers = []
 
+tcase_timeout = 120
+
 
 # fixtures
 @pytest.fixture(scope="module", params=configurations, ids=case_ids)
@@ -469,9 +471,9 @@ def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id
 
         for index, log_str in enumerate(get_configuration['metadata']['LOG_MONITOR_STR'][stage]):
             try:
-                log_monitor.start(timeout=120, callback=lambda x: wait_until(x, log_str))
-            except TimeoutError as err:
-                assert False, f'Expected message {log_str} never arrived! Stage: {stage}, message number: {index}'
+                log_monitor.start(timeout=tcase_timeout, callback=lambda x: wait_until(x, log_str))
+            except TimeoutError:
+                assert False, f"Expected message '{log_str}' never arrived! Stage: {stage+1}, message number: {index+1}"
 
         for i in range(0, get_configuration['metadata']['SIMULATOR_NUMBER']):
             # Clean after every stage


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #2671 |

## Description

After the merge of https://github.com/wazuh/wazuh/issues/4243, some logs changed, so we have updated this test in order to check those logs correctly.

## Testing

### Package
| Version | Link|
|---|---|
|v4.4.0|https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/var/wazuh-manager-4.4.0-2671.fix.agentd.x86_64.rpm
|v4.4.0|https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/var/wazuh-agent-4.4.0-2671.fix.agentd.x86_64.rpm
|v4.4.0|https://packages-dev.wazuh.com/warehouse/test/4.4/windows/wazuh-agent-4.4.0-2671.fix.agentd.msi

## Testing

### test_agentd

|  CentOS Agent  | Jenkins     | Notes
|---    |---    |---    |
| R1  |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration/23736/console/)  | |
| R2  |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration/23737/console/)  | |
| R3  |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration/23738/console/)  | |



|  Windows  | Jenkins     | Notes
|---    |---    |---    
| R1  |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration/23736/console/)  | |
| R2  |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration/23737/console/)  | |
| R3  |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration/23738/console/)  | |



* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress 

## Checks

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the [QA-Docs Schema 2.0](https://github.com/wazuh/wazuh-qa/wiki/QA-Documentation---How-to-document-a-test-using-Schema-2.0).