### PR TITLE
Add test for tasks order

### DIFF
--- a/tests/reliability/test_cluster/test_cluster_logs/conftest.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/conftest.py
@@ -126,4 +126,19 @@ def pytest_runtest_makereport(item, call):
             extra.append(pytest_html.extras.html('<p>' + '\n\n'.join(output) + '</p>'))
             extra.append(pytest_html.extras.html("</p><h2>Test output</h2>"))
 
+        # Attach nodes were some tasks were repeted or not completed in the requested order from the
+        # 'test_cluster_task_order' test.
+        elif report.head_line == 'test_cluster_task_order' and item.module.incorrect_order:
+            for key in item.module.incorrect_order:
+                extra.append(pytest_html.extras.html("<h2>Wrong task order.</h2>"))
+                extra.append(pytest_html.extras.html(f"<p><b>Concatenated tasks '{key}' and "
+                                                     f"'{item.module.incorrect_order[key]['child_task']}'"
+                                                     f" failed due to {item.module.incorrect_order[key]['status']}"
+                                                     f" logs:\n\t{item.module.incorrect_order[key]['log']}</b>"))
+                # for failed_task in item.module.incorrect_order[key]:
+                #     extra.append(pytest_html.extras.html('<b> - Log type:</b> {log_type}\n'
+                #                                          '<b>   Expected logs:</b> {expected_logs}\n'
+                #                                          '<b>   Found log:</b> {found_log}'.format(**failed_task)))
+            extra.append(pytest_html.extras.html("</p><h2>Test output</h2>"))
+
         report.extra = extra

--- a/tests/reliability/test_cluster/test_cluster_logs/conftest.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/conftest.py
@@ -135,10 +135,7 @@ def pytest_runtest_makereport(item, call):
                                                      f"'{item.module.incorrect_order[key]['child_task']}'"
                                                      f" failed due to {item.module.incorrect_order[key]['status']}"
                                                      f" logs:\n\t{item.module.incorrect_order[key]['log']}</b>"))
-                # for failed_task in item.module.incorrect_order[key]:
-                #     extra.append(pytest_html.extras.html('<b> - Log type:</b> {log_type}\n'
-                #                                          '<b>   Expected logs:</b> {expected_logs}\n'
-                #                                          '<b>   Found log:</b> {found_log}'.format(**failed_task)))
+
             extra.append(pytest_html.extras.html("</p><h2>Test output</h2>"))
 
         report.extra = extra

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/README.md
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/README.md
@@ -13,7 +13,7 @@ To verify that:
 
 ## General info
 ### Parameters
