### PR TITLE
E2E test: Test the detection of a Shellshock attack

### DIFF
--- a/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
@@ -43,11 +43,11 @@
           <location>/var/log/httpd/access_log</location>
           </localfile>
 
+    - name: Restart the manager
+      shell: systemctl restart wazuh-manager
+
     - name: Start Apache
       shell: systemctl start httpd
       # If the return code is 3, it means that Apache is not running.
       # If Apache has been recently installed, it is necessary to start it
       when: (apache_check.rc == 3 or installation is succeeded)
-
-    - name: Restart the manager
-      shell: systemctl restart wazuh-manager

--- a/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
@@ -7,16 +7,20 @@
       shell: systemctl status firewalld --no-pager
       register: firewall_check
       when: ansible_facts['distribution'] == "CentOS"
+      # Ignore non-zero return codes for use in subsequent checks
       ignore_errors: true
 
     - name: Stop Firewalld if it's installed and active
       shell: systemctl stop firewalld
+      # If the return code is 0, it means that firewalld is running, it is necessary to stop it to allow
+      # the shellshock attack.
       when: (ansible_facts['distribution'] == "CentOS" and firewall_check.rc == 0)
 
     - name: Check if Apache is installed or not on CentOS
       shell: systemctl status httpd --no-pager
       register: apache_check
       when: ansible_facts['distribution'] == "CentOS"
+      # Ignore non-zero return codes for use in subsequent checks (Apache installation)
       ignore_errors: true
 
     - name: Install Apache Server on CentOS
@@ -24,6 +28,8 @@
         yum update httpd -y
         yum install httpd -y
       register: installation
+      # If the return code is 0, it means that Apache is running.
+      # If the return code is 3, it means that Apache is installed but not running.
       when: (ansible_facts['distribution'] == "CentOS" and apache_check.rc != 0 and apache_check.rc != 3)
 
     - name: Configure a localfile instance to collect the logs from Apache
@@ -39,6 +45,8 @@
 
     - name: Start Apache
       shell: systemctl start httpd
+      # If the return code is 3, it means that Apache is not running.
+      # If Apache has been recently installed, it is necessary to start it
       when: (apache_check.rc == 3 or installation is succeeded)
 
     - name: Restart the manager

--- a/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
@@ -1,0 +1,45 @@
+- name: Test setup
+  hosts: wazuh-manager
+  become: true
+  tasks:
+
+    - name: Check if Firewalld is installed on CentOS
+      shell: systemctl status firewalld --no-pager
+      register: firewall_check
+      when: ansible_facts['distribution'] == "CentOS"
+      ignore_errors: true
+
+    - name: Stop Firewalld if it's installed and active
+      shell: systemctl stop firewalld
+      when: (ansible_facts['distribution'] == "CentOS" and firewall_check.rc == 0)
+
+    - name: Check if Apache is installed or not on CentOS
+      shell: systemctl status httpd --no-pager
+      register: apache_check
+      when: ansible_facts['distribution'] == "CentOS"
+      ignore_errors: true
+
+    - name: Install Apache Server on CentOS
+      shell: |
+        yum update httpd -y
+        yum install httpd -y
+      register: installation
+      when: (ansible_facts['distribution'] == "CentOS" and apache_check.rc != 0 and apache_check.rc != 3)
+
+    - name: Configure a localfile instance to collect the logs from Apache
+      blockinfile:
+        path: /var/ossec/etc/ossec.conf
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+        insertbefore: ^</ossec_config>
+        block: |
+          <localfile>
+          <log_format>apache</log_format>
+          <location>/var/log/httpd/access_log</location>
+          </localfile>
+
+    - name: Start Apache
+      shell: systemctl start httpd
+      when: (apache_check.rc == 3 or installation is succeeded)
+
+    - name: Restart the manager
+      shell: systemctl restart wazuh-manager

--- a/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/configuration.yaml
@@ -3,6 +3,22 @@
   become: true
   tasks:
 
