### PR TITLE
Logcollector Tier 0: Failed test_basic_configuration_log_format - 4.4.0

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -11,6 +11,8 @@ from time import sleep
 
 from wazuh_testing.tools import LOGCOLLECTOR_STATISTICS_FILE, WAZUH_PATH, monitoring
 
+GENERIC_CALLBACK_MSG_LOG_FILE_DUPLICATED = r".*Log file (.+) is duplicated."
+
 GENERIC_CALLBACK_ERROR_COMMAND_MONITORING = 'The expected command monitoring log has not been produced'
 GENERIC_CALLBACK_ERROR_INVALID_LOCATION = 'The expected invalid location error log has not been produced'
 GENERIC_CALLBACK_ERROR_ANALYZING_FILE = 'The expected analyzing file log has not been produced'
@@ -19,6 +21,7 @@ GENERIC_CALLBACK_ERROR_ANALYZING_MACOS = "The expected analyzing macos log has n
 GENERIC_CALLBACK_ERROR_TARGET_SOCKET = "The expected target socket log has not been produced"
 GENERIC_CALLBACK_ERROR_TARGET_SOCKET_NOT_FOUND = "The expected target socket not found error has not been produced"
 GENERIC_CALLBACK_ERROR_READING_FILE = "The expected invalid content error log has not been produced"
