### PR TITLE
Adapt Gcloud integration tests to logging parameter deprecation

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/gcloud.py
+++ b/deps/wazuh_testing/wazuh_testing/gcloud.py
@@ -27,7 +27,8 @@ def validate_gcp_event(event):
 
 
 def callback_detect_start_gcp(line):
-    if 'wm_gcp_pubsub_main(): INFO: Module started.' in line:
+    match = re.match(r'.*wazuh-modulesd:gcp-pubsub.*INFO: Module started.$', line)
+    if match:
         return line
     return None
 
@@ -63,7 +64,7 @@ def callback_received_messages_number(line):
 
 
 def callback_detect_all_gcp(line):
-    match = re.match(r'.*wazuh-modulesd:gcp-pubsub\[\d+\].*', line)
+    match = re.match(r'.*wazuh-modulesd:gcp-pubsub.*', line)
     if match:
         return line
     return None

--- a/deps/wazuh_testing/wazuh_testing/gcloud.py
+++ b/deps/wazuh_testing/wazuh_testing/gcloud.py
@@ -56,7 +56,7 @@ def detect_gcp_start(file_monitor):
 
 
 def callback_received_messages_number(line):
-    match = re.match(r'.*wm_gcp_pubsub_run\(\): INFO: - INFO - Received and acknowledged (\d+) messages', line)
+    match = re.match(r'.*wm_gcp_parse_output\(\): INFO: Received and acknowledged (\d+) messages', line)
     if match:
         return match.group(1)
     return None

--- a/tests/integration/test_gcloud/test_configuration/data/invalid_conf.yaml
+++ b/tests/integration/test_gcloud/test_configuration/data/invalid_conf.yaml
@@ -253,7 +253,7 @@
         value: ''
 # conf 18
 - tags:
-  - invalid_logging
+  - invalid_schedule
   apply_to_modules:
   - 'MODULE_NAME'
   sections:
@@ -265,11 +265,11 @@
         value: 'SUBSCRIPTION_NAME'
     - credentials_file:
         value: 'CREDENTIALS_FILE'
-    - logging:
+    - day:
         value: 'aaaaa'
 # conf 19
 - tags:
-  - invalid_logging
+  - invalid_schedule
   apply_to_modules:
   - 'MODULE_NAME'
   sections:
@@ -281,7 +281,7 @@
         value: 'SUBSCRIPTION_NAME'
     - credentials_file:
         value: 'CREDENTIALS_FILE'
-    - logging:
+    - day:
         value: ''
 # conf 20
 - tags:
@@ -297,7 +297,7 @@
         value: 'SUBSCRIPTION_NAME'
     - credentials_file:
         value: 'CREDENTIALS_FILE'
-    - day:
+    - wday:
         value: 'aaaaa'
 # conf 21
 - tags:
@@ -313,7 +313,7 @@
         value: 'SUBSCRIPTION_NAME'
     - credentials_file:
         value: 'CREDENTIALS_FILE'
-    - day:
+    - wday:
         value: ''
 # conf 22
 - tags:
@@ -329,7 +329,7 @@
         value: 'SUBSCRIPTION_NAME'
     - credentials_file:
         value: 'CREDENTIALS_FILE'
-    - wday:
+    - time:
         value: 'aaaaa'
 # conf 23
 - tags:
@@ -345,41 +345,9 @@
         value: 'SUBSCRIPTION_NAME'
     - credentials_file:
         value: 'CREDENTIALS_FILE'
-    - wday:
+    - time:
         value: ''
 # conf 24
-- tags:
-  - invalid_schedule
-  apply_to_modules:
-  - 'MODULE_NAME'
-  sections:
-  - section: gcp-pubsub
-    elements:
-    - project_id:
-        value: 'PROJECT_ID'
-    - subscription_name:
-        value: 'SUBSCRIPTION_NAME'
-    - credentials_file:
-        value: 'CREDENTIALS_FILE'
-    - time:
-        value: 'aaaaa'
-# conf 25
-- tags:
-  - invalid_schedule
-  apply_to_modules:
-  - 'MODULE_NAME'
-  sections:
-  - section: gcp-pubsub
-    elements:
-    - project_id:
-        value: 'PROJECT_ID'
-    - subscription_name:
-        value: 'SUBSCRIPTION_NAME'
-    - credentials_file:
-        value: 'CREDENTIALS_FILE'
-    - time:
-        value: ''
-# conf 26
 - tags:
   - invalid_day_wday
   apply_to_modules:
