### PR TITLE
Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup - 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@ Release report: https://github.com/wazuh/wazuh/issues/13321
 - Add FIM Windows 4659 events tests. ([#648](https://github.com/wazuh/wazuh-qa/pull/648))
 
 ### Changed
+
+- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3109]())
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ Release report: https://github.com/wazuh/wazuh/issues/13321
 
 ### Changed
 
-- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3109]())
+- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3109](https://github.com/wazuh/wazuh-qa/pull/3109))
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
+++ b/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
@@ -64,6 +64,7 @@ data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(data_dir, 'syscollector.yaml')
 with open(messages_path) as f:
     test_cases = yaml.safe_load(f)
+local_internal_options = {'analysisd.debug': '2'}
 
 
 # Fixtures
@@ -77,8 +78,9 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          list(test_cases),
                          ids=[test_case['name'] for test_case in test_cases])
-def test_syscollector_events(test_case, get_configuration, mock_agent_module, configure_custom_rules, restart_analysisd,
-                             wait_for_analysisd_startup, connect_to_sockets_function, file_monitoring):
+def test_syscollector_events(test_case, configure_local_internal_options_module, get_configuration, mock_agent_module,
+                             configure_custom_rules, restart_analysisd, wait_for_analysisd_startup,
+                             connect_to_sockets_function, file_monitoring):
     '''
     description: Check if Analysisd handle Syscollector deltas properly by generating alerts.
 


### PR DESCRIPTION
|Related issue|
|-------------|
|  Close #3058           |

## Description

The test failed because a Local_internal_options was missing
<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added
- Add `configure_local_internal_options_module` fixture in ordet to set analysisd in debug mode


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @CamiRomero  (Developer)  |  test_analysisd/test_syscollector/test_syscollector_events.py         | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29357/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29358/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29359/)  | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9123873/R1-3058.tar.gz) [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9123874/R2-3058.tar.gz) [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9123875/R3-3058.tar.gz)|   CentOS-8      |   [d5c764d](https://github.com/wazuh/wazuh-qa/pull/3109/commits/d5c764d603bf79a4716c581061c7b6187e61736a )      | Nothing to highlight |
| @user (Reviewer)   |          | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


