### PR TITLE
Logcollector Tier 0: Failed test_age_datetime_changed

### DIFF
--- a/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
+++ b/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
@@ -58,6 +58,7 @@ tags:
     - logcollector_age
 '''
 import os
+import sys
 import time
 import tempfile
 from datetime import datetime
@@ -135,6 +136,7 @@ def restart_logcollector_function():
 
 
 @pytest.mark.parametrize('new_datetime', new_host_datetime)
+@pytest.mark.skipif(sys.platform == 'win32', reason='It will be blocked by https://github.com/wazuh/wazuh-qa/issues/2174.')
 def test_configuration_age_datetime(get_configuration, configure_environment, configure_local_internal_options_module,
                                     restart_monitord, restart_logcollector_function, file_monitoring,
                                     new_datetime, get_files_list, create_file_structure_function):


### PR DESCRIPTION
|Related issue|
|---|
|Close #2818 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The test `test_logcollector/test_age/test_age_datetime_changed.py` is failing randomly on the Nightly executions because of the use TimeMachine.travel_to_future function. We decided to skip this test only on windows OS and add this improvement to Issue https://github.com/wazuh/wazuh-qa/issues/2174.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
|  test/integration/test_logcollector | CentOS - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26620/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26621/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26622/)|  |   |
|  test/integration/test_logcollector | Windows - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26620/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26621/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26622/)|  |   | 
|  test/integration/test_logcollector | Ubuntu - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26620/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26621/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26622/)|  |   | 
## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
