### PR TITLE
Add test_providers cases for Ubuntu 22 

### DIFF
--- a/tests/integration/test_vulnerability_detector/data/feeds/ubuntu22/custom_ubuntu22_oval_feed.xml
+++ b/tests/integration/test_vulnerability_detector/data/feeds/ubuntu22/custom_ubuntu22_oval_feed.xml
@@ -1,0 +1,57 @@
+<oval_definitions
+    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+    xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+    xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
+    xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#macos linux-definitions-schema.xsd">
+
+    <generator>
+        <oval:product_name>Canonical CVE OVAL Generator</oval:product_name>
+        <oval:product_version>1.1</oval:product_version>
+        <oval:schema_version>5.11.1</oval:schema_version>
+        <oval:timestamp>2022-05-02T15:47:01</oval:timestamp>
+    </generator>
+
+    <definitions>
+        <definition class="inventory" id="oval:com.ubuntu.jammy:def:100" version="1">
+            <metadata>
+                <title>Check that Ubuntu 22.04 LTS (jammy) is installed.</title>
+                <description></description>
+            </metadata>
+            <criteria>
+                <criterion test_ref="oval:com.ubuntu.jammy:tst:100" comment="The host is part of the unix family." />
+                <criterion test_ref="oval:com.ubuntu.jammy:tst:101" comment="The host is running Ubuntu jammy." />
+            </criteria>
+        </definition>
+    </definitions>
+    <tests>
+        <ind-def:family_test id="oval:com.ubuntu.jammy:tst:100" check="at least one" check_existence="at_least_one_exists" version="1" comment="Is the host part of the unix family?">
+            <ind-def:object object_ref="oval:com.ubuntu.jammy:obj:100"/>
+            <ind-def:state state_ref="oval:com.ubuntu.jammy:ste:100"/>
+        </ind-def:family_test>
+
+        <ind-def:textfilecontent54_test id="oval:com.ubuntu.jammy:tst:101" check="at least one" check_existence="at_least_one_exists" version="1" comment="Is the host running Ubuntu jammy?">
+            <ind-def:object object_ref="oval:com.ubuntu.jammy:obj:101"/>
+            <ind-def:state state_ref="oval:com.ubuntu.jammy:ste:101"/>
+        </ind-def:textfilecontent54_test>
+    </tests>
+    <objects>
+        <ind-def:family_object id="oval:com.ubuntu.jammy:obj:100" version="1" comment="The singleton family object."/>
+
+        <ind-def:textfilecontent54_object id="oval:com.ubuntu.jammy:obj:101" version="1" comment="The singleton release codename object.">
+            <ind-def:filepath>/etc/lsb-release</ind-def:filepath>
+            <ind-def:pattern operation="pattern match">^[\s\S]*DISTRIB_CODENAME=([a-z]+)$</ind-def:pattern>
+            <ind-def:instance datatype="int">1</ind-def:instance>
+        </ind-def:textfilecontent54_object>
+    </objects>
+    <states>
+        <ind-def:family_state id="oval:com.ubuntu.jammy:ste:100" version="1" comment="The singleton family object.">
+            <ind-def:family>unix</ind-def:family>
+        </ind-def:family_state>
+
+        <ind-def:textfilecontent54_state id="oval:com.ubuntu.jammy:ste:101" version="1" comment="Ubuntu 22.04 LTS">
+            <ind-def:subexpression>jammy</ind-def:subexpression>
+        </ind-def:textfilecontent54_state>
+    </states>
+</oval_definitions>

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
@@ -52,6 +52,15 @@
   metadata:
     provider_name: 'Ubuntu Trusty'
 
+- name: 'Ubuntu Jammy'
+  description: 'Test disabled Ubuntu 22'
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: 'canonical'
+    OS: 'jammy'
+  metadata:
+    provider_name: 'Ubuntu Jammy'
+
 - name: 'RHEL 8'
   description: 'Test disabled Red Hat Enterprise Linux 8'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
@@ -52,6 +52,15 @@
   metadata:
     provider_name: 'Ubuntu Trusty'
 
+- name: 'Ubuntu Jammy'
+  description: 'Test enabled Ubuntu 22'
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: 'canonical'
+    OS: 'jammy'
+  metadata:
+    provider_name: 'Ubuntu Jammy'
+
 - name: 'RHEL 8'
   description: 'Test enabled Red Hat Enterprise Linux 8'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
@@ -52,6 +52,15 @@
     provider_name: 'Ubuntu Focal'
     os: 'focal'
 
