### PR TITLE
Fix: Adapt QA framework requirements for python3.10 - 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ Release report: https://github.com/wazuh/wazuh-qa/issues/2500
 - Add FIM Windows 4659 events tests. ([#648](https://github.com/wazuh/wazuh-qa/pull/648))
 
 ### Changed
+
+- Increase framework version of jq and pytest to support python3.10 ([#3107](https://github.com/wazuh/wazuh-qa/pull/3107))
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ Release report: https://github.com/wazuh/wazuh-qa/issues/2500
 
 ### Changed
 
-- Increase framework version of jq and pytest to support python3.10 ([#3107](https://github.com/wazuh/wazuh-qa/pull/3107))
+- Increase framework version of jq and pytest in the requirements file to support python3.10 ([#3107](https://github.com/wazuh/wazuh-qa/pull/3107))
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Release report: TBD
 
 ### Changed
 
-- Fix GCloud IT: test_max_messages error not received expected messages - ([#3083](https://github.com/wazuh/wazuh-qa/pull/3083)) \- (Tests) 
+- Fix GCloud IT: test_max_messages error not received expected messages - ([#3083](https://github.com/wazuh/wazuh-qa/pull/3083)) \- (Tests)
 - Update syscollector deltas integration tests ([#2921](https://github.com/wazuh/wazuh-qa/pull/2921)) \- (Tests)
 - Update deprecated WDB commands ([#2966](https://github.com/wazuh/wazuh-qa/pull/2966)) \- (Tests)
 - Move the 'get_datetime_diff' function to 'wazuh-testing' utils module ([#2782](https://github.com/wazuh/wazuh-qa/pull/2782)) \- (Framework + Tests)
@@ -57,14 +57,28 @@ Release report: TBD
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
 
 
-## [4.3.6] - Development (unreleased)
+## [4.3.7] - Development (unreleased)
 
 Wazuh commit: TBD \
 Release report: TBD
 
+### Changed
+
+- Increase framework version of jq and pytest in the requirements file to support python3.10 ([#3107](https://github.com/wazuh/wazuh-qa/pull/3108)) \- (Framework)
+
+## [4.3.6] - 20-07-2022
+
+Wazuh commit: https://github.com/wazuh/wazuh/commit/be15851b8ead7512d9cd4ef1ee18b3b953173211 \
+Release report: https://github.com/wazuh/wazuh/issues/14188
+
+### Added
+
+- Add Remoted IT - test_multi_groups ([#3060](https://github.com/wazuh/wazuh-qa/pull/3060)) \- (Framework + Tests)
+
 ### Fixed
 
 - Fix GCloud IT - test_max_messages error ([#3006](https://github.com/wazuh/wazuh-qa/pull/3006)) \- (Framework + Tests)
+- Fix Remoted IT - test_agent_communication ([#3088](https://github.com/wazuh/wazuh-qa/pull/3088)) \- (Framework)
 
 
 ## [4.3.5] - 29-06-2022
@@ -136,7 +150,6 @@ Release report: https://github.com/wazuh/wazuh/issues/13321
 
 ### Changed
 
-- Increase framework version of jq and pytest in the requirements file to support python3.10 ([#3107](https://github.com/wazuh/wazuh-qa/pull/3107))
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,14 +21,14 @@ py~=1.10.0
 pycryptodome>=3.9.8
 pyOpenSSL==19.1.0
 pytest-html==3.1.1
-pytest==6.2.2
+pytest==6.2.5
 pyyaml==5.4
 requests==2.23.0
 scipy>=1.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 setuptools~=56.0.0
 testinfra==5.0.0
-jq==1.1.2; platform_system == "Linux" or platform_system == "Darwin"
+jq>=1.1.2; platform_system == "Linux" or platform_system == "Darwin"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 urllib3
 numpydoc>=1.1.0


### PR DESCRIPTION
|Related issue|
|-------------|
|      closes #2991      |

## Description

QA framework dependencies present installation errors for python 3.10. In this PR we changed `pytest` and `jq` versions to fix this issue.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `requirements.txt`

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Rebits (Developer)  |        |   [:green_circle:](https://ci.wazuh.info/job/Test_integration/29323/consoleFull)   |  [:green_circle:](https://github.com/wazuh/wazuh-qa/pull/3107#issuecomment-1190047124)         |         |         | Nothing to highlight |

