### PR TITLE
IT: VDT - Add test_providers cases for SUSE Linux Enterprise

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
@@ -141,3 +141,12 @@
     OS: ''
   metadata:
     provider_name: 'Microsoft Security Update'
+
+- name: 'SUSE Linux Enterprise Server 12'
+  description: 'Test enabled SUSE Server 12'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'suse'
+    OS: '12-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 12'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
@@ -142,6 +142,15 @@
   metadata:
     provider_name: 'Microsoft Security Update'
 
+- name: 'SUSE Linux Enterprise Server 11'
+  description: 'Test enabled SUSE Server 11'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'suse'
+    OS: '11-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 11'
+
 - name: 'SUSE Linux Enterprise Server 12'
   description: 'Test enabled SUSE Server 12'
   configuration_parameters:
@@ -150,3 +159,39 @@
     OS: '12-server'
   metadata:
     provider_name: 'SUSE Linux Enterprise Server 12'
+
+- name: 'SUSE Linux Enterprise Server 15'
+  description: 'Test enabled SUSE Server 15'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'suse'
+    OS: '15-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 15'
+
+- name: 'SUSE Linux Enterprise Desktop 11'
+  description: 'Test enabled SUSE Desktop 11'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'suse'
+    OS: '11-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 11'
+
+- name: 'SUSE Linux Enterprise Desktop 12'
+  description: 'Test enabled SUSE Desktop 12'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'suse'
+    OS: '12-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 12'
+
+- name: 'SUSE Linux Enterprise Desktop 15'
+  description: 'Test enabled SUSE Desktop 15'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'suse'
+    OS: '15-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 15'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
@@ -142,6 +142,15 @@
   metadata:
     provider_name: 'Microsoft Security Update'
 
+- name: 'SUSE Linux Enterprise Server 11'
+  description: 'Test enabled SUSE Server 11'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'suse'
+    OS: '11-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 11'
+
 - name: 'SUSE Linux Enterprise Server 12'
   description: 'Test enabled SUSE Server 12'
   configuration_parameters:
@@ -150,3 +159,39 @@
     OS: '12-server'
   metadata:
     provider_name: 'SUSE Linux Enterprise Server 12'
+
+- name: 'SUSE Linux Enterprise Server 15'
+  description: 'Test enabled SUSE Server 15'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'suse'
+    OS: '15-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 15'
+
+- name: 'SUSE Linux Enterprise Desktop 11'
+  description: 'Test enabled SUSE Desktop 11'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'suse'
+    OS: '11-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 11'
+
+- name: 'SUSE Linux Enterprise Desktop 12'
+  description: 'Test enabled SUSE Desktop 12'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'suse'
+    OS: '12-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 12'
+
+- name: 'SUSE Linux Enterprise Desktop 15'
+  description: 'Test enabled SUSE Desktop 15'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'suse'
+    OS: '15-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 15'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
@@ -141,3 +141,12 @@
     OS: ''
   metadata:
     provider_name: 'Microsoft Security Update'
+
+- name: 'SUSE Linux Enterprise Server 12'
+  description: 'Test enabled SUSE Server 12'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'suse'
+    OS: '12-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 12'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_missing_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_missing_os.yaml
@@ -53,3 +53,11 @@
   metadata:
     provider_name: 'Arch Linux'
     os: ['']
+
+- name: 'SUSE Linux Enterprise'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise'
+    os: ['']

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_missing_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_missing_os.yaml
@@ -60,4 +60,4 @@
     PROVIDER: 'suse'
   metadata:
     provider_name: 'SUSE Linux Enterprise'
-    os: ['']
+    os: ['11-server', '12-server', '15-server', '11-desktop', '12-desktop', '15-desktop', '']

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
@@ -141,3 +141,57 @@
   metadata:
     provider_name: 'Microsoft Security Update'
     os: ''
+
+- name: 'SUSE Linux Enterprise Desktop 11'
+  description: 'SUSE Linux Enterprise Desktop 11 provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '11-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 11'
+    os: '11-desktop'
+
+- name: 'SUSE Linux Enterprise Desktop 12'
+  description: 'SUSE Linux Enterprise Desktop 12 provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '12-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 12'
+    os: '12-desktop'
+
+- name: 'SUSE Linux Enterprise Desktop 15'
+  description: 'SUSE Linux Enterprise Desktop 15 provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '15-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 15'
+    os: '15-desktop'
+
+- name: 'SUSE Linux Enterprise Server 11'
+  description: 'SUSE Linux Enterprise Server 11'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '11-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 11'
+    os: '11-server'
+
+- name: 'SUSE Linux Enterprise Server 12'
+  description: 'SUSE Linux Enterprise Server 12'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '12-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 12'
+    os: '12-server'
+
+- name: 'SUSE Linux Enterprise Server 15'
+  description: 'SUSE Linux Enterprise Server 15'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '15-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 15'
+    os: '15-server'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_from_year.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_from_year.yaml
@@ -42,7 +42,7 @@
   metadata:
     provider: 'msu'
 