@@ -397,7 +365,7 @@
         value: 1
     - wday:
         value: 'monday'
-# conf 27
+# conf 25
 - tags:
   - invalid_gcp_wmodule
   apply_to_modules:

--- a/tests/integration/test_gcloud/test_configuration/data/wazuh_remote_conf.yaml
+++ b/tests/integration/test_gcloud/test_configuration/data/wazuh_remote_conf.yaml
@@ -33,8 +33,6 @@
         value: 'PULL_ON_START'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'
     - interval:
         value: 'INTERVAL'
     - day:
@@ -67,8 +65,6 @@
         value: 'MAX_MESSAGES'
     - max_messages:
         value: 50
-    - logging:
-        value: 'LOGGING'
     - wday:
         value: 'WDAY'
     - wday:

--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -71,7 +71,6 @@ enabled = 'yes'
 pull_on_start = 'yes'
 max_messages = 200
 interval = '2h'
-logging = "debug"
 day = 9
 wday = 'tuesday'
 time = '08:00'
@@ -89,7 +88,7 @@ conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'ENABLED': enabled,
                'PULL_ON_START': pull_on_start, 'MAX_MESSAGES': max_messages,
-               'INTERVAL': interval, 'LOGGING': logging, 'DAY': day, 'WDAY': wday,
+               'INTERVAL': interval, 'DAY': day, 'WDAY': wday,
                'TIME': time, 'MODULE_NAME': __name__}
 p, m = generate_params(extra_params=conf_params,
                        modes=monitoring_modes)
@@ -211,5 +210,4 @@ def test_remote_configuration(get_configuration, configure_environment, reset_os
         assert gcp_remote['enabled'] == 'yes'
         assert gcp_remote['pull_on_start'] == 'yes'
         assert gcp_remote['max_messages'] == 100
-        assert gcp_remote['logging'] == 'info'
         assert gcp_remote['interval'] == 3600

--- a/tests/integration/test_gcloud/test_functionality/data/wazuh_conf.yaml
+++ b/tests/integration/test_gcloud/test_functionality/data/wazuh_conf.yaml
@@ -19,5 +19,3 @@
         value: 'INTERVAL'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'

--- a/tests/integration/test_gcloud/test_functionality/data/wazuh_schedule_conf.yaml
+++ b/tests/integration/test_gcloud/test_functionality/data/wazuh_schedule_conf.yaml
@@ -23,8 +23,6 @@
         value: 'DAY_TIME'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'
 # conf 2
 - tags:
   - ossec_wday_conf
@@ -49,8 +47,6 @@
         value: 'WDAY_TIME'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'
 # conf 3
 - tags:
   - ossec_time_conf
@@ -73,8 +69,6 @@
         value: 'INTERVAL'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'
 # conf 4
 - tags:
   - ossec_day_multiple_conf
@@ -95,8 +89,6 @@
         value: '2M'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'
 # conf 5
 - tags:
   - ossec_wday_multiple_conf
@@ -117,8 +109,6 @@
         value: '3w'
     - max_messages:
         value: 'MAX_MESSAGES'
-    - logging:
-        value: 'LOGGING'
 # conf 6
 - tags:
   - ossec_time_multiple_conf
@@ -137,5 +127,3 @@
         value: 'MAX_MESSAGES'
     - interval:
         value: '4d'
-    - logging:
-        value: 'LOGGING'

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -100,7 +100,7 @@ conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'INTERVAL': interval,
                'PULL_ON_START': pull_on_start, 'MAX_MESSAGES': max_messages,
-               'LOGGING': logging, 'DAY': day, 'WDAY': wday, 'DAY_TIME': day_time,
+               'DAY': day, 'WDAY': wday, 'DAY_TIME': day_time,
                'WDAY_TIME': day_time, 'TIME': day_time, 'MODULE_NAME': __name__}
 
 p, m = generate_params(extra_params=conf_params,

--- a/tests/integration/test_gcloud/test_functionality/test_interval.py
+++ b/tests/integration/test_gcloud/test_functionality/test_interval.py
@@ -86,7 +86,7 @@ monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'PULL_ON_START': pull_on_start,
-               'MAX_MESSAGES': max_messages, 'LOGGING': logging, 'MODULE_NAME': __name__}
+               'MAX_MESSAGES': max_messages, 'MODULE_NAME': __name__}
 
 p, m = generate_params(extra_params=conf_params,
                        apply_to_all=({'INTERVAL': interval_value} for interval_value in interval),

--- a/tests/integration/test_gcloud/test_functionality/test_logging.py
+++ b/tests/integration/test_gcloud/test_functionality/test_logging.py
@@ -57,7 +57,7 @@ from wazuh_testing import global_parameters
 from wazuh_testing.fim import generate_params
 from wazuh_testing.gcloud import callback_detect_all_gcp
 from wazuh_testing.tools import LOG_FILE_PATH
-from wazuh_testing.tools.configuration import load_wazuh_configurations
+import wazuh_testing.tools.configuration as conf
 from wazuh_testing.tools.monitoring import FileMonitor
 
 # Marks
@@ -69,7 +69,6 @@ pytestmark = pytest.mark.tier(level=0)
 interval = '25s'
 pull_on_start = 'yes'
 max_messages = 100
-logging = ['info', 'debug', 'warning', 'error', 'critical']
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
@@ -84,15 +83,54 @@ conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'INTERVAL': interval,
                'PULL_ON_START': pull_on_start, 'MAX_MESSAGES': max_messages,
                'MODULE_NAME': __name__}
