### PR TITLE
E2E test: IP reputation and Active Response

### DIFF
--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -16,29 +16,33 @@
       shell: yum install python39 -y
 
     - name: Download Alienvault IP
-      become: yes
-      shell: wget https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset -O /var/ossec/etc/lists/alienvault_reputation.ipset
+      become: true
+      shell: >
+        wget https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset
+        -O /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Download script to convert from ipset format to cdblist format
-      become: yes
+      become: true
       shell: wget https://wazuh.com/resources/iplist-to-cdblist.py -O /tmp/iplist-to-cdblist.py
 
     - name: Add the attacker IP to the list
-      become: yes
+      become: true
       shell: echo "{{ attacker_ip_win }}" >> /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Convert .ipset to .cdb using script
-      become: yes
-      shell: python3 /tmp/iplist-to-cdblist.py /var/ossec/etc/lists/alienvault_reputation.ipset /var/ossec/etc/lists/blacklist-alienvault
+      become: true
+      shell: >
+        python3 /tmp/iplist-to-cdblist.py /var/ossec/etc/lists/alienvault_reputation.ipset
+        /var/ossec/etc/lists/blacklist-alienvault
 
     - name: Remove the .ipset file and the script
-      become: yes
+      become: true
       shell: |
         rm -rf /var/ossec/etc/lists/alienvault_reputation.ipset
         rm -rf /var/ossec/etc/lists/iplist-to-cdblist.py
 
     - name: Assign the right permissions and owner to the file
-      become: yes
+      become: true
       shell: |
         chown wazuh:wazuh /var/ossec/etc/lists/blacklist-alienvault
         chmod 660 /var/ossec/etc/lists/blacklist-alienvault
@@ -84,13 +88,13 @@
         path: /var/ossec/etc/rules/local_rules.xml
         insertafter: </groups>
         block: |
-         <group name="attack,">
-         <rule id="100100" level="10">
-         <if_group>web|attack|attacks</if_group>
-         <list field="srcip" lookup="address_match_key">etc/lists/blacklist-alienvault</list>
-         <description>IP address found in AlienVault reputation database.</description>
-         </rule>
-         </group>
+          <group name="attack,">
+          <rule id="100100" level="10">
+          <if_group>web|attack|attacks</if_group>
+          <list field="srcip" lookup="address_match_key">etc/lists/blacklist-alienvault</list>
+          <description>IP address found in AlienVault reputation database.</description>
+          </rule>
+          </group>
         marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
 
     - name: Restart the manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -11,10 +11,6 @@
       become: true
       shell: systemctl start httpd
 
-    - name: Install pyhton
-      become: true
-      shell: yum install python39 -y
-
     - name: Download Alienvault IP set
       become: true
       shell: >

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -27,7 +27,7 @@
 
     - name: Add the attacker IP to the list
       become: true
-      shell: echo "{{ attacker_ip_win }}" >> /var/ossec/etc/lists/alienvault_reputation.ipset
+      shell: echo "{{ hostvars['wazuh-windows']['ip_address'] }}" >> /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Convert .ipset to .cdb using script
       become: true
@@ -100,3 +100,13 @@
     - name: Restart the manager
       become: true
       shell: systemctl restart wazuh-manager
+
+- name: Windows agent configuration
+  hosts: wazuh-windows
+  tasks:
+
+    - name: Add hostname to hosts file
+      win_lineinfile:
+        path: C:\Windows\System32\drivers\etc\hosts
+        line: |
+          {{ hostvars['wazuh-manager']['ip_address'] }} wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -5,7 +5,7 @@
 
     - name: Install apache
       become: true
-      shell: dnf install httpd -y
+      shell: yum install httpd -y
 
     - name: Start apache
       become: true
@@ -25,7 +25,7 @@
 
     - name: Add the attacker IP to the list
       become: yes
-      shell: echo "192.168.0.16" >> /var/ossec/etc/lists/alienvault_reputation.ipset
+      shell: echo "{{ attacker_ip_win }}" >> /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Convert .ipset to .cdb using script
       become: yes
@@ -43,7 +43,7 @@
         chown wazuh:wazuh /var/ossec/etc/lists/blacklist-alienvault
         chmod 660 /var/ossec/etc/lists/blacklist-alienvault
 
-    - name: Configure localfile
+    - name: Configure ossec.conf
       blockinfile:
         path: /var/ossec/etc/ossec.conf
         insertbefore: </ossec_config>