+    - name: Configure a localfile instance to collect the logs from Apache
+      blockinfile:
+        path: /var/ossec/etc/ossec.conf
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+        insertbefore: ^</ossec_config>
+        block: |
+          <localfile>
+          <log_format>apache</log_format>
+          <location>/var/log/httpd/access_log</location>
+          </localfile>
+
+    - name: Restart wazuh-manager
+      systemd:
+        state: restarted
+        name: wazuh-manager
+
     - name: Check if Firewalld is installed on CentOS
       shell: systemctl status firewalld --no-pager
       register: firewall_check
@@ -32,22 +48,10 @@
       # If the return code is 3, it means that Apache is installed but not running.
       when: (ansible_facts['distribution'] == "CentOS" and apache_check.rc != 0 and apache_check.rc != 3)
 
-    - name: Configure a localfile instance to collect the logs from Apache
-      blockinfile:
-        path: /var/ossec/etc/ossec.conf
-        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
-        insertbefore: ^</ossec_config>
-        block: |
-          <localfile>
-          <log_format>apache</log_format>
-          <location>/var/log/httpd/access_log</location>
-          </localfile>
-
-    - name: Restart the manager
-      shell: systemctl restart wazuh-manager
-
     - name: Start Apache
-      shell: systemctl start httpd
+      systemd:
+        state: started
+        name: httpd
       # If the return code is 3, it means that Apache is not running.
       # If Apache has been recently installed, it is necessary to start it
       when: (apache_check.rc == 3 or installation is succeeded)

--- a/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/generate_events.yaml
@@ -11,7 +11,7 @@
 
     - name: Wait for alerts to be generated
       wait_for:
-        timeout: 5
+        timeout: 10
 
     - name: Get alerts.json
       fetch:

--- a/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/playbooks/generate_events.yaml
@@ -1,0 +1,20 @@
+- name: Generate events
+  hosts: wazuh-manager
+  become: true
+  tasks:
+
+    - name: Truncate alerts file
+      shell: echo "" > /var/ossec/logs/alerts/alerts.json
+
+    - name: "{{ event_description }}"
+      shell: "{{ command }}"
+
+    - name: Wait for alerts to be generated
+      wait_for:
+        timeout: 5
+
+    - name: Get alerts.json
+      fetch:
+        src: /var/ossec/logs/alerts/alerts.json
+        dest: /tmp/
+        flat: true

--- a/tests/end_to_end/test_shellshock_attack_detection/data/test_cases/cases_shellshock_attack_detection.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/test_cases/cases_shellshock_attack_detection.yaml
@@ -1,0 +1,10 @@
+- name: shellshock_attack
+  description: Test if an alert is generated when a shellshock attack is attempted
+  configuration_parameters: null
+  metadata:
+    rule.id: "31166"
+    rule.description: "Shellshock attack attempt"
+    rule.level: 6
+    extra_vars:
+      event_description: Shellshock attack
+      command: 'curl -k "localhost" -H "User-Agent: () { :; }; /bin/cat /etc/passwd"'

--- a/tests/end_to_end/test_shellshock_attack_detection/data/test_cases/cases_shellshock_attack_detection.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/test_cases/cases_shellshock_attack_detection.yaml
@@ -2,9 +2,9 @@
   description: Test if an alert is generated when a shellshock attack is attempted
   configuration_parameters: null
   metadata:
-    rule.id: "31166"
-    rule.description: "Shellshock attack attempt"
+    rule.id: 31166
+    rule.description: Shellshock attack attempt
     rule.level: 6
     extra_vars:
       event_description: Shellshock attack
-      command: 'curl -k "localhost" -H "User-Agent{{ ":" }} () { :; }; /bin/cat /etc/passwd"'
+      command: curl -k "localhost" -H "User-Agent{{":"}} () { :; }; /bin/cat /etc/passwd"