+- name: 'Ubuntu Jammy'
+  description: 'Ubuntu 22 provider'
+  configuration_parameters:
+    PROVIDER: 'canonical'
+    OS: 'jammy'
+  metadata:
+    provider_name: 'Ubuntu Jammy'
+    os: 'jammy'
+
 - name: 'Debian Stretch'
   description: 'Debian Stretch provider'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_interval.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_update_interval.yaml
@@ -18,14 +18,54 @@
     provider_name: 'Red Hat Enterprise Linux 8'
     update_interval: '5s'
 
-- name: 'Canonical'
-  description: 'Test update interval 5s Canonical'
+- name: 'Ubuntu Focal'
+  description: 'Test update interval 5s Ubuntu Focal'
   configuration_parameters:
     PROVIDER: 'canonical'
     OS: 'focal'
     UPDATE_INTERVAL: '5s'
   metadata:
     provider_name: 'Ubuntu Focal'
+    update_interval: '5s'
+
+- name: 'Ubuntu Bionic'
+  description: 'Test update interval 5s Ubuntu Bionic'
+  configuration_parameters:
+    PROVIDER: 'canonical'
+    OS: 'bionic'
+    UPDATE_INTERVAL: '5s'
+  metadata:
+    provider_name: 'Ubuntu Bionic'
+    update_interval: '5s'
+
+- name: 'Ubuntu Xenial'
+  description: 'Test update interval 5s Ubuntu Xenial'
+  configuration_parameters:
+    PROVIDER: 'canonical'
+    OS: 'xenial'
+    UPDATE_INTERVAL: '5s'
+  metadata:
+    provider_name: 'Ubuntu Xenial'
+    update_interval: '5s'
+
+- name: 'Ubuntu Trusty'
+  description: 'Test update interval 5s Ubuntu Trusty'
+  configuration_parameters:
+    PROVIDER: 'canonical'
+    OS: 'trusty'
+    UPDATE_INTERVAL: '5s'
+  metadata:
+    provider_name: 'Ubuntu Trusty'
+    update_interval: '5s'
+
+- name: 'Ubuntu Jammy'
+  description: 'Test update interval 5s Ubuntu Jammy'
+  configuration_parameters:
+    PROVIDER: 'canonical'
+    OS: 'jammy'
+    UPDATE_INTERVAL: '5s'
+  metadata:
+    provider_name: 'Ubuntu Jammy'
     update_interval: '5s'
 
 - name: 'Debian'

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -36,6 +36,9 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Ubuntu Jammy
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_missing_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_missing_os.py
@@ -37,6 +37,9 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Ubuntu Jammy
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_os.py
@@ -37,6 +37,9 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Ubuntu Jammy
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_os.py
@@ -55,7 +55,6 @@ import os
 import pytest
 from datetime import date
 
-from wazuh_testing.db_interface import cve_db
 from wazuh_testing.tools import configuration
 from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
@@ -37,6 +37,9 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Ubuntu Jammy
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_from_year.py
@@ -56,7 +56,6 @@ import pytest
 from datetime import date
 
 from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
-from wazuh_testing.db_interface.cve_db import check_inserted_value_exists
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
 
 

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
@@ -37,6 +37,9 @@ os_version:
     - Red Hat 8
     - Ubuntu Focal
     - Ubuntu Bionic
+    - Ubuntu Xenial
+    - Ubuntu Trusty
+    - Ubuntu Jammy
 
 references:
     - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/2841|

## Description
As part of https://github.com/wazuh/wazuh-qa/issues/2841 were added cases in the test_providers suite related to Ubuntu 22 support for the Wazuh Vulnerability Detector module.

### **List some specific changes applied:**

- Added a case for Ubuntu Jammy on test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml file.
- Added a case for Ubuntu Jammy on test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml file.
- Added a case for Ubuntu Jammy on test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml file.
- Added the cases Ubuntu Xenial, Ubuntu Boinic, Ubuntu Trusty and Ubuntu Jammy on test_vulnerability_detector/test_providers/data/test_cases/cases_update_interval.yaml file.
- Updated the documentation with the Ubuntu 22 support.

## Logs example
  ## Tests Results
| Test Path | Os/Type | Jenkins | Local | Date | By | 
|--|--|--|--|--|--|
| test_vulnerability_detector/test_providers/ | Manager | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/26063/)  [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/26062/)  [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/26064/) | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8626152/R1.zip)  [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8626153/R2.zip)  [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8626154/R3.zip)  |  04/05/2022 |  Seyla

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