@@ -78,7 +78,7 @@
           </active-response>
         marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
 
-    - name: Configure local rules virus total integration
+    - name: Configure local rules active response
       become: true
       blockinfile:
         path: /var/ossec/etc/rules/local_rules.xml
@@ -94,4 +94,5 @@
         marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
 
     - name: Restart the manager
+      become: true
       shell: systemctl restart wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -56,6 +56,7 @@
           <log_format>apache</log_format>
           <location>/var/log/httpd/access_log</location>
           </localfile>
+
           <ruleset>
           <!-- Default ruleset -->
           <decoder_dir>ruleset/decoders</decoder_dir>

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -78,7 +78,7 @@
           </active-response>
         marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
 
-    - name: Configure local rules active response
+    - name: Configure local rules
       become: true
       blockinfile:
         path: /var/ossec/etc/rules/local_rules.xml

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -1,0 +1,97 @@
+- name: Test manager configuration
+  hosts: wazuh-manager
+  become: true
+  tasks:
+
+    - name: Install apache
+      become: true
+      shell: dnf install httpd -y
+
+    - name: Start apache
+      become: true
+      shell: systemctl start httpd
+
+    - name: Install pyhton
+      become: true
+      shell: yum install python39 -y
+
+    - name: Download Alienvault IP
+      become: yes
+      shell: wget https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset -O /var/ossec/etc/lists/alienvault_reputation.ipset
+
+    - name: Download script to convert from ipset format to cdblist format
+      become: yes
+      shell: wget https://wazuh.com/resources/iplist-to-cdblist.py -O /tmp/iplist-to-cdblist.py
+
+    - name: Add the attacker IP to the list
+      become: yes
+      shell: echo "192.168.0.16" >> /var/ossec/etc/lists/alienvault_reputation.ipset
+
+    - name: Convert .ipset to .cdb using script
+      become: yes
+      shell: python3 /tmp/iplist-to-cdblist.py /var/ossec/etc/lists/alienvault_reputation.ipset /var/ossec/etc/lists/blacklist-alienvault
+
+    - name: Remove the .ipset file and the script
+      become: yes
+      shell: |
+        rm -rf /var/ossec/etc/lists/alienvault_reputation.ipset
+        rm -rf /var/ossec/etc/lists/iplist-to-cdblist.py
+
+    - name: Assign the right permissions and owner to the file
+      become: yes
+      shell: |
+        chown wazuh:wazuh /var/ossec/etc/lists/blacklist-alienvault
+        chmod 660 /var/ossec/etc/lists/blacklist-alienvault
+
+    - name: Configure localfile
+      blockinfile:
+        path: /var/ossec/etc/ossec.conf
+        insertbefore: </ossec_config>
+        block: |
+          <localfile>
+          <log_format>apache</log_format>
+          <location>/var/log/httpd/access_log</location>
+          </localfile>
+          <ruleset>
+          <!-- Default ruleset -->
+          <decoder_dir>ruleset/decoders</decoder_dir>
+          <rule_dir>ruleset/rules</rule_dir>
+          <rule_exclude>0215-policy_rules.xml</rule_exclude>
+          <list>etc/lists/audit-keys</list>
+          <list>etc/lists/blacklist-alienvault</list>
+          <!-- User-defined ruleset -->
+          <decoder_dir>etc/decoders</decoder_dir>
+          <rule_dir>etc/rules</rule_dir>
+          </ruleset>
+
+          <command>
+          <name>firewall-drop</name>
+          <executable>firewall-drop</executable>
+          <timeout_allowed>yes</timeout_allowed>
+          </command>
+
+          <active-response>
+          <command>firewall-drop</command>
+          <location>server</location>
+          <rules_id>100100</rules_id>
+          <timeout>10s</timeout>
+          </active-response>
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+
+    - name: Configure local rules virus total integration
+      become: true
+      blockinfile:
+        path: /var/ossec/etc/rules/local_rules.xml
+        insertafter: </groups>
+        block: |
+         <group name="attack,">
+         <rule id="100100" level="10">
+         <if_group>web|attack|attacks</if_group>
+         <list field="srcip" lookup="address_match_key">etc/lists/blacklist-alienvault</list>
+         <description>IP address found in AlienVault reputation database.</description>
+         </rule>
+         </group>
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+
+    - name: Restart the manager
+      shell: systemctl restart wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -14,11 +14,11 @@
     - name: Download Alienvault IP set
       become: true
       shell: |
