### PR TITLE
Add provisioning data file to launch the system tests in a Jenkins pipeline

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/monitoring.py
@@ -988,7 +988,7 @@ class HostMonitor:
                 monitor = QueueMonitor(tailer.queue, time_step=self._time_step)
                 try:
                     self._queue.put({host: monitor.start(timeout=case['timeout'],
-                                                         callback=make_callback(pattern=case['regex'], prefix=None),
+                                                         callback=make_callback(pattern=case['regex'], prefix='.*'),
                                                          update_position=False
                                                          ).result()})
                 except TimeoutError:

--- a/tests/system/provisioning/one_manager_agent/roles/agent-role/tasks/main.yml
+++ b/tests/system/provisioning/one_manager_agent/roles/agent-role/tasks/main.yml
@@ -50,7 +50,7 @@
   copy:
     src: ../files/ossec.conf
     dest: /var/ossec/etc/ossec.conf
-    owner: ossec
+    owner: root
     mode: '0644'
 
 - name: Remove client.keys
@@ -62,7 +62,7 @@
   lineinfile:
     path: /var/ossec/etc/client.keys
     line: "{{ agent_id }} {{agent_hostname}} any {{ agent_key }}"
-    owner: ossec
+    owner: root
     mode: "0644"
     create: yes
 

--- a/tests/system/provisioning/provisioning_data.json
+++ b/tests/system/provisioning/provisioning_data.json
@@ -1,0 +1,30 @@
+{
+    "agentless_cluster": [
+        "test_jwt_invalidation/test_change_rbac_mode.py",
+        "test_jwt_invalidation/test_change_security_resources.py",
+        "test_jwt_invalidation/test_disconnected_nodes.py",
+        "test_jwt_invalidation/test_revoke_endpoint.py",
+        "test_jwt_invalidation/test_update_password.py",
+        "test_cluster/test_integrity_sync/test_integrity_sync.py"
+    ],
+    "basic_cluster": [
+        "test_cluster/test_agent_files_deletion/test_agent_files_deletion.py",
+        "test_cluster/test_agent_info_sync/test_agent_info_sync.py",
+        "test_cluster/test_agent_key_polling/test_agent_key_polling.py",
+        "test_multigroups/test_multigroups.py"
+    ],
+    "basic_environment": [
+        "test_agent_auth/test_agent_auth.py",
+        "test_enrollment/test_enrollment.py"
+    ],
+    "enrollment_cluster": [
+        "test_cluster/test_agent_enrollment/test_agent_enrollment.py"
+    ],
+    "manager_agent": [
+        "test_active_response_log_format/test_active_response_log_format.py"
+    ],
+    "one_manager_agent": [
+        "test_fim/test_files/test_files_cud.py",
+        "test_fim/test_synchronization/test_synchronization.py"
+    ]
+}


### PR DESCRIPTION
| Related issue |
|--------------------|
| close #2700 |

This PR adds the necessary from the `wazuh-qa` repository to launch the system tests in a Jenkins pipeline build.

To do this, it has been added the following:

- Provisioning data file that contains the provisioning type for each system tests
- Fixes with monitoring prefix and client.keys owner file

Tested in https://devel.ci.wazuh.info/job/Test_system/109/