### PR TITLE
 IT FIM - Fix Solaris and Macos fails for 4.3

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/fim.py
+++ b/deps/wazuh_testing/wazuh_testing/fim.py
@@ -882,7 +882,7 @@ def modify_file_inode(path, name):
     path_to_file = os.path.join(path, name)
 
     shutil.copy2(path_to_file, os.path.join(tempfile.gettempdir(), inode_file))
-    os.replace(os.path.join(tempfile.gettempdir(), inode_file), path_to_file)
+    shutil.move(os.path.join(tempfile.gettempdir(), inode_file), path_to_file)
 
 
 def modify_file_win_attributes(path, name):

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_realtime.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_realtime.yaml
@@ -2,7 +2,7 @@
 - tags:
   - ossec_conf
   apply_to_modules:
-  - MODULE_NAME
+  - test_basic_usage_realtime_unsupported
   sections:
   - section: syscheck
     elements:
@@ -13,3 +13,17 @@
         attributes:
         - check_all: 'yes'
         - realtime: 'yes'
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
@@ -52,20 +52,17 @@ tags:
 import os
 
 import pytest
-import re
-from wazuh_testing import global_parameters
-from wazuh_testing.fim import generate_params, regular_file_cud, LOG_FILE_PATH, callback_num_inotify_watches, \
-                              detect_initial_scan, callback_ignore_realtime_flag, CHECK_ALL, REQUIRED_ATTRIBUTES
+
+from wazuh_testing.fim import generate_params, regular_file_cud, detect_initial_scan, callback_ignore_realtime_flag
 from wazuh_testing.tools import PREFIX
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.configuration import load_wazuh_configurations
+
 
 # Marks
-
-
 pytestmark = [pytest.mark.darwin, pytest.mark.sunos5, pytest.mark.tier(level=0)]
 
-# variables
 
+# Variables
 realtime_flag_timeout = 60
 directory_str = os.path.join(PREFIX, 'dir')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -73,27 +70,22 @@ configurations_path = os.path.join(test_data_path, 'wazuh_conf_check_realtime.ya
 test_file = 'testfile.txt'
 test_directories = [directory_str]
 
-# configurations
 
-
-conf_params = {'TEST_DIRECTORIES': directory_str, 'MODULE_NAME': __name__}
+# Configurations
+conf_params = {'TEST_DIRECTORIES': directory_str}
 parameters, metadata = generate_params(extra_params=conf_params, modes=['scheduled'])
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
 local_internal_options = {'syscheck.debug': '2', 'monitord.rotate_log': '0'}
 daemons_handler_configuration = {'daemons': ['wazuh-syscheckd']}
 
-# fixtures
-
-
+# Fixtures
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
 
-# tests
-
-
+# Tests
 def test_realtime_unsupported(get_configuration, configure_environment, file_monitoring,
                               configure_local_internal_options_module, daemons_handler):
     '''
@@ -144,5 +136,5 @@ def test_realtime_unsupported(get_configuration, configure_environment, file_mon
     detect_initial_scan(log_monitor)
 
     regular_file_cud(directory_str, log_monitor, file_list=[test_file], time_travel=True, triggers_event=True,
-                     event_mode="scheduled")
+                     event_mode="scheduled", min_timeout=15)
 

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_change_target.py
@@ -192,19 +192,19 @@ def test_symbolic_change_target(tags_to_apply, main_folder, aux_folder, get_conf
         fim.create_file(fim.REGULAR, main_folder, file1, content='')
         fim.create_file(fim.REGULAR, aux_folder, file1, content='')
         fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
-        add = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event,
+        add = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event,
                                       error_message='Did not receive expected "Sending FIM event: ..." event'
                                       ).result()
         assert 'added' in add['data']['type'] and file1 in add['data']['path'], \
             f"'added' event not matching for {file1}"
         with pytest.raises(TimeoutError):
-            event = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event)
+            event = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event)
             logger.error(f'Unexpected event {event.result()}')
             raise AttributeError(f'Unexpected event {event.result()}')
     else:
         fim.create_file(fim.REGULAR, aux_folder, file1, content='')
         with pytest.raises(TimeoutError):
-            event = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event)
+            event = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event)
             logger.error(f'Unexpected event {event.result()}')
             raise AttributeError(f'Unexpected event {event.result()}')
 

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_delete_symlink.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_delete_symlink.py
@@ -171,7 +171,7 @@ def test_symbolic_delete_symlink(tags_to_apply, main_folder, aux_folder, get_con
     if tags_to_apply == {'monitored_dir'}:
         fim.create_file(fim.REGULAR, main_folder, file1, content='')
         fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
-        wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event,
+        wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event,
                                 error_message='Did not receive expected "Sending FIM event: ..." event')
 
     # Remove symlink and don't expect events
@@ -181,7 +181,7 @@ def test_symbolic_delete_symlink(tags_to_apply, main_folder, aux_folder, get_con
     fim.modify_file_content(main_folder, file1, new_content='Sample modification')
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
     with pytest.raises(TimeoutError):
-        event = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event)
+        event = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event)
         logger.error(f'Unexpected event {event.result()}')
         raise AttributeError(f'Unexpected event {event.result()}')
 
@@ -193,6 +193,6 @@ def test_symbolic_delete_symlink(tags_to_apply, main_folder, aux_folder, get_con
 
     fim.modify_file_content(main_folder, file1, new_content='Sample modification 2')
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
-    modify = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event).result()
+    modify = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event).result()
     assert 'modified' in modify['data']['type'] and file1 in modify['data']['path'], \
         f"'modified' event not matching for {file1}"

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_monitor_symlink.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_monitor_symlink.py
@@ -163,14 +163,14 @@ def test_symbolic_monitor_symlink(tags_to_apply, main_folder, get_configuration,
     if tags_to_apply == {'monitored_dir'}:
         fim.create_file(fim.REGULAR, main_folder, file1, content='')
         fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
-        add = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event).result()
+        add = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event).result()
         assert 'added' in add['data']['type'] and file1 in add['data']['path'], \
             "'added' event not matching"
 
     # Modify the linked file and expect an event
     fim.modify_file_content(main_folder, file1, 'Sample modification')
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
-    modify = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event,
+    modify = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event,
                                      error_message='Did not receive expected '
                                                    '"Sending FIM event: ..." event').result()
     assert 'modified' in modify['data']['type'] and file1 in modify['data']['path'], \
@@ -179,7 +179,7 @@ def test_symbolic_monitor_symlink(tags_to_apply, main_folder, get_configuration,
     # Delete the linked file and expect an event
     delete_f(main_folder, file1)
     fim.check_time_travel(scheduled, monitor=wazuh_log_monitor)
-    delete = wazuh_log_monitor.start(timeout=3, callback=fim.callback_detect_event,
+    delete = wazuh_log_monitor.start(timeout=10, callback=fim.callback_detect_event,
                                      error_message='Did not receive expected '
                                                    '"Sending FIM event: ..." event').result()
     assert 'deleted' in delete['data']['type'] and file1 in delete['data']['path'], \


### PR DESCRIPTION
<table>
  <tr>
    <th>Related issues</th>
    <th><a href="[url](https://github.com/wazuh/wazuh-qa/issues/2881)">#2881</a></th>
  </tr>
</table>

# Description

During runs of the Nightly pipeline, it was found that the test module `test_basic_usage_realtime_unsupported.py` was having flaky behaviour, on Solaris OS. This PR applies a fix to that test, as well as two other modules that also presented flaky behaviour during testing.
     
Also, during testing it was found that the modify_file_inode function on the deps/wazuh_testing/fim.py module would cause `OS ERROR 18: Invalid cross device link ` on some systems, because of the function `os.replace`. The function was replaced by shutil.move, that has the same functionality and parameters but does not generate this error.

--- 
## Affected Test Modules
- test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
- test_fim/test_files/test_follow_symbolic_link/test_change_target.py
- test_fim/test_files/test_follow_symbolic_link/test_delete_symlink.py
- test_fim/test_files/test_follow_symbolic_link/test_monitor_symlink.py

## Configuration options
|OS | Version | Branch | Type |
|--|--|--|--|
| Solaris | 4.3.4 | pre-release | Agent|
| MacOs | 4.3.4 | pre-release | Agent|

**Local Internal Options:**

#### Agent
> syscheck.debug=2
> agent.debug=2
> windows.debug=2
> monitord.rotate_log=0

---
## Tests Results
| Test Path | Os/Type | Local | Jenkins | Date | By |
|--|--|--|--|--|--|
| test_fim/test_synchronization/ | Windows | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8854787/R1.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8854788/R2.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/8854941/R3.zip) | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/27642/)  [:green_circle:](https://ci.wazuh.info/job/Test_integration/27649/)  [:green_circle:](https://ci.wazuh.info/job/Test_integration/27650/)| 08/06/2022 |  @Deblintrake09   |  

---
## Required
- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs example

<!--
Paste here related logs and alerts
-->

## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.