### PR TITLE
IT: VDT - Add test_feeds cases for SUSE Linux Enterprise

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/__init__.py
@@ -31,6 +31,7 @@ CUSTOM_CPE_HELPER = 'custom_cpe_helper.json'
 CUSTOM_ARCHLINUX_JSON_FEED = 'custom_archlinux_feed.json'
 CUSTOM_ALAS_JSON_FEED = 'custom_alas_feed.json'
 CUSTOM_ALAS2_JSON_FEED = 'custom_alas2_feed.json'
+CUSTOM_SUSE_OVAL_FEED = 'custom_suse_oval_feed.xml'
 
 VULNERABILITY_DETECTOR_PREFIX = r'.*wazuh-modulesd:vulnerability-detector.*'
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_import_invalid_feed_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_import_invalid_feed_type.yaml
@@ -318,3 +318,50 @@
     elements:
       - disabled:
           value: 'yes'
+
+# SUSE configuration
+- sections:
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: 'suse'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - url: CUSTOM_FEED_URL
+                  value: '11-desktop'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'no'
+
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -177,3 +177,69 @@
     provider_os: 'MSU'
     download_timeout: 120
     update_treshold_weeks: 3
+
+- name: 'SUSE11-SERVER'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '11-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 11'
+    provider_os: '11-server'
+    download_timeout: 360
+    update_treshold_weeks: 3
+
+- name: 'SUSE12-SERVER'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '12-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 12'
+    provider_os: '12-server'
+    download_timeout: 360
+    update_treshold_weeks: 3
+
+- name: 'SUSE15-SERVER'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '15-server'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 15'
+    provider_os: '15-server'
+    download_timeout: 360
+    update_treshold_weeks: 3
+
+- name: 'SUSE11-Desktop'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '11-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 11'
+    provider_os: '11-desktop'
+    download_timeout: 360
+    update_treshold_weeks: 3
+
+- name: 'SUSE12-Desktop'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '12-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 12'
+    provider_os: '12-desktop'
+    download_timeout: 360
+    update_treshold_weeks: 3
+
+- name: 'SUSE15-Desktop'
+  description: 'SUSE Linux Enterprise provider'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '15-desktop'
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 15'
+    provider_os: '15-desktop'
+    download_timeout: 360
+    update_treshold_weeks: 3

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -178,68 +178,68 @@
     download_timeout: 120
     update_treshold_weeks: 3
 
-- name: 'SUSE11-SERVER'
+- name: 'SUSE Linux Enterprise Server 11'
   description: 'SUSE Linux Enterprise provider'
   configuration_parameters:
     PROVIDER: 'suse'
     OS: '11-server'
   metadata:
     provider_name: 'SUSE Linux Enterprise Server 11'
-    provider_os: '11-server'
+    provider_os: 'SLES11'
     download_timeout: 360
-    update_treshold_weeks: 3
+    update_treshold_weeks: 2
 
-- name: 'SUSE12-SERVER'
+- name: 'SUSE Linux Enterprise Server 12'
   description: 'SUSE Linux Enterprise provider'
   configuration_parameters:
     PROVIDER: 'suse'
     OS: '12-server'
   metadata:
     provider_name: 'SUSE Linux Enterprise Server 12'
-    provider_os: '12-server'
+    provider_os: 'SLES12'
     download_timeout: 360
-    update_treshold_weeks: 3
+    update_treshold_weeks: 2
 
-- name: 'SUSE15-SERVER'
+- name: 'SUSE Linux Enterprise Server 15'
   description: 'SUSE Linux Enterprise provider'
   configuration_parameters:
     PROVIDER: 'suse'
     OS: '15-server'
   metadata:
     provider_name: 'SUSE Linux Enterprise Server 15'
-    provider_os: '15-server'
+    provider_os: 'SLES15'
     download_timeout: 360
-    update_treshold_weeks: 3
+    update_treshold_weeks: 2
 
-- name: 'SUSE11-Desktop'
+- name: 'SUSE Linux Enterprise Desktop 11'
   description: 'SUSE Linux Enterprise provider'
   configuration_parameters:
     PROVIDER: 'suse'
     OS: '11-desktop'
   metadata:
     provider_name: 'SUSE Linux Enterprise Desktop 11'
-    provider_os: '11-desktop'
+    provider_os: 'SLED11'
     download_timeout: 360
-    update_treshold_weeks: 3
+    update_treshold_weeks: 2
 
