### PR TITLE
E2E test: Test the detection of a suspicious binary

### DIFF
--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -4,6 +4,7 @@
 import os
 import ansible_runner
 import pytest
+import yaml
 from tempfile import gettempdir
 
 from wazuh_testing.tools.file import remove_file
@@ -14,15 +15,16 @@ alerts_json = os.path.join(gettempdir(), 'alerts.json')
 
 
 @pytest.fixture(scope='function')
-def clean_environment(get_dashboard_credentials):
+def clean_environment(get_dashboard_credentials, request):
     """Remove the temporary file that contains the alerts and delete indices using the API.
 
       Args:
-          credentials(dict): wazuh-indexer credentials.
+          credentials (dict): wazuh-indexer credentials.
+          request (fixture): Provide information on the executing test function.
     """
     yield
     remove_file(alerts_json)
-    e2e.delete_index_api(credentials=get_dashboard_credentials)
+    e2e.delete_index_api(credentials=get_dashboard_credentials, ip_address=request.module.current_hostname)
 
 
 @pytest.fixture(scope='module')
@@ -37,11 +39,17 @@ def get_dashboard_credentials(request):
     if not inventory_playbook:
         raise ValueError('Inventory not specified')
 
-    inventory = ansible_runner.get_inventory(action='host', inventories=inventory_playbook, response_format='json',
-                                             host='wazuh-manager')
+    # Get the hostname from the inventory
+    hostname = [*yaml.safe_load(open(inventory_playbook[0]))['all']['hosts'].keys()][0]
 
-    # Inventory is a tuple, with the second value empty, so we must access inventory[0]
-    dashboard_credentials = {'user': inventory[0]['dashboard_user'], 'password': inventory[0]['dashboard_password']}
+    # get_inventory returns a tuple with the second element empty, that's why we access to the first element using [0]
+    inventory = ansible_runner.get_inventory(action='host', host=hostname, inventories=inventory_playbook,
+                                             response_format='json')[0]
+
+    dashboard_credentials = {
+        'user': inventory['dashboard_user'],
+        'password': inventory['dashboard_password']
+    }
 
     yield dashboard_credentials
 
@@ -60,15 +68,23 @@ def configure_environment(request):
     if not inventory_playbook:
         raise ValueError('Inventory not specified')
 
+    # Get the hostname from the inventory
+    hostname = [*yaml.safe_load(open(inventory_playbook))['all']['hosts'].keys()][0]
+    # Set the current hostname as an attribute of the test
+    request.module.current_hostname = hostname
+
     # For each configuration playbook previously declared in the test, get the complete path and run it
     for playbook in getattr(request.module, 'configuration_playbooks'):
         configuration_playbook_path = os.path.join(getattr(request.module, 'test_data_path'), 'playbooks', playbook)
         parameters = {'playbook': configuration_playbook_path, 'inventory': inventory_playbook}
 
+        # Add the hostname to the extravars dictionary
+        parameters.update({'extravars': {'inventory_hostname': hostname}})
+
         # Check if the module has extra variables to pass to the playbook
         configuration_extra_vars = getattr(request.module, 'configuration_extra_vars', None)
         if configuration_extra_vars is not None:
-            parameters.update({'extravars': configuration_extra_vars})
+            parameters['extravars'].update(configuration_extra_vars)
 
         ansible_runner.run(**parameters)
 
@@ -87,14 +103,21 @@ def generate_events(request, metadata):
     if not inventory_playbook:
         raise ValueError('Inventory not specified')
 
+    # Get the hostname from the inventory
+    hostname = [*yaml.safe_load(open(inventory_playbook))['all']['hosts'].keys()][0]
+
     # For each event generation playbook previously declared in the test, obtain the complete path and execute it.
     for playbook in getattr(request.module, 'events_playbooks'):
         events_playbook_path = os.path.join(getattr(request.module, 'test_data_path'), 'playbooks', playbook)
 
         parameters = {'playbook': events_playbook_path, 'inventory': inventory_playbook}
+
+        # Add the hostname to the extravars dictionary
+        parameters.update({'extravars': {'inventory_hostname': hostname}})
+
         # Check if the test case has extra variables to pass to the playbook and add them to the parameters in that case
         if 'extra_vars' in metadata:
-            parameters.update({'extravars': metadata['extra_vars']})
+            parameters['extravars'].update(metadata['extra_vars'])
 
         ansible_runner.run(**parameters)
 

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -14,15 +14,29 @@ alerts_json = os.path.join(gettempdir(), 'alerts.json')
 
 
 @pytest.fixture(scope='function')
