### PR TITLE
E2E Test: Windows Defender

### DIFF
--- a/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
@@ -17,7 +17,8 @@
       ansible.windows.win_shell: |
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<ossec_config>"
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<localfile>"
-        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<location>Microsoft-Windows-Windows Defender/Operational</location>"
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' `
+        "`n<location>Microsoft-Windows-Windows Defender/Operational</location>"
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<log_format>eventchannel</log_format>"
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n</localfile>"
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n</ossec_config>"
@@ -50,4 +51,3 @@
     - name: Restart wazuh-manager
       become: true
       shell: systemctl restart wazuh-manager
-

--- a/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
@@ -13,7 +13,7 @@
         dest: C:\temp
         remote_src: true
 
-    - name: Enable the agent module to collect installed packages (Windows)
+    - name: Enable the agent to collect eventchannel logs
       ansible.windows.win_shell: |
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<ossec_config>"
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<localfile>"

--- a/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
@@ -1,0 +1,53 @@
+- name: Test agent configuration
+  hosts: wazuh-windows
+  tasks:
+
+    - name: Create temp folder
+      win_file:
+        path: C:\temp
+        state: directory
+
+    - name: Copy ossec.conf
+      ansible.windows.win_copy:
+        src: C:\Program Files (x86)\ossec-agent\ossec.conf
+        dest: C:\temp
+        remote_src: true
+
+    - name: Enable the agent module to collect installed packages (Windows)
+      ansible.windows.win_shell: |
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<ossec_config>"
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<localfile>"
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<location>Microsoft-Windows-Windows Defender/Operational</location>"
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<log_format>eventchannel</log_format>"
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n</localfile>"
+        Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n</ossec_config>"
+
+    - name: Restart wazuh-agent (Windows)
+      ansible.windows.win_shell: |
+        net stop wazuh
+        net start wazuh
+
+- name: Test manager configuration
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Configure local rules
+      become: true
+      blockinfile:
+        path: /var/ossec/etc/rules/local_rules.xml
+        insertafter: </groups>
+        block: |
+          <group name="Defense Evasion,WindowsDefender">
+          <rule id="255303" level="12">
+          <if_sid>62100</if_sid>
+          <field name="win.system.eventID">^5001$</field>
+          <description>Windows Defender Real-time Protection was disabled.</description>
+          <group>defender,attack.t1089</group>
+          </rule>
+          </group>
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+
+    - name: Restart wazuh-manager
+      become: true
+      shell: systemctl restart wazuh-manager
+

--- a/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/configuration.yaml
@@ -13,7 +13,7 @@
         dest: C:\temp
         remote_src: true
 
-    - name: Enable the agent to collect eventchannel logs
+    - name: Enable the agent to collect Windows Defender logs
       ansible.windows.win_shell: |
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<ossec_config>"
         Add-Content 'C:\Program Files (x86)\ossec-agent\ossec.conf' "`n<localfile>"

--- a/tests/end_to_end/test_windows_defender/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/generate_events.yaml
@@ -1,0 +1,29 @@
+- name: Truncate files
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Truncate file alert.json
+      shell: echo "" > /var/ossec/logs/alerts/alerts.json
+      become: true
+
+- name: Generate events
+  hosts: wazuh-windows
+  tasks:
+
+    - name: Disable Windows Defender
+      ansible.windows.win_shell: Set-MpPreference -DisableRealtimeMonitoring 1
+
+- name: Wait alert
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Waiting for vulnerability scan, alert reporting and indexing
+      wait_for:
+        timeout: 60
+
+    - name: Get alerts.json
+      fetch:
+        src: /var/ossec/logs/alerts/alerts.json
+        dest: /tmp/
+        flat: true
+      become: true

--- a/tests/end_to_end/test_windows_defender/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/generate_events.yaml
@@ -10,16 +10,16 @@
   hosts: wazuh-windows
   tasks:
 
-    - name: Disable Windows Defender
-      ansible.windows.win_shell: Set-MpPreference -DisableRealtimeMonitoring 1
+    - name: "{{ event_description }}"
+      ansible.windows.win_shell: "{{ command }}"
 
 - name: Wait alert
   hosts: wazuh-manager
   tasks:
 
-    - name: Waiting for vulnerability scan, alert reporting and indexing
+    - name: Waiting for alert
       wait_for:
-        timeout: 60
+        timeout: 5
 
     - name: Get alerts.json
       fetch:

