### PR TITLE
Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup - 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ Release report: https://github.com/wazuh/wazuh/issues/13321
 - Add FIM Windows 4659 events tests. ([#648](https://github.com/wazuh/wazuh-qa/pull/648))
 
 ### Changed
+
+- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3109]())
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ Release report: https://github.com/wazuh/wazuh/issues/13321
 
 ### Changed
 
-- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3109]())
+- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3110](https://github.com/wazuh/wazuh-qa/pull/3110))
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3110](https://github.com/wazuh/wazuh-qa/pull/3110)) \- (Tests)
 - Update syscollector deltas integration tests ([#2921](https://github.com/wazuh/wazuh-qa/pull/2921)) \- (Tests)
 - Update deprecated WDB commands ([#2966](https://github.com/wazuh/wazuh-qa/pull/2966)) \- (Tests)
 - Move the 'get_datetime_diff' function to 'wazuh-testing' utils module ([#2782](https://github.com/wazuh/wazuh-qa/pull/2782)) \- (Framework + Tests)
@@ -135,7 +136,6 @@ Release report: https://github.com/wazuh/wazuh/issues/13321
 
 ### Changed
 
-- Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3110](https://github.com/wazuh/wazuh-qa/pull/3110))
 - Migrate `test_rids` documentation to `qa-docs`. ([#2422](https://github.com/wazuh/wazuh-qa/pull/2422))
 - Google Cloud. IT Tests: Fixing and rework for 4.3.0-RC2. ([#2420](https://github.com/wazuh/wazuh-qa/pull/2420))
 - Refactor: FIM `test_report_changes` according to new standard.  Phase 1. ([#2417](https://github.com/wazuh/wazuh-qa/pull/2417))

--- a/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
+++ b/tests/integration/test_analysisd/test_syscollector/test_syscollector_events.py
@@ -64,6 +64,7 @@ data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 messages_path = os.path.join(data_dir, 'syscollector.yaml')
 with open(messages_path) as f:
     test_cases = yaml.safe_load(f)
+local_internal_options = {'analysisd.debug': '2'}
 
 
 # Fixtures
@@ -77,8 +78,9 @@ def get_configuration(request):
 @pytest.mark.parametrize('test_case',
                          list(test_cases),
                          ids=[test_case['name'] for test_case in test_cases])
-def test_syscollector_events(test_case, get_configuration, mock_agent_module, configure_custom_rules, restart_analysisd,
-                             wait_for_analysisd_startup, connect_to_sockets_function, file_monitoring):
+def test_syscollector_events(test_case, configure_local_internal_options_module, get_configuration, mock_agent_module,
+                             configure_custom_rules, restart_analysisd, wait_for_analysisd_startup,
+                             connect_to_sockets_function, file_monitoring):
     '''
     description: Check if Analysisd handle Syscollector deltas properly by generating alerts.
 


### PR DESCRIPTION
|Related issue|
|-------------|
|  Close #3058           |

## Description

The test failed because a Local_internal_options was missing
<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added
- Add `configure_local_internal_options_module` fixture in order to set analysisd in debug mode.


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @CamiRomero  (Developer)  |  test_analysisd/test_syscollector/test_syscollector_events.py         | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29377/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29378/) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/29379/)  | [:green_circle: ]((https://github.com/wazuh/wazuh-qa/files/9123944/R1-3058.tar.gz)) [:green_circle: ]((https://github.com/wazuh/wazuh-qa/files/9123948/R2-3058.tar.gz)) [:green_circle: ]((https://github.com/wazuh/wazuh-qa/files/9123951/R3-3058.tar.gz))|   CentOS-8      |   [67de5](https://github.com/wazuh/wazuh-qa/pull/3110/commits/67de522e68be73ae2b6f1c58de60f5f6122f347b )      | Nothing to highlight |
| @damarisg    |    test_analysisd/      | [🟢](https://ci.wazuh.info/job/Test_integration/29488/)[🟢](https://ci.wazuh.info/job/Test_integration/29494/)[🟢](https://ci.wazuh.info/job/Test_integration/29495/) | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |      [67de5](https://github.com/wazuh/wazuh-qa/pull/3110/commits/67de522e68be73ae2b6f1c58de60f5f6122f347b )        |         | Nothing to highlight |