-def clean_environment(get_dashboard_credentials):
+def clean_environment(get_dashboard_credentials, request, metadata):
     """Remove the temporary file that contains the alerts and delete indices using the API.
 
       Args:
           credentials (dict): wazuh-indexer credentials.
+          request (fixture): Provide information on the executing test function.
+          metadata (dict): Dictionary with test case metadata.
     """
     yield
     remove_file(alerts_json)
     e2e.delete_index_api(credentials=get_dashboard_credentials)
+    inventory_playbook = request.config.getoption('--inventory_path')
+
+    # Execute each playbook for the teardown
+    for playbook in getattr(request.module, 'teardown_playbook'):
+        teardown_playbook_path = os.path.join(getattr(request.module, 'test_data_path'), 'playbooks', playbook)
+
+        parameters = {'playbook': teardown_playbook_path, 'inventory': inventory_playbook}
+        # Check if the test case has extra variables to pass to the playbook and add them to the parameters in that case
+        if 'extra_vars' in metadata:
+            parameters.update({'extravars': metadata['extra_vars']})
+
+        ansible_runner.run(**parameters)
 
 
 @pytest.fixture(scope='module')
@@ -92,20 +106,6 @@ def generate_events(request, metadata):
         events_playbook_path = os.path.join(getattr(request.module, 'test_data_path'), 'playbooks', playbook)
 
         parameters = {'playbook': events_playbook_path, 'inventory': inventory_playbook}
-        # Check if the test case has extra variables to pass to the playbook and add them to the parameters in that case
-        if 'extra_vars' in metadata:
-            parameters.update({'extravars': metadata['extra_vars']})
-
-        ansible_runner.run(**parameters)
-
-    yield
-    inventory_playbook = request.config.getoption('--inventory_path')
-
-    # Execute each playbook for the teardown
-    for playbook in getattr(request.module, 'teardown_playbook'):
-        teardown_playbook_path = os.path.join(getattr(request.module, 'test_data_path'), 'playbooks', playbook)
-
-        parameters = {'playbook': teardown_playbook_path, 'inventory': inventory_playbook}
         # Check if the test case has extra variables to pass to the playbook and add them to the parameters in that case
         if 'extra_vars' in metadata:
             parameters.update({'extravars': metadata['extra_vars']})

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/configuration/trojan_script.sh
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/configuration/trojan_script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "`date` this is evil"   > /tmp/trojan_created_file
+echo 'test for /usr/bin/w trojaned file' >> /tmp/trojan_created_file
+#Now running original binary
+/usr/bin/w.copy

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/configuration.yaml
@@ -1,5 +1,5 @@
 - name: Configure environment
-  hosts: "{{ inventory_hostname }}"
+  hosts: wazuh-manager
   become: true
   tasks:
 

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/configuration.yaml
@@ -1,0 +1,15 @@
+- name: Configure environment
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Create a copy of the system binary
+      copy:
+        src: /usr/bin/w
+        dest: /usr/bin/w.copy
+        mode: preserve
+        remote_src: true
+
+    - name: Replace the content of the system binary with the trojan script
+      copy:
+        src: "{{ trojan_script_path }}"
+        dest: /usr/bin/w

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/configuration.yaml
@@ -1,5 +1,6 @@
 - name: Configure environment
-  hosts: wazuh-manager
+  hosts: "{{ inventory_hostname }}"
+  become: true
   tasks:
 
     - name: Create a copy of the system binary

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/generate_events.yaml
@@ -1,0 +1,22 @@
+- name: Generate events
+  hosts: wazuh-manager
+  become: true
+  tasks:
+
+    - name: Truncate alerts file
+      shell: echo "" > /var/ossec/logs/alerts/alerts.json
+
+    - name: Restart manager to run the rootcheck scan
+      systemd:
+        state: restarted
+        name: wazuh-manager
+
+    - name: Wait for alerts to be generated
+      wait_for:
+        timeout: 10
+
+    - name: Get alerts.json
+      fetch:
+        src: /var/ossec/logs/alerts/alerts.json
+        dest: /tmp/
+        flat: true

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/generate_events.yaml
@@ -1,5 +1,5 @@
 - name: Generate events
-  hosts: "{{ inventory_hostname }}"
+  hosts: wazuh-manager
   become: true
   tasks:
 

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/generate_events.yaml
@@ -1,5 +1,5 @@
 - name: Generate events
-  hosts: wazuh-manager
+  hosts: "{{ inventory_hostname }}"
   become: true
   tasks:
 

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/teardown_playbook.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/teardown_playbook.yaml
@@ -1,0 +1,16 @@
+- name: Cleanup environment
+  hosts: "{{ inventory_hostname }}"
+  become: true
+  tasks:
+
+    - name: Restore the system binary
+      copy:
+        src: /usr/bin/w.copy
+        dest: /usr/bin/w
+        mode: preserve
+        remote_src: true
+
+    - name: Delete the system binary copy
+      file:
+        path: /usr/bin/w.copy
+        state: absent

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/teardown_playbook.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/playbooks/teardown_playbook.yaml
@@ -1,5 +1,5 @@
 - name: Cleanup environment
