### PR TITLE
Fix GCloud IT: test_max_messages error

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/gcloud.py
+++ b/deps/wazuh_testing/wazuh_testing/gcloud.py
@@ -56,9 +56,10 @@ def detect_gcp_start(file_monitor):
 
 
 def callback_received_messages_number(line):
-    match = re.match(r'.*wm_gcp_pubsub_run\(\): INFO: - INFO - Received and acknowledged (\d+) messages', line)
+    received_messages_number = rf".*wm_gcp_pubsub_run\(\): INFO: - INFO - Received and acknowledged (\d+) messages"
+    match = re.findall(received_messages_number, line)
     if match:
-        return match.group(1)
+        return match
     return None
 
 

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -59,6 +59,7 @@ tags:
     - scan
     - maximum
 '''
+from itertools import count
 import os
 import sys
 
@@ -82,6 +83,7 @@ interval = '25s'
 pull_messages_timeout = global_parameters.default_timeout + 60
 pull_on_start = 'no'
 max_messages = 100
+count_message = 0
 logging = 'info'
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -190,8 +192,10 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
         # GCP might log messages from sources other than ourselves
         for number_pulled in numbers_pulled:
             if int(number_pulled) != 0:
-                assert int(number_pulled) >= publish_messages
+                if (int(number_pulled) >= publish_messages):
+                    count_message += 1
                 assert int(number_pulled) <= max_messages
+        assert count_message >=1
     else:
         for number_pulled in numbers_pulled:
             if int(number_pulled) != 0:

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -124,7 +124,8 @@ def get_configuration(request):
     ['- DEBUG - GCP message' for _ in range(100)],
     ['- DEBUG - GCP message' for _ in range(120)]
 ], indirect=True)
-def test_max_messages(get_configuration, configure_environment, reset_ossec_log, publish_messages, daemons_handler, wait_for_gcp_start):
+def test_max_messages(get_configuration, configure_environment, reset_ossec_log, publish_messages,
+                      daemons_handler, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module pulls a message number less than or equal to the limit set
                  in the 'max_messages' tag. For this purpose, the test will use a fixed limit and generate a
@@ -195,7 +196,7 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
                     # A counter is used to prevent it from failing due to logs from other sources
                     count_message += 1
                 assert int(number_pulled) <= max_messages
-        assert count_message >=1
+        assert count_message >= 1
     else:
         for number_pulled in numbers_pulled:
             if int(number_pulled) != 0:

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -59,11 +59,10 @@ tags:
     - scan
     - maximum
 '''
-from itertools import count
 import os
 import sys
-
 import pytest
+
 from wazuh_testing import global_parameters
 from wazuh_testing.fim import generate_params
 from wazuh_testing.gcloud import callback_detect_start_fetching_logs, callback_received_messages_number
@@ -193,6 +192,7 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
         for number_pulled in numbers_pulled:
             if int(number_pulled) != 0:
                 if (int(number_pulled) >= publish_messages):
+                    # A counter is used to prevent it from failing due to logs from other sources
                     count_message += 1
                 assert int(number_pulled) <= max_messages
         assert count_message >=1

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -199,5 +199,4 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
         assert count_message >= 1
     else:
         for number_pulled in numbers_pulled:
-            if int(number_pulled) != 0:
-                assert int(number_pulled) <= max_messages
+            assert int(number_pulled) <= max_messages

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -109,6 +109,7 @@ truncate_file(LOG_FILE_PATH)
 
 # fixtures
 
+
 @pytest.fixture(scope='module', params=configurations)
 def get_configuration(request):
     """Get configurations from the module."""
@@ -180,11 +181,11 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
                             callback=callback_detect_start_fetching_logs,
                             error_message='Did not receive expected '
                                           '"Starting fetching of logs" event')
-    
+
     numbers_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
-                                                callback=callback_received_messages_number,
-                                                error_message='Did not receive expected '
-                                                              '- INFO - Received and acknowledged x messages').result()
+                                             callback=callback_received_messages_number,
+                                             error_message='Did not receive expected '
+                                                           '- INFO - Received and acknowledged x messages').result()
     if publish_messages <= max_messages:
         # GCP might log messages from sources other than ourselves
         for number_pulled in numbers_pulled:
@@ -194,4 +195,4 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
     else:
         for number_pulled in numbers_pulled:
             if int(number_pulled) != 0:
