### PR TITLE
Fix GCloud IT: test_max_messages error not received expected messages - 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix GCloud IT: test_max_messages error not received expected messages - ([#3083](https://github.com/wazuh/wazuh-qa/pull/3083)) \- (Tests) 
 - Update syscollector deltas integration tests ([#2921](https://github.com/wazuh/wazuh-qa/pull/2921)) \- (Tests)
 - Update deprecated WDB commands ([#2966](https://github.com/wazuh/wazuh-qa/pull/2966)) \- (Tests)
 - Move the 'get_datetime_diff' function to 'wazuh-testing' utils module ([#2782](https://github.com/wazuh/wazuh-qa/pull/2782)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/gcloud.py
+++ b/deps/wazuh_testing/wazuh_testing/gcloud.py
@@ -57,7 +57,7 @@ def detect_gcp_start(file_monitor):
 
 
 def callback_received_messages_number(line):
-    received_messages_number = rf".*wm_gcp_pubsub_run\(\): INFO: - INFO - Received and acknowledged (\d+) messages"
+    received_messages_number = r'.*wm_gcp_parse_output\(\): INFO: Received and acknowledged (\d+) messages'
     match = re.findall(received_messages_number, line)
     if match:
         return match


### PR DESCRIPTION
|Related issue|
|-------------|
|     Close #3063         |

## Description
We need to modify a callback, the failure is due to a change in the regex when wanting to run the test in Wazuh 4.3.x.
<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Update `callback_received_messages_number` in `deps/wazuh_testing/wazuh_testing/gcloud.py`
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|     
| Camila  |  test_gcloud/         | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29016/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29017/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29018/) |:no_entry_sign: :no_entry_sign: :no_entry_sign:| CentOS-8    |  [2e958df](https://github.com/wazuh/wazuh-qa/pull/3083/commits/2e958dff464abb8a9fbcbee3613c696ba153e0e8)  | For this PR, we decided only to execute it on Jenkins. |
| Seyla  |     test_gcloud/      | [🟢](https://ci.wazuh.info/job/Test_integration/29063/) [🟢](https://ci.wazuh.info/job/Test_integration/29061/)[🟢](https://ci.wazuh.info/job/Test_integration/29019/) | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |    CentOS-8    |  [2e958df](https://github.com/wazuh/wazuh-qa/pull/3083/commits/2e958dff464abb8a9fbcbee3613c696ba153e0e8)   | Nothing to highlight |