-        curl {{ s3_url }}ip_reputation/alienvault_reputation.ipset -o /var/ossec/etc/lists/alienvault_reputation.ipset
+        curl {{ s3_url }}/ip_reputation/alienvault_reputation.ipset -o /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Download script to convert from ipset format to cdblist format
       become: true
-      shell: curl {{ s3_url }}ip_reputation/iplist-to-cdblist.py -o /tmp/iplist-to-cdblist.py
+      shell: curl {{ s3_url }}/ip_reputation/iplist-to-cdblist.py -o /tmp/iplist-to-cdblist.py
 
     - name: Add the attacker IP to the list
       become: true

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -15,15 +15,15 @@
       become: true
       shell: yum install python39 -y
 
-    - name: Download Alienvault IP
+    - name: Download Alienvault IP set
       become: true
       shell: >
-        wget https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset
-        -O /var/ossec/etc/lists/alienvault_reputation.ipset
+        curl https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset
+        -o /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Download script to convert from ipset format to cdblist format
       become: true
-      shell: wget https://wazuh.com/resources/iplist-to-cdblist.py -O /tmp/iplist-to-cdblist.py
+      shell: curl https://wazuh.com/resources/iplist-to-cdblist.py -o /tmp/iplist-to-cdblist.py
 
     - name: Add the attacker IP to the list
       become: true

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/configuration.yaml
@@ -13,13 +13,12 @@
 
     - name: Download Alienvault IP set
       become: true
-      shell: >
-        curl https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset
-        -o /var/ossec/etc/lists/alienvault_reputation.ipset
+      shell: |
+        curl {{ s3_url }}ip_reputation/alienvault_reputation.ipset -o /var/ossec/etc/lists/alienvault_reputation.ipset
 
     - name: Download script to convert from ipset format to cdblist format
       become: true
-      shell: curl https://wazuh.com/resources/iplist-to-cdblist.py -o /tmp/iplist-to-cdblist.py
+      shell: curl {{ s3_url }}ip_reputation/iplist-to-cdblist.py -o /tmp/iplist-to-cdblist.py
 
     - name: Add the attacker IP to the list
       become: true

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
@@ -11,8 +11,8 @@
   tasks:
 
     - name: "{{ event_description }}"
-      ansible.windows.win_shell:   "{{ command }}"
-      ignore_errors: yes # Ignore powershell error
+      ansible.windows.win_shell: "{{ command }}"
+      ignore_errors: true # Ignore powershell error
 
 - name: Wait alert
   hosts: wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
@@ -10,19 +10,17 @@
   hosts: wazuh-windows
   tasks:
 
-    - name: apache
-      ansible.windows.win_shell: |
-        $Web = New-Object Net.WebClient
-        $Web.DownloadString("http://192.168.0.17")
-      ignore_errors: yes
+    - name: "{{ event_description }}"
+      ansible.windows.win_shell:   "{{ command }}"
+      ignore_errors: yes # Added 'ignore errors' because the IP is blacklisted
 
 - name: Wait alert
   hosts: wazuh-manager
   tasks:
 
-    - name: Waiting for vulnerability scan, alert reporting and indexing
+    - name: Waiting for alert
       wait_for:
-        timeout: 60
+        timeout: 5
 
     - name: Get alerts.json
       fetch:

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
@@ -12,8 +12,8 @@
 
     - name: "{{ event_description }}"
       ansible.windows.win_shell: "{{ command }}"
-      # Ignore powershell error
-      ignore_errors: true
+      register: result
+      failed_when: "'Forbidden' not in result.stderr"
 
 - name: Wait alert
   hosts: wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
@@ -1,0 +1,32 @@
+- name: Truncate files
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Truncate file alert.json
+      shell: echo "" > /var/ossec/logs/alerts/alerts.json
+      become: true
+
+- name: Generate events
+  hosts: wazuh-windows
+  tasks:
+
+    - name: apache
+      ansible.windows.win_shell: |
+        $Web = New-Object Net.WebClient
+        $Web.DownloadString("http://192.168.0.17")
+      ignore_errors: yes
+
+- name: Wait alert
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Waiting for vulnerability scan, alert reporting and indexing
+      wait_for:
+        timeout: 60
+
+    - name: Get alerts.json
+      fetch:
+        src: /var/ossec/logs/alerts/alerts.json
+        dest: /tmp/
+        flat: true
+      become: true

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
@@ -12,7 +12,7 @@
 
     - name: "{{ event_description }}"
       ansible.windows.win_shell:   "{{ command }}"
