### PR TITLE
2825 fix multigroups

### DIFF
--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -42,6 +42,7 @@ tags:
 import hashlib
 import os
 import re
+import subprocess as sb
 from time import sleep
 
 import pytest
@@ -103,13 +104,12 @@ def prepare_environment(request, register_agent):
     new_agent_group()
 
     agent_id = getattr(request.module, 'response_data')['id']
-    with open(os.path.join(groups_folder, agent_id), "w") as f:
-        f.write(f"default,{DEFAULT_TESTING_GROUP_NAME}")
+
+    sb.run([f"{WAZUH_PATH}/bin/agent_groups", "-q", "-i", agent_id, "-g", DEFAULT_TESTING_GROUP_NAME])
 
     yield
 
     remove_agent_group(DEFAULT_TESTING_GROUP_NAME)
-    delete_file(os.path.join(groups_folder, agent_id))
 
 
 @pytest.fixture(scope='function')

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -52,6 +52,7 @@ from wazuh_testing.remote import DEFAULT_TESTING_GROUP_NAME, new_agent_group, \
                                   remove_agent_group
 from wazuh_testing.tools import REMOTE_DAEMON, WAZUH_PATH, configuration
 from wazuh_testing.tools.file import delete_file
+import wazuh_testing.tools as tools
 from wazuh_testing.tools.services import check_daemon_status, control_service
 from wazuh_testing.tools.wazuh_manager import remove_agents
 
@@ -105,11 +106,13 @@ def prepare_environment(request, register_agent):
 
     agent_id = getattr(request.module, 'response_data')['id']
 
-    sb.run([f"{WAZUH_PATH}/bin/agent_groups", "-q", "-i", agent_id, "-g", DEFAULT_TESTING_GROUP_NAME])
+    sb.run([f"{tools.WAZUH_PATH}/bin/agent_groups", "-q", "-a", "-i", agent_id, "-g", 'default'])
+    sb.run([f"{tools.WAZUH_PATH}/bin/agent_groups", "-q", "-a", "-i", agent_id, "-g", DEFAULT_TESTING_GROUP_NAME])
 
     yield
 
     remove_agent_group(DEFAULT_TESTING_GROUP_NAME)
+    delete_file(os.path.join(groups_folder, agent_id))
 
 
 @pytest.fixture(scope='function')
@@ -166,13 +169,13 @@ def test_merged_mg_file_content(metadata, configure_local_internal_options_modul
         - prepare_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-    
+
     assertions:
         - Verify that the file exists or not in the multigroups directory.
         - Verify that the file is or is not in the merged.mg file
-    
+
     input_description: Different test cases defined in a YAML file.
-    
+
     expected_output:
         - r'^!0 testing_file$'
     '''


### PR DESCRIPTION
|Related issue|
|---|
|2825|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Working on https://github.com/wazuh/wazuh/issues/10771, the core team detected that there are affected tests by the new changes.

The objective of this PR is to perform the refactor of each affected test.
## Configuration options

## Local internal options

> remoted.debug=2
> wazuh_database.interval=1
> wazuh_db.commit_time=2
> wazuh_db.commit_time_max=3
> monitord.rotate_log=0

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs example

<!--
Paste here related logs and alerts
-->

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
| integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py  | CentOS - Manager | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/25506/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/25507/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/25508/)| 25/04/2022 |  @CamiRomero  | 


- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
- [x] `provision_documentation.sh` generate the docs without errors.