+GENERIC_CALLBACK_ERROR_LOG_FILE_DUPLICATED = "The expected warning log file duplicated has not been produced."
 GENERIC_CALLBACK_ERROR = 'The expected error output has not been produced'
 
 LOG_COLLECTOR_GLOBAL_TIMEOUT = 40

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
@@ -289,7 +289,7 @@ def check_log_file_duplicated():
                             error_message=logcollector.GENERIC_CALLBACK_ERROR_LOG_FILE_DUPLICATED)
     wazuh_log_monitor.start(timeout=logcollector.LOG_COLLECTOR_GLOBAL_TIMEOUT,
                             callback=logcollector.callback_monitoring_macos_logs(),
-                            error_message="The expected macos log monitoring has not been produced")
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_ANALYZING_MACOS)
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
@@ -304,7 +304,7 @@ def test_log_format(configure_local_internal_options_module, get_configuration,
                  Finally, the test will verify that the Wazuh API returns the same values for the 'localfile' section
                  that the configured one.
 
-    wazuh_min_version: 4.3.0
+    wazuh_min_version: 4.4.0
 
     tier: 0
 

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_log_format.py
@@ -70,7 +70,7 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools import get_service
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.file import truncate_file
-from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
 from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, WINDOWS_AGENT_DETECTOR_PREFIX
 from wazuh_testing.tools.services import control_service
 from wazuh_testing.tools.utils import lower_case_key_dictionary_array
@@ -137,7 +137,7 @@ windows_tcases = [
 macos_tcases = [{'LOCATION': 'macos', 'LOG_FORMAT': 'macos', 'VALID_VALUE': True},
                 {'LOCATION': '/tmp/log.txt', 'LOG_FORMAT': 'macos', 'VALID_VALUE': True},
                 {'LOCATION1': 'macos', 'LOG_FORMAT1': 'macos', 'LOCATION2': 'macos', 'LOG_FORMAT2': 'macos',
-                 'VALID_VALUE': False, 'CONFIGURATION': 'wazuh_duplicated_macos_configuration.yaml'},
+                 'VALID_VALUE': True, 'CONFIGURATION': 'wazuh_duplicated_macos_configuration.yaml'},
                 {'LOG_FORMAT': 'macos', 'VALID_VALUE': True,
                  'CONFIGURATION': 'wazuh_no_defined_location_macos_configuration.yaml'}
                 ]
@@ -264,26 +264,32 @@ def check_log_format_invalid(cfg):
     if cfg['valid_value']:
         pytest.skip('Valid values provided')
 
-    if 'log_format1' in cfg and 'log_format2' in cfg:
-        log_callback = logcollector.callback_multiple_macos_block_configuration()
-        wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
-    else:
+    log_callback = gc.callback_invalid_value('log_format', cfg['log_format'], prefix)
+    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                            error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
 
-        log_callback = gc.callback_invalid_value('log_format', cfg['log_format'], prefix)
-        wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
-
-        log_callback = gc.callback_error_in_configuration('ERROR', prefix,
-                                                          conf_path=f'{wazuh_configuration}')
-        wazuh_log_monitor.start(timeout=5, callback=log_callback,
-                                error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
+    log_callback = gc.callback_error_in_configuration('ERROR', prefix,
+                                                      conf_path=f'{wazuh_configuration}')
+    wazuh_log_monitor.start(timeout=5, callback=log_callback,
+                            error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
 
     if sys.platform != 'win32':
         log_callback = gc.callback_error_in_configuration('CRITICAL', prefix,
                                                           conf_path=f'{wazuh_configuration}')
         wazuh_log_monitor.start(timeout=5, callback=log_callback,
                                 error_message=gc.GENERIC_CALLBACK_ERROR_MESSAGE)
+
+
+def check_log_file_duplicated():
+    """Check if Wazuh shows a warning message when the configuration is duplicated."""
+    wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
+    wazuh_log_monitor.start(timeout=logcollector.LOG_COLLECTOR_GLOBAL_TIMEOUT,
+                            callback=generate_monitoring_callback(
+                                     logcollector.GENERIC_CALLBACK_MSG_LOG_FILE_DUPLICATED),
+                            error_message=logcollector.GENERIC_CALLBACK_ERROR_LOG_FILE_DUPLICATED)
+    wazuh_log_monitor.start(timeout=logcollector.LOG_COLLECTOR_GLOBAL_TIMEOUT,
+                            callback=logcollector.callback_monitoring_macos_logs(),
+                            error_message="The expected macos log monitoring has not been produced")
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
@@ -298,7 +304,7 @@ def test_log_format(configure_local_internal_options_module, get_configuration,
                  Finally, the test will verify that the Wazuh API returns the same values for the 'localfile' section
                  that the configured one.
 
-    wazuh_min_version: 4.2.0
+    wazuh_min_version: 4.3.0
 
     tier: 0
 
@@ -352,7 +358,10 @@ def test_log_format(configure_local_internal_options_module, get_configuration,
 
     if cfg['valid_value']:
         control_service('start', daemon=LOGCOLLECTOR_DAEMON)
-        check_log_format_valid(cfg)
+        if 'location1' in cfg:
+            check_log_file_duplicated()
+        else:
+            check_log_format_valid(cfg)
     else:
         if sys.platform == 'win32':
             pytest.xfail("Windows agent allows invalid localfile configuration:\


### PR DESCRIPTION
|Related issue|
|---|
| #2914|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The test `test_logcollector/test_configuration/test_basic_configuration_log_format.py` was adapted in order to validate  that when the configurations of `Logcollector` in `macOS` have two blocks of configurations, the module works properly.

Changes:

- Add generic variables in `deps/wazuh_testing/wazuh_testing/logcollector.py`
- Modify `duplicated_macos_configuration` test cases to a valid case
- Remove block of code related with `duplicated_macos_configuration` in `check_log_format_invalid` function
- Create new function `check_log_file_duplicated` that validated two message in logs:
-> `WARNING: (1958): Log file 'macos' is duplicated.`
-> `Monitoring macOS logs with: {MACOS_LOG_COMMAND_PATH} stream --style syslog"`
- Modify `test_log_format` in order to use the new function `check_log_file_duplicated`

<!--
When proceed, this section should include new configuration parameters.
-->
## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By | Note | 
|--|--|--|--|--|--|--|
|  test/integration/test_logcollector | CentOS - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26904/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26915/)[:green_circle:]()| 26/05/2022  |  @CamiRomero   |
|  test/integration/test_logcollector | Windows - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26904/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26915/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26916/)| 26/05/2022  |  @CamiRomero   |
|  test/integration/test_logcollector | Ubuntu - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26904/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26915/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26916/)| 26/05/2022  |  @CamiRomero   |
|  test/integration/test_logcollector | Solaris - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26904/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26915/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26916/)|  26/05/2022  |  @CamiRomero   |
|  test/integration/test_logcollector | MacOS - Agent | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26904/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26915/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26916/)| 26/05/2022  |  @CamiRomero   |
|  test/integration/test_logcollector | Ubuntu - Manager | Jenkins | [:green_circle:](https://ci.wazuh.info/job/Test_integration/26917/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26918/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/26920/)|  26/05/2022  |  @CamiRomero   |

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [x] The test is documented in wazuh-qa/docs.
