### PR TITLE
Move the 'get_datetime_diff' function to 'wazuh-testing' utils module

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -185,6 +185,7 @@ def get_datetime_diff(phase_datetimes, date_format):
 
     Args:
         phase_datetimes (list): List containing start and end datetimes.
+        date_format (str): Expected datetime shape.
     """
     return datetime.strptime(phase_datetimes[1], date_format) - datetime.strptime(phase_datetimes[0], date_format)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/utils.py
@@ -1,18 +1,17 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import ipaddress
+import json
 import logging
-import re
-import string
 import numbers
+import re
+import socket
+import string
+from datetime import datetime
 from functools import wraps
 from random import randint, SystemRandom
 from time import sleep
-from random import randint, SystemRandom, choice
-import string
-import json
-import socket
-import ipaddress
 
 
 def retry(exceptions, attempts=5, delay=1, delay_multiplier=2):
@@ -179,3 +178,13 @@ def format_ipv6_long(ipv6_address):
         str: IPV6 long form
     """
     return (ipaddress.ip_address(ipv6_address).exploded).upper()
+
+
+def get_datetime_diff(phase_datetimes, date_format):
+    """Calculate the difference between two datetimes.
+
+    Args:
+        phase_datetimes (list): List containing start and end datetimes.
+    """
+    return datetime.strptime(phase_datetimes[1], date_format) - datetime.strptime(phase_datetimes[0], date_format)
+

--- a/tests/performance/test_cluster/test_cluster_performance/data/25w_50000a_thresholds.yaml
+++ b/tests/performance/test_cluster/test_cluster_performance/data/25w_50000a_thresholds.yaml
@@ -53,7 +53,7 @@ resources:
         workers:
           max: 47.85
           mean: 9.35
-          reg_cof: 0.06
+          reg_cof: 0.1
       FD:
         master:
           max: 160

--- a/tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py
+++ b/tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py
@@ -21,12 +21,12 @@ exceeded_thresholds = []
 # Fixtures
 @pytest.fixture()
 def n_workers(pytestconfig):
-    return pytestconfig.getoption("n_workers")
+    return pytestconfig.getoption('n_workers')
 
 
 @pytest.fixture()
 def n_agents(pytestconfig):
-    return pytestconfig.getoption("n_agents")
+    return pytestconfig.getoption('n_agents')
 
 
 def test_cluster_performance(artifacts_path, n_workers, n_agents):
@@ -54,19 +54,19 @@ def test_cluster_performance(artifacts_path, n_workers, n_agents):
     try:
         cluster_info = ClusterEnvInfo(artifacts_path).get_all_info()
     except FileNotFoundError:
-        pytest.fail(f'Path "{artifacts_path}" could not be found or it may not follow the proper structure.')
+        pytest.fail(f"Path '{artifacts_path}' could not be found or it may not follow the proper structure.")
 
     if cluster_info.get('worker_nodes', 0) != int(n_workers):
-        pytest.fail(f'Information of {n_workers} workers was expected inside the artifacts folder, but '
-                    f'{cluster_info.get("worker_nodes", 0)} were found.')
+        pytest.fail(f"Information of {n_workers} workers was expected inside the artifacts folder, but "
+                    f"{cluster_info.get('worker_nodes', 0)} were found.")
 
     # Calculate stats from data inside artifacts path.
     data = {'tasks': ClusterCSVTasksParser(artifacts_path).get_stats(),
             'resources': ClusterCSVResourcesParser(artifacts_path).get_stats()}
 
     if not data['tasks'] or not data['resources']:
-        pytest.fail(f'Stats could not be retrieved, "{artifacts_path}" path may not exist, it is empty or it may not'
-                    f' follow the proper structure.')
+        pytest.fail(f"Stats could not be retrieved, '{artifacts_path}' path may not exist, it is empty or it may not"
+                    f" follow the proper structure.")
 
     # Compare each stat with its threshold.
     for data_name, data_stats in data.items():
@@ -82,15 +82,15 @@ def test_cluster_performance(artifacts_path, n_workers, n_agents):
                                                             'phase': phase})
 
     try:
-        assert not exceeded_thresholds, f"Some thresholds were exceeded:\n- " + '\n- '.join(
+        assert not exceeded_thresholds, 'Some thresholds were exceeded:\n- ' + '\n- '.join(
             '{stat} {column} {value} >= {threshold} ({node}, {file}, {phase})'.format(**item) for item in
             exceeded_thresholds)
     finally:
         # Add useful information to report as stdout
         try:
-            print(f'\nSetup phase took {get_datetime_diff(cluster_info["phases"]["setup_phase"], date_format)}s '
-                  f'({cluster_info["phases"]["setup_phase"][0]} - {cluster_info["phases"]["setup_phase"][1]}).')
-            print(f'Stable phase took {get_datetime_diff(cluster_info["phases"]["stable_phase"], date_format)}s '
-                  f'({cluster_info["phases"]["stable_phase"][0]} - {cluster_info["phases"]["stable_phase"][1]}).')
+            print(f"\nSetup phase took {get_datetime_diff(cluster_info['phases']['setup_phase'], date_format)}s "
+                  f"({cluster_info['phases']['setup_phase'][0]} - {cluster_info['phases']['setup_phase'][1]}).")
+            print(f"Stable phase took {get_datetime_diff(cluster_info['phases']['stable_phase'], date_format)}s "
+                  f"({cluster_info['phases']['stable_phase'][0]} - {cluster_info['phases']['stable_phase'][1]}).")
         except KeyError:
             print('No information available about test phases.')

--- a/tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py
+++ b/tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py
@@ -1,8 +1,7 @@
-# Copyright (C) 2015-2021, Wazuh Inc.
+# Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from datetime import datetime
 from os import listdir
 from os.path import join, dirname, realpath
 
@@ -10,6 +9,7 @@ import pytest
 from yaml import safe_load
 
 from wazuh_testing.tools.performance.csv_parser import ClusterCSVTasksParser, ClusterCSVResourcesParser, ClusterEnvInfo
+from wazuh_testing.tools.utils import get_datetime_diff
 
 test_data_path = join(dirname(realpath(__file__)), 'data')
 configurations = {file.replace('_thresholds.yaml', ''): safe_load(open(join(test_data_path, file))) for file in
@@ -27,16 +27,6 @@ def n_workers(pytestconfig):
 @pytest.fixture()
 def n_agents(pytestconfig):
     return pytestconfig.getoption("n_agents")
-
-
-# Functions
-def get_datetime_diff(phase_datetimes):
-    """Calculate the difference between two datetimes.
-
-    Args:
-        phase_datetimes (list): List containing start and end datetimes.
-    """
-    return datetime.strptime(phase_datetimes[1], date_format) - datetime.strptime(phase_datetimes[0], date_format)
 
 
 def test_cluster_performance(artifacts_path, n_workers, n_agents):
@@ -98,10 +88,9 @@ def test_cluster_performance(artifacts_path, n_workers, n_agents):
     finally:
         # Add useful information to report as stdout
         try:
-            print('\n')
-            print(f'Setup phase took {get_datetime_diff(cluster_info["phases"]["setup_phase"])}s '
+            print(f'\nSetup phase took {get_datetime_diff(cluster_info["phases"]["setup_phase"], date_format)}s '
                   f'({cluster_info["phases"]["setup_phase"][0]} - {cluster_info["phases"]["setup_phase"][1]}).')
-            print(f'Stable phase took {get_datetime_diff(cluster_info["phases"]["stable_phase"])}s '
+            print(f'Stable phase took {get_datetime_diff(cluster_info["phases"]["stable_phase"], date_format)}s '
                   f'({cluster_info["phases"]["stable_phase"][0]} - {cluster_info["phases"]["stable_phase"][1]}).')
         except KeyError:
             print('No information available about test phases.')


### PR DESCRIPTION
|Related issue|
|---|
|#2287|

## Description
This closes #2287. The aim of this pull is to move the `get_datetime_diff` function from the `cluster_performance_test` into the `wazuh_testing.utils` module. After this change, the test continues to work as expected:
```
(wazuh_qa_env) yanazaeva@pop-os:~/git/wazuh-qa/deps/wazuh_testing$ python3.9 -m pytest  ../../tests/performance/test_cluster/test_cluster_performance/ --artifacts_path=/docs/rc5/50000A25W --n_workers=25 --n_agents=50000
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/yanazaeva/git/wazuh-qa
plugins: testinfra-5.0.0, metadata-1.11.0, html-3.1.1
collected 1 item                                                                                                                                                                                                  

../../tests/performance/test_cluster/test_cluster_performance/test_cluster_performance.py .                                                                                                                 [100%]

================================================================================================ 1 passed in 0.50s ================================================================================================
```

||Results|
|:--:|:--:|
|R1| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8465374/1.zip) |
|R2| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8465376/2.zip) |
|R3| [🟢 ](https://github.com/wazuh/wazuh-qa/files/8465377/3.zip) |