+log_levels = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
 
 p, m = generate_params(extra_params=conf_params,
-                       apply_to_all=({'LOGGING': logging_value} for logging_value in logging),
+                       apply_to_all=(),
                        modes=monitoring_modes)
 
-configurations = load_wazuh_configurations(configurations_path, __name__, params=p, metadata=m)
+configurations = conf.load_wazuh_configurations(configurations_path, __name__,
+                                           params=p, metadata=m)
 
 
 # fixtures
+@pytest.fixture(scope='package', params= [
+    {'wazuh_modules.debug': 0, 'analysisd.debug': 2,
+      'monitord.rotate_log': 0, 'monitord.day_wait': 0,
+      'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
+    {'wazuh_modules.debug': 1, 'analysisd.debug': 2,
+     'monitord.rotate_log': 0, 'monitord.day_wait': 0,
+     'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
+    {'wazuh_modules.debug': 2, 'analysisd.debug': 2,
+     'monitord.rotate_log': 0, 'monitord.day_wait': 0,
+     'monitord.keep_log_days': 0, 'monitord.size_rotate': 0}
+])
+def get_local_internal_options(request):
+    """Get internal configuration."""
+    return request.param
+
+
+@pytest.fixture(scope='package')
+def configure_local_internal_options_package(get_local_internal_options):
+    """Fixture to configure the local internal options file.
+
+    It uses the test variable local_internal_options. This should be
+    a dictionary wich keys and values corresponds to the internal option configuration, For example:
+    local_internal_options = {'monitord.rotate_log': '0', 'syscheck.debug': '0' }
+    """
+    local_internal_options = get_local_internal_options
+
+    backup_local_internal_options = conf.get_local_internal_options_dict()
+
+    conf.set_local_internal_options_dict(local_internal_options)
+    import wazuh_testing.tools.services as services
+    services.restart_wazuh_daemon('wazuh-modulesd')
+
+
+    yield
+
+    conf.set_local_internal_options_dict(backup_local_internal_options)
+
 
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
@@ -104,16 +142,18 @@ def get_configuration(request):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 @pytest.mark.parametrize('publish_messages', [
-    ['- DEBUG - GCP message' for _ in range(5)]
+    (['{level} GCP'.format(level=log_level) for log_level in log_levels]),
 ], indirect=True)
-def test_logging(get_configuration, configure_environment, reset_ossec_log, publish_messages, daemons_handler, wait_for_gcp_start):
+def test_logging(get_configuration, configure_environment, reset_ossec_log,
+                 publish_messages, configure_local_internal_options_package,
+                 daemons_handler, wait_for_gcp_start):
     '''
-    description: Check if the 'gcp-pubsub' module generates logs according to the set type in the 'logging' tag.
-                 For this purpose, the test will use different logging levels (depending on the test case) and
+    description: Check if the 'gcp-pubsub' module generates logs according to the debug level set for wazuh_modules.
+                 For this purpose, the test will use different debug levels (depending on the test case) and
                  gets the GCP events. Finally, the test will verify that the type of all retrieved events matches
                  the one specified in the configuration.
 
-    wazuh_min_version: 4.2.0
+    wazuh_min_version: 4.4.0
 
     tier: 0
 
@@ -127,6 +167,10 @@ def test_logging(get_configuration, configure_environment, reset_ossec_log, publ
         - publish_messages:
             type: list
             brief: List of testing GCP logs.
+        - configure_local_internal_options_package:
+            type: fixture
+            brief: Fixture to modify the local_internal_options.conf file
+                   and restart modulesd.
         - restart_wazuh:
             type: fixture
             brief: Reset the 'ossec.log' file and start a new monitor.
@@ -150,26 +194,25 @@ def test_logging(get_configuration, configure_environment, reset_ossec_log, publ
         - scheduled
     '''
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
-    logging_opt = get_configuration['sections'][0]['elements'][6]['logging']['value']
+    logging_opt = int([x[-2] for x in conf.get_wazuh_local_internal_options()
+                   if x.startswith('wazuh_modules.debug')][0])
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
-
-    if logging_opt == 'info':
-        key_words = ['- DEBUG -', '- WARNING -', '- ERROR -', '- CRITICAL -']
-    elif logging_opt == 'debug':
-        key_words = ['- INFO -', '- WARNING -', '- ERROR -', '- CRITICAL -']
-    elif logging_opt == 'warning':
-        key_words = ['- INFO -', '- DEBUG -', '- ERROR -', '- CRITICAL -']
-    elif logging_opt == 'warning':
-        key_words = ['- INFO -', '- DEBUG -', '- WARNING -', '- CRITICAL -']
+    if logging_opt == 0:
+        skipped_keywords = ['DEBUG:']
     else:
-        key_words = ['- INFO -', '- DEBUG -', '- WARNING -', '- ERROR -']
+        skipped_keywords = []
 
     for nevents in range(0, 12):
-        event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout + time_interval + 5,
-                                        callback=callback_detect_all_gcp,
-                                        accum_results=1,
-                                        error_message='Did not receive expected '
-                                                      'wazuh-modulesd:gcp-pubsub[]').result()
-
-        for key in key_words:
+        try:
+            event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout + time_interval + 5,
+                                            callback=callback_detect_all_gcp,
+                                            accum_results=1,
+                                            error_message='Did not receive expected '
+                                                          'wazuh-modulesd:gcp-pubsub[]').result()
+        except TimeoutError:
+            if logging_opt == 0:
+                continue
+            else:
+                raise
+        for key in skipped_keywords:
             assert key not in event

