### PR TITLE
WazuhDB IT: Nightly report - Fix test_wazuh_db_messages_agent 

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
@@ -103,14 +103,14 @@
                                         "type":"PACKAGE",
                                         "status":"VALID",
                                         "check_pkg_existence":false,
-                                        "severity":"-",
+                                        "severity":"Untriaged",
                                         "cvss2_score":0,
                                         "cvss3_score":0}'
     output: 'ok {"action":"INSERT","status":"SUCCESS"}'
     stage: "agent vuln_cves insert package with same CVE without checking if the package is present in sys_programs"
   -
     input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2"'
-    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"-","cvss2_score":0,"cvss3_score":0,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
+    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"Untriaged","cvss2_score":0,"cvss3_score":0,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
     stage: "agent vuln_cves checking package insertion with same CVE"
     use_regex: "yes"
   -


### PR DESCRIPTION
|Related issue|
|---|
|closes #2768|

### Description

https://github.com/wazuh/wazuh/pull/12695 development replaces the value "-" with "Untriaged".

`Insert package with the same CVE without checking if the package is present in sys_programs` case has been changed accordingly.

### Testing

### Package
| Version | Revision | Link|
|---|---|---|
|4.4.0|0.40400.20220406|https://packages-dev.wazuh.com/staging/yum/wazuh-manager-4.4.0-0.40400.20220406.x86_64.rpm)

### `test_wazuh_db`

|  Centos: 8 - Manager    | Jenkins     | Notes
|---    |---    |---    |
| R1   | [:green_circle:  ](https://ci.wazuh.info/job/Test_integration_launcher/59/console)  |
| R2   | [:green_circle:  ](https://ci.wazuh.info/job/Test_integration_launcher/60/console) |
| R3   | [:green_circle:  ](https://ci.wazuh.info/job/Test_integration_launcher/61/console)    |

* * * 

- :green_circle:: All pass
- :yellow_circle:: Some warnings
- :red_circle:: Some errors/fails
- :large_blue_circle:: In progress