### PR TITLE
Fix Remoted IT: `test_agent_communication`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Release report: TBD
 ### Fixed
 
 - Fix GCloud IT - test_max_messages error ([#3006](https://github.com/wazuh/wazuh-qa/pull/3006)) \- (Framework + Tests)
-
+- Fix Remoted IT - test_agent_communication ([#3088](https://github.com/wazuh/wazuh-qa/pull/3088)) \- (Framework)
 
 ## [4.3.5] - 29-06-2022
 

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -631,10 +631,10 @@ def check_push_shared_config(agent, sender, injector=None):
         # Add agent to group and check if the configuration is pushed.
         add_agent_to_group(DEFAULT_TESTING_GROUP_NAME, agent.id)
 
-        for _ in range(5):
+        for _ in range(2):
             # send some keep alive messages until manager push the new group configuration
             sender.send_event(agent.keep_alive_event)
-            time.sleep(1)
+            time.sleep(10)
 
         check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=10,
                                      error_message="New group shared config not received")

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -636,7 +636,7 @@ def check_push_shared_config(agent, sender, injector=None):
             sender.send_event(agent.keep_alive_event)
             time.sleep(10)
 
-        check_agent_received_message(agent, '#!-up file .* merged.mg', timeout=10,
+        check_agent_received_message(agent, r'#!-up file .* merged.mg', timeout=10,
                                      error_message="New group shared config not received")
 
     finally:


### PR DESCRIPTION
|Related issue|
|-------------|
|   Closes: #3087     |

## Description

After the review made in #3060, we have seen that two tests of `test_agent_communication` were failing consistently:
- `test_shared_configuration.py`
- `test_agent_version_shared_configuration_startup_message.py`

The error was that the keep-alives were not being sent correctly.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Update `check_push_shared_config` in `wazuh_testing/remote.py`


## Testing performed

### Package

|Component|Link|
|:--:|:--:|
|Manager|https://packages-dev.wazuh.com/warehouse/pullrequests/4.3/rpm/var/wazuh-manager-4.3.6-0.commit2c426d5.x86_64.rpm|

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @juliamagan  (Developer)  |   test_remoted/        | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/29103/)[🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/29104/)[🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/29105/)| [🟢](https://github.com/wazuh/wazuh-qa/files/9085830/R1-3087-centos-manager.tar.gz)[🟢](https://github.com/wazuh/wazuh-qa/files/9086006/R2-3087-centos-manager.tar.gz)[🟢](https://github.com/wazuh/wazuh-qa/files/9086225/R3-3087-centos-manager.tar.gz)  |    CentOS     |     9988190     | Nothing to highlight |
| @jmv74211  (Reviewer)   |           | 🟢🟢🟢 | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |        | Nothing to highlight |