--- a/tests/integration/test_gcloud/test_functionality/test_logging.py
+++ b/tests/integration/test_gcloud/test_functionality/test_logging.py
@@ -114,7 +114,7 @@ def get_local_internal_options(request):
 def configure_local_internal_options_package(get_local_internal_options):
     """Fixture to configure the local internal options file.
 
-    It uses the test variable local_internal_options. This should be
+    It uses the test fixture get_local_internal_options. This should be
     a dictionary wich keys and values corresponds to the internal option configuration, For example:
     local_internal_options = {'monitord.rotate_log': '0', 'syscheck.debug': '0' }
     """
@@ -180,6 +180,7 @@ def test_logging(get_configuration, configure_environment, reset_ossec_log,
 
     assertions:
         - Verify that the logging level of retrieved GCP events matches the one specified in the 'logging' tag.
+        - Verify that the module outputs messages that correspond to the logging level.
 
     input_description: A test case (ossec_conf) is contained in an external YAML file (wazuh_conf.yaml)
                        which includes configuration settings for the 'gcp-pubsub' module. That is

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -74,7 +74,6 @@ interval = '25s'
 pull_messages_timeout = global_parameters.default_timeout + 60
 pull_on_start = 'no'
 max_messages = 100
-logging = 'info'
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
@@ -88,7 +87,7 @@ conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'INTERVAL': interval,
                'PULL_ON_START': pull_on_start, 'MAX_MESSAGES': max_messages,
-               'LOGGING': logging, 'MODULE_NAME': __name__}
+               'MODULE_NAME': __name__}
 
 p, m = generate_params(extra_params=conf_params,
                        modes=monitoring_modes)
@@ -160,7 +159,7 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
 
     expected_output:
         - r'wm_gcp_main(): DEBUG.* Starting fetching of logs.'
-        - r'.*wm_gcp_run.*: INFO.* - INFO - Received and acknowledged .* messages'
+        - r'.*wm_gcp_run.*: INFO.* INFO: Received and acknowledged .* messages'
 
     tags:
         - logs
@@ -179,7 +178,7 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
         number_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
                                                 callback=callback_received_messages_number,
                                                 error_message='Did not receive expected '
-                                                              '- INFO - Received and acknowledged x messages').result()
+                                                              'INFO: Received and acknowledged x messages').result()
         # GCP might log messages from sources other than ourselves
         assert int(number_pulled) >= publish_messages
     else:
@@ -195,6 +194,6 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
         number_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
                                                 callback=callback_received_messages_number,
                                                 error_message='Did not receive expected '
-                                                              '- INFO - Received and acknowledged x messages').result()
+                                                              'INFO: Received and acknowledged x messages').result()
         # GCP might log messages from sources other than ourselves
         assert int(number_pulled) >= remainder

--- a/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
+++ b/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
@@ -84,7 +84,7 @@ monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'INTERVAL': interval,
-               'MAX_MESSAGES': max_messages, 'LOGGING': logging, 'MODULE_NAME': __name__}
+               'MAX_MESSAGES': max_messages, 'MODULE_NAME': __name__}
 
 p, m = generate_params(extra_params=conf_params,
                        apply_to_all=({'PULL_ON_START': pull_on_start_value} for pull_on_start_value in pull_on_start),

--- a/tests/integration/test_gcloud/test_functionality/test_rules.py
+++ b/tests/integration/test_gcloud/test_functionality/test_rules.py
@@ -69,7 +69,6 @@ pytestmark = [pytest.mark.tier(level=0), pytest.mark.server]
 interval = '10s'
 pull_on_start = 'no'
 max_messages = 100
-logging = 'debug'
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
@@ -84,7 +83,7 @@ conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
                'CREDENTIALS_FILE': global_parameters.gcp_credentials_file, 'INTERVAL': interval,
                'PULL_ON_START': pull_on_start, 'MAX_MESSAGES': max_messages,
-               'LOGGING': logging, 'MODULE_NAME': __name__}
+               'MODULE_NAME': __name__}
 
 p, m = generate_params(extra_params=conf_params,
                        modes=monitoring_modes)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2693|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we adapt the GCloud integration tests to the deprecation of the logging parameter. After the changes made in wazuh/wazuh#10334, the module stopped using a custom `logging` parameter to start using the `wazuh_modules.debug` value, as the rest of the external integrations do. 
This change has required modifying some of the regex that the `wazuh-testing` library uses to detect GCP logs, along with minor changes in most of the tests. The only test that required a more thorough refactor is the `test_logging` one, which tested that, for every logging level, the module would only receive the messages pertaining to that same logging level. Since now the module uses 'cascade' logging levels, that is, the more verbose levels contain the less verbose ones, the test needed a complete refactor, and it now tests that for lower logging levels the module won't get debug messages and that for greater ones it will get messages having the expected debug levels.

To make sure that Wazuh is restarted once the `local_internal_options.conf` file was set for the `test_logging` test, we added `package` level fixtures to set the configuration file.

## Tests
<details><summary>Integration tests execution</summary>

The GCloud tests executed using the [10334-standardize-gcp-logging](https://github.com/wazuh/wazuh/tree/feature/10334-standardize-gcp-logging) branch show the following results:

        ==================================== test session starts ====================================
        platform linux -- Python 3.6.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
        rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
        plugins: html-3.1.1, testinfra-5.0.0, metadata-1.11.0
        collected 84 items                                                                          
        
        test_gcloud/test_configuration/test_invalid.py .........................              [ 29%]
        test_gcloud/test_configuration/test_remote_configuration.py ...                       [ 33%]
        test_gcloud/test_configuration/test_schedule.py .........                             [ 44%]
        test_gcloud/test_functionality/test_day_wday.py .ssssss.ssssss.ssssss.ssssss.ssssss.  [ 86%]
        test_gcloud/test_functionality/test_interval.py ..                                    [ 89%]
        test_gcloud/test_functionality/test_logging.py ...                                    [ 92%]
        test_gcloud/test_functionality/test_max_messages.py ...                               [ 96%]
        test_gcloud/test_functionality/test_pull_on_start.py ..                               [ 98%]
        test_gcloud/test_functionality/test_rules.py .                                        [100%]
        
        ================== 54 passed, 30 skipped, 53 warnings in 588.91s (0:09:48) ==================


</details>

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.