### PR TITLE
4.3 Logcollector IT: Adapt test_log_format duplicated macos block case

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -378,6 +378,11 @@ def callback_log_stream_exited_error():
     return monitoring.make_callback(pattern=log_format_message, prefix=prefix)
 
 
+def callback_duplicated_macos_log_file():
+    log_format_message = "WARNING: \(\d+\): Log file 'macos' is duplicated."
+    return monitoring.make_callback(pattern=log_format_message, prefix=prefix)
+
+
 def callback_reconnect_eventchannel(location):
     """Create a callback to detect if specified channel has been reconnected successfully.
     Args:

--- a/tests/integration/test_logcollector/test_configuration/data/wazuh_duplicated_macos_configuration.yaml
+++ b/tests/integration/test_logcollector/test_configuration/data/wazuh_duplicated_macos_configuration.yaml
@@ -8,9 +8,9 @@
     - name: 'logcollector_configuration_block1'
     elements:
     - location:
-        value: LOCATION1
+        value: LOCATION
     -  log_format:
-         value: LOG_FORMAT1
+         value: LOG_FORMAT
   - section: localfile
     attributes:
     - name: 'logcollector_configuration_block2'

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
@@ -80,8 +80,8 @@ windows_tcases = [
 
 macos_tcases = [{'LOCATION': 'macos', 'LOG_FORMAT': 'macos', 'VALID_VALUE': True},
                 {'LOCATION': '/tmp/log.txt', 'LOG_FORMAT': 'macos', 'VALID_VALUE': True},
-                {'LOCATION1': 'macos', 'LOG_FORMAT1': 'macos', 'LOCATION2': 'macos', 'LOG_FORMAT2': 'macos',
-                 'VALID_VALUE': False, 'CONFIGURATION': 'wazuh_duplicated_macos_configuration.yaml'},
+                {'LOCATION': 'macos', 'LOG_FORMAT': 'macos', 'LOCATION2': 'macos', 'LOG_FORMAT2': 'macos',
+                 'VALID_VALUE': True, 'CONFIGURATION': 'wazuh_duplicated_macos_configuration.yaml'},
                 {'LOG_FORMAT': 'macos', 'VALID_VALUE': True,
                  'CONFIGURATION': 'wazuh_no_defined_location_macos_configuration.yaml'}
                 ]
@@ -116,7 +116,8 @@ metadata_multiple_logcollector_configuration = [metadata_value for metadata_valu
                                                 'configuration' in metadata_value and
                                                 metadata_value['configuration'] == multiple_logcollector_configuration]
 
-configuration_ids += [f"{x['location1']}_{x['log_format1']}_{x['location1']}_{x['log_format2']}" for x in metadata_multiple_logcollector_configuration]
+configuration_ids += [f"{x['location']}_{x['log_format']}_{x['location2']}_{x['log_format2']}"
+                      for x in metadata_multiple_logcollector_configuration]
 
 configurations += load_wazuh_configurations(configurations_path_multiple_logcollector, __name__,
                                             params=parameters_multiple_logcollector_configuration,
@@ -179,6 +180,10 @@ def check_log_format_valid(cfg):
             log_callback = logcollector.callback_missing_location_macos()
             wazuh_log_monitor.start(timeout=5, callback=log_callback,
                                     error_message="The expected warning missing location value has not been produced")
+        if 'location2' in cfg and cfg['location2'] == 'macos':
+            log_callback = logcollector.callback_duplicated_macos_log_file()
+            wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                                    error_message="The expected warning Log file 'macos' is duplicated")
 
         log_callback = logcollector.callback_monitoring_macos_logs()
         wazuh_log_monitor.start(timeout=5, callback=log_callback,


### PR DESCRIPTION
|Related issue|
|---|
| closes #2759|

## Description
As explained in #2759, after [2759](https://github.com/wazuh/wazuh/pull/13035), is possible to use multiple macOS `log_format` configuration blocks.
In this case, it should produce only the following warning message:
```
2022/04/05 17:10:21 wazuh-logcollector[11215] logcollector.c:1705 at remove_duplicates(): WARNING: (1958): Log file 'macos' is duplicated
```

### Testing

### Package
| Version | Revision | Link|
|---|---|---|
|4.3|0.commitca1e731


## Testing

### Module 1

|  OS  | Local   |  Notes
|---    |---    |--- 
| R1   | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/8426389/R3-2760-log_format_macos.zip)  | |
| R2   | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8426390/R2-2760-log_format_macos.zip)   |   | 
| R3   | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8426391/R1-2760-log_format_macos.zip)   |  | 

* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress


## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.