### PR TITLE
Fix: Adapt QA framework requirements for python3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,14 +21,14 @@ py~=1.10.0
 pycryptodome>=3.9.8
 pyOpenSSL==19.1.0
 pytest-html==3.1.1
-pytest==6.2.2
+pytest==6.2.5
 pyyaml==5.4
 requests==2.23.0
 scipy>=1.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 setuptools~=56.0.0
 testinfra==5.0.0
-jq==1.1.2; platform_system == "Linux" or platform_system == "Darwin"
+jq>=1.1.2; platform_system == "Linux" or platform_system == "Darwin"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 urllib3
 numpydoc>=1.1.0


### PR DESCRIPTION
|Related issue|
|-------------|
|      closes #2991      |

## Description

QA framework dependencies present installation errors for python 3.10. In this PR we changed `pytest` and `jq` versions to fix this issue.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `requirements.txt`

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Rebits (Developer)  |        |   [:green_circle:](https://ci.wazuh.info/job/Test_integration/29323/consoleFull)   |  [:green_circle:](https://github.com/wazuh/wazuh-qa/pull/3103#issuecomment-1189196000)         |         |         | Nothing to highlight |