-- name: 'suse'
+- name: 'SUSE'
   description: 'SUSE Linux Enterprise'
   configuration_parameters:
     PROVIDER: 'suse'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_from_year.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_from_year.yaml
@@ -41,3 +41,13 @@
     UPDATE_FROM_YEAR: YEAR
   metadata:
     provider: 'msu'
+
+- name: 'suse'
+  description: 'SUSE Linux Enterprise'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: 11-desktop
+    UPDATE_FROM_YEAR: YEAR
+  metadata:
+    provider: 'suse'
+    provider_name: 'SUSE Linux Enterprise Desktop 11'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_interval.yaml
@@ -57,3 +57,13 @@
   metadata:
     provider_name: 'Arch Linux'
     update_interval: '5s'
+
+- name: 'SUSE'
+  description: 'Test update interval 5s SUSE'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '12-server'
+    UPDATE_INTERVAL: '5s'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 12'
+    update_interval: '5s'

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -58,8 +58,6 @@ import pytest
 from datetime import date
 
 from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
-from wazuh_testing.db_interface import cve_db
-from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -36,6 +36,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_missing_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_missing_os.py
@@ -37,6 +37,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py
@@ -52,6 +52,7 @@ import os
 import pytest
 
 from wazuh_testing.tools import configuration
+from wazuh_testing.tools.services import control_service
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 from wazuh_testing.db_interface import cve_db
 from wazuh_testing.modules import vulnerability_detector as vd
@@ -140,6 +141,9 @@ def test_check_log_multiple_provider_feeds(configuration, metadata, set_wazuh_co
         - 'Refresh of <provider_name> database finished'
         - 'The update of the <provider_name> feed finished'
     '''
+    # Restart Wazuh
+    control_service('restart')
+
     # Check processing feed logs (Redhat and Debian have differente order)
     evm.check_fetching_feed_log(metadata['oval_feed_path'])
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_os.py
@@ -58,9 +58,7 @@ import os
 import pytest
 from datetime import date
 
-from wazuh_testing.db_interface import cve_db
 from wazuh_testing.tools import configuration
-from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_os.py
@@ -37,6 +37,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
@@ -38,11 +38,6 @@ os_version:
     - Ubuntu Focal
     - Ubuntu Bionic
     - SUSE Linux Enterprise Desktop 11
-    - SUSE Linux Enterprise Desktop 12
-    - SUSE Linux Enterprise Desktop 15
-    - SUSE Linux Enterprise Server 11
-    - SUSE Linux Enterprise Server 12
-    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
@@ -59,7 +59,6 @@ import pytest
 from datetime import date
 
 from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
-from wazuh_testing.db_interface.cve_db import check_inserted_value_exists
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
@@ -37,6 +37,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
@@ -37,6 +37,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
@@ -37,12 +37,7 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
-    - SUSE Linux Enterprise Desktop 11
-    - SUSE Linux Enterprise Desktop 12
-    - SUSE Linux Enterprise Desktop 15
-    - SUSE Linux Enterprise Server 11
     - SUSE Linux Enterprise Server 12
-    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html


### PR DESCRIPTION
|Related issue|
|---|
| [2808](https://github.com/wazuh/wazuh-qa/issues/2808) |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As part of https://github.com/wazuh/wazuh-qa/issues/2792, it is necessary to add cases in the test_providers suite related to SUSE Linux Enterprise support for the Wazuh Vulnerability Detector module.
<!--
Add a clear description of how the problem has been solved.
-->

## Test added: 
- `Test enabled/disabled`: Check that the provider's feeds start downloading when activated.
- `Test missing os`: Test the behavior when the <os> tag is omitted. Check failure if the tag is required, and in case it is not, it starts downloading the feeds as normal
- `Test OS`: Test that it starts downloading the feeds of the specified OS.
- `Test update from year`: Test if the feed is updated from a specific date. If the option does not apply, check warning warning.
- `Test update interval`: Test that the feed is updated at the specified interval

## Configuration options

local_internal_options
> wazuh_modules.debug=2
monitord.rotate_log=0
<!--
When proceed, this section should include new configuration parameters.
-->


<!--
Paste here related logs and alerts
-->


## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
|  test/integration/test_vulnerability_detector/test_providers | CentOS - Manager | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/25794/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/25795/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/25796/)| 28/04/2022 |  @CamiRomero  | 


- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.