### PR TITLE
Report Generator: Add metric support

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/sources/report_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/sources/report_generator.py
@@ -496,7 +496,6 @@ class ReportGenerator:
 
             metric_total[daemon] = StatisticsAnalyzer.calculate_values(metric_csv, self.metric_fields)
 
-        # name = f"{component}-{hosts_regex}" if hosts_regex != '.*' else component
         return metric_total
 
     def make_report(self):


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-qa/issues/2696|

## Description
A report generator is a QA tool used to obtain a JSON environment report. This includes information about error messages, daemons statistics, etc
This PR includes the metric analysis specified in the artifacts.

**Example**:  [report.zip](https://github.com/wazuh/wazuh-qa/files/8334289/report.zip)
**Build**: https://devel.ci.wazuh.info/job/Generic_reliability_launcher/236/