--- a/tests/end_to_end/test_windows_defender/data/playbooks/teardown.yaml
+++ b/tests/end_to_end/test_windows_defender/data/playbooks/teardown.yaml
@@ -1,0 +1,22 @@
+- name: Cleanup environment
+  hosts: wazuh-windows
+  tasks:
+
+    - name: Restore ossec.conf without changes
+      ansible.windows.win_copy:
+        src: C:\temp\ossec.conf
+        dest: C:\Program Files (x86)\ossec-agent
+        remote_src: true
+
+    - name: Delete C:\temp folder
+      ansible.windows.win_file:
+        path: C:\temp
+        state: absent
+
+    - name: Enable Windows Defender
+      ansible.windows.win_shell: set-MpPreference -DisableRealtimeMonitoring $False
+
+    - name: Restart wazuh-agent (Windows)
+      ansible.windows.win_shell: |
+        net stop wazuh
+        net start wazuh

--- a/tests/end_to_end/test_windows_defender/data/test_cases/cases_windows_defender.yaml
+++ b/tests/end_to_end/test_windows_defender/data/test_cases/cases_windows_defender.yaml
@@ -1,0 +1,11 @@
+- name: detect_windows_defender_disable
+  description: Detect when Windows Defender is disabled
+  configuration_parameters: null
+  metadata:
+    extra_vars:
+      os: Windows
+      event_description: Disable Windows Defender
+      command: Set-MpPreference -DisableRealtimeMonitoring 1
+    rule.id: 255303
+    rule.level: 12
+    rule.description: Windows Defender Real-time Protection was disabled.

--- a/tests/end_to_end/test_windows_defender/data/test_cases/cases_windows_defender.yaml
+++ b/tests/end_to_end/test_windows_defender/data/test_cases/cases_windows_defender.yaml
@@ -3,7 +3,6 @@
   configuration_parameters: null
   metadata:
     extra_vars:
-      os: Windows
       event_description: Disable Windows Defender
       command: Set-MpPreference -DisableRealtimeMonitoring 1
     rule.id: 255303

--- a/tests/end_to_end/test_windows_defender/test_windows_defender.py
+++ b/tests/end_to_end/test_windows_defender/test_windows_defender.py
@@ -11,7 +11,7 @@ from wazuh_testing import event_monitor as evm
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-test_cases_file_path = os.path.join(test_data_path, 'test_cases', 'cases_vulnerability_detector.yaml')
+test_cases_file_path = os.path.join(test_data_path, 'test_cases', 'cases_windows_defender.yaml')
 
 # Playbooks
 configuration_playbooks = ['configuration.yaml']
@@ -19,50 +19,50 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 # Configuration
-#configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
-#@pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
-def test_vulnerability_detector(configure_environment, generate_events):
+@pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
+def test_windows_defender(configure_environment, metadata, get_dashboard_credentials, generate_events,
+                          clean_alerts_index):
     """
     Test to detect a vulnerability
     """
-    print('HOLAAA')
-    # rule_level = metadata['rule.level']
-    # rule_id = metadata['rule.id']
-    # rule_description = metadata['rule.description']
+    rule_level = metadata['rule.level']
+    rule_id = metadata['rule.id']
+    rule_description = metadata['rule.description']
 
-    # expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)",' \
-    #                       fr'"rule"\:{{"level"\:{rule_level},' \
-    #                       fr'"description"\:"{rule_description}","id"\:"{rule_id}".*\}}'
+    expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)",' \
+                          fr'"rule"\:{{"level"\:{rule_level},' \
+                          fr'"description"\:"{rule_description}","id"\:"{rule_id}".*\}}'
 
-    # expected_indexed_alert = fr'.*"rule":.*"level": {rule_level},.*"description": "{rule_description}"' \
-    #                          fr'.*"id": "{rule_id}".*' \
-    #                          r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
+    expected_indexed_alert = fr'.*"rule":.*"level": {rule_level},.*"description": "{rule_description}"' \
+                             fr'.*"id": "{rule_id}".*' \
+                             r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
 
-    # # Check that alert has been raised and save timestamp
-    # raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
-    #                                error_message='The alert has not occurred').result()
-    # raised_alert_timestamp = raised_alert.group(1)
+    # Check that alert has been raised and save timestamp
+    raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
+                                   error_message='The alert has not occurred').result()
+    raised_alert_timestamp = raised_alert.group(1)
 
-    # query = e2e.make_query([
-    #     {
-    #         "term": {
-    #             "rule.id": f"{rule_id}"
-    #         }
-    #     },
-    #     {
-    #         "term": {
-    #             "timestamp": f"{raised_alert_timestamp}"
-    #         }
-    #     }
-    # ])
+    query = e2e.make_query([
+        {
+            "term": {
+                "rule.id": f"{rule_id}"
+            }
+        },
+        {
+            "term": {
+                "timestamp": f"{raised_alert_timestamp}"
+            }
+        }
+    ])
 
-    # # Check if the alert has been indexed and get its data
-    # response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
-    # indexed_alert = json.dumps(response.json())
+    # Check if the alert has been indexed and get its data
+    response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
+    indexed_alert = json.dumps(response.json())
 
