### PR TITLE
Adapting the performance and reliability tests for Python version 3.7.10

### DIFF
--- a/tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py
+++ b/tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py
@@ -55,7 +55,8 @@ def test_cluster_performance(artifacts_path, n_workers, n_agents):
         pytest.fail("Parameters '--artifacts_path=<path> --n_workers=<n_workers> --n_agents=<n_agents>' are required.")
 
     # Check if there are threshold data for the specified number of workers and agents.
-    if (selected_conf := f"{n_workers}w_{n_agents}a") not in configurations:
+    selected_conf = f"{n_workers}w_{n_agents}a"
+    if selected_conf not in configurations:
         pytest.fail(f"This is not a supported configuration: {selected_conf}. "
                     f"Supported configurations are: {', '.join(configurations.keys())}.")
 
@@ -97,6 +98,7 @@ def test_cluster_performance(artifacts_path, n_workers, n_agents):
     finally:
         # Add useful information to report as stdout
         try:
+            print('\n')
             print(f'Setup phase took {get_datetime_diff(cluster_info["phases"]["setup_phase"])}s '
                   f'({cluster_info["phases"]["setup_phase"][0]} - {cluster_info["phases"]["setup_phase"][1]}).')
             print(f'Stable phase took {get_datetime_diff(cluster_info["phases"]["stable_phase"])}s '

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -25,14 +25,16 @@ def test_cluster_connection(artifacts_path):
     if not artifacts_path:
         pytest.fail("Parameter '--artifacts_path=<path>' is required.")
 
-    if len(cluster_log_files := glob(join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))) == 0:
+    cluster_log_files = glob(join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))
+    if len(cluster_log_files) == 0:
         pytest.fail(f'No files found inside {artifacts_path}.')
 
     for log_file in cluster_log_files:
         with open(log_file) as f:
             s = mmap(f.fileno(), 0, access=ACCESS_READ)
             # Search first successful connection message.
-            if not (conn := re.search(rb'^.*Sucessfully connected to master.*$', s, flags=re.MULTILINE)):
+            conn = re.search(rb'^.*Sucessfully connected to master.*$', s, flags=re.MULTILINE)
+            if not conn:
                 pytest.fail(f'Could not find "Sucessfully connected to master" message in the '
                             f'{node_name.search(log_file)[1]}')
 

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_error_logs/test_cluster_error_logs.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_error_logs/test_cluster_error_logs.py
@@ -41,13 +41,15 @@ def test_cluster_error_logs(artifacts_path):
     if not artifacts_path:
         pytest.fail('Parameter "--artifacts_path=<path>" is required.')
 
-    if len(cluster_log_files := glob(join(artifacts_path, '*', 'logs', 'cluster.log'))) == 0:
+    cluster_log_files = glob(join(artifacts_path, '*', 'logs', 'cluster.log'))
+    if len(cluster_log_files) == 0:
         pytest.fail(f'No files found inside {artifacts_path}.')
 
     for log_file in cluster_log_files:
         with open(log_file) as f:
             s = mmap(f.fileno(), 0, access=ACCESS_READ)
-            if error_lines := re.findall(rb'(^.*?error.*?$)', s, flags=re.MULTILINE | re.IGNORECASE):
+            error_lines = re.findall(rb'(^.*?error.*?$)', s, flags=re.MULTILINE | re.IGNORECASE)
+            if error_lines:
                 error_lines = [error for error in error_lines if not error_in_white_list(error)]
                 if error_lines:
                     nodes_with_errors.update({node_name.search(log_file)[1]: error_lines})

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_logs_order/test_cluster_logs_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_logs_order/test_cluster_logs_order.py
@@ -52,7 +52,8 @@ def test_check_logs_order_workers(artifacts_path):
     if not artifacts_path:
         pytest.fail('Parameter "--artifacts_path=<path>" is required.')
 
-    if len(cluster_log_files := glob(os.path.join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))) == 0:
+    cluster_log_files = glob(os.path.join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))
+    if len(cluster_log_files) == 0:
         pytest.fail(f'No files found inside {artifacts_path}.')
 
     for log_file in cluster_log_files:
@@ -60,7 +61,8 @@ def test_check_logs_order_workers(artifacts_path):
 
         with open(log_file) as file:
             for line in file.readlines():
-                if result := logs_format.search(line):
+                result = logs_format.search(line)
+                if result:
                     if result.group(1) in logs_order and result.group(1) not in failed_tasks:
                         tree_info = logs_order[result.group(1)]
                         for child in tree_info['tree'].children(tree_info['node']):

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py
@@ -32,14 +32,16 @@ def test_cluster_sync(artifacts_path):
     if not artifacts_path:
         pytest.fail('Parameter "--artifacts_path=<path>" is required.')
 
-    if len(cluster_log_files := glob(join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))) == 0:
+    cluster_log_files = glob(join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))
+    if len(cluster_log_files) == 0:
         pytest.fail(f'No files found inside {artifacts_path}.')
 
     repeat_counter = 0
     for log_file in cluster_log_files:
         with open(log_file) as f:
             s = mmap(f.fileno(), 0, access=ACCESS_READ)
-            if not (sync_logs := integrity_regex.findall(s)):
+            sync_logs = integrity_regex.findall(s)
+            if not sync_logs:
                 pytest.fail(f'No integrity sync logs found in {node_name.search(log_file)[1]}')
 
             for i in range(len(sync_logs)):


### PR DESCRIPTION
|Related issue|
|---|
|#2747|

This closes #2747. The aim of this issue is to remove the [walrus](https://realpython.com/python-walrus-operator/) operator which is not compatible with Python version 3.7.10. This is required for the automation of these tests. 