### PR TITLE
Fix `test_agent_key_polling`

### DIFF
--- a/tests/system/test_cluster/test_agent_key_polling/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_key_polling/data/messages.yml
@@ -13,9 +13,9 @@ wazuh-agent2:
   - regex: '.*Lost connection with manager. Setting lock.*'
     path: '/var/ossec/logs/ossec.log'
     timeout: 90
-  - regex: '.*Trying to connect to server \(wazuh-worker1.*'
+  - regex: '.*Trying to connect to server \(\[wazuh-worker1.*'
     path: '/var/ossec/logs/ossec.log'
     timeout: 90
-  - regex: '.*Connected to the server \(wazuh-worker1.*'
+  - regex: '.*Connected to the server \(\[wazuh-worker1.*'
     path: '/var/ossec/logs/ossec.log'
     timeout: 90


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #2608 |


## Description

After the development done in https://github.com/wazuh/wazuh/issues/4243, some logs were changed. Now, when the IP and the port are sent together, the IP is between brackets.

**Example**

```
022/02/25 17:18:30 wazuh-agentd: INFO: Closing connection to server ([wazuh-worker1/172.19.0.5]:1514/tcp).
2022/02/25 17:18:30 wazuh-agentd: INFO: Trying to connect to server ([wazuh-worker1/172.19.0.5]:1514/tcp).
```

## Testing

|Environment|Branch|
|:--:|:--:|
|basic_cluster|wazuh_branch: `master`, wazuh_qa_branch: `master`

|| Results |
|:--:|:--:|
|R1|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8264492/R1-test-agent-key-polling.zip)
|R2|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8264493/R2-test-agent-key-polling.zip)
|R3|[🟢 ](https://github.com/wazuh/wazuh-qa/files/8264495/R3-test-agent-key-polling.zip)