-  hosts: "{{ inventory_hostname }}"
+  hosts: wazuh-manager
   become: true
   tasks:
 

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/test_cases/cases_detecting_suspicious_binaries.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/test_cases/cases_detecting_suspicious_binaries.yaml
@@ -3,7 +3,7 @@
   configuration_parameters: null
   metadata:
     rule.id: 510
-    rule.description: Host-based anomaly detection event (rootcheck).
+    rule.description: Host-based anomaly detection event \(rootcheck\).
     rule.level: 7
     extra:
       data.title: Trojaned version of file detected.

--- a/tests/end_to_end/test_detecting_suspicious_binaries/data/test_cases/cases_detecting_suspicious_binaries.yaml
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/data/test_cases/cases_detecting_suspicious_binaries.yaml
@@ -1,0 +1,10 @@
+- name: detect_trojaned_file
+  description: Test the detection of a trojaned file
+  configuration_parameters: null
+  metadata:
+    rule.id: 510
+    rule.description: Host-based anomaly detection event (rootcheck).
+    rule.level: 7
+    extra:
+      data.title: Trojaned version of file detected.
+      data.file: /bin/w

--- a/tests/end_to_end/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
@@ -74,9 +74,7 @@ def test_detecting_suspicious_binaries(configure_environment, metadata, get_dash
     sleep(fw.T_5)
 
     # Get indexed alert
-    # current_hostname is defined in conftest (configure_environment)
-    response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials,
-                                         ip_address=current_hostname)
+    response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
     indexed_alert = json.dumps(response.json())
 
     # Check that the alert data is the expected one

--- a/tests/end_to_end/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
@@ -1,0 +1,90 @@
+import os
+import json
+import re
+import pytest
+from datetime import datetime
+from tempfile import gettempdir
+from time import sleep
+
+import wazuh_testing as fw
+from wazuh_testing.tools.time import parse_date_time_format
+from wazuh_testing import end_to_end as e2e
+from wazuh_testing import event_monitor as evm
+from wazuh_testing.tools import configuration as config
+
+# Test cases data
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_path = os.path.join(test_data_path, 'test_cases')
+test_cases_file_path = os.path.join(test_cases_path, 'cases_detecting_suspicious_binaries.yaml')
+trojan_script_path = os.path.join(test_data_path, 'configuration', 'trojan_script.sh')
+alerts_json = os.path.join(gettempdir(), 'alerts.json')
+
+# Playbooks
+configuration_playbooks = ['configuration.yaml']
+events_playbooks = ['generate_events.yaml']
+configuration_extra_vars = {'trojan_script_path': trojan_script_path}
+
+# Configuration
+configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+
+@pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+def test_detecting_suspicious_binaries(configure_environment, metadata, get_dashboard_credentials, generate_events,
+                                       clean_environment):
+    rule_description = metadata['rule.description']
+    rule_id = metadata['rule.id']
+    rule_level = metadata['rule.level']
+    data_title = metadata['extra']['data.title']
+    data_file = metadata['extra']['data.file']
+    timestamp_regex = r'\d+-\d+-\d+T\d+:\d+:\d+\.\d+\+\d+'
+
+    expected_alert_json = fr".+timestamp\":\"({timestamp_regex})\",.+level\":{rule_level}.+description\"" \
+                          fr":\"{re.escape(rule_description)}.+id.+{rule_id}.+title.+{data_title}.+" \
+                          fr"file.+{re.escape(data_file)}"
+
+    expected_indexed_alert = fr".+file.+{re.escape(data_file)}.+title.+{data_title}.+level.+{rule_level}.+" \
+                             fr"description.+{re.escape(rule_description)}.+id.+{rule_id}.+"\
+                             fr"timestamp\": \"({timestamp_regex})\""
+
+    query = e2e.make_query([
+        {
+          "term": {
+            "data.file": f"{data_file}"
+          }
+        },
+        {
+          "term": {
+            "rule.id": f"{rule_id}"
+          }
+        },
+        {
+          "term": {
+            "data.title": f"{data_title}"
+          }
+        }
+    ])
+
+    # Check that alert has been raised and save timestamp
+    raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
+                                   error_message='The alert has not occurred').result()
+    raised_alert_timestamp = raised_alert.group(1)
+    raised_alert_timestamp = datetime.strptime(parse_date_time_format(raised_alert_timestamp), '%Y-%m-%d %H:%M:%S')
+
+    # Wait a few seconds for the alert to be indexed (alert.json -> filebeat -> wazuh-indexer)
+    sleep(fw.T_5)
+
+    # Get indexed alert
+    response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
+    indexed_alert = json.dumps(response.json())
+
+    # Check that the alert data is the expected one
+    alert_data = re.search(expected_indexed_alert, indexed_alert)
+    assert alert_data is not None, 'Alert triggered, but not indexed'
+
+    # Get indexed alert timestamp
+    indexed_alert_timestamp = alert_data.group(1)
+    indexed_alert_timestamp = datetime.strptime(parse_date_time_format(indexed_alert_timestamp), '%Y-%m-%d %H:%M:%S')
+
+    # Check that alert has been indexed (checking that the timestamp is the expected one)
+    assert indexed_alert_timestamp == raised_alert_timestamp, 'Alert triggered, but not indexed'