-      ignore_errors: yes # Added 'ignore errors' because the IP is blacklisted
+      ignore_errors: yes # Ignore powershell error
 
 - name: Wait alert
   hosts: wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/generate_events.yaml
@@ -12,7 +12,8 @@
 
     - name: "{{ event_description }}"
       ansible.windows.win_shell: "{{ command }}"
-      ignore_errors: true # Ignore powershell error
+      # Ignore powershell error
+      ignore_errors: true
 
 - name: Wait alert
   hosts: wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/teardown.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/teardown.yaml
@@ -27,3 +27,13 @@
     - name: Restart the manager
       become: true
       shell: systemctl restart wazuh-manager
+
+- name: Cleanup Windows agent environment
+  hosts: wazuh-windows
+  tasks:
+
+    - name: Delete syscheck configuration
+      win_lineinfile:
+        path: C:\Windows\System32\drivers\etc\hosts
+        regex: wazuh-manager
+        state: absent

--- a/tests/end_to_end/test_ip_reputation/data/playbooks/teardown.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/playbooks/teardown.yaml
@@ -1,0 +1,29 @@
+- name: Cleanup environment
+  hosts: wazuh-manager
+  tasks:
+
+    - name: Uninstall apache
+      become: true
+      command: yum remove httpd -y
+
+    - name: Uninstall python
+      become: true
+      command: yum remove python39 -y
+
+    - name: Delete added rules
+      become: true
+      blockinfile:
+        path: /var/ossec/etc/rules/local_rules.xml
+        block: ''
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+
+    - name: Delete the ossec.conf configuration
+      become: true
+      blockinfile:
+        path: /var/ossec/etc/ossec.conf
+        block: ''
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+
+    - name: Restart the manager
+      become: true
+      shell: systemctl restart wazuh-manager

--- a/tests/end_to_end/test_ip_reputation/data/test_cases/cases_ip_reputation.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/test_cases/cases_ip_reputation.yaml
@@ -1,0 +1,15 @@
+- name: ip_reputation_active_response
+  description: Detecting IP reputation
+  configuration_parameters: null
+  metadata:
+    extra_vars:
+      event_description: Access Apache wen server
+      command: |
+        $Web = New-Object Net.WebClient
+        $Web.DownloadString("http://192.168.0.17")
+    rule.id: 641
+    rule.level: 12
+    rule.description: 
+    rule.id.alienvault: 100100
+    rule.level.alienvault: 10
+    rule.description.alienvault: IP address found in AlienVault reputation database

--- a/tests/end_to_end/test_ip_reputation/data/test_cases/cases_ip_reputation.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/test_cases/cases_ip_reputation.yaml
@@ -3,13 +3,15 @@
   configuration_parameters: null
   metadata:
     extra_vars:
-      event_description: Access Apache wen server
+      event_description: Access Apache web server
       command: |
         $Web = New-Object Net.WebClient
-        $Web.DownloadString("http://192.168.0.17")
-    rule.id: 641
-    rule.level: 12
-    rule.description: 
-    rule.id.alienvault: 100100
-    rule.level.alienvault: 10
-    rule.description.alienvault: IP address found in AlienVault reputation database
+        $Web.DownloadString("http://wazuh-manager")
+    malicious_ip:
+      rule.id: 100100
+      rule.level: 10
+      rule.description: IP address found in AlienVault reputation database.
+    active_response:
+      rule.id: 651
+      rule.level: 3
+      rule.description : Host Blocked by firewall-drop Active Response

--- a/tests/end_to_end/test_ip_reputation/data/test_cases/cases_ip_reputation.yaml
+++ b/tests/end_to_end/test_ip_reputation/data/test_cases/cases_ip_reputation.yaml
@@ -14,4 +14,4 @@
     active_response:
       rule.id: 651
       rule.level: 3
-      rule.description : Host Blocked by firewall-drop Active Response
+      rule.description: Host Blocked by firewall-drop Active Response