-- name: 'SUSE12-Desktop'
+- name: 'SUSE Linux Enterprise Desktop 12'
   description: 'SUSE Linux Enterprise provider'
   configuration_parameters:
     PROVIDER: 'suse'
     OS: '12-desktop'
   metadata:
     provider_name: 'SUSE Linux Enterprise Desktop 12'
-    provider_os: '12-desktop'
+    provider_os: 'SLED12'
     download_timeout: 360
-    update_treshold_weeks: 3
+    update_treshold_weeks: 2
 
-- name: 'SUSE15-Desktop'
+- name: 'SUSE Linux Enterprise Desktop 13'
   description: 'SUSE Linux Enterprise provider'
   configuration_parameters:
     PROVIDER: 'suse'
     OS: '15-desktop'
   metadata:
     provider_name: 'SUSE Linux Enterprise Desktop 15'
-    provider_os: '15-desktop'
+    provider_os: 'SLED15'
     download_timeout: 360
-    update_treshold_weeks: 3
+    update_treshold_weeks: 2

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_duplicate_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_duplicate_feeds.yaml
@@ -59,3 +59,13 @@
   metadata:
     provider_name: 'Microsoft Security Update'
     provider_json_name: ''
+
+- name: 'SUSE'
+  description: 'SUSE Linux Enterprise'
+  configuration_parameters:
+    PROVIDER: 'suse'
+    OS: '11-desktop'
+    OS_PATH: CUSTOM_SUSE_OVAL_FEED
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 11'
+    provider_json_name: ''

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_import_invalid_feed_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_import_invalid_feed_type.yaml
@@ -61,3 +61,12 @@
     custom_feed_url: https://s3.amazonaws.com/ci.wazuh.com/qa/testing_files/dummy_files/dummy.mp3
     provider_feed_names:
       - "nvd provider"
+
+- name: 'SUSE - JPG'
+  description: 'Check downloading and parsing of JPG file as invalid feed in Suse provider'
+  configuration_parameters: null
+  metadata:
+    target: 'suse'
+    custom_feed_url: https://s3.amazonaws.com/ci.wazuh.com/qa/testing_files/dummy_files/dummy.jpg
+    provider_feed_names:
+      - "suse SLED11"

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -135,3 +135,63 @@
     path: '/tmp/oval-definitions-bullseye.xml'
     extension: 'xml'
     url: 'https://www.debian.org/security/oval/oval-definitions-bullseye.xml'