-The test needs to receive one parameter  (artifacts) in order to be run. If this parameter is not specified, the test will fail. The required parameter is:
+The test needs to receive one parameter (artifacts) in order to be run. If this parameter is not specified, the test will fail. The required parameter is:
 - `--artifacts_path`: Path where cluster logs can be found inside each worker folder. It should follow the structure below:
     ```.
     ├── worker_x

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/README.md
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/README.md
@@ -1,0 +1,126 @@
+# Test cluster sync
+
+## Overview 
+
+Check that cluster concatenated tasks follow the desired order.
+
+Currently, there are two concatenated tasks: `Local agent-groups` and `Agent-groups send`. In this test, we are proving that the former task is executed once the latter task is finished and so on. 
+
+## Objective
+
+To verify that:
+- Tasks are executed in the desired way.
+
+## General info
+### Parameters
+The test needs to receive one parameter  (artifacts) in order to be run. If this parameter is not specified, the test will fail. The required parameter is:
+- `--artifacts_path`: Path where cluster logs can be found inside each worker folder. It should follow the structure below:
+    ```.
+    ├── worker_x
+    │   └── logs
+    │       └── cluster.log
+    ├── worker_y
+    │   └── logs
+    │       └── cluster.log
+    └── ...
+    ```
+- `--html=report.html`: Create a html report with the test results. 
+- `--self-contained-html`: Store all the necessary data for the report inside the html file.
+
+#### Example output
+```shell
+python3.9 -m pytest ../../tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py --artifacts_path=/docs/final2_agent_groups/artifacts -sxvv --self-contained-html --html=report.html 
+=============================================================================================== test session starts ===============================================================================================
+platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/yanazaeva/git/wazuh-qa/wazuh_qa_env/bin/python3.9
+cachedir: .pytest_cache
+metadata: {'Python': '3.9.5', 'Platform': 'Linux-5.15.15-76051515-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'testinfra': '5.0.0', 'metadata': '1.11.0', 'html': '3.1.1'}}
+rootdir: /home/yanazaeva/git/wazuh-qa
+plugins: testinfra-5.0.0, metadata-1.11.0, html-3.1.1
+collected 1 item                                                                                                                                                                                                  
+
+../../tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py::test_cluster_task_order FAILED
+
+==================================================================================================== FAILURES =====================================================================================================
+_____________________________________________________________________________________________ test_cluster_task_order _____________________________________________________________________________________________
+
+artifacts_path = '/docs/final2_agent_groups/artifacts'
+
+    def test_cluster_task_order(artifacts_path):
+        """Check that cluster tasks appear in the expected order.
+    
+        Check that for each concatenated tasks, the corresponding logs are apprearing correctly.
+    
+        Args:
+            artifacts_path (str): Path where folders with cluster information can be found.
+        """
+        if not artifacts_path:
+            pytest.fail('Parameter "--artifacts_path=<path>" is required.')
+    
+        worker_log_files = glob(os.path.join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))
+        master_log_file = os.path.join(artifacts_path, 'master', 'logs', 'cluster.log')
+    
+        if len(worker_log_files) == 0:
+            pytest.fail(f'No files found inside {artifacts_path}.')
+    
+        with open(master_log_file) as file:
+            for line in file.readlines():
+                # Check if the task corresponds to any of the concatenated ones.
+                for parent_task, info in concatenated_tasks.items():
+                    if info['child_task'] in line and info['child_log'] in line and info['started']:
+                        worker_name = logs_format.search(line).group(1).split(' ')[1]
+                        if worker_name in info['workers'] and parent_task not in incorrect_order:
+                            incorrect_order[parent_task] = {'child_task': info['child_task'], 'log': line,
+                                                            'status': 'repeated'}
+                            break
+                        else:
+                            info['workers'].append(worker_name)
+                            worker_names.append(worker_name) if worker_name not in worker_names else worker_names
+    
+                    if info['parent_end_log'] in line and parent_task in line:
+                        if info['started']:
+                            if len(info['workers']) != len(worker_names):
+                                # Check if the information is already there, so we are not storing repeated situations
+                                if parent_task not in incorrect_order:
+                                    incorrect_order[parent_task] = {'child_task': info['child_task'], 'log':
+                                                                    f"The following worker(s) did not performed the "
+                                                                    f"expected task: "
+                                                                    f"{set(worker_names) ^ set(info['workers'])}",
+                                                                    'status': 'missing'}
+                            info['workers'].clear()
+                        else:
+                            info['started'] = True
+    
+                [concatenated_tasks.pop(x) for x in incorrect_order.keys() if x in concatenated_tasks]
+    
+        if incorrect_order:
+            result = ''
+            for key, value in incorrect_order.items():
+                if value['status'] == 'repeated':
+                    result += f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} " \
+                              f"logs:\n\t{value['log']}"
+                elif value['status'] == 'missing':
+                    result += f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} " \
+                              f"logs:\n\t{value['log']}"
+    
+>           pytest.fail(result)
+E           Failed: Concatenated tasks 'Local agent-groups' and 'Agent-groups send' failed due to missing logs:
+E           	The following worker(s) did not performed the expected task: {'CLUSTER-Workload_benchmarks_metrics_B122_manager_1'}
+
+../../tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py:76: Failed
+------------------------------------------------------------- generated html file: file:///home/yanazaeva/git/wazuh-qa/deps/wazuh_testing/report.html -------------------------------------------------------------
+============================================================================================= short test summary info =============================================================================================
+FAILED ../../tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py::test_cluster_task_order - Failed: Concatenated tasks 'Local agent-groups' and 'Agent-groups se...
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+================================================================================================ 1 failed in 0.05s ================================================================================================
+```
+
+### Tests information
+
+| Number of tests | Time spent |
+|:--:|:--:|
+| 1 | 0.01 - 0.10s |
+
+## Expected behavior
+
+- Fail if a manager has executed two or more times the `Agent-groups send` task, in between two `Local agent-groups` tasks.
+- Fail if a manager did not execute the `Agent-groups send` task in between two `Local agent-groups` tasks.

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
@@ -19,7 +19,7 @@ worker_names = []
 def test_cluster_task_order(artifacts_path):
     """Check that cluster tasks appear in the expected order.
 
-    Check that for each concatenated tasks, the corresponding logs are apprearing correctly.
+    Check that for each concatenated task, the corresponding logs are appearing correctly.
 
     Args:
         artifacts_path (str): Path where folders with cluster information can be found.

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
@@ -49,14 +49,13 @@ def test_cluster_task_order(artifacts_path):
 
                 if info['parent_end_log'] in line and parent_task in line:
                     if info['started']:
-                        if len(info['workers']) != len(worker_names):
-                            # Check if the information is already there, so we are not storing repeated situations
-                            if parent_task not in incorrect_order:
-                                incorrect_order[parent_task] = {'child_task': info['child_task'], 'log':
-                                                                f"The following worker(s) did not performed the "
-                                                                f"expected task: "
-                                                                f"{set(worker_names) ^ set(info['workers'])}",
-                                                                'status': 'missing'}
+                        # Check if the information is already there, so we are not storing repeated situations
+                        if len(info['workers']) != len(worker_names) and parent_task not in incorrect_order:
+                            incorrect_order[parent_task] = {'child_task': info['child_task'],
+                                                            'log': f"The following worker(s) did not performed "
+                                                                   f"the '{info['child_task']}' task: "
+                                                                   f"{set(worker_names) ^ set(info['workers'])}",
+                                                            'status': 'missing'}
                         info['workers'].clear()
                     else:
                         info['started'] = True
@@ -66,11 +65,8 @@ def test_cluster_task_order(artifacts_path):
     if incorrect_order:
         result = ''
         for key, value in incorrect_order.items():
-            if value['status'] == 'repeated':
-                result += f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} " \
-                          f"logs:\n\t{value['log']}"
-            elif value['status'] == 'missing':
-                result += f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} " \
-                          f"logs:\n\t{value['log']}"
+            result = result.join(
+                f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} "
+                f"logs:\n\t{value['log']}")
 
         pytest.fail(result)

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
@@ -11,8 +11,8 @@ import pytest
 logs_format = re.compile(r'.* \[(Worker.*|Master)] \[(.*)] (.*)')
 incorrect_order = {}
 concatenated_tasks = {
-    'Local agent-groups': {'child_task': 'Agent-groups send', 'parent_end_log': 'Starting', 'child_log': 'Starting',
-                           'workers': [], 'started': False}}
+    'Local agent-groups': {'child_task': r'Agent-groups send( full)?', 'parent_end_log': 'Starting',
+                           'child_log': 'Starting', 'workers': [], 'started': False}}
 worker_names = []
 
 
@@ -37,7 +37,7 @@ def test_cluster_task_order(artifacts_path):
         for line in file.readlines():
             # Check if the task corresponds to any of the concatenated ones.
             for parent_task, info in concatenated_tasks.items():
-                if info['child_task'] in line and info['child_log'] in line and info['started']:
+                if re.match(info['child_task'], line) and info['child_log'] in line and info['started']:
                     worker_name = logs_format.search(line).group(1).split(' ')[1]
                     if worker_name in info['workers'] and parent_task not in incorrect_order:
                         incorrect_order[parent_task] = {'child_task': info['child_task'], 'log': line,

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2015-2022, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import re
+from glob import glob
+
+import pytest
+
+logs_format = re.compile(r'.* \[(Worker.*|Master)] \[(.*)] (.*)')
+incorrect_order = {}
+concatenated_tasks = {
+    'Local agent-groups': {'child_task': 'Agent-groups send', 'parent_end_log': 'Starting', 'child_log': 'Starting',
+                           'workers': [], 'started': False}}
+worker_names = []
+
+
+def test_cluster_task_order(artifacts_path):
+    """Check that cluster tasks appear in the expected order.
+
+    Check that for each concatenated tasks, the corresponding logs are apprearing correctly.
+
+    Args:
+        artifacts_path (str): Path where folders with cluster information can be found.
+    """
+    if not artifacts_path:
+        pytest.fail('Parameter "--artifacts_path=<path>" is required.')
+
+    worker_log_files = glob(os.path.join(artifacts_path, 'worker_*', 'logs', 'cluster.log'))
+    master_log_file = os.path.join(artifacts_path, 'master', 'logs', 'cluster.log')
+
+    if len(worker_log_files) == 0:
+        pytest.fail(f'No files found inside {artifacts_path}.')
+
+    with open(master_log_file) as file:
+        for line in file.readlines():
+            # Check if the task corresponds to any of the concatenated ones.
+            for parent_task, info in concatenated_tasks.items():
+                if info['child_task'] in line and info['child_log'] in line and info['started']:
+                    worker_name = logs_format.search(line).group(1).split(' ')[1]
+                    if worker_name in info['workers'] and parent_task not in incorrect_order:
+                        incorrect_order[parent_task] = {'child_task': info['child_task'], 'log': line,
+                                                        'status': 'repeated'}
+                        break
+                    else:
+                        info['workers'].append(worker_name)
+                        worker_names.append(worker_name) if worker_name not in worker_names else worker_names
+
+                if info['parent_end_log'] in line and parent_task in line:
+                    if info['started']:
+                        if len(info['workers']) != len(worker_names):
+                            # Check if the information is already there, so we are not storing repeated situations
+                            if parent_task not in incorrect_order:
+                                incorrect_order[parent_task] = {'child_task': info['child_task'], 'log':
+                                                                f"The following worker(s) did not performed the "
+                                                                f"expected task: "
+                                                                f"{set(worker_names) ^ set(info['workers'])}",
+                                                                'status': 'missing'}
+                        info['workers'].clear()
+                    else:
+                        info['started'] = True
+
+            [concatenated_tasks.pop(x) for x in incorrect_order.keys() if x in concatenated_tasks]
+
+    if incorrect_order:
+        result = ''
+        for key, value in incorrect_order.items():
+            if value['status'] == 'repeated':
+                result += f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} " \
+                          f"logs:\n\t{value['log']}"
+            elif value['status'] == 'missing':
+                result += f"Concatenated tasks '{key}' and '{value['child_task']}' failed due to {value['status']} " \
+                          f"logs:\n\t{value['log']}"
+
+        pytest.fail(result)


### PR DESCRIPTION
|Related issue|
|---|
|#2727|

## Description
This closes #2727. The aim of this pull is to add a test to check if the tasks are executed in the desired order. 