--- a/tests/end_to_end/test_ip_reputation/test_ip_reputation.py
+++ b/tests/end_to_end/test_ip_reputation/test_ip_reputation.py
@@ -38,13 +38,13 @@ def test_ip_reputation(configure_environment, metadata, get_dashboard_credential
 
     for alert in ip_alerts:
         expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)",' \
-                            fr'"rule"\:{{"level"\:{alert["rule_level"]},' \
-                            fr'"description"\:"{alert["rule_description"]}","id"\:"{alert["rule_id"]}".*\}}'
+                              fr'"rule"\:{{"level"\:{alert["rule_level"]},' \
+                              fr'"description"\:"{alert["rule_description"]}","id"\:"{alert["rule_id"]}".*\}}'
 
         expected_indexed_alert = fr'.*"rule":.*"level": {alert["rule_level"]},' \
-                                fr'.*"description": "{alert["rule_description"]}"' \
-                                fr'.*"id": "{alert["rule_id"]}".*'\
-                                r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
+                                 fr'.*"description": "{alert["rule_description"]}"' \
+                                 fr'.*"id": "{alert["rule_id"]}".*'\
+                                 r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
 
         # Check that alert has been raised and save timestamp
         raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,

--- a/tests/end_to_end/test_ip_reputation/test_ip_reputation.py
+++ b/tests/end_to_end/test_ip_reputation/test_ip_reputation.py
@@ -27,24 +27,28 @@ def test_ip_reputation(configure_environment, metadata, get_dashboard_credential
     Test to detect a IP Reputation
     """
 
-    first_alert = {"rule_id": metadata['malicious_ip']['rule.id'], "rule_level": metadata['malicious_ip']['rule.level'],
+    first_alert = {"rule_id": metadata['malicious_ip']['rule.id'],
+                   "rule_level": metadata['malicious_ip']['rule.level'],
                    "rule_description": metadata['malicious_ip']['rule.description']}
-    second_alert = {"rule_id": metadata['active_response']['rule.id'], "rule_level": metadata['active_response']['rule.level'],
+    second_alert = {"rule_id": metadata['active_response']['rule.id'],
+                    "rule_level": metadata['active_response']['rule.level'],
                     "rule_description": metadata['active_response']['rule.description']}
 
     ip_alerts = [first_alert, second_alert]
 
     for alert in ip_alerts:
-        expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)","rule"\:{{"level"\:{alert["rule_level"]},' \
+        expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)",' \
+                            fr'"rule"\:{{"level"\:{alert["rule_level"]},' \
                             fr'"description"\:"{alert["rule_description"]}","id"\:"{alert["rule_id"]}".*\}}'
 
-        expected_indexed_alert = fr'.*"rule":.*"level": {alert["rule_level"]},.*"description": "{alert["rule_description"]}"' \
+        expected_indexed_alert = fr'.*"rule":.*"level": {alert["rule_level"]},' \
+                                fr'.*"description": "{alert["rule_description"]}"' \
                                 fr'.*"id": "{alert["rule_id"]}".*'\
                                 r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
 
         # Check that alert has been raised and save timestamp
         raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
-                                    error_message='The alert has not occurred').result()
+                                       error_message='The alert has not occurred').result()
         raised_alert_timestamp = raised_alert.group(1)
 
         rule_id = alert["rule_id"]
@@ -53,12 +57,12 @@ def test_ip_reputation(configure_environment, metadata, get_dashboard_credential
 
             {
                 "term": {
-                "rule.id": f"{rule_id}"
+                   "rule.id": f"{rule_id}"
                 }
             },
             {
                 "term": {
-                "timestamp": f"{raised_alert_timestamp}"
+                  "timestamp": f"{raised_alert_timestamp}"
                 }
             }
         ])

--- a/tests/end_to_end/test_ip_reputation/test_ip_reputation.py
+++ b/tests/end_to_end/test_ip_reputation/test_ip_reputation.py
@@ -1,0 +1,66 @@
+import os
+import json
+import re
+import pytest
+from tempfile import gettempdir
+
+from wazuh_testing import end_to_end as e2e
+from wazuh_testing import event_monitor as evm
+from wazuh_testing.tools import configuration as config
+
+
+alerts_json = os.path.join(gettempdir(), 'alerts.json')
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_file_path = os.path.join(test_data_path, 'test_cases', 'cases_sql_injection.yaml')
+configuration_playbooks = ['configuration.yaml']
+events_playbooks = ['generate_events.yaml']
+teardown_playbooks = ['teardown.yaml']
+
+#configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+
+@pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
+#@pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
+def test_ip_reputation(configure_environment, metadata, get_dashboard_credentials, generate_events,
+                       clean_alerts_index):
+    """
+    Test to detect a SQL injection attack
+    """
+    # rule_id = metadata['rule.id']
+    # rule_level = metadata['rule.level']
+    # rule_description = metadata['rule.description']
+    # rule_mitre_technique = metadata['extra']['mitre_technique']
+
+    # expected_alert_json = fr'\{{"timestamp":"(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)","rule"\:{{"level"\:{rule_level},' \
+    #                       fr'"description"\:"{rule_description}","id"\:"{rule_id}".*\}}'
+
+    # expected_indexed_alert = fr'.*"rule":.*"level": {rule_level},.*"description": "{rule_description}"' \
+    #                          fr'.*"mitre":.*"{rule_mitre_technique}".*"id": "{rule_id}".*'\
+    #                          r'"timestamp": "(\d+\-\d+\-\w+\:\d+\:\d+\.\d+\+\d+)".*'
+
+    # # Check that alert has been raised and save timestamp
+    # raised_alert = evm.check_event(callback=expected_alert_json, file_to_monitor=alerts_json,
+    #                                error_message='The alert has not occurred').result()
+    # raised_alert_timestamp = raised_alert.group(1)
+
+    # query = e2e.make_query([
+
+    #      {
+    #         "term": {
+    #            "rule.id": f"{rule_id}"
+    #         }
+    #      },
+    #      {
+    #         "term": {
+    #            "timestamp": f"{raised_alert_timestamp}"
+    #         }
+    #      }
+    #  ])
+
+    # # Check if the alert has been indexed and get its data
+    # response = e2e.get_alert_indexer_api(query=query, credentials=get_dashboard_credentials)
+    # indexed_alert = json.dumps(response.json())
+
+    # # Check that the alert data is the expected one
+    # alert_data = re.search(expected_indexed_alert, indexed_alert)
+    # assert alert_data is not None, 'Alert triggered, but not indexed'


### PR DESCRIPTION
|Related issue|
|-------------|
|    https://github.com/wazuh/wazuh-qa/issues/2895     |

## Description

The test research was accomplished in https://github.com/wazuh/wazuh-qa/issues/2875. So, in this issue, we develop the E2E test to cover those use cases.
<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added

IP Reputation + Active Response test case

### Configuration options

To launch these tests, we must indicate the path of the inventory:

```
python -m pytest -vvvs tests/end_to_end/test_ip_reputation/ --inventory_path=/home/belen/Repositories/wazuh-qa/tests/end_to_end/general_playbooks/inventory.yml 
```
It should be noted that, for local environments, it will be necessary to create the inventory for the moment. It should contain the following:

```
all:
  hosts:
    wazuh-manager:
      ansible_connection: ssh
      ansible_user: vagrant
      ansible_ssh_private_key_file: <PRIVATE_KEY>
      ansible_python_interpreter: /usr/bin/python3
      dashboard_user: <DASHBOARD_USER>
      dashboard_password: <DASHBOARD_PASSWORD>
      ip_address: <MANAGER_IP>
    wazuh-windows:
      ansible_user: vagrant
      ansible_password: vagrant
      ansible_connection: winrm
      ansible_winrm_server_cert_validation: ignore
      ansible_winrm_transport: basic
      ansible_winrm_port: 5985
      ansible_python_interpreter: C:\Users\vagrant\AppData\Local\Programs\Pyhton\Python39\python.exe
      ip_address: <AGENT_IP>
  vars:
    s3_url: <E2E_URL>
 
```

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @BelenValdivia  (Developer)  |     test_ip_reputation/        | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢](https://github.com/wazuh/wazuh-qa/files/9252204/R1-test-ip-reputation-active-response.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9252206/R2-test-ip-reputation-active-response.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9252207/R3-test-ip-reputation-active-response.zip)  |  Centos and Windows       |   584adc0c189079565afb4016ceaf6acf555e4e51| Nothing to highlight |
| @juliamagan  (Reviewer)   |    test_ip_reputation/       | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |[🟢 ](https://github.com/wazuh/wazuh-qa/files/9308018/R1-3141-test-ip-reputation.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9308024/R2-3141-test-ip-reputation.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9308030/R3-3141-test-ip-reputation.zip) |   CentOS and Windows     |     f6ad3ef   | Nothing to highlight |