--- a/tests/end_to_end/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
+++ b/tests/end_to_end/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
@@ -23,6 +23,7 @@ alerts_json = os.path.join(gettempdir(), 'alerts.json')
 configuration_playbooks = ['configuration.yaml']
 events_playbooks = ['generate_events.yaml']
 configuration_extra_vars = {'trojan_script_path': trojan_script_path}
+teardown_playbook = ['teardown_playbook.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)


### PR DESCRIPTION
|Related issue|
|-------------|
|    #3035    |

## Description

**The added module tests the [detection of suspicious binaries](https://documentation.wazuh.com/current/proof-of-concept-guide/poc-detect-trojan.html) (only a test case was developed, and it uses a trojan script).**

**Design**

<details>
<summary>Design diagram</summary>

![image](https://user-images.githubusercontent.com/39094716/173584591-325113e6-3cf7-450b-97e3-ba95a802d687.png)

</details>

<details>
<summary>General steps</summary>

- Generate the test cases (config, metadata, and ids) using the YAML's inside the `test_cases` folder
- Configure the environment using a pytest fixture from the `end_to_end` test suite
  - Run each playbook defined in the test module using the inventory passed by parameter to the `pytest` library
- Get the dashboard credentials using the fixture from the `end_to_end` test suite
- Generate the events using a playbook from the `playbooks` folder
- Get the alerts (if they were generated) from the wazuh-indexer API
- Check if the expected alert matched one of the alerts obtained from the API
  - If an exception is raised, check if the alert at least is found in the log file
    - If not, raise a TimeoutError
    - If yes, raise the previously captured exception (AssertionError)
- **NEW!**: Clean the environment (tasks to be executed in the Ansible controlled nodes)

</details>

**Execution**

<details>
<summary>The only precondition to running the test is to create an inventory as follows:</summary>

```
all:
  hosts:
    wazuh-manager:
      ansible_connection: ssh
      ansible_user: <VM USER>
      ansible_ssh_private_key_file: <PRIVATE KEY PATH>
      ansible_python_interpreter: <PYTHON INTERPRETER PATH>
      dashboard_user: <USER>
      dashboard_password: <PASS>
```
</details>

<details>
<summary>Then, you will be able to run it by executing:</summary>

<code>
python -m pytest tests/end_to_end/TEST-PATH --inventory_path PATH-TO-INVENTORY
</code>

</details>

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- `trojan_script.sh` was added to use it in the setup stage.
- `teardown_playbook.yaml` was added to clean the environment.
- `configuration.yaml` was added to setup the environment.
- `generate_events.yaml` was added to generate the alerts in the host.
- `cases_detecting_suspicious_binaries.yaml` contains the test cases to be executed.
- `test_detecting_suspicious_binaries.py` was added to test the Wazuh capability.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `tests/end_to_end/conftest.py` updated to configure dynamically the hostname in the playbooks and also to run a teardown stage at the end of each test case. (⚠️¡BREAKING CHANGES!⚠️)

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  |    end_to_end/test_detecting_suspicious_binaries/       | N/A | [🟢](https://github.com/wazuh/wazuh-qa/files/9072191/r1-CentOS-manager-3035.zip)[🟢](https://github.com/wazuh/wazuh-qa/files/9072192/r2-CentOS-manager-3035.zip)[🟢](https://github.com/wazuh/wazuh-qa/files/9072193/r3-CentOS-manager-3035.zip)  | CentOS        |   https://github.com/wazuh/wazuh-qa/pull/3069/commits/d48e39518cfa34dbe84fd8a2fbb254fb32006ae4     | - |
| @juliamagan (Reviewer)   |           | N/A | ⚫⚫⚫  |        |         | Nothing to highlight |