--- a/tests/end_to_end/test_shellshock_attack_detection/data/test_cases/cases_shellshock_attack_detection.yaml
+++ b/tests/end_to_end/test_shellshock_attack_detection/data/test_cases/cases_shellshock_attack_detection.yaml
@@ -7,4 +7,4 @@
     rule.level: 6
     extra_vars:
       event_description: Shellshock attack
-      command: 'curl -k "localhost" -H "User-Agent: () { :; }; /bin/cat /etc/passwd"'
+      command: 'curl -k "localhost" -H "User-Agent{{ ":" }} () { :; }; /bin/cat /etc/passwd"'

--- a/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
+++ b/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
@@ -33,7 +33,7 @@ def test_shellshock_attack_detection(configure_environment, metadata, get_dashbo
     expected_alert_json = fr".+timestamp\":\"(.+)\",.+level\":{rule_level},\"description\":\"{rule_description}\"," \
                           fr"\"id\":\"{rule_id}\""
 
-    expected_indexed_alert = fr".+level\": {rule_level}, \"description\": \"{rule_description}\"" \
+    expected_indexed_alert = fr".+level\": {rule_level}.+\"description\": \"{rule_description}\"" \
                              fr".+\"id\": \"{rule_id}\".+timestamp\": \"(.+)\"" \
                              r'},.+'
 
@@ -45,7 +45,7 @@ def test_shellshock_attack_detection(configure_environment, metadata, get_dashbo
         },
         {
             "term": {
-                "rule.level": rule_level
+                "rule.level": f"{rule_level}"
             }
         }
     ])
@@ -57,7 +57,7 @@ def test_shellshock_attack_detection(configure_environment, metadata, get_dashbo
     raised_alert_timestamp = datetime.strptime(parse_date_time_format(raised_alert_timestamp), '%Y-%m-%d %H:%M:%S')
 
     # Wait a few seconds for the alert to be indexed (alert.json -> filebeat -> wazuh-indexer)
-    sleep(fw.T_5)
+    sleep(fw.T_10)
 
     # Get indexed alert
     response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)

