### PR TITLE
Enrollment IT: Fix test_agentd_server_address_configuration

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/agent.py
+++ b/deps/wazuh_testing/wazuh_testing/agent.py
@@ -315,8 +315,8 @@ def callback_invalid_server_address(server_ip):
     return monitoring.make_callback(pattern=msg, prefix=monitoring.AGENT_DETECTOR_PREFIX)
 
 
-def callback_unable_to_connect(server_ip, port='1515'):
-    msg = f"ERROR: \(\d+\): Unable to connect to enrollment service at '\[{server_ip}\]:{port}'"
+def callback_could_not_resolve_hostname(server_ip):
+    msg = f"ERROR: Could not resolve hostname: {server_ip}"
     return monitoring.make_callback(pattern=msg, prefix=monitoring.AGENT_DETECTOR_PREFIX)
 
 

--- a/tests/integration/test_enrollment/data/server_address_configuration.yaml
+++ b/tests/integration/test_enrollment/data/server_address_configuration.yaml
@@ -9,3 +9,5 @@
               elements:
               - address:
                   value: SERVER_ADDRESS
+              - max_retries:
+                  value: 1

--- a/tests/integration/test_enrollment/test_agentd_server_address_configuration.py
+++ b/tests/integration/test_enrollment/test_agentd_server_address_configuration.py
@@ -64,7 +64,7 @@ import sys
 import pytest
 
 from wazuh_testing.agent import callback_connected_to_manager_ip, callback_invalid_server_address, \
-                                callback_unable_to_connect, CLIENT_KEYS_PATH
+                                callback_could_not_resolve_hostname, CLIENT_KEYS_PATH
 from wazuh_testing.tools import HOSTS_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.file import truncate_file
@@ -211,7 +211,7 @@ def test_agentd_server_address_configuration(configure_local_internal_options_mo
                               error_message="The expected 'Connected to enrollment service' message has not been \
                                              produced")
         else:
-            callback = callback_unable_to_connect(final_manager_address)
+            callback = callback_could_not_resolve_hostname(final_manager_address)
             log_monitor.start(timeout=DEFAULT_WAIT_FILE_TIMEOUT, callback=callback,
-                              error_message="The expected 'Unable to connect to enrollment service' message has not \
+                              error_message="The expected 'Could not resolve hostname' message has not \
                                              been produced")


### PR DESCRIPTION
|Related issue|
|---|
|closes #2756 |

## Description

Replace the `Unable to connect message for `Could not resolve hostname`.

## 05/04/202
### Package
| Version | Revision | Link|
|---|---|---|
|4.4.0||


### Testing

### Package
| Version | Revision | Link|
|---|---|---|
|4.4.0| 0.40400.20220404| https://packages-dev.wazuh.com/staging/yum/wazuh-manager-4.4.0-0.40400.20220404.x86_64.rpm


## Testing

### Module 1

|  OS  | Jenkins      | Notes
|---    |---    |---    
| R1   |  [:green_circle:   ](https://ci.wazuh.info/job/Test_integration_launcher/56/console)   | |
| R2   |  [:green_circle:    ](https://ci.wazuh.info/job/Test_integration_launcher/57/console)    | |
| R3   |  [:green_circle:  ](https://ci.wazuh.info/job/Test_integration_launcher/58/console)    | |

* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress