### PR TITLE
IT VDT: Fix test_download_feeds indentation error

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -121,7 +121,7 @@ def test_download_feeds(configuration, metadata, set_wazuh_configuration_vdt, tr
         - r'Starting .* database update'
         - r'The update of the .* feed finished successfully'
     '''
- try:
+    try:
         # Check that the feed update has started
         evm.check_provider_database_update_start_log(metadata['provider_name'])
         # Check that the feed has been updated successfully


### PR DESCRIPTION
|Related issue|
|---|
|[#2930](https://github.com/wazuh/wazuh-qa/pull/2930) |

## Description

While adding the xfail to test_download_feeds, an indentation was accidentally deleted and pushed to the repo. this PR fixes that error, since the original branch has been deleted and it has already been pushed to master.

## Logs example
## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By | Note | 
|--|--|--|--|--|--|--|
|  test/integration/test_vulnerability_detector | CentOS - Manager | Local | [:large_blue_circle:]() | 30/05/2022  |  @Deblintrake09    |

![Captura de pantalla de 2022-05-30 10-25-13](https://user-images.githubusercontent.com/14501079/171001864-76b318a6-1317-4611-8c56-58bea4a9e2ad.png)

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.