-    # # Check that the alert data is the expected one
-    # alert_data = re.search(expected_indexed_alert, indexed_alert)
-    # assert alert_data is not None, 'Alert triggered, but not indexed'
+    # Check that the alert data is the expected one
+    alert_data = re.search(expected_indexed_alert, indexed_alert)
+    assert alert_data is not None, 'Alert triggered, but not indexed'

--- a/tests/end_to_end/test_windows_defender/test_windows_defender.py
+++ b/tests/end_to_end/test_windows_defender/test_windows_defender.py
@@ -1,0 +1,68 @@
+import os
+import json
+import re
+import pytest
+from tempfile import gettempdir
+
+from wazuh_testing.tools import configuration as config
+from wazuh_testing import end_to_end as e2e
+from wazuh_testing import event_monitor as evm
+
+# Test cases data
+alerts_json = os.path.join(gettempdir(), 'alerts.json')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_file_path = os.path.join(test_data_path, 'test_cases', 'cases_vulnerability_detector.yaml')
+
+# Playbooks
+configuration_playbooks = ['configuration.yaml']
+events_playbooks = ['generate_events.yaml']
+teardown_playbooks = ['teardown.yaml']
+
+# Configuration
+#configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+#@pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
+def test_vulnerability_detector(configure_environment, generate_events):
+    """
+    Test to detect a vulnerability
+    """
+    print('HOLAAA')
+    # rule_level = metadata['rule.level']
+    # rule_id = metadata['rule.id']
+    # rule_description = metadata['rule.description']
+
+    # expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)",' \
+    #                       fr'"rule"\:{{"level"\:{rule_level},' \
+    #                       fr'"description"\:"{rule_description}","id"\:"{rule_id}".*\}}'
+
+    # expected_indexed_alert = fr'.*"rule":.*"level": {rule_level},.*"description": "{rule_description}"' \
+    #                          fr'.*"id": "{rule_id}".*' \
+    #                          r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
+
+    # # Check that alert has been raised and save timestamp
+    # raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
+    #                                error_message='The alert has not occurred').result()
+    # raised_alert_timestamp = raised_alert.group(1)
+
+    # query = e2e.make_query([
+    #     {
+    #         "term": {
+    #             "rule.id": f"{rule_id}"
+    #         }
+    #     },
+    #     {
+    #         "term": {
+    #             "timestamp": f"{raised_alert_timestamp}"
+    #         }
+    #     }
+    # ])
+
+    # # Check if the alert has been indexed and get its data
+    # response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
+    # indexed_alert = json.dumps(response.json())
+
+    # # Check that the alert data is the expected one
+    # alert_data = re.search(expected_indexed_alert, indexed_alert)
+    # assert alert_data is not None, 'Alert triggered, but not indexed'


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh-qa/issues/3127     |

## Description

The test research was accomplished in https://github.com/wazuh/wazuh-qa/issues/2878. So, in this issue, we develop the E2E test to cover those use cases.
<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added

Windows Defender disable event 

### Configuration options

To launch these tests, we must indicate the path of the inventory:

```
python -m pytest -vvvs tests/end_to_end/test_windows_defender/ --inventory_path=/home/belen/Repositories/wazuh-qa/tests/end_to_end/general_playbooks/inventory.yml 
```
It should be noted that, for local environments, it will be necessary to create the inventory for the moment. It should contain the following:

```
all:
  hosts:
    wazuh-manager:
      ansible_connection: ssh
      ansible_user: vagrant
      ansible_ssh_private_key_file: <path_to_private_key>
      ansible_python_interpreter: /usr/bin/python3
     
    wazuh-windows:
      ansible_user: vagrant
      ansible_password: vagrant
      ansible_connection: winrm
      ansible_winrm_server_cert_validation: ignore
      ansible_winrm_transport: basic
      ansible_winrm_port: 5985
      ansible_python_interpreter: C:\Users\vagrant\AppData\Local\Programs\Pyhton\Python39\python.exe
```

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |    test_windows_defender/       | :no_entry_sign: :no_entry_sign: :no_entry_sign:|  [🟢](https://github.com/wazuh/wazuh-qa/files/9222205/R1-test-windows-defender.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9222206/R2-test-windows-defender.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9222207/R3-test-windows-defender.zip) |     Windows    |    a2a32cf09b49f318393d5d1265e16a29a635d7b7     | Nothing to highlight |
| @user (Reviewer)   |    test_windows_defender/       | :no_entry_sign: :no_entry_sign: :no_entry_sign:| [🟢 ](https://github.com/wazuh/wazuh-qa/files/9258705/R1-3138-test-windows-defender.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9258707/R2-3138-test-windows-defender.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9258712/R3-3138-test-windows-defender.zip) |    CentOS and Windows    |   dfea381      | Nothing to highlight |