-                assert int(number_pulled) <= max_messages 
+                assert int(number_pulled) <= max_messages

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -83,7 +83,6 @@ interval = '25s'
 pull_messages_timeout = global_parameters.default_timeout + 60
 pull_on_start = 'no'
 max_messages = 100
-count_message = 0
 logging = 'info'
 wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -175,6 +174,7 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
         - logs
         - scheduled
     '''
+    count_message = 0
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
 

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2021, Wazuh Inc.
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
 
@@ -180,27 +180,18 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
                             callback=callback_detect_start_fetching_logs,
                             error_message='Did not receive expected '
                                           '"Starting fetching of logs" event')
-
+    
+    numbers_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
+                                                callback=callback_received_messages_number,
+                                                error_message='Did not receive expected '
+                                                              '- INFO - Received and acknowledged x messages').result()
     if publish_messages <= max_messages:
-        number_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
-                                                callback=callback_received_messages_number,
-                                                error_message='Did not receive expected '
-                                                              '- INFO - Received and acknowledged x messages').result()
         # GCP might log messages from sources other than ourselves
-        assert int(number_pulled) >= publish_messages
+        for number_pulled in numbers_pulled:
+            if int(number_pulled) != 0:
+                assert int(number_pulled) >= publish_messages
+                assert int(number_pulled) <= max_messages
     else:
-        ntimes = int(publish_messages / max_messages)
-        remainder = int(publish_messages % max_messages)
-
-        for i in range(ntimes):
-            number_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
-                                                    callback=callback_received_messages_number,
-                                                    error_message='Did not receive expected '
-                                                                  'Received and acknowledged x messages').result()
-            assert int(number_pulled) == max_messages
-        number_pulled = wazuh_log_monitor.start(timeout=pull_messages_timeout,
-                                                callback=callback_received_messages_number,
-                                                error_message='Did not receive expected '
-                                                              '- INFO - Received and acknowledged x messages').result()
-        # GCP might log messages from sources other than ourselves
-        assert int(number_pulled) >= remainder
+        for number_pulled in numbers_pulled:
+            if int(number_pulled) != 0:
+                assert int(number_pulled) <= max_messages 

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -188,6 +188,8 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
                                              callback=callback_received_messages_number,
                                              error_message='Did not receive expected '
                                                            '- INFO - Received and acknowledged x messages').result()
+    # Validate that the number pulled is at least once greater or equal than the published messages
+    # and less than the maximum number of messages extracted allowed in each iteration
     if publish_messages <= max_messages:
         # GCP might log messages from sources other than ourselves
         for number_pulled in numbers_pulled:
@@ -198,5 +200,6 @@ def test_max_messages(get_configuration, configure_environment, reset_ossec_log,
                 assert int(number_pulled) <= max_messages
         assert count_message >= 1
     else:
+        # Validate that the number pulled always is less than the maximum messages pulled allowed in each iteration
         for number_pulled in numbers_pulled:
             assert int(number_pulled) <= max_messages


### PR DESCRIPTION
|Related issue|
|---|
|Close  #3033 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The test `test_max_messages` was a flaky test because sometimes the test takes the last log received with the amount 0. To solve this problem:

- We changed the callback function `callback_received_messages_number`, now returning all the matches.
- We need to refactor the test in order to use the new callback function
- We add a new assertion that checks that the module will only pull messages up to the limit

Modules Involved:

- tests/integration/test_gcloud/test_functionality/test_max_messages.py
- deps/wazuh_testing/wazuh_testing/gcloud.py

<!--
Add a clear description of how the problem has been solved.
-->

## Logs example

## Tests Results
| Test Path | Os/Type | Execution Type | Results | Date | By |
|--|--|--|--|--|--|
|  tests/integration/test_gcloud/test_functionality/test_max_messages.py| CentOS - Manager | Jenkins | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/28153/)  [:green_circle: ](https://ci.wazuh.info/job/Test_integration/28153/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/28156/) | 27/06/2022 | @CamiRomero   | 

## Tests

- [x] Proven that tests **pass** when they have to pass.
- [x] Proven that tests **fail** when they have to fail.
<!--
Important: Don't remove these checks if your PR modifies Python code.
-->
- [x] Python codebase satisfies PEP-8 style style guide. `pycodestyle --max-line-length=120 --show-source --show-pep8 file.py`.
- [x] Python codebase is documented following the Google Style for Python docstrings.