### PR TITLE
Add a test to check the multigroups shared file content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release report: TBD
 - Add test to check if files can be accessed while FIM has them opened ([#705](https://github.com/wazuh/wazuh-qa/pull/705))
 - Analysisd - add a new test to check analysisd socket properties ([#2405](https://github.com/wazuh/wazuh-qa/pull/2405))
 - Add system test to check synchronization between agent and manager when one of this was stopped. ([#2536](https://github.com/wazuh/wazuh-qa/pull/2536))
+- Add a test to check the multigroups shared file content. ([#2746](https://github.com/wazuh/wazuh-qa/pull/2746))
 
 ### Changed
 

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -24,10 +24,18 @@ def remove_agents(agents_id, remove_type='wazuhdb'):
                                 stderr=subprocess.STDOUT)
             elif remove_type == 'wazuhdb':
                 result = query_wdb(f"global delete-agent {str(agent_id)}")
-            elif remove_type == 'api':
-                api_details = get_api_details_dict()
-                api_query = f"{api_details['base_url']}/agents?older_than=0s&agents_list={agents_id}&status=all"
-                response = requests.delete(api_query, headers=api_details['auth_headers'], verify=False)
+        if remove_type == 'api':
+            api_details = get_api_details_dict()
+            payload = {
+                'agents_list': agents_id,
+                'status': 'all',
+                'older_than': '0s'
+            }
+            url = f"{api_details['base_url']}/agents"
+            response = requests.delete(url, headers=api_details['auth_headers'], params=payload, verify=False)
+            response_data = response.json()
+            if response.status_code != 200:
+                raise RuntimeError(f"Error deleting an agent: {response_data}")
 
 
 def remove_all_agents(remove_type):

--- a/tests/integration/test_remoted/conftest.py
+++ b/tests/integration/test_remoted/conftest.py
@@ -10,7 +10,7 @@ from wazuh_testing.remote import callback_detect_remoted_started, new_agent_grou
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 from wazuh_testing.tools.file import truncate_file
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.services import check_daemon_status, control_service
+from wazuh_testing.tools.services import control_service
 
 DAEMON_NAME = "wazuh-remoted"
 

--- a/tests/integration/test_remoted/test_multi_groups/data/test_cases/case_file_actions.yaml
+++ b/tests/integration/test_remoted/test_multi_groups/data/test_cases/case_file_actions.yaml
@@ -1,0 +1,12 @@
+- name: 'check_that_the_new_file_is_added'
+  description: 'When a file is created in the group directory, the merged.mg file should be updated and the new file must appears inside it.'
+  configuration_parameters:
+    ACTION: create
+  metadata:
+    action: create
+- name: 'check_that_the_old_file_is_deleted'
+  description: 'When a file is deleted in the group directory, the merged.mg file should be updated without the file in it.'
+  configuration_parameters:
+    ACTION: delete
+  metadata:
+    action: delete

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -189,7 +189,7 @@ def test_merged_mg_file_content(metadata, configure_local_internal_options_modul
             match_regex = re.compile(rf"^{expected_line}$")
             match_expected_line = list(filter(match_regex.match, merged_file_lines))
     else:
-        raise RuntimeError(f"The file: {merged_mg_file} was not created.")
+        raise FileNotFoundError(f"The file: {merged_mg_file} was not created.")
 
     expected_conditions = [True, [expected_line + '\n']] if action == 'create' else [False, []]
 

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -1,0 +1,208 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Whenever a file is created or deleted from the group directory the merged.mg file must be updated. This test
+       checks the content of the merged.mg file that wazuh-remoted compiles for multi-groups.
+
+tier: 0
+
+modules:
+    - remoted
+
+components:
+    - manager
+
+daemons:
+    - wazuh-remoted
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - Debian Buster
+    - Red Hat 8
+    - Ubuntu Focal
+    - Ubuntu Bionic
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-remoted.html
+
+tags:
+    - remoted
+'''
+import hashlib
+import os
+import re
+from time import sleep
+
+import pytest
+import requests
+from wazuh_testing.api import get_api_details_dict
+from wazuh_testing.remote import DEFAULT_TESTING_GROUP_NAME, new_agent_group, \
+                                  remove_agent_group
+from wazuh_testing.tools import REMOTE_DAEMON, WAZUH_PATH, configuration
+from wazuh_testing.tools.file import delete_file
+from wazuh_testing.tools.services import check_daemon_status, control_service
+
+# Marks
+pytestmarks = [pytest.mark.linux, pytest.mark.server, pytest.mark.tier(level=0)]
+
+# Variables
+agent_name = 'testing_agent'
+agent_ip = 'any'
+groups_folder = os.path.join(WAZUH_PATH, 'queue', 'agent-groups')
+default_group_name = 'default'
+groups_list = [default_group_name, DEFAULT_TESTING_GROUP_NAME]
+mg_name = hashlib.sha256(','.join(groups_list).encode()).hexdigest()[:8]
+mg_folder_path = os.path.join(WAZUH_PATH, 'var', 'multigroups', mg_name)
+merged_mg_file = os.path.join(mg_folder_path, 'merged.mg')
+shared_folder_path = os.path.join(WAZUH_PATH, 'etc', 'shared')
+shared_file_name = 'testing_file'
+shared_file_path = os.path.join(shared_folder_path, DEFAULT_TESTING_GROUP_NAME, shared_file_name)
+response_data = None
+elapsed_time = 2
+wait_time = 1
+expected_line = f"!0 {shared_file_name}"
+
+# Configuration
+local_internal_options = {'remoted.shared_reload': f"{wait_time}"}
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_path = os.path.join(test_data_path, 'test_cases')
+tcases_data = os.path.join(test_cases_path, 'case_file_actions.yaml')
+configuration_parameters, configuration_metadata, test_case_ids = configuration.get_test_cases_data(tcases_data)
+
+
+# Fixtures
+@pytest.fixture(scope="module")
+def restart_remoted():
+    """Restart the wazuh-remoted daemon."""
+
+    control_service('restart', daemon=REMOTE_DAEMON)
+    check_daemon_status(target_daemon=REMOTE_DAEMON)
+
+    yield
+
+    control_service('stop', daemon=REMOTE_DAEMON)
+    check_daemon_status(target_daemon=REMOTE_DAEMON, running_condition=False)
+
+
+@pytest.fixture(scope='function')
+def prepare_environment(request, register_agent):
+    """Configure a custom environment for testing."""
+
+    new_agent_group()
+
+    agent_id = getattr(request.module, 'response_data')['id']
+    with open(os.path.join(groups_folder, agent_id), "w") as f:
+        f.write(f"default,{DEFAULT_TESTING_GROUP_NAME}")
+
+    yield
+
+    remove_agent_group(DEFAULT_TESTING_GROUP_NAME)
+    delete_file(os.path.join(groups_folder, agent_id))
+
+
+@pytest.fixture(scope='function')
+def register_agent(request):
+    """Register an agent via API."""
+
+    api_details = get_api_details_dict()
+    data = {
+        'name': agent_name,
+        'ip': agent_ip
+    }
+    url = f"{api_details['base_url']}/agents"
+    response = requests.post(url=url, headers=api_details['auth_headers'], json=data, verify=False)
+    response_data = response.json()
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Error registering an agent: {response_data}")
+
+    setattr(request.module, 'response_data', response_data['data'])
+
+    yield
+
+    url = f"{api_details['base_url']}/agents"
+    payload = {
+        'agents_list': [getattr(request.module, 'response_data')['id']],
+        'status': ['never_connected'],
+        'older_than': '0s'
+    }
+    response = requests.delete(url=url, headers=api_details['auth_headers'], params=payload, verify=False)
+    response_data = response.json()
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Error deleting an agent: {response_data}")
+    elif len(response_data['data']['affected_items']) != 1:
+        raise RuntimeError(f"Only 1 agent should have been deleted: {response_data}")
+
+
+def manipulate_file(action, file_path):
+    if action == 'create':
+        f = open(file_path, "w")
+        f.close()
+    else:
+        delete_file(file_path)
+
+
+@pytest.mark.parametrize('metadata', configuration_metadata, ids=test_case_ids)
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+def test_merged_mg_file_content(metadata, configure_local_internal_options_module, restart_remoted,
+                                prepare_environment):
+    '''
+    description: Check the content of the merged.mg file that wazuh-remoted compiles for multi-groups.
+    
+    wazuh_min_version: 4.3.0
+
+    parameters:
+        - metadata:
+            type: dict
+            brief: Metadata containing the action to execute.
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Fixture to configure the local internal options file.
+        - restart_remoted:
+            type: fixture
+            brief: Restart the wazuh-remoted daemon.
+        - prepare_environment:
+            type: fixture
+            brief: Configure a custom environment for testing.
+    
+    assertions:
+        - Verify that the file exists or not in the multigroups directory.
+        - Verify that the file is or is not in the merged.mg file
+    
+    input_description: Different test cases defined in a YAML file.
+    
+    expected_output:
+        - r'^!0 testing_file$'
+    '''
+    action = metadata['action']
+    match_expected_line = None
+
+    manipulate_file(action, shared_file_path)
+    sleep(wait_time + elapsed_time)
+
+    file_exists = os.path.exists(os.path.join(mg_folder_path, shared_file_name))
+    if os.path.exists(merged_mg_file):
+        with open(merged_mg_file, 'r') as merged_file:
+            merged_file_lines = merged_file.readlines()
+            match_regex = re.compile(rf"^{expected_line}$")
+            match_expected_line = list(filter(match_regex.match, merged_file_lines))
+    else:
+        raise RuntimeError(f"The file: {merged_mg_file} was not created.")
+
+    expected_conditions = [True, [expected_line + '\n']] if action == 'create' else [False, []]
+
+    assert file_exists == expected_conditions[0], f"The file was not {action}d in the multigroups directory.\n"
+    assert match_expected_line == expected_conditions[1], f"The file is \
+                                                          {'not' if action == 'created' else ''} in {merged_mg_file}."

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -52,6 +52,7 @@ from wazuh_testing.remote import DEFAULT_TESTING_GROUP_NAME, new_agent_group, \
 from wazuh_testing.tools import REMOTE_DAEMON, WAZUH_PATH, configuration
 from wazuh_testing.tools.file import delete_file
 from wazuh_testing.tools.services import check_daemon_status, control_service
+from wazuh_testing.tools.wazuh_manager import remove_agents
 
 # Marks
 pytestmarks = [pytest.mark.linux, pytest.mark.server, pytest.mark.tier(level=0)]
@@ -131,19 +132,8 @@ def register_agent(request):
 
     yield
 
-    url = f"{api_details['base_url']}/agents"
-    payload = {
-        'agents_list': [getattr(request.module, 'response_data')['id']],
-        'status': ['never_connected'],
-        'older_than': '0s'
-    }
-    response = requests.delete(url=url, headers=api_details['auth_headers'], params=payload, verify=False)
-    response_data = response.json()
-
-    if response.status_code != 200:
-        raise RuntimeError(f"Error deleting an agent: {response_data}")
-    elif len(response_data['data']['affected_items']) != 1:
-        raise RuntimeError(f"Only 1 agent should have been deleted: {response_data}")
+    registered_agent = getattr(request.module, 'response_data')['id']
+    remove_agents(agents_id=[registered_agent], remove_type='api')
 
 
 def manipulate_file(action, file_path):

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -150,8 +150,8 @@ def test_merged_mg_file_content(metadata, configure_local_internal_options_modul
                                 prepare_environment):
     '''
     description: Check the content of the merged.mg file that wazuh-remoted compiles for multi-groups.
-    
-    wazuh_min_version: 4.3.0
+
+    wazuh_min_version: 4.2.2
 
     parameters:
         - metadata:


### PR DESCRIPTION
|Related issue|
|---|
|#1852|

| Components | Tier | Type | Modules | Daemons |
|---|---|---|---|---|
| Manager | 0 | Integration | Remoted | wazuh-remoted |

This PR closes #1852.

***

### OS

- [x] Linux

***

## Description

Whenever a file is **created or deleted** from the group directory the `merged.mg` file must be updated. This test checks the content of the `merged.mg` file that wazuh-remoted compiles for multi-groups when a file inside the multigroup folder is created or deleted.

To test this behavior, the test:

1. Sets the value of `remoted.shared_reload` (which represents the number of seconds between reloading of shared files) to 1.
2. Restarts the `wazuh-remoted` daemon once to apply the configuration.
3. For each test case (create a file and delete a file):
   - Registers an agent through the API of Wazuh
   - Creates an agent group
   - Adds the registered agent to the created group
   - Cleans the environment (remove the agent and the group)
4. Finally, restore the configuration made and stop the daemon.

## DoD

- [x] Demonstrate that the test passes when it has to.
- [x] Demonstrate that the test fails when it has to.
- [x] 3 rounds executed in Jenkins.
- [x] python3 -m pycodestyle --max-line-length=120 tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
- [x] The test is documented in wazuh-qa/docs correctly