### PR TITLE
 IT Authd: Fix authd nightly fails - 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release report: TBD
 
 ### Changed
 
+- Change how 'service_control' collects clusterd and apid pids ([#3140](https://github.com/wazuh/wazuh-qa/pull/3140)) \- (Framework)
 - Change scan test module fixtures to allow use commit instead of branches ([#3134](https://github.com/wazuh/wazuh-qa/issues/3134)) \- (Tests)
 - Update syscollector deltas integration tests ([#2921](https://github.com/wazuh/wazuh-qa/pull/2921)) \- (Tests)
 - Update deprecated WDB commands ([#2966](https://github.com/wazuh/wazuh-qa/pull/2966)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -115,8 +115,12 @@ def control_service(action, daemon=None, debug_mode=False):
                 for proc in psutil.process_iter():
                     try:
                         if daemon in ['wazuh-clusterd', 'wazuh-apid']:
-                            if any(filter(lambda x: f"{daemon}.py" in x, proc.cmdline())):
-                                processes.append(proc)
+                                for file in os.listdir(f'{WAZUH_PATH}/var/run'):
+                                    if daemon in file:
+                                        pid = file.split("-")
+                                        pid = pid[2][0:-4]
+                                        if pid == str(proc.pid):
+                                            processes.append(proc)
                         elif daemon in proc.name() or daemon in ' '.join(proc.cmdline()):
                             processes.append(proc)
                     except (psutil.NoSuchProcess, psutil.AccessDenied):

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -115,12 +115,12 @@ def control_service(action, daemon=None, debug_mode=False):
                 for proc in psutil.process_iter():
                     try:
                         if daemon in ['wazuh-clusterd', 'wazuh-apid']:
-                                for file in os.listdir(f'{WAZUH_PATH}/var/run'):
-                                    if daemon in file:
-                                        pid = file.split("-")
-                                        pid = pid[2][0:-4]
-                                        if pid == str(proc.pid):
-                                            processes.append(proc)
+                            for file in os.listdir(f'{WAZUH_PATH}/var/run'):
+                                if daemon in file:
+                                    pid = file.split("-")
+                                    pid = pid[2][0:-4]
+                                    if pid == str(proc.pid):
+                                        processes.append(proc)
                         elif daemon in proc.name() or daemon in ' '.join(proc.cmdline()):
                             processes.append(proc)
                     except (psutil.NoSuchProcess, psutil.AccessDenied):


### PR DESCRIPTION
|Related issue|
|-------------|
|#2922|

## Description

The Authd test suite was failing in the nightly pipeline. It was found that the errors and fails were being caused by the `control_service` function failing to stop the clusterd daemon. During research it was found that sometimes it was unable to get the process that needed to be stopped. This PR fixes that by changing how `control_service` gets the PID for the process and the process itself.


---

### Updated

- Modified `control_service` function from `/deps/wazuh_testing/tools/services.py`. Changed how it gets the PIDs of the `clusterd` and `apid`daemons, now it retrieves them from the `/var/ossec/var/run` folder and the files associated with each daemon.

---

## Testing performed
| Tester             | Test path | Local | Jenkins  | OS | Commit | Package revision | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|-------|
| @Deblintrake09 (Developer)  | /test_authd/           | ⚫⚫⚫  | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/29984/) [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/29985/) [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/29986/) | Centos8 | https://github.com/wazuh/wazuh/commit/5104716dbad4138c6e99339118f742e7fc5f925f | 13608.dev.cloud.limits | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

