### PR TITLE
 Add test_feeds cases for Amazon Linux 2022 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Release report: TBD
 - Analysisd - add a new test to check analysisd socket properties ([#2405](https://github.com/wazuh/wazuh-qa/pull/2405))
 - Add system test to check synchronization between agent and manager when one of this was stopped. ([#2536](https://github.com/wazuh/wazuh-qa/pull/2536))
 - Add a test to check the multigroups shared file content. ([#2746](https://github.com/wazuh/wazuh-qa/pull/2746))
-
+- Add test_feeds cases for Amazon Linux 2022. ([#2868](https://github.com/wazuh/wazuh-qa/pull/2868))
 ### Changed
 
 - Refactor VDT integration tests: feeds and scan types ([#2650](https://github.com/wazuh/wazuh-qa/pull/2650))

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -156,6 +156,17 @@
     download_timeout: 120
     update_treshold_weeks: 3
 
+- name: 'ALAS-3'
+  description: 'Amazon Linux provider'
+  configuration_parameters:
+    PROVIDER: 'alas'
+    OS: 'amazon-linux-2022'
+  metadata:
+    provider_name: 'Amazon Linux 2022'
+    provider_os: 'Amazon-Linux-2022'
+    download_timeout: 120
+    update_treshold_weeks: 3
+
 - name: 'NVD'
   description: 'National Vulnerability Database provider'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -156,7 +156,7 @@
     download_timeout: 120
     update_treshold_weeks: 3
 
-- name: 'ALAS-3'
+- name: 'ALAS-2022'
   description: 'Amazon Linux provider'
   configuration_parameters:
     PROVIDER: 'alas'

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -85,7 +85,7 @@ def test_download_feeds(configuration, metadata, set_wazuh_configuration_vdt, tr
         - Check in log that the database provider has been updated successfully.
         - Check that the timestamp of the feed metadata does not exceed the established threshold limit.
 
-    wazuh_min_version: 4.2.0
+    wazuh_min_version: 4.4.0
 
     tier: 2
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 
@@ -31,6 +31,7 @@ os_version:
     - Arch Linux
     - Amazon Linux 2
     - Amazon Linux 1
+    - Amazon Linux 2022
     - CentOS 8
     - CentOS 7
     - Debian Buster

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 
@@ -31,6 +31,7 @@ os_version:
     - Arch Linux
     - Amazon Linux 2
     - Amazon Linux 1
+    - Amazon Linux 2022
     - CentOS 8
     - CentOS 7
     - Debian Buster

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -132,7 +132,7 @@ def test_duplicate_feeds(configuration, metadata, set_wazuh_configuration_vdt, t
         - Wait until the next feeds download and indexation.
         - Check that the number of vulnerabilities info is the same than the before indexation.
 
-    wazuh_min_version: 4.3.0
+    wazuh_min_version: 4.4.0
 
     tier: 2
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
@@ -96,7 +96,7 @@ def test_import_invalid_feed_type(configuration, metadata, set_wazuh_configurati
         - Check that no junk data has been inserted into the database.
         - Check that wazuh-modulesd is running (it has not crashed after parsing unexpected file types).
 
-    wazuh_min_version: 4.3.0
+    wazuh_min_version: 4.4.0
 
     tier: 2
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 
@@ -29,6 +29,7 @@ os_version:
     - Arch Linux
     - Amazon Linux 2
     - Amazon Linux 1
+    - Amazon Linux 2022
     - CentOS 8
     - CentOS 7
     - Debian Buster
@@ -47,13 +48,11 @@ import os
 import pytest
 import json
 
-from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
-from wazuh_testing.tools.configuration import update_configuration_template
-from wazuh_testing.db_interface import agent_db, cve_db
+from wazuh_testing.tools.configuration import get_test_cases_data
+from wazuh_testing.db_interface import cve_db
 from wazuh_testing.tools.file import read_yaml
 from wazuh_testing.processes import check_if_modulesd_is_running
 from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
-from wazuh_testing.modules import vulnerability_detector as vd
 
 
 pytestmark = [pytest.mark.server]


### PR DESCRIPTION
|Related issue|
|---|
| Close #2901 |


## Description
Add cases in the test_feeds suite related to Amazon Linux 2022 support for the Wazuh Vulnerability Detector module.

**Suite test_feeds**

- `Test download feeds`: Prove that it is downloaded, and that the update date is recent.
- `Test duplicate feeds`: Test that after downloading the feed again, the vulnerabilities of the feeds are not duplicated
- `Test import invalid feed type`: Test behavior when an invalid feed URL is entered

The test will be run when the development was finished

## Tests Results

| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
|  test/integration/test_vulnerability_detector/test_feeds | CentOS - Manager | Jenkins | Waiting Core development |  |  @CamiRomero  | 


## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.

