### PR TITLE
IT - Fix authd tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
+import requests
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb
+from wazuh_testing.api import get_api_details_dict
 
 
 def list_agents_ids():
@@ -12,7 +14,7 @@ def list_agents_ids():
 
 
 def remove_agents(agents_id, remove_type='wazuhdb'):
-    if remove_type not in ['wazuhdb', 'manage_agents']:
+    if remove_type not in ['wazuhdb', 'manage_agents', 'api']:
         raise ValueError("Invalid type of agent removal: %s" % remove_type)
 
     if agents_id:
@@ -22,6 +24,10 @@ def remove_agents(agents_id, remove_type='wazuhdb'):
                                 stderr=subprocess.STDOUT)
             elif remove_type == 'wazuhdb':
                 result = query_wdb(f"global delete-agent {str(agent_id)}")
+            elif remove_type == 'api':
+                api_details = get_api_details_dict()
+                api_query = f"{api_details['base_url']}/agents?older_than=0s&agents_list={agents_id}&status=all"
+                response = requests.delete(api_query, headers=api_details['auth_headers'], verify=False)
 
 
 def remove_all_agents(remove_type):

--- a/tests/integration/test_authd/conftest.py
+++ b/tests/integration/test_authd/conftest.py
@@ -13,6 +13,7 @@ from wazuh_testing.tools.services import control_service, check_daemon_status, d
 from wazuh_testing.tools.monitoring import QueueMonitor
 from wazuh_testing.authd import DAEMON_NAME
 from wazuh_testing.api import callback_detect_api_start, get_api_details_dict
+from wazuh_testing.tools.wazuh_manager import remove_agents
 
 
 AUTHD_STARTUP_TIMEOUT = 30
@@ -211,3 +212,11 @@ def insert_pre_existent_agents(get_current_test_case, stop_authd_function):
         insert_agent_in_db(id, name, ip, registration_time, connection_status, disconnection_time)
 
     keys_file.close()
+
+
+@pytest.fixture(scope='function')
+def delete_agents():
+
+    yield
+
+    remove_agents('all', 'api')

--- a/tests/integration/test_authd/test_authd_valid_name_ip.py
+++ b/tests/integration/test_authd/test_authd_valid_name_ip.py
@@ -65,6 +65,7 @@ receiver_sockets_params = [(("localhost", 1515), 'AF_INET', 'SSL_TLSv1_2')]
 monitored_sockets_params = [('wazuh-modulesd', None, True), ('wazuh-db', None, True), ('wazuh-authd', None, True)]
 receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
 hostname = socket.gethostname()
+daemons_handler_configuration = {'all_daemons': True}
 
 # Fixtures
 
@@ -84,7 +85,7 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case', [case for case in test_authd_valid_name_ip_tests],
                          ids=[test_case['name'] for test_case in test_authd_valid_name_ip_tests])
 def test_authd_force_options(get_configuration, configure_environment, configure_sockets_environment,
-                             clean_client_keys_file_module, restart_authd, wait_for_authd_startup_module,
+                             clean_client_keys_file_module, daemons_handler, wait_for_authd_startup_module,
                              connect_to_sockets_module, test_case, delete_agents):
     '''
     description:

--- a/tests/integration/test_authd/test_authd_valid_name_ip.py
+++ b/tests/integration/test_authd/test_authd_valid_name_ip.py
@@ -80,11 +80,12 @@ def get_configuration(request):
 # Test
 
 
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @pytest.mark.parametrize('test_case', [case for case in test_authd_valid_name_ip_tests],
                          ids=[test_case['name'] for test_case in test_authd_valid_name_ip_tests])
 def test_authd_force_options(get_configuration, configure_environment, configure_sockets_environment,
                              clean_client_keys_file_module, restart_authd, wait_for_authd_startup_module,
-                             connect_to_sockets_module, test_case, tear_down):
+                             connect_to_sockets_module, test_case, delete_agents):
     '''
     description:
         Checks that every input message in authd port generates the adequate output.


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #2733 |


## Description

`test_authd_valid_name_ip`  was failing because the environment was not being cleaned properly and sometimes we were getting the following error:

```
ERROR: Duplicate agent name: user1
```

## Packages

|Version| Link|
|:--:|:--:|
|v4.4.0| https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/var/wazuh-manager-4.4.0-agentd.test.x86_64.rpm

## Testing

|CentOS Manager| Jenkins|
|:--:|:--:|
|R1|
|R2|
|R3|