+
+- name: 'SUSE Linux Enterprise Desktop 11'
+  description: 'SUSE Linux Enterprise Desktop 11 provider'
+  configuration_parameters:
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 11'
+    expected_format: 'xml'
+    path: '/tmp/suse.linux.enterprise.desktop.11.xml'
+    extension: 'xml'
+    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.11.xml'
+
+- name: 'SUSE Linux Enterprise Desktop 12'
+  description: 'SUSE Linux Enterprise Desktop 12 provider'
+  configuration_parameters:
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 12'
+    expected_format: 'xml'
+    path: '/tmp/suse.linux.enterprise.desktop.12.xml'
+    extension: 'xml'
+    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml'
+
+- name: 'SUSE Linux Enterprise Desktop 15'
+  description: 'SUSE Linux Enterprise Desktop 15 provider'
+  configuration_parameters:
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Desktop 15'
+    expected_format: 'xml'
+    path: '/tmp/suse.linux.enterprise.desktop.15.xml'
+    extension: 'xml'
+    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.15.xml'
+
+- name: 'SUSE Linux Enterprise Server 11'
+  description: 'SUSE Linux Enterprise Server 11 provider'
+  configuration_parameters:
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 11'
+    expected_format: 'xml'
+    path: '/tmp/suse.linux.enterprise.server.11.xml'
+    extension: 'xml'
+    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.11.xml'
+
+- name: 'SUSE Linux Enterprise Server 12'
+  description: 'SUSE Linux Enterprise Server 12 provider'
+  configuration_parameters:
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 12'
+    expected_format: 'xml'
+    path: '/tmp/suse.linux.enterprise.server.12.xml'
+    extension: 'xml'
+    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml'
+
+- name: 'SUSE Linux Enterprise Server 15'
+  description: 'SUSE Linux Enterprise Server 15 provider'
+  configuration_parameters:
+  metadata:
+    provider_name: 'SUSE Linux Enterprise Server 15'
+    expected_format: 'xml'
+    path: '/tmp/suse.linux.enterprise.server.15.xml'
+    extension: 'xml'
+    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml'

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -37,6 +37,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -37,6 +37,7 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -75,6 +75,7 @@ custom_canonical_oval_feed_path = os.path.join(CUSTOM_FEED_PATH, 'feeds', 'canon
 custom_alas_feed_path = os.path.join(CUSTOM_FEED_PATH, 'feeds', 'alas', vd.CUSTOM_ALAS_JSON_FEED)
 custom_archlinux_feed_path = os.path.join(CUSTOM_FEED_PATH, 'feeds', 'arch', vd.CUSTOM_ARCHLINUX_JSON_FEED)
 custom_msu_feed_path = os.path.join(CUSTOM_FEED_PATH, 'feeds', 'msu', vd.CUSTOM_MSU_JSON_FEED)
+custom_suse_feed_path = os.path.join(CUSTOM_FEED_PATH, 'feeds', 'suse', vd.CUSTOM_SUSE_OVAL_FEED)
 
 # Test configurations
 configuration_parameters, configuration_metadata, test_case_ids = configuration.get_test_cases_data(
@@ -85,10 +86,10 @@ configurations = configuration.load_configuration_template(configurations_path, 
 # Set offline custom feeds configuration
 to_modify = ['CUSTOM_REDHAT_OVAL_FEED_PATH', 'CUSTOM_REDHAT_JSON_FEED_PATH', 'CUSTOM_DEBIAN_OVAL_FEED_PATH',
              'CUSTOM_DEBIAN_JSON_FEED_PATH', 'CUSTOM_CANONICAL_OVAL_FEED_PATH', 'CUSTOM_ALAS_JSON_FEED_PATH',
-             'CUSTOM_ARCHLINUX_JSON_FEED_PATH', 'CUSTOM_MSU_JSON_FEED_PATH']
+             'CUSTOM_ARCHLINUX_JSON_FEED_PATH', 'CUSTOM_MSU_JSON_FEED_PATH', 'CUSTOM_SUSE_OVAL_FEED']
 new_values = [custom_redhat_oval_feed_path, custom_redhat_json_feed_path, custom_debian_oval_feed_path,
               custom_debian_json_feed_path, custom_canonical_oval_feed_path, custom_alas_feed_path,
-              custom_archlinux_feed_path, custom_msu_feed_path]
+              custom_archlinux_feed_path, custom_msu_feed_path, custom_suse_feed_path]
 configurations = configuration.update_configuration_template(configurations, to_modify, new_values)
 configuration_metadata = configuration.update_configuration_template(configuration_metadata, to_modify, new_values)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
@@ -47,13 +47,11 @@ import os
 import pytest
 import json
 
-from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
-from wazuh_testing.tools.configuration import update_configuration_template
-from wazuh_testing.db_interface import agent_db, cve_db
+from wazuh_testing.tools.configuration import get_test_cases_data
+from wazuh_testing.db_interface import cve_db
 from wazuh_testing.tools.file import read_yaml
 from wazuh_testing.processes import check_if_modulesd_is_running
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
-from wazuh_testing.modules import vulnerability_detector as vd
 
 
 pytestmark = [pytest.mark.server]

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -37,6 +37,12 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
@@ -58,7 +58,7 @@ import pytest
 from datetime import datetime
 
 from wazuh_testing.tools import file
-from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.tools.configuration import get_test_cases_data
 
 
 # Reference paths


### PR DESCRIPTION
|Related issue|
|---|
|[2807](https://github.com/wazuh/wazuh-qa/issues/2807)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As part of https://github.com/wazuh/wazuh-qa/issues/2792, it is necessary to add cases in the test_feeds suite related to SUSE Linux Enterprise support for the Wazuh Vulnerability Detector module.
<!--
Add a clear description of how the problem has been solved.
-->
## Test added: 


- `Test download feeds`: Prove that it is downloaded, and that the update date is recent.
- `Test duplicate feeds`: Test that after downloading the feed again, the vulnerabilities of the feeds are not duplicated
- `Test import invalid feed type`: Test behavior when an invalid feed URL is entered
- `Test validate feed content`: It downloads the feed files and checks that they are parseable (XML or JSON).

## Configuration options

local_internal_options
> wazuh_modules.debug=2
monitord.rotate_log=0


## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
|  test/integration/test_vulnerability_detector/test_feeds | CentOS - Manager | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/25753/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/25754/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/25755/)| 27/04/2022 |  @CamiRomero  | 
## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.