### PR TITLE
Add IT to verify Active Response works with overwritten rules - 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release report: TBD
 
 ### Added
 
+- Add test to verify Active Response works with overwritten rules ([#3080](https://github.com/wazuh/wazuh-qa/pull/3080)) \- (Framework + Tests)
 - New vulnerability Detector integration tests for Ubuntu 22.04 ([#2957](https://github.com/wazuh/wazuh-qa/pull/2957)) \- (Framework + Tests)
 - New vulnerability Detector integration tests for Amazon Linux 2022 ([#2955](https://github.com/wazuh/wazuh-qa/pull/2955)) \- (Framework + Tests)
 - New vulnerability detector tests for SUSE Linux Enterpise Support ([#2945](https://github.com/wazuh/wazuh-qa/pull/2945)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/processes/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/processes/__init__.py
@@ -4,3 +4,8 @@ from wazuh_testing.tools.services import check_if_process_is_running
 def check_if_modulesd_is_running():
     """Check if modulesd daemon is running"""
     assert check_if_process_is_running('wazuh-modulesd'), 'wazuh-modulesd is not running. It may have crashed'
+
+
+def check_if_analysisd_is_running():
+    """Check if analysisd daemon is running"""
+    assert check_if_process_is_running('wazuh-analysisd'), 'wazuh-analysisd is not running. It may have crashed'

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -72,6 +72,7 @@ else:
     PYTHON_PATH = os.path.join(WAZUH_PATH, 'framework', 'python')
     AGENT_AUTH_BINARY_PATH = os.path.join(WAZUH_PATH, 'bin', 'agent-auth')
     ANALYSISD_BINARY_PATH = os.path.join(WAZUH_PATH, 'bin', 'wazuh-analysisd')
+    AR_SCRIPTS_PATH = os.path.join(WAZUH_PATH, 'active-response', 'bin')
     if sys.platform == 'sunos5':
         HOSTS_FILE_PATH = os.path.join('/', 'etc', 'inet', 'hosts')
     else:

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -516,3 +516,12 @@ def download_text_file(file_url, local_destination_path):
 def get_file_lines(path):
     with open(path, "r+") as file_to_read:
         return file_to_read.readlines()
+
+
+def change_permission(file_path, permissions):
+    """change the mode of path to the numeric mode.
+    Args:
+        file_path (str): Path to file.
+        permissions (str): level of permission.
+    """
+    os.chmod(file_path, permissions)

--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -21,7 +21,6 @@ import yaml
 from wazuh_testing import logger
 
 
-
 def read_json(file_path):
     """
     Read a JSON file from a given path, return a dictionary with the json data.
@@ -129,6 +128,7 @@ def random_string(length, encode=None):
 
     return st
 
+
 def generate_string(stringLength=10, character='0'):
     """Generate a string with line breaks.
 
@@ -153,6 +153,7 @@ def generate_string(stringLength=10, character='0'):
             generated_string += '\n'
 
     return generated_string
+
 
 def read_file(file_path):
     with open(file_path) as f:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,6 +119,7 @@ def restart_wazuh_daemon_function(daemon=None):
     truncate_file(LOG_FILE_PATH)
     control_service("restart", daemon=daemon)
 
+
 @pytest.fixture(scope='module')
 def restart_wazuh_daemon_after_finishing(daemon=None):
     """
@@ -127,6 +128,7 @@ def restart_wazuh_daemon_after_finishing(daemon=None):
     yield
     truncate_file(LOG_FILE_PATH)
     control_service("restart", daemon=daemon)
+
 
 @pytest.fixture(scope='module')
 def reset_ossec_log(get_configuration, request):
@@ -937,6 +939,7 @@ def set_wazuh_configuration(configuration):
     # Restore previous configuration
     conf.write_wazuh_conf(backup_config)
 
+
 @pytest.fixture(scope='function')
 def configure_local_internal_options_function(request):
     """Fixture to configure the local internal options file.
@@ -961,6 +964,7 @@ def configure_local_internal_options_function(request):
     logger.debug(f"Restore local_internal_option to {str(backup_local_internal_options)}")
     conf.set_local_internal_options_dict(backup_local_internal_options)
 
+
 @pytest.fixture(scope='function')
 def truncate_monitored_files():
     """Truncate all the log files and json alerts files before and after the test execution"""
@@ -973,7 +977,6 @@ def truncate_monitored_files():
 
     for log_file in log_files:
         truncate_file(log_file)
-
 
 
 @pytest.fixture(scope='function')
@@ -1086,14 +1089,14 @@ def remove_backups(backups_path):
     recursive_directory_creation(backups_path)
     os.chmod(backups_path, 0o777)
 
-    
-@pytest.fixture(scope='function')    
+
+@pytest.fixture(scope='function')
 def mock_agent_with_custom_system(agent_system):
     """Fixture to create a mocked agent with custom system specified as parameter"""
     if agent_system not in mocking.SYSTEM_DATA:
         raise ValueError(f"{agent_system} is not supported as mocked system for an agent")
 
-    agent_id = mocking.create_mocked_agent(**mocking.SYSTEM_DATA[agent_system] )
+    agent_id = mocking.create_mocked_agent(**mocking.SYSTEM_DATA[agent_system])
 
     yield agent_id
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ from wazuh_testing import global_parameters, logger, ALERTS_JSON_PATH
 from wazuh_testing.logcollector import create_file_structure, delete_file_structure
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_CONF, get_service, ALERT_FILE_PATH, WAZUH_LOCAL_INTERNAL_OPTIONS
 from wazuh_testing.tools.configuration import get_wazuh_conf, set_section_wazuh_conf, write_wazuh_conf
-from wazuh_testing.tools.file import truncate_file, recursive_directory_creation, remove_file
+from wazuh_testing.tools.file import truncate_file, recursive_directory_creation, remove_file, copy, write_file
 from wazuh_testing.tools.monitoring import QueueMonitor, FileMonitor, SocketController, close_sockets
 from wazuh_testing.tools.services import control_service, check_daemon_status, delete_dbs
 from wazuh_testing.tools.time import TimeMachine
@@ -1114,3 +1114,23 @@ def setup_alert_monitor():
     log_monitor = FileMonitor(ALERTS_JSON_PATH)
 
     yield log_monitor
+
+
+@pytest.fixture(scope='function')
+def copy_file(source_path, destination_path):
+    """Copy file from source to destination"""
+    for i in range(len(source_path)):
+        copy(source_path[i], destination_path[i])
+
+    yield
+    for file in destination_path:
+        remove_file(file)
+
+
+@pytest.fixture(scope='function')
+def create_file_to_monitor(file_to_monitor):
+    """Create a file to monitor"""
+    write_file(file_to_monitor)
+
+    yield
+    remove_file(file_to_monitor)

--- a/tests/integration/test_active_response/test_analysisd/conftest.py
+++ b/tests/integration/test_active_response/test_analysisd/conftest.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import pytest
 
+
 @pytest.fixture(scope='function')
 def set_wazuh_configuration_analysisd(configuration, set_wazuh_configuration):
     """Set wazuh configuration

--- a/tests/integration/test_active_response/test_analysisd/conftest.py
+++ b/tests/integration/test_active_response/test_analysisd/conftest.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2015-2022, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import pytest
+
+@pytest.fixture(scope='function')
+def set_wazuh_configuration_analysisd(configuration, set_wazuh_configuration):
+    """Set wazuh configuration
+    Args:
+        configuration (dict): Configuration template data to write in the ossec.conf.
+        set_wazuh_configuration (fixture): Set the wazuh configuration according to the configuration data.
+    """
+    yield

--- a/tests/integration/test_active_response/test_analysisd/data/configuration_template/configuration_overwritten_rules.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/configuration_template/configuration_overwritten_rules.yaml
@@ -2,9 +2,9 @@
     - section: command
       elements:
         - name:
-            value: 'custom-ar'
+            value: custom-ar
         - executable:
-            value: 'custom-ar.sh'
+            value: custom-ar.sh
         - timeout_allowed:
             value: 'no'
 
@@ -22,33 +22,33 @@
     - section: localfile
       elements:
         - location:
-            value: '/tmp/file_to_monitor.log'
+            value: /tmp/file_to_monitor.log
         - log_format:
-            value: 'syslog'
+            value: syslog
 
     - section: vulnerability-detector
       elements:
-      - enabled:
-          value: 'no'
+        - enabled:
+            value: 'no'
 
     - section: sca
       elements:
-      - enabled:
-          value: 'no'
+        - enabled:
+            value: 'no'
 
     - section: rootcheck
       elements:
-      - disabled:
-          value: 'yes'
+        - disabled:
+            value: 'yes'
 
     - section: syscheck
       elements:
-      - disabled:
-          value: 'yes'
+        - disabled:
+            value: 'yes'
 
     - section: wodle
       attributes:
-        - name: 'syscollector'
+        - name: syscollector
       elements:
         - disabled:
             value: 'yes'

--- a/tests/integration/test_active_response/test_analysisd/data/configuration_template/configuration_overwritten_rules.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/configuration_template/configuration_overwritten_rules.yaml
@@ -1,0 +1,64 @@
+- sections:
+    - section: command
+      elements:
+        - name:
+            value: 'custom-ar'
+        - executable:
+            value: 'custom-ar.sh'
+        - timeout_allowed:
+            value: 'no'
+
+    - section: active-response
+      elements:
+        - disabled:
+            value: 'no'
+        - command:
+            value: COMMAND
+        - location:
+            value: LOCATION
+        - rules_id:
+            value: RULES
+
+    - section: localfile
+      elements:
+        - location:
+            value: '/tmp/file_to_monitor.log'
+        - log_format:
+            value: 'syslog'
+
+    - section: vulnerability-detector
+      elements:
+      - enabled:
+          value: 'no'
+
+    - section: sca
+      elements:
+      - enabled:
+          value: 'no'
+
+    - section: rootcheck
+      elements:
+      - disabled:
+          value: 'yes'
+
+    - section: syscheck
+      elements:
+      - disabled:
+          value: 'yes'
+
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: rule_test
+      elements:
+        - enabled:
+            value: 'yes'

--- a/tests/integration/test_active_response/test_analysisd/data/rules/0270-web_appsec_rules_edit.xml
+++ b/tests/integration/test_active_response/test_analysisd/data/rules/0270-web_appsec_rules_edit.xml
@@ -1,0 +1,8 @@
+<group name="web,appsec,attack,">
+  <rule id="31533" level="9" frequency="50" timeframe="5" overwrite="yes">
+    <if_matched_sid>31530</if_matched_sid>
+    <same_source_ip/>
+    <description>Local - High amount of POST requests in a small period of time (likely bot) (50/5s).</description>
+    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+</group>

--- a/tests/integration/test_active_response/test_analysisd/data/rules/local_rules.xml
+++ b/tests/integration/test_active_response/test_analysisd/data/rules/local_rules.xml
@@ -1,0 +1,33 @@
+<group name="local,">
+  <rule id="100000" level="10">
+    <match>TEST 1</match>
+    <description>Rule to bind AR</description>
+  </rule>
+
+  <rule id="100001" level="10">
+    <match>TEST 2</match>
+    <description>Rule to bind AR</description>
+  </rule>
+
+  <rule id="100002" level="10">
+    <match>TEST 3</match>
+    <description>Rule to overwrite</description>
+  </rule>
+
+  <rule id="100002" level="6" overwrite="yes">
+    <match>TEST 4</match>
+    <description>Overwrite rule</description>
+  </rule>
+
+  <rule id="100003" level="4">
+    <if_sid>100001</if_sid>
+    <match>TEST 5</match>
+    <description>Rule to force the fail</description>
+  </rule>
+
+  <rule id="100004" level="10">
+    <if_sid>100003</if_sid>
+    <match>TEST 6</match>
+    <description>Rule to force the fail</description>
+  </rule>
+</group>

--- a/tests/integration/test_active_response/test_analysisd/data/scripts/custom-ar.sh
+++ b/tests/integration/test_active_response/test_analysisd/data/scripts/custom-ar.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+touch /tmp/file-ar.txt

--- a/tests/integration/test_active_response/test_analysisd/data/test_cases/cases_overwritten_rules.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/test_cases/cases_overwritten_rules.yaml
@@ -1,0 +1,26 @@
+- name: 'Overwritten rules - Rule test 100001'
+  description: 'Verify Active Response works with overwritten rules'
+  configuration_parameters:
+    COMMAND: 'custom-ar'
+    LOCATION: 'local'
+    RULES: '100001'
+  metadata:
+    log_sample: 'Dec 25 20:45:02 MyHost example[12345]: TEST 2'
+
+- name: 'Overwritten rules - Rule test 100002'
+  description: 'Verify Active Response works with overwritten rules'
+  configuration_parameters:
+    COMMAND: 'custom-ar'
+    LOCATION: 'local'
+    RULES: '100002'
+  metadata:
+    log_sample: 'Dec 25 20:45:02 MyHost example[12345]: TEST 4'
+
+- name: 'Overwritten rules - Rule test 100004'
+  description: 'Verify Active Response works with overwritten rules'
+  configuration_parameters:
+    COMMAND: 'custom-ar'
+    LOCATION: 'local'
+    RULES: '100004'
+  metadata:
+    log_sample: 'Dec 25 20:45:02 MyHost example[12345]: TEST 2 TEST 5 TEST 6'

--- a/tests/integration/test_active_response/test_analysisd/data/test_cases/cases_overwritten_rules.yaml
+++ b/tests/integration/test_active_response/test_analysisd/data/test_cases/cases_overwritten_rules.yaml
@@ -1,26 +1,26 @@
-- name: 'Overwritten rules - Rule test 100001'
-  description: 'Verify Active Response works with overwritten rules'
+- name: Overwritten rules - Rule test 100001
+  description: Verify Active Response works with overwritten rules
   configuration_parameters:
-    COMMAND: 'custom-ar'
-    LOCATION: 'local'
+    COMMAND: custom-ar
+    LOCATION: local
     RULES: '100001'
   metadata:
     log_sample: 'Dec 25 20:45:02 MyHost example[12345]: TEST 2'
 
-- name: 'Overwritten rules - Rule test 100002'
-  description: 'Verify Active Response works with overwritten rules'
+- name: Overwritten rules - Rule test 100002
+  description: Verify Active Response works with overwritten rules
   configuration_parameters:
-    COMMAND: 'custom-ar'
-    LOCATION: 'local'
+    COMMAND: custom-ar
+    LOCATION: local
     RULES: '100002'
   metadata:
     log_sample: 'Dec 25 20:45:02 MyHost example[12345]: TEST 4'
 
-- name: 'Overwritten rules - Rule test 100004'
-  description: 'Verify Active Response works with overwritten rules'
+- name: Overwritten rules - Rule test 100004
+  description: Verify Active Response works with overwritten rules
   configuration_parameters:
-    COMMAND: 'custom-ar'
-    LOCATION: 'local'
+    COMMAND: custom-ar
+    LOCATION: local
     RULES: '100004'
   metadata:
     log_sample: 'Dec 25 20:45:02 MyHost example[12345]: TEST 2 TEST 5 TEST 6'

--- a/tests/integration/test_active_response/test_analysisd/test_overwritten_rules_ar.py
+++ b/tests/integration/test_active_response/test_analysisd/test_overwritten_rules_ar.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+import time
+
+from wazuh_testing import global_parameters
+from wazuh_testing.processes import check_if_analysisd_is_running
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.tools.file import change_permission, remove_file
+from wazuh_testing.tools import CUSTOM_RULES_PATH, LOCAL_RULES_PATH, AR_SCRIPTS_PATH
+
+pytestmark = [pytest.mark.tier(level=0), pytest.mark.server]
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+RULES_PATH = os.path.join(TEST_DATA_PATH, 'rules')
+CUSTOM_AR_SCRIPT_PATH = os.path.join(TEST_DATA_PATH, 'scripts')
+
+# Configuration and cases data
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_overwritten_rules.yaml')
+cases_path = os.path.join(TEST_CASES_PATH, 'cases_overwritten_rules.yaml')
+custom_rule = os.path.join(RULES_PATH, '0270-web_appsec_rules_edit.xml')
+local_rules = os.path.join(RULES_PATH, 'local_rules.xml')
+custom_ar_script = os.path.join(CUSTOM_AR_SCRIPT_PATH, 'custom-ar.sh')
+wazuh_ar_script = os.path.join(AR_SCRIPTS_PATH, 'custom-ar.sh')
+output_custom_ar_script = '/tmp/file-ar.txt'
+source_path = [custom_rule, local_rules, custom_ar_script]
+destination_path = [f"{CUSTOM_RULES_PATH}/0270-web_appsec_rules_edit.xml", LOCAL_RULES_PATH, wazuh_ar_script]
+
+
+# Test configurations
+configuration_parameters, configuration_metadata, case_ids = get_test_cases_data(cases_path)
+configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
+
+
+@pytest.mark.parametrize("source_path", [source_path])
+@pytest.mark.parametrize("destination_path", [destination_path])
+@pytest.mark.parametrize("file_to_monitor", ['/tmp/file_to_monitor.log'])
+@pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=case_ids)
+def test_overwritten_rules_ar(configuration, metadata, create_file_to_monitor, file_to_monitor,
+                              set_wazuh_configuration_analysisd, copy_file, source_path, destination_path,
+                              restart_wazuh_daemon_function):
+    change_permission(wazuh_ar_script, 0o777)
+    cmd = "echo '{}' >> '{}'".format(metadata['log_sample'], file_to_monitor)
+    os.system(cmd)
+
+    # Checking if AR works properly
+    time.sleep(global_parameters.default_timeout)
+    assert os.path.exists(output_custom_ar_script)
+
+    # Check that wazuh-analysisd is running and has not crashed when trying to parse files with unexpected file types
+    check_if_analysisd_is_running()
+
+    # Remove file created by active response
+    remove_file(output_custom_ar_script)


### PR DESCRIPTION
|Related issue|
|---|
| Close #2918 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The is a  failure that occurs when binding an active response for a rule that will be overwritten. If that overwrite rule doesn't apply the same AR, the AR is freed so the next time it is consulted to apply it to another rule, a segmentation fault appears. So we create an integration test to cover this case and ensure it doesn't appear again.
<!--
Add a clear description of how the problem has been solved.
-->


### Updated
- Modify the `write_file` function from `deps/wazuh_testing/wazuh_testing/tools/file.py` in order to write an empty file if no data is provided.

### Added
- Added `check_if_daemons_are_running ` function in `deps/wazuh_testing/wazuh_testing/processes/__init__.py` that check if analysisd daemon is running
- Added `set_wazuh_configuration_analysisd` fixture in `tests/integration/test_active_response/test_analysisd/conftest.py` that allows configuring the test of analysisd.
- Added ossec.conf configuration in `tests/integration/test_active_response/test_analysisd/data/configuration_template/configuration_overwritten_rules.yaml`
- Added custom rule in `tests/integration/test_active_response/test_analysisd/data/rules/0270-web_appsec_rules_edit.xml`
- Added `local_rules` in `tests/integration/test_active_response/test_analysisd/data/rules/local_rules.xml`
- Added custom script from `Active Response` in `tests/integration/test_active_response/test_analysisd/data/scripts/custom-ar.sh`
- Added new test to verify if `Active Response` works with overwritten rules in `tests/integration/test_active_response/test_analysisd/test_overwritten_rules_ar.py`


## Testing performed
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @CamiRomero  (Developer)  | /test_active_response/           | [:green_circle:](https://ci.wazuh.info/job/Test_integration/28970/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/28981/)  [:green_circle:](https://ci.wazuh.info/job/Test_integration/28982/)  | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9073549/R1-2819.tar.gz)[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9073553/R2-2819.tar.gz) [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9073557/R3-2819.tar.gz) | Centos8 |  https://github.com/wazuh/wazuh-qa/pull/3080/commits/985ee2e9df2ae66a5a99c0bdf9141a8ed2245d91  |  |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | |