### PR TITLE
IT - Fix agentd tests

### DIFF
--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -97,12 +97,12 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [  # Stage 1
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
-                f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
-                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
-                f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
-                f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
-                f'Requesting a key from server: {SERVER_HOSTS[2]}/{SERVER_ADDRESS}'
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
+                f'Requesting a key from server: {SERVER_HOSTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[2]}]:{REMOTED_PORTS[2]}',
+                f'Requesting a key from server: {SERVER_HOSTS[2]}'
             ]
         ]
     },
@@ -122,16 +122,16 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [  # Stage 1 - Enroll to first server
-                f'Requesting a key from server: {SERVER_HOSTS[0]}/{SERVER_ADDRESS}',
+                f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f'Valid key received',
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
                 f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}",
             ],
             [  # Stage 2 - Pass second server and connect to third
-                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
-                f'Requesting a key from server: {SERVER_HOSTS[1]}/{SERVER_ADDRESS}',
-                f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
-                f'Connected to the server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
+                f'Requesting a key from server: {SERVER_HOSTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[2]}]:{REMOTED_PORTS[2]}',
+                f'Connected to the server ([{SERVER_HOSTS[2]}]:{REMOTED_PORTS[2]}',
                 f"Received message: '#!-agent ack '"
             ]
         ]
@@ -154,15 +154,15 @@ metadata = [
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f'Valid key received',
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
-                f'Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
+                f'Connected to the server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
             ],
             [
                 #f'Lost connection with manager. Setting lock.',
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
-                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
-                f'Connected to the server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
+                f'Connected to the server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
                 f"Received message: '#!-agent ack '",
             ]
         ]
@@ -186,15 +186,15 @@ metadata = [
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
                 f"Connected to enrollment service at '[{SERVER_ADDRESS}]:{AUTHD_PORT}'",
                 f'Valid key received',
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
-                f'Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
+                f'Connected to the server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
                 f"Received message: '#!-agent ack '"
             ],  # Stage 2 - Enroll and connect to second server after failed attempts to connect with server 1
             [
                 f'Server unavailable. Setting lock.',
                 f'Requesting a key from server: {SERVER_HOSTS[0]}',
-                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
-                f'Connected to the server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
+                f'Connected to the server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
                 f"Received message: '#!-agent ack '",
             ]
         ]
@@ -214,11 +214,11 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
                 f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}",
             ],
             [
-                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
                 f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}",
             ],
             [
@@ -242,18 +242,18 @@ metadata = [
         },
         'LOG_MONITOR_STR': [
             [
-                f'Trying to connect to server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}',
-                f"Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}",
+                f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
+                f"Connected to the server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}",
                 f"Received message: '#!-agent ack '",
             ],
             [
-                f'Trying to connect to server ([{SERVER_HOSTS[1]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
                 f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[1]}",
             ],
             [
-                f'Trying to connect to server ([{SERVER_HOSTS[2]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}',
+                f'Trying to connect to server ([{SERVER_HOSTS[2]}]:{REMOTED_PORTS[2]}',
                 f"Unable to connect to '[{SERVER_ADDRESS}]:{REMOTED_PORTS[2]}",
-                f"Connected to the server ([{SERVER_HOSTS[0]}/{SERVER_ADDRESS}]:{REMOTED_PORTS[0]}",
+                f"Connected to the server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}",
                 f'Server responded. Releasing lock.',
                 f"Received message: '#!-agent ack '"
             ]


### PR DESCRIPTION
|Related issue|
|---|
| Closes: #2729 |


## Description
After the merge of https://github.com/wazuh/wazuh/pull/12704/, we can see that the following log:

```
2022/03/28 12:48:06 wazuh-agentd[69594] start_agent.c:89 at connect_server(): INFO: Trying to connect to server ([testServer1/127.0.0.1]:1514/tcp).
```

changed to:

```
2022/03/26 00:56:46 wazuh-agentd[12567] start_agent.c:89 at connect_server(): INFO: Trying to connect to server ([testServer1]:1514/tcp).
```


## Packages
|Version| Link|
|:--:|:--:|
|v4.4.0| https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/var/wazuh-manager-4.4.0-agentd.test.x86_64.rpm
|v4.4.0| https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/var/wazuh-agent-4.4.0-agentd.test.x86_64.rpm
|v4.4.0| https://packages-dev.wazuh.com/warehouse/test/4.4/windows/wazuh-agent-4.4.0-agentd.test.msi

## Testing

|CentOS Agent|Jenkins|
|:--:|:--:|
|R1| [🟢  ](https://ci.wazuh.info/view/Tests/job/Test_integration/24561/)
|R2| [🟢 ](https://ci.wazuh.info/view/Tests/job/Test_integration/24568/)
|R3| [🟢 ](https://ci.wazuh.info/view/Tests/job/Test_integration/24569/)

|Windos Agent|Jenkins|
|:--:|:--:|
|R1| [🟡   ](https://ci.wazuh.info/view/Tests/job/Test_integration/24561/)
|R2| [🟡  ](https://ci.wazuh.info/view/Tests/job/Test_integration/24568/)
|R3|[🟡  ](https://ci.wazuh.info/view/Tests/job/Test_integration/24569/)