### PR TITLE
Change method from `GET` to `POST` in API login requests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/api.py
+++ b/deps/wazuh_testing/wazuh_testing/api.py
@@ -56,7 +56,7 @@ def get_token_login_api(protocol, host, port, user, password, login_endpoint, ti
     login_url = f"{get_base_url(protocol, host, port)}{login_endpoint}"
 
     for _ in range(login_attempts):
-        response = requests.get(login_url, headers=get_login_headers(user, password), verify=False, timeout=timeout)
+        response = requests.post(login_url, headers=get_login_headers(user, password), verify=False, timeout=timeout)
 
         if response.status_code == 200:
             return json.loads(response.content.decode())['data']['token']

--- a/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
@@ -92,7 +92,7 @@ class APISimulator:
         for _ in range(10):
             try:
                 self.logger.info('Trying to obtain API token')
-                response = requests.post(f'{self.base_url}{authenticate_url}', headers=basic_auth, verify=False)
+                response = requests.post(f"{self.base_url}{authenticate_url}", headers=basic_auth, verify=False)
                 if response.status_code != 200:
                     self.logger.error(f'Failed to obtain API token: {response.json()}')
                     self.logger.error('Retrying in 1s...')

--- a/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/api_simulator.py
@@ -92,7 +92,7 @@ class APISimulator:
         for _ in range(10):
             try:
                 self.logger.info('Trying to obtain API token')
-                response = requests.get(f'{self.base_url}{authenticate_url}', headers=basic_auth, verify=False)
+                response = requests.post(f'{self.base_url}{authenticate_url}', headers=basic_auth, verify=False)
                 if response.status_code != 200:
                     self.logger.error(f'Failed to obtain API token: {response.json()}')
                     self.logger.error('Retrying in 1s...')

--- a/deps/wazuh_testing/wazuh_testing/tools/key_polling_api.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/key_polling_api.py
@@ -51,7 +51,7 @@ def insert_agent_manual(token, agent_id=None, agent_ip=None, agent_name=None, ag
 
 def read_token(new_token=False):
     def obtain_token():
-        response = requests.post(f'{BASE_URL}/security/user/authenticate', headers=login_headers(), verify=False)
+        response = requests.post(f"{BASE_URL}/security/user/authenticate", headers=login_headers(), verify=False)
         return response.json()['data']['token']
 
     if not exists(TOKEN_FILE) or new_token:

--- a/deps/wazuh_testing/wazuh_testing/tools/key_polling_api.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/key_polling_api.py
@@ -51,7 +51,7 @@ def insert_agent_manual(token, agent_id=None, agent_ip=None, agent_name=None, ag
 
 def read_token(new_token=False):
     def obtain_token():
-        response = requests.get(f'{BASE_URL}/security/user/authenticate', headers=login_headers(), verify=False)
+        response = requests.post(f'{BASE_URL}/security/user/authenticate', headers=login_headers(), verify=False)
         return response.json()['data']['token']
 
     if not exists(TOKEN_FILE) or new_token:

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -183,19 +183,18 @@ class HostManager:
         Returns:
             API token (str): Usable API token.
         """
+        login_endpoint = '/security/user/authenticate'
+        login_method = 'POST'
+        login_body = ''
         if auth_context is not None:
             login_endpoint = '/security/user/authenticate/run_as'
-            login_method = 'POST'
             login_body = 'body="{}"'.format(json.dumps(auth_context).replace('"', '\\"').replace(' ', ''))
-        else:
-            login_endpoint = '/security/user/authenticate'
-            login_method = 'POST'
-            login_body = ''
 
         try:
-            token_response = self.get_host(host).ansible('uri', f'url=https://localhost:{port}{login_endpoint} '
-                                                                f'user={user} password={password} method={login_method} '
-                                                                f'{login_body} validate_certs=no force_basic_auth=yes',
+            token_response = self.get_host(host).ansible('uri', f"url=https://localhost:{port}{login_endpoint} "
+                                                                f"user={user} password={password} "
+                                                                f"method={login_method} {login_body} validate_certs=no "
+                                                                f"force_basic_auth=yes",
                                                          check=check)
             return token_response['json']['data']['token']
         except KeyError:

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -189,7 +189,7 @@ class HostManager:
             login_body = 'body="{}"'.format(json.dumps(auth_context).replace('"', '\\"').replace(' ', ''))
         else:
             login_endpoint = '/security/user/authenticate'
-            login_method = 'GET'
+            login_method = 'POST'
             login_body = ''
 
         try:

--- a/tests/integration/test_api/test_middlewares/test_response_postprocessing.py
+++ b/tests/integration/test_api/test_middlewares/test_response_postprocessing.py
@@ -69,7 +69,7 @@ from wazuh_testing import api
          {'title': 'Not Found', 'detail': '404: Not Found'}),
         ('GET', '/agents', None, False, 401,
          {'title': 'Unauthorized', 'detail': 'No authorization token provided'}),
-        ('GET', '/security/user/authenticate', None, False, 401,
+        ('POST', '/security/user/authenticate', None, False, 401,
          {'title': 'Unauthorized', 'detail': 'Invalid credentials'})
     ])
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')


### PR DESCRIPTION
|Related issue|
|---|
|#2705|



## Description

This PR closes #2705.


Apart from the change listed in the related issue, I have added more changes to tests and tools using the login endpoint.

The related API tests will fail until https://github.com/wazuh/wazuh/issues/10203 is merged.

## Checks

- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
