### PR TITLE
Add 'force reconnect' feature to agent_simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 Wazuh commit: TBD \
 Release report: TBD
 
+### Added
+
+- Add 'Force reconnect' feature to agent_simulator tool. ([#3093](https://github.com/wazuh/wazuh-qa/issues/3093)) \- (Tools)
+
 ### Changed
 
 - Update cluster logs in reliability tests ([#2772](https://github.com/wazuh/wazuh-qa/pull/2772)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Release report: TBD
 
 ### Added
 
-- Add 'Force reconnect' feature to agent_simulator tool. ([#3093](https://github.com/wazuh/wazuh-qa/issues/3093)) \- (Tools)
+- Add 'Force reconnect' feature to agent_simulator tool. ([#3111](https://github.com/wazuh/wazuh-qa/pull/3111)) \- (Tools)
 
 ### Changed
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -479,7 +479,7 @@ class Agent:
             if kind == 'file' and "merged.mg" in name:
                 self.update_checksum(checksum)
         elif '#!-force_reconnect' in msg_decoded_list[0]:
-            sender.reconnect()
+            sender.reconnect(self.startup_msg)
 
     def process_command(self, sender, message_list):
         """Process agent received commands through the socket.
@@ -1503,11 +1503,13 @@ class Sender:
         if is_udp(self.protocol):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-    def reconnect(self):
+    def reconnect(self, event):
         if is_tcp(self.protocol):
             self.socket.shutdown(socket.SHUT_RDWR)
             self.socket.close()
             self.connect()
+            if event:
+                self.send_event(event)
 
     def send_event(self, event):
         if is_tcp(self.protocol):

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -677,7 +677,8 @@ class Agent:
     def init_rootcheck(self):
         """Initialize rootcheck module."""
         if self.rootcheck is None:
-            self.rootcheck = Rootcheck(os = self.os, agent_name = self.name, agent_id = self.id, rootcheck_sample = self.rootcheck_sample)
+            self.rootcheck = Rootcheck(os=self.os, agent_name=self.name, agent_id=self.id,
+                                       rootcheck_sample=self.rootcheck_sample)
 
     def init_fim(self):
         """Initialize fim module."""


### PR DESCRIPTION
|Related issue|
|-------------|
| #3093 |

## Description

A [new system has been added](https://github.com/wazuh/wazuh/issues/13195) to the Wazuh master node that reconnects agents of a cluster when it is unbalanced. 

Large-scale tests (50,000 agents) will be required. For them, wazuh-qa's agent_simulator tool is used. It is important that said simulator is able to restart the connection with the manager so that the balancer can redistribute them.

Therefore, this PR adds the reconnect option to agent_simulator, which is a cornerstone of how the new rebalancing system works.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Agent_simulator now processes the `#!-force_reconnect` message and restarts the connection.

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Selutario (Developer)  |           | ⚫⚫⚫ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9142667/test1.txt) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9142678/test2.txt) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9142688/test3.txt)  | Ubuntu 20.04|         | Nothing to highlight |
| @juliamagan  (Reviewer)   |    test_active_response/    (Manager)   | [🟢 ](https://ci.wazuh.info/job/Test_integration/29600/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29618/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29619/)| :no_entry_sign: :no_entry_sign: :no_entry_sign:  |    CentOS    |   5e72428     | Nothing to highlight |
| @juliamagan  (Reviewer)   |    test_rids/       | [🟢 ](https://ci.wazuh.info/job/Test_integration/29603/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29620/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29621/) | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |    CentOS    |   5e72428     | Nothing to highlight |
| @juliamagan  (Reviewer)   |    test_rootcheck/       | [🟢 ](https://ci.wazuh.info/job/Test_integration/29604/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29622/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29623/) | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |    CentOS    |   5e72428     | Nothing to highlight |
| @juliamagan  (Reviewer)   |    test_remoted/       | [🟢 ](https://ci.wazuh.info/job/Test_integration/29602/)[🔴 ](https://ci.wazuh.info/job/Test_integration/29624/)[🟢 ](https://ci.wazuh.info/job/Test_integration/29625/)  | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |    CentOS    |   5e72428     | Not related to development |