--- a/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
+++ b/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
@@ -40,7 +40,7 @@ def test_shellshock_attack_detection(configure_environment, metadata, get_dashbo
     query = e2e.make_query([
         {
             "term": {
-                "rule.id": rule_id
+                "rule.id": f"{rule_id}"
             }
         },
         {

--- a/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
+++ b/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
@@ -57,7 +57,7 @@ def test_shellshock_attack_detection(configure_environment, metadata, get_dashbo
     raised_alert_timestamp = datetime.strptime(parse_date_time_format(raised_alert_timestamp), '%Y-%m-%d %H:%M:%S')
 
     # Wait a few seconds for the alert to be indexed (alert.json -> filebeat -> wazuh-indexer)
-    sleep(fw.T_10)
+    sleep(fw.T_5)
 
     # Get indexed alert
     response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)

--- a/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
+++ b/tests/end_to_end/test_shellshock_attack_detection/test_shellshock_attack_detection.py
@@ -1,0 +1,75 @@
+import os
+import json
+import re
+import pytest
+from datetime import datetime
+from tempfile import gettempdir
+from time import sleep
+
+import wazuh_testing as fw
+from wazuh_testing.tools.time import parse_date_time_format
+from wazuh_testing import end_to_end as e2e
+from wazuh_testing import event_monitor as evm
+from wazuh_testing.tools import configuration as config
+
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_file_path = os.path.join(test_data_path, 'test_cases', 'cases_shellshock_attack_detection.yaml')
+alerts_json = os.path.join(gettempdir(), 'alerts.json')
+configuration_playbooks = ['configuration.yaml']
+events_playbooks = ['generate_events.yaml']
+
+configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+@pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
+def test_shellshock_attack_detection(configure_environment, metadata, get_dashboard_credentials, generate_events,
+                                     clean_environment):
+    rule_level = metadata['rule.level']
+    rule_description = metadata['rule.description']
+    rule_id = metadata['rule.id']
+
+    expected_alert_json = fr".+timestamp\":\"(.+)\",.+level\":{rule_level},\"description\":\"{rule_description}\"," \
+                          fr"\"id\":\"{rule_id}\""
+
+    expected_indexed_alert = fr".+level\": {rule_level}, \"description\": \"{rule_description}\"" \
+                             fr".+\"id\": \"{rule_id}\".+timestamp\": \"(.+)\"" \
+                             r'},.+'
+
+    query = e2e.make_query([
+        {
+            "term": {
+                "rule.id": rule_id
+            }
+        },
+        {
+            "term": {
+                "rule.level": rule_level
+            }
+        }
+    ])
+
+    # Check that alert has been raised and save timestamp
+    raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
+                                   error_message='The alert has not occurred').result()
+    raised_alert_timestamp = raised_alert.group(1)
+    raised_alert_timestamp = datetime.strptime(parse_date_time_format(raised_alert_timestamp), '%Y-%m-%d %H:%M:%S')
+
+    # Wait a few seconds for the alert to be indexed (alert.json -> filebeat -> wazuh-indexer)
+    sleep(fw.T_5)
+
+    # Get indexed alert
+    response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
+    indexed_alert = json.dumps(response.json())
+
+    # Check that the alert data is the expected one
+    alert_data = re.search(expected_indexed_alert, indexed_alert)
+    assert alert_data is not None, 'Alert triggered, but not indexed'
+
+    # Get indexed alert timestamp
+    indexed_alert_timestamp = alert_data.group(1)
+    indexed_alert_timestamp = datetime.strptime(parse_date_time_format(indexed_alert_timestamp), '%Y-%m-%d %H:%M:%S')
+
+    # Check that alert has been indexed (checking that the timestamp is the expected one)
+    assert indexed_alert_timestamp == raised_alert_timestamp, 'Alert triggered, but not indexed'


### PR DESCRIPTION
|Related issue|
|---|
|#2888|

## Description

⚠️ Important: Because of the event is generated in the same manager where the alert is collected, the alert described [here](https://github.com/wazuh/wazuh-qa/issues/2861#issuecomment-1118528061) is different from the alert generated in this test (Rule ID from manual testing: 31168 - Rule ID from the automated test: 31166)

### Design

- Generate the test cases (config, metadata, and ids) using the YAML's inside the `test_cases` folder
- Configure the environment using a pytest fixture from the `end_to_end` test suite
  - Run each playbook defined in the test module using the inventory passed by parameter to the `pytest` library
- Get the dashboard credentials using the fixture from the `end_to_end` test suite
- Generate the events using a playbook from the `playbooks` folder
- Get the alerts (if they were generated) from the wazuh-indexer API
- Check if the expected alert matched one of the alerts obtained from the API
  - If an exception is raised, check if the alert at least is found in the log file
    - If not, raise a TimeoutError
    - If yes, raise the previously captured exception (AssertionError)

![image](https://user-images.githubusercontent.com/39094716/173584591-325113e6-3cf7-450b-97e3-ba95a802d687.png)

### Development

The only precondition to run: Create an inventory as follows
```
all:
  hosts:
    wazuh-manager:
      ansible_connection: ssh
      ansible_user: <VM USER>
      ansible_ssh_private_key_file: <PRIVATE KEY PATH>
      ansible_python_interpreter: <PYTHON INTERPRETER PATH>
      dashboard_user: <USER>
      dashboard_password: <PASS>
```

Execute the test:

<code>
python -m pytest tests/end_to_end/TEST-PATH --inventory_path PATH-TO-INVENTORY
</code>

### Test execution

|Local|OS|Commit|By
|--|--|--|--
| [🟢](https://github.com/wazuh/wazuh-qa/files/9004388/r1-CentOS-manager-2888.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9004389/r2-CentOS-manager-2888.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9004390/r3-CentOS-manager-2888.zip) | CentOS | https://github.com/wazuh/wazuh-qa/pull/3028/commits/a99e552bdc0bd25b423d54c15c2f963bf4ac2c4a | @mauromalara 

