### PR TITLE
E2E tests: Create Audit test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/event_monitor.py
@@ -1,0 +1,39 @@
+import re
+
+from wazuh_testing.tools.monitoring import FileMonitor
+
+
+def make_callback(pattern, prefix=''):
+    """Create a callback function from a text pattern.
+    Args:
+        pattern (str): String to match on the log.
+        prefix (str): regular expression used as prefix before the pattern.
+    Returns:
+        lambda: function that returns if there's a match in the file
+    """
+    pattern = r'\s+'.join(pattern.split())
+    regex = re.compile(r'{}{}'.format(prefix, pattern))
+
+    return lambda line: regex.match(line)
+
+
+def check_event(file_monitor=None, callback='', error_message=None, update_position=True, timeout=20,
+                accum_results=1, file_to_monitor=None):
+    """Check if an API event occurs
+    Args:
+        file_monitor (FileMonitor): FileMonitor object to monitor the file content.
+        callback (str): log regex to check in the file
+        error_message (str): error message to show in case of expected event does not occur
+        update_position (boolean): filter configuration parameter to search in the file
+        timeout (str): timeout to check the event in the file
+        prefix (str): log pattern regex
+        accum_results (int): Accumulation of matches.
+    """
+    file_monitor = FileMonitor(file_to_monitor) if file_monitor is None else file_monitor
+    error_message = f"Could not find this event in {file_to_monitor}: {callback}" if error_message is None else \
+        error_message
+
+    result = file_monitor.start(timeout=timeout, update_position=update_position, accum_results=accum_results,
+                                callback=make_callback(callback), error_message=error_message)
+
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ wmi>=1.5.1; platform_system=='Windows'
 deepdiff==5.6.0; platform_system == "Linux" or platform_system=='Windows'
 libcst==0.3.23 ; python_version <= '3.6'
 treelib==1.6.1
+pytest-ansible-playbook

--- a/tests/end_to_end/general_playbooks/get_alerts.yml
+++ b/tests/end_to_end/general_playbooks/get_alerts.yml
@@ -5,4 +5,5 @@
       fetch:
         src: /var/ossec/logs/alerts/alerts.json
         dest: /home/juliamagan/Desktop/QA/2893/
+        flat: yes
       become: True

--- a/tests/end_to_end/general_playbooks/get_alerts.yml
+++ b/tests/end_to_end/general_playbooks/get_alerts.yml
@@ -1,9 +1,0 @@
-- name: Get alerts
-  hosts: wazuh-manager
-  tasks:
-    - name: Get alerts.json
-      fetch:
-        src: /var/ossec/logs/alerts/alerts.json
-        dest: /home/juliamagan/Desktop/QA/2893/
-        flat: yes
-      become: True

--- a/tests/end_to_end/general_playbooks/get_alerts.yml
+++ b/tests/end_to_end/general_playbooks/get_alerts.yml
@@ -1,0 +1,8 @@
+- name: Get alerts
+  hosts: wazuh-manager
+  tasks:
+    - name: Get alerts.json
+      fetch:
+        src: /var/ossec/logs/alerts/alerts.json
+        dest: /home/juliamagan/Desktop/QA/2893/
+      become: True

--- a/tests/end_to_end/test_audit/conftest.py
+++ b/tests/end_to_end/test_audit/conftest.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from wazuh_testing.tools.file import remove_file, get_file_lines
+
+alerts_json = os.path.join('/tmp', 'alerts.json')
+credentials_file = os.path.join('/tmp', 'passwords.wazuh')
+
+
+@pytest.fixture(scope='function')
+def clean_environment():
+
+    yield
+
+    remove_file(alerts_json)
+    remove_file(credentials_file)
+
+
+@pytest.fixture(scope='function')
+def get_dashboard_credentials():
+
+    password = ''
+    user = ''
+
+    for line in get_file_lines(credentials_file):
+        if 'username: admin' in line:
+            user = 'admin'
+
+        if 'password: ' in line and user == 'admin':
+            password_line = line
+            password = password_line.split()[1]
+
+    dashboard_credentials = [user, password]
+
+    yield dashboard_credentials

--- a/tests/end_to_end/test_audit/playbooks/configuration.yml
+++ b/tests/end_to_end/test_audit/playbooks/configuration.yml
@@ -1,0 +1,22 @@
+---
+- name: Test case configuration
+  hosts: wazuh-manager
+  tasks:
+    - name: Get euid
+      shell: echo $EUID
+      register: euid
+    - debug:
+            var: euid.stdout
+    - name: Create wazuh audit rules file
+      become: True
+      copy:
+        dest: /etc/audit/rules.d/wazuh.rules
+        content: |
+          -a exit,always -F euid={{euid.stdout}} -F arch=b32 -S execve -k audit-wazuh-c
+          -a exit,always -F euid={{euid.stdout}} -F arch=b64 -S execve -k audit-wazuh-c
+    - name: Delete previous audit rules
+      become: True
+      shell: auditctl -D
+    - name: Load audit rules
+      become: True
+      shell: auditctl -R /etc/audit/rules.d/wazuh.rules

--- a/tests/end_to_end/test_audit/playbooks/credentials.yml
+++ b/tests/end_to_end/test_audit/playbooks/credentials.yml
@@ -1,0 +1,16 @@
+---
+- name: Get credentials
+  hosts: wazuh-manager
+  tasks:
+    - name: Unzip wazuh install files
+      unarchive:
+        src: /home/vagrant/wazuh-install-files.tar
+        dest: /home/vagrant
+        remote_src: yes
+      become: True
+    - name: Get passwords file
+      fetch:
+        src: /home/vagrant/wazuh-install-files/passwords.wazuh
+        dest: /tmp/
+        flat: yes
+      become: True

--- a/tests/end_to_end/test_audit/playbooks/generate_events.yml
+++ b/tests/end_to_end/test_audit/playbooks/generate_events.yml
@@ -1,5 +1,20 @@
+- name: Clean alerts.json
+  hosts: wazuh-manager
+  tasks:
+    - name: Truncate file
+      shell: echo "" > /var/ossec/logs/alerts/alerts.json
+      become: True
 - name: Generate events
   hosts: wazuh-manager
   tasks:
     - name: Ping google
       shell: ping -c 1 www.google.com
+- name: Get alerts
+  hosts: wazuh-manager
+  tasks:
+    - name: Get alerts.json
+      fetch:
+        src: /var/ossec/logs/alerts/alerts.json
+        dest: /tmp/
+        flat: yes
+      become: True

--- a/tests/end_to_end/test_audit/playbooks/generate_events.yml
+++ b/tests/end_to_end/test_audit/playbooks/generate_events.yml
@@ -1,0 +1,5 @@
+- name: Generate events
+  hosts: wazuh-manager
+  tasks:
+    - name: Ping google
+      shell: ping -c 1 www.google.com

--- a/tests/end_to_end/test_audit/test_audit.py
+++ b/tests/end_to_end/test_audit/test_audit.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.ansible_playbook_setup('configuration.yml', 'generate_events.yml', 'get_alerts.yml')
+def test_bar(ansible_playbook):
+    assert 1 == 1

--- a/tests/end_to_end/test_audit/test_audit.py
+++ b/tests/end_to_end/test_audit/test_audit.py
@@ -1,6 +1,16 @@
 import pytest
+import os
+
+from wazuh_testing.event_monitor import check_event
+
+alerts_json = os.path.join('/tmp', 'alerts.json')
 
 
-@pytest.mark.ansible_playbook_setup('configuration.yml', 'generate_events.yml', 'get_alerts.yml')
-def test_bar(ansible_playbook):
-    assert 1 == 1
+@pytest.mark.ansible_playbook_setup('credentials.yml', 'configuration.yml', 'generate_events.yml')
+def test_audit(ansible_playbook, get_dashboard_credentials, clean_environment):
+
+    expected_alert = r'\{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)","rule"\:{"level"\:3,"description"\:"Audit\: '\
+                        r'Command\: \/usr\/bin\/ping\.","id"\:"80792","firedtimes"\:(\d+).*euid=1000.*' \
+                        r'a3=\\"www\.google\.com\\".*\}'
+
+    check_event(callback=expected_alert, file_to_monitor=alerts_json)


### PR DESCRIPTION
|Related issue|
|---|
|Closes: #2893 and #2933 |


## Description

In this PR a test has been created to test the Audit demo case. For this purpose we have created:

- New module: `end_to_end`.
- Common libraries: `event_monitor`.
- New requirement: `pytest-ansible-playbook`.

Each test will include in its directory a `data` folder, where you will find the test configuration as playbooks, and the test itself.

## Configuration options

To launch these tests, we must indicate the path of the playbooks and inventory:

```
python -m pytest -vvvs tests/end_to_end/test_audit/ --ansible-playbook-directory=./tests/end_to_end/test_audit/playbooks/ --ansible-playbook-inventory=/home/juliamagan/Desktop/wazuh-qa/tests/end_to_end/general_playbooks/inventory.yml 
```
It should be noted that, for local environments, it will be necessary to create the inventory for the moment. It should contain the following:

```
all:
  hosts:
    wazuh-manager:
      ansible_connection: ssh
      ansible_user: vagrant
      ansible_ssh_private_key_file: <path_to_private_key>
      ansible_python_interpreter: /usr/bin/python3
```


## Checks

- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the [QA-Docs Schema 2.0](https://github.com/wazuh/wazuh-qa/wiki/QA-Documentation---How-to-document-a-test-using-Schema-2.0).