### PR TITLE
Show log order errors in all tasks for each worker

### DIFF
--- a/tests/reliability/test_cluster/test_cluster_logs/conftest.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/conftest.py
@@ -105,12 +105,13 @@ def pytest_runtest_makereport(item, call):
         elif report.head_line == 'test_check_logs_order_workers' and item.module.incorrect_order:
             extra.append(pytest_html.extras.html("<h2>Wrong logs order</h2>"))
             # Keys are human/natural sorted.
-            for item in sorted(item.module.incorrect_order,
-                               key=lambda d: [atoi(c) for c in re.split(r'(\d+)', d['node'])]):
-                extra.append(pytest_html.extras.html('<p><b>{node}:</b>\n'
-                                                     '<b> - Log type:</b> {log_type}\n'
-                                                     '<b> - Expected logs:</b> {expected_logs}\n'
-                                                     '<b> - Found log:</b> {found_log}</p>'.format(**item)))
+            for key in sorted(item.module.incorrect_order.keys(),
+                              key=lambda d: [atoi(c) for c in re.split(r'(\d+)', d)]):
+                extra.append(pytest_html.extras.html(f"<p><b>{key}:</b>\n"))
+                for failed_task in item.module.incorrect_order[key]:
+                    extra.append(pytest_html.extras.html('<b> - Log type:</b> {log_type}\n'
+                                                         '<b>   Expected logs:</b> {expected_logs}\n'
+                                                         '<b>   Found log:</b> {found_log}'.format(**failed_task)))
             extra.append(pytest_html.extras.html("</p><h2>Test output</h2>"))
 
         # Attach repeated Integrity synchronizations per each node in the 'test_cluster_sync' test.


### PR DESCRIPTION
|Related issue|
|---|
| Closes #2644 |


## Description

As explained in #2644, until now, if more than one cluster task printed logs in an incorrect order, the [test_cluster_logs_order](https://github.com/wazuh/wazuh-qa/tree/master/tests/reliability/test_cluster/test_cluster_logs/test_cluster_logs_order) would only report the error for the first failing task. This could cause other errors to go unnoticed.

After this PR, all incorrect tasks are reported. However, as it could be expected, only the first error in each task is shown. The reason is that, once a task prints a log in an incorrect order, all the remaining logs won't match the expected order either.


## Logs example

In this example we can see that errors have been reported for tasks `Agent-info sync` and `Integrity check` of worker 4. Before this PR, only the error for task `Agent-info sync` would have been reported:
```
E           Failed: 
E           
E           worker_4
E            - Log type: Agent-info sync
E              Expected logs: ['Starting.*']
E              Found log: 2021/09/29 11:51:11 DEBUG: [Worker CLUSTER-Workload_benchmarks_metrics_B59_manager_4] [Agent-info sync] Obtained 0 chunks of data in 0.000s.
E           
E            - Log type: Integrity check
E              Expected logs: ['Sending zip file to master.*']
E              Found log: 2021/09/29 11:51:22 DEBUG: [Worker CLUSTER-Workload_benchmarks_metrics_B59_manager_4] [Integrity check] Zip file sent to master.
E           
E           
E           worker_10
E            - Log type: Integrity sync
E              Expected logs: ['Starting.*']
E              Found log: 2021/09/29 11:59:40 INFO: [Worker CLUSTER-Workload_benchmarks_metrics_B59_manager_10] [Integrity sync] Files to create: 0 | Files to update: 1 | Files to delete: 0 | Files to send: 278
```

The report.html will show that information too:
![image](https://user-images.githubusercontent.com/23361101/159700339-eb3426ac-6ac4-478d-a71e-a3e3b9e0bfeb.png)


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.