### PR TITLE
Update xfailed API workload tests list

### DIFF
--- a/tests/performance/test_api/test_api_endpoints_performance.py
+++ b/tests/performance/test_api/test_api_endpoints_performance.py
@@ -17,19 +17,7 @@ xfailed_items = {
                                     'https://github.com/wazuh/wazuh-qa/issues/1266',
                          'method': 'put'},
     '/agents/group': {'message': 'Slow agent-group files creation: https://github.com/wazuh/wazuh/issues/8625',
-                      'method': 'put'},
-    '/syscheck': {'message': 'The `queue/alerts/ar` socket does not accept agent lists: '
-                             'https://github.com/wazuh/wazuh/issues/9125',
-                  'method': 'put'},
-    '/rootcheck': {'message': 'The `queue/alerts/ar` socket does not accept agent lists: '
-                              'https://github.com/wazuh/wazuh/issues/9125',
-                   'method': 'put'},
-    '/agents': {'message': 'The `queue/sockets/auth` socket does not accept agent lists: '
-                           'https://github.com/wazuh/wazuh/issues/9127',
-                'method': 'delete'},
-    '/groups': {'message': 'Timeout caused by agent-group file manipulation in the Framework: '
-                           'https://github.com/wazuh/wazuh/issues/9141',
-                'method': 'delete'}
+                      'method': 'put'}
 }
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#2996|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #2996. In this PR we have updated the list of tests marked as `xfailed` for the Workload tests. This update is based on the results obtained here: https://github.com/wazuh/wazuh/issues/13536#issuecomment-1154860411 after merge changes in `agent-groups`: https://github.com/wazuh/wazuh/issues/10771

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

- [ ] Proven that tests **pass** when they have to pass.
- [ ] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [ ] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [ ] Python codebase is documented following the Google Style for Python docstrings.
- [ ] The test is documented in wazuh-qa/docs.
- [ ] `provision_documentation.sh` generate the docs without errors.