### PR TITLE
Add API integration test cases for API middleware functions

### DIFF
--- a/tests/integration/test_api/test_config/test_logs/data/conf.yaml
+++ b/tests/integration/test_api/test_config/test_logs/data/conf.yaml
@@ -9,3 +9,8 @@
   configuration:
     logs:
       level: debug
+- tags:
+  - logs_debug2
+  configuration:
+    logs:
+      level: debug2

--- a/tests/integration/test_api/test_middlewares/test_response_postprocessing.py
+++ b/tests/integration/test_api/test_middlewares/test_response_postprocessing.py
@@ -1,0 +1,127 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the response_postprocessing middleware of the API handled by the 'wazuh-apid' daemon is
+       working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh
+       manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+
+components:
+    - api
+
+suite: middlewares
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-apid
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+
+tags:
+    - api
+    - response
+    - response fields
+'''
+import json
+
+import pytest
+import requests
+from wazuh_testing import api
+
+
+# Tests
+
+@pytest.mark.parametrize(
+    'method, endpoint_url, json_body, use_login_token, expected_status_code, expected_response_text', [
+        ('POST', '/agents', {"wrong_key": "val"}, True, 400,
+         {'title': 'Bad Request', 'detail': "'name' is a required property"}),
+        ('GET', '/not_found_endpoint', None, True, 404,
+         {'title': 'Not Found', 'detail': '404: Not Found'}),
+        ('GET', '/agents', None, False, 401,
+         {'title': 'Unauthorized', 'detail': 'No authorization token provided'}),
+        ('GET', '/security/user/authenticate', None, False, 401,
+         {'title': 'Unauthorized', 'detail': 'Invalid credentials'})
+    ])
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+def test_response_postprocessing(get_api_details, method, endpoint_url, json_body, use_login_token,
+                                 expected_status_code, expected_response_text):
+    '''
+    description: Check if the response_postprocessing API middleware works.
+
+    wazuh_min_version: 4.0.0
+
+    tier: 0
+
+    parameters:
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+        - method:
+            type: str
+            brief: Method used in the API request.
+        - endpoint_url:
+            type: str
+            brief: Endpoint requested in the test.
+        - json_body:
+            type: dict
+            brief: JSON body used in POST API requests.
+        - use_login_token:
+            type: bool
+            brief: Variable used to determine whether a login token for the API request is needed or not.
+        - expected_status_code:
+            type: int
+            brief: Status code expected in the API response.
+        - expected_response_text:
+            type: dict
+            brief: Dictionary representing the expected API response text.
+
+    assertions:
+        - Verify that the fields are the expected ones when getting a 400 status code response (bad request).
+        - Verify that the fields are the expected ones when getting a 404 status code response (not found).
+        - Verify that the details are the expected ones when getting a 401 status code response (unauthorized).
+        - Verify that the details are the expected ones when getting a 401 status code response (invalid credentials).
+
+    tags:
+        - headers
+        - security
+    '''
+    api_details = get_api_details()
+    headers = api_details['auth_headers'] if use_login_token else api.get_login_headers('wrong_user', 'wrong_password')
+
+    # Make an API request
+    response = getattr(requests, method.lower())(f"{api_details['base_url']}/{endpoint_url}", headers=headers,
+                                                 verify=False, json=json_body)
+
+    assert response.headers['Content-Type'] == 'application/problem+json; charset=utf-8'
+    assert response.status_code == expected_status_code
+    assert json.loads(response.text) == expected_response_text  # type and status keys deleted

--- a/tests/integration/test_api/test_middlewares/test_response_postprocessing.py
+++ b/tests/integration/test_api/test_middlewares/test_response_postprocessing.py
@@ -9,7 +9,7 @@ type: integration
 
 brief: These tests will check if the response_postprocessing middleware of the API handled by the 'wazuh-apid' daemon is
        working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh
-       manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+       manager from a web browser, command line tools like 'cURL' or any script or program that can make web requests.
 
 components:
     - api

--- a/tests/integration/test_api/test_middlewares/test_set_secure_headers.py
+++ b/tests/integration/test_api/test_middlewares/test_set_secure_headers.py
@@ -1,0 +1,100 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: These tests will check if the set_secure_headers middleware of the API handled by the 'wazuh-apid' daemon is
+       working properly. The Wazuh API is an open source 'RESTful' API that allows for interaction with the Wazuh
+       manager from a web browser, command line tool like 'cURL' or any script or program that can make web requests.
+
+components:
+    - api
+
+suite: middlewares
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-apid
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - CentOS 6
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Debian Buster
+    - Debian Stretch
+    - Debian Jessie
+    - Debian Wheezy
+    - Red Hat 8
+    - Red Hat 7
+    - Red Hat 6
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+
+tags:
+    - api
+    - response
+    - headers
+'''
+import pytest
+import requests
+
+
+# Tests
+
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+def test_secure_headers(get_api_details):
+    '''
+    description: Check if the set_secure_headers API middleware works.
+                 For this purpose, the test makes an API request and checks that the response headers fulfill the REST
+                 recommended standard.
+
+    wazuh_min_version: 4.1.0
+
+    tier: 0
+
+    parameters:
+        - get_api_details:
+            type: fixture
+            brief: Get API information.
+
+    assertions:
+        - Verify that the response headers fulfill the REST recommended standard in terms of security.
+
+    tags:
+        - headers
+        - security
+    '''
+    api_details = get_api_details()
+
+    # Make an API request
+    response = requests.get(f"{api_details['base_url']}/agents", headers=api_details['auth_headers'], verify=False)
+
+    # Check response headers fulfill the REST standard
+    security_headers_keys = {'Cache-control', 'Content-Security-Policy', 'Content-Type', 'Strict-Transport-Security',
+                             'X-Content-Type-Options', 'X-Frame-Options'}
+    security_headers_keys_with_values = {'Cache-control': 'no-store', 'Content-Security-Policy': 'none',
+                                         'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'DENY'}
+
+    # Check that all the security headers are in the response
+    assert security_headers_keys.issubset(response.headers.keys())
+    # Check that Cache-control, Content-Security-Policy, X-Content-Type-Options and X-Frame-Options have the expected
+    # values
+    assert all(
+        security_headers_keys_with_values[key] in response.headers[key] for key in security_headers_keys_with_values)


### PR DESCRIPTION
|Related issue|
|---|
|#2576|



## Description

This pull request closes #2576.

This PR adds new QA API integration tests to our `tests/integration/test_api` directory.

New tests in `test_api/test_middlewares`:

- `test_response_postprocessing.py`
- `test_set_secure_headers.py`

New test cases in `test_api/test_config/test_logs`:

- `test_logs.py`

### Test results


```console
/wazuh-qa/tests/integration/test_api# pytest test_middlewares/test_response_postprocessing.py -vv
=========================== test session starts ============================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0
collected 4 items                                                          

test_middlewares/test_response_postprocessing.py::test_response_postprocessing[POST-/agents-json_body0-True-400-expected_response_text0] PASSED [ 25%]
test_middlewares/test_response_postprocessing.py::test_response_postprocessing[GET-/not_found_endpoint-None-True-404-expected_response_text1] PASSED [ 50%]
test_middlewares/test_response_postprocessing.py::test_response_postprocessing[GET-/agents-None-False-401-expected_response_text2] PASSED [ 75%]
test_middlewares/test_response_postprocessing.py::test_response_postprocessing[GET-/security/user/authenticate-None-False-401-expected_response_text3] PASSED [100%]

============================ 4 passed in 1.96s =============================

```

```console
/wazuh-qa/tests/integration/test_api# pytest test_config/test_logs/test_logs.py 
=========================== test session starts ============================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0
collected 15 items                                                         

test_config/test_logs/test_logs.py .s...s....ss...                   [100%]

================= 11 passed, 4 skipped in 97.59s (0:01:37) =================
```

```console
/wazuh-qa/tests/integration/test_api# pytest test_middlewares/test_set_secure_headers.py 
=========================== test session starts ============================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0
collected 1 item                                                           

test_middlewares/test_set_secure_headers.py .                        [100%]

============================ 1 passed in 0.52s =============================
```

```console
/wazuh-qa/tests/integration/test_api# pytest test_config/
=========================== test session starts ============================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0
collected 62 items                                                         

test_config/test_DOS_blocking_system/test_DOS_blocking_system.py .ss [  4%]
.                                                                    [  6%]
test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py . [  8%]
ss.                                                                  [ 12%]
test_config/test_cache/test_cache.py .ss.                            [ 19%]
test_config/test_cors/test_cors.py xX                                [ 22%]
test_config/test_drop_privileges/test_drop_privileges.py .ss.        [ 29%]
test_config/test_experimental_features/test_experimental_features.py . [ 30%]
ss.                                                                  [ 35%]
test_config/test_host_port/test_host_port.py .s.ss.s.                [ 48%]
test_config/test_https/test_https.py .ss.                            [ 54%]
test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py . [ 56%]
ss.                                                                  [ 61%]
test_config/test_logs/test_logs.py .s...s....ss...                   [ 85%]
test_config/test_max_upload_size/test_max_upload_size.py ....        [ 91%]
test_config/test_rbac/test_rbac_mode.py .ss.                         [ 98%]
test_config/test_request_timeout/test_request_timeout.py .           [100%]

============================= warnings summary =============================
test_api/test_config/test_max_upload_size/test_max_upload_size.py::test_max_upload_size[max_upload_size_0-content_size_100-tags_to_apply0]
test_api/test_config/test_max_upload_size/test_max_upload_size.py::test_max_upload_size[max_upload_size_5-content_size_20-tags_to_apply0]
test_api/test_config/test_max_upload_size/test_max_upload_size.py::test_max_upload_size[max_upload_size_40-content_size_10-tags_to_apply0]
test_api/test_config/test_max_upload_size/test_max_upload_size.py::test_max_upload_size[max_upload_size_40-content_size_500-tags_to_apply0]
test_api/test_config/test_request_timeout/test_request_timeout.py::test_request_timeout[get_configuration0-tags_to_apply0]
  /usr/lib/python3/dist-packages/urllib3/connectionpool.py:999: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
= 36 passed, 24 skipped, 1 xfailed, 1 xpassed, 5 warnings in 719.04s (0:11:59) =
```

```console
/wazuh-qa/tests/integration/test_api# pytest test_middlewares/
=========================== test session starts ============================
platform linux -- Python 3.8.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0
collected 5 items                                                          

test_middlewares/test_response_postprocessing.py ....                [ 80%]
test_middlewares/test_set_secure_headers.py .                        [100%]

============================ 5 passed in 2.54s =============================
```


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.