### PR TITLE
Remove `integrity_sync` data in stable phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release report: TBD
 
 - Update cluster logs in reliability tests ([#2772](https://github.com/wazuh/wazuh-qa/pull/2772))
 
+### Fixed
+
+- Fix an error in the cluster performance tests related to CSV parser ([#2999](https://github.com/wazuh/wazuh-qa/pull/2999))
+
 ## [4.4.0] - Development (unreleased)
 
 Wazuh commit: TBD \

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/csv_parser.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/csv_parser.py
@@ -127,7 +127,7 @@ class ClusterCSVParser:
             for phase in [self.SETUP_PHASE, self.STABLE_PHASE]:
                 for file_name, file_df in files.items():
                     trimmed_df = self._trim_dataframe(file_df, phase, setup_datetime)
-                    if len(trimmed_df):
+                    if len(trimmed_df) and not (phase == self.STABLE_PHASE and file_name == 'integrity_sync'):
                         result[phase][file_name][node] = self._calculate_stats(trimmed_df)
 
         return result

--- a/tests/performance/test_cluster/test_cluster_performance/data/10w_50000a_thresholds.yaml
+++ b/tests/performance/test_cluster/test_cluster_performance/data/10w_50000a_thresholds.yaml
@@ -98,6 +98,6 @@ resources:
           mean: 197162          # (197 MB)
           reg_cof: 209.6
         workers:
-          max: 201480           # (201 MB)
+          max: 256000           # (250 MB)
           mean: 145000          # (145 MB)
           reg_cof: 260


### PR DESCRIPTION
|Related issue|
|---|
| Closes #2814 |

## Description

This PR fixes the problem reported at #2814. 

The problem occurs because the setup and stable phases are calculated using only the data of the master node (since that is the only node whose performance is seriously affected during setup). However, sometimes workers can display a last Integrity_sync log dated after the end of the setup phase on the master, causing the failure.

Integrity sync data in a worker after the setup phase is now discarded, so the error no longer occurs.

## Logs example

```
$ python3 -m pytest performance/test_cluster/test_cluster_performance/test_cluster_performance.py --artifacts_path=/home/selu/Descargas/cluster_performance/fix_performance/artifacts --n_agents=50000 --n_workers=10 -vv

========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.10, pytest-5.0.0, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-117-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.0.0', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'html': '3.1.1', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'pep8': '1.0.6', 'cov': '2.10.0', 'asyncio': '0.14.0'}}
rootdir: /home/selu/Git/wazuh-qa/tests
plugins: metadata-1.10.0, html-3.1.1, testinfra-5.0.0, tavern-1.2.2, pep8-1.0.6, cov-2.10.0, asyncio-0.14.0
collected 1 item                                                                                                                                                       

performance/test_cluster/test_cluster_performance/test_cluster_performance.py::test_cluster_performance PASSED                                                   [100%]

======================================================================= 1 passed in 0.50 seconds =======================================================================
```

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.