### PR TITLE
E2E Test: New test case added to test Wazuh when an RDP brute force attack is attempted

### DIFF
--- a/tests/end_to_end/test_brute_force/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_brute_force/data/playbooks/configuration.yaml
@@ -1,0 +1,10 @@
+- name: Configure environment
+  hosts: localhost
+  become: true
+  tasks:
+
+    # Install hydra to attempt the RDP brute force attack
+    - name: Install hydra
+      package:
+        name: hydra
+        state: present

--- a/tests/end_to_end/test_brute_force/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_brute_force/data/playbooks/generate_events.yaml
@@ -10,6 +10,7 @@
   hosts: localhost
   tasks:
 
+    # Case: Unix agent
     - name: SSH connection
       expect:
         command: ssh {{item}}@wazuh-agent -i {{hostvars['wazuh-agent']['ansible_ssh_private_key_file']}}
@@ -17,18 +18,20 @@
           (.*)continue connecting(.*): 'yes'
           (?i)password: 1
         timeout: 5
-      loop:
-        - test_user
-        - test_user
-        - test_user
-        - test_user
-        - test_user
-        - test_user
-        - test_user
-        - test_user
+      loop: [test_user, test_user, test_user, test_user, test_user, test_user, test_user, test_user]
       register: result
       failed_when:
         - "'Permission denied' not in result.stdout"
+      when: agent_os == "Linux"
+
+    # Case: Windows agent
+    - name: Attempt a RDP brute force attack
+      shell: hydra -l {{ item }} -p invalid_password rdp://wazuh-windows
+      loop: [test_user, test_user, test_user, test_user, test_user, test_user, test_user, test_user]
+      register: result
+      failed_when:
+        - "'0 valid password found' not in result.stdout"
+      when: agent_os == "Windows"
 
     - name: Wait for alert
       wait_for:
@@ -42,5 +45,5 @@
       fetch:
         src: /var/ossec/logs/alerts/alerts.json
         dest: /tmp/
-        flat: yes
+        flat: true
       become: true

--- a/tests/end_to_end/test_brute_force/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_brute_force/data/playbooks/generate_events.yaml
@@ -18,7 +18,15 @@
           (.*)continue connecting(.*): 'yes'
           (?i)password: 1
         timeout: 5
-      loop: [test_user, test_user, test_user, test_user, test_user, test_user, test_user, test_user]
+      loop:
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
       register: result
       failed_when:
         - "'Permission denied' not in result.stdout"
@@ -27,7 +35,15 @@
     # Case: Windows agent
     - name: Attempt a RDP brute force attack
       shell: hydra -l {{ item }} -p invalid_password rdp://wazuh-windows
-      loop: [test_user, test_user, test_user, test_user, test_user, test_user, test_user, test_user]
+      loop:
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
+        - test_user
       register: result
       failed_when:
         - "'0 valid password found' not in result.stdout"

--- a/tests/end_to_end/test_brute_force/data/test_cases/cases_brute_force.yaml
+++ b/tests/end_to_end/test_brute_force/data/test_cases/cases_brute_force.yaml
@@ -7,3 +7,17 @@
     rule.description: "sshd: brute force trying to get access to the system. Non existent user."
     extra:
       mitre_technique: Brute Force
+    extra_vars:
+      agent_os: Linux
+
+- name: rdp_brute_force
+  description: Check if the alert is generated when executing a brute force attack via RDP.
+  configuration_parameters: null
+  metadata:
+    rule.id: 60204
+    rule.level: 10
+    rule.description: Multiple Windows logon failures.
+    extra:
+      mitre_technique: Brute Force
+    extra_vars:
+      agent_os: Windows

--- a/tests/end_to_end/test_brute_force/test_brute_force.py
+++ b/tests/end_to_end/test_brute_force/test_brute_force.py
@@ -14,6 +14,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 test_cases_file_path = os.path.join(test_data_path, 'test_cases', 'cases_brute_force.yaml')
 
 # Playbooks
+configuration_playbooks = ['configuration.yaml']
 events_playbooks = ['generate_events.yaml']
 teardown_playbooks = None
 
@@ -23,21 +24,21 @@ configurations, configuration_metadata, cases_ids = config.get_test_cases_data(t
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
-def test_brute_force(metadata, get_dashboard_credentials, generate_events, clean_alerts_index):
+def test_brute_force(configure_environment, metadata, get_dashboard_credentials, generate_events, clean_alerts_index):
     """
-    Test to detect a SSH Brute Force attack
+    Test to detect a SSH/RDP Brute Force attack
     """
     rule_id = metadata['rule.id']
     rule_level = metadata['rule.level']
     rule_description = metadata['rule.description']
     rule_mitre_technique = metadata['extra']['mitre_technique']
+    timestamp = r'\d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+'
 
-    expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)","rule"\:{{"level"\:{rule_level},' \
-                          fr'"description"\:"{rule_description}","id"\:"{rule_id}".*\}}'
+    expected_alert_json = fr'\{{"timestamp":"({timestamp})","rule"\:{{"level"\:{rule_level},' \
+                          fr'"description"\:"{rule_description}","id"\:"{rule_id}".*'
 
     expected_indexed_alert = fr'.*"rule":.*"level": {rule_level},.*"description": "{rule_description}"' \
-                             fr'.*"mitre":.*"{rule_mitre_technique}".*"id": "{rule_id}".*'\
-                             r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
+                             fr'.*"mitre":.*"{rule_mitre_technique}".*"id": "{rule_id}".*'
 
     # Check that alert has been raised and save timestamp
     raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
@@ -46,14 +47,14 @@ def test_brute_force(metadata, get_dashboard_credentials, generate_events, clean
 
     query = e2e.make_query([
         {
-           "term": {
-              "rule.id": f"{rule_id}"
-           }
+            "term": {
+                "rule.id": f"{rule_id}"
+            }
         },
         {
-           "term": {
-              "timestamp": f"{raised_alert_timestamp}"
-           }
+            "term": {
+                "timestamp": f"{raised_alert_timestamp}"
+            }
         }
     ])
 


### PR DESCRIPTION
|Related issue|
|-------------|
| #3026 |

## Description

[An existing test was modified](https://github.com/wazuh/wazuh-qa/pull/2938) to implement this test case. `hydra` was utilized to generate the RDP event and the unique requirement to execute this test is to create an inventory as follows:

```
all:
  hosts:
    wazuh-manager:
      ansible_connection: ssh
      ansible_user: ...
      ansible_password: ...
      ansible_ssh_private_key_file: ...
      ansible_python_interpreter: ...
      dashboard_user: ...
      dashboard_password: ...
  children:
    agents:
      hosts:
        wazuh-agent:
          ansible_connection: ssh
          ansible_user: ...
          ansible_password: ...
          ansible_ssh_private_key_file: ...
          ansible_python_interpreter: ...
        wazuh-windows:
          ansible_user: ...
          ansible_password: ...
          ansible_connection: winrm
          ansible_winrm_server_cert_validation: ignore
          ansible_winrm_transport: basic
          ansible_winrm_port: 5985
          ansible_python_interpreter: ...
```

### Added

- `configuration.yaml`: New playbook added to guarantee `hydra` is installed in the Ansible Control node

### Updated

- `cases_brute_force.yaml`: New test case added.
- `generate_events.yaml`: A task to attempt the RDP attack was added and the previously implemented task for SSH brute force attack was updated.
- `test_brute_force.py`: The "timestamp" regular expression was arranged to match the alert, whatever the configuration of the managed node is.

---

## Testing performed [![Code analysis](https://github.com/wazuh/wazuh-qa/actions/workflows/code_analysis.yaml/badge.svg?branch=3026-e2e-test-rdp-brute-force-attack)](https://github.com/wazuh/wazuh-qa/actions/runs/2761640677)

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  | end_to_end/test_brute_force | N/A | [🟢](https://github.com/wazuh/wazuh-qa/files/9221222/r1-CentOS-manager-3026.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9221223/r2-CentOS-manager-3026.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9221224/r3-CentOS-manager-3026.zip) | CentOS / Windows | 12ba212 | Nothing to highlight |
| @juliamagan  (Reviewer)   |     test_brute_force/      | :no_entry_sign: :no_entry_sign: :no_entry_sign: | [🟢 ](https://github.com/wazuh/wazuh-qa/files/9233259/R3-3137-test-rdp-brute-force.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9233265/R2-3137-test-rdp-brute-force.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9233266/R3-3137-test-rdp-brute-force.zip)  |   CentOS / Windows     |    12ba212     | Nothing to highlight |
