### PR TITLE
IT VDT: Remove Debian Stretch Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release report: TBD
 
 ### Changed
 
+- VDT ITs: Remove Debian Stretch test support. ([#3172](https://github.com/wazuh/wazuh-qa/pull/3172)) \- (Tests)
 - Change how 'service_control' collects clusterd and apid pids ([#3140](https://github.com/wazuh/wazuh-qa/pull/3140)) \- (Framework)
 - Change scan test module fixtures to allow use commit instead of branches ([#3134](https://github.com/wazuh/wazuh-qa/issues/3134)) \- (Tests)
 - Update syscollector deltas integration tests ([#2921](https://github.com/wazuh/wazuh-qa/pull/2921)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Release report: TBD
 
 ### Changed
 
-- VDT ITs: Remove Debian Stretch test support. ([#3172](https://github.com/wazuh/wazuh-qa/pull/3172)) \- (Tests)
 - Change how 'service_control' collects clusterd and apid pids ([#3140](https://github.com/wazuh/wazuh-qa/pull/3140)) \- (Framework)
 - Change scan test module fixtures to allow use commit instead of branches ([#3134](https://github.com/wazuh/wazuh-qa/issues/3134)) \- (Tests)
 - Update syscollector deltas integration tests ([#2921](https://github.com/wazuh/wazuh-qa/pull/2921)) \- (Tests)
@@ -60,6 +59,9 @@ Release report: TBD
 - Fix the unstable FIM tests that need refactoring ([#2458](https://github.com/wazuh/wazuh-qa/pull/2458)) \- (Framework + Tests)
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
 
+### Removed
+
+- VDT ITs: Remove Debian Stretch test support. ([#3172](https://github.com/wazuh/wazuh-qa/pull/3172)) \- (Tests)
 
 ## [4.3.7] - Development (unreleased)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -101,18 +101,6 @@
     provider_os: 'JAMMY'
     update_treshold_weeks: 2
 
-
-- name: 'STRETCH'
-  description: 'Debian provider'
-  configuration_parameters:
-    PROVIDER: 'debian'
-    OS: 'stretch'
-  metadata:
-    provider_name: 'Debian Stretch'
-    provider_os: 'STRETCH'
-    download_timeout: 120
-    update_treshold_weeks: 2
-
 - name: 'BUSTER'
   description: 'Debian provider'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -1,245 +1,245 @@
-- name: 'RHEL5'
-  description: 'Red Hat Enterprise Linux provider'
+- name: RHEL5
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '5'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 5'
-    provider_json_name: 'JSON Red Hat Enterprise Linux'
-    provider_os: 'RHEL5'
+    provider_name: Red Hat Enterprise Linux 5
+    provider_json_name: JSON Red Hat Enterprise Linux
+    provider_os: RHEL5
     download_timeout: 150
     update_treshold_weeks: 2
 
-- name: 'RHEL6'
-  description: 'Red Hat Enterprise Linux provider'
+- name: RHEL6
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '6'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 6'
-    provider_json_name: 'JSON Red Hat Enterprise Linux'
-    provider_os: 'RHEL6'
+    provider_name: Red Hat Enterprise Linux 6
+    provider_json_name: JSON Red Hat Enterprise Linux
+    provider_os: RHEL6
     download_timeout: 150
     update_treshold_weeks: 2
 
-- name: 'RHEL7'
-  description: 'Red Hat Enterprise Linux provider'
+- name: RHEL7
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '7'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 7'
-    provider_json_name: 'JSON Red Hat Enterprise Linux'
-    provider_os: 'RHEL7'
+    provider_name: Red Hat Enterprise Linux 7
+    provider_json_name: JSON Red Hat Enterprise Linux
+    provider_os: RHEL7
     download_timeout: 150
     update_treshold_weeks: 2
 
-- name: 'RHEL8'
-  description: 'Red Hat Enterprise Linux provider'
+- name: RHEL8
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '8'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 8'
-    provider_json_name: 'JSON Red Hat Enterprise Linux'
-    provider_os: 'RHEL8'
+    provider_name: Red Hat Enterprise Linux 8
+    provider_json_name: JSON Red Hat Enterprise Linux
+    provider_os: RHEL8
     download_timeout: 150
     update_treshold_weeks: 2
 
-- name: 'TRUSTY'
-  description: 'Canonical provider'
+- name: TRUSTY
+  description: Canonical provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'trusty'
+    PROVIDER: canonical
+    OS: trusty
   metadata:
-    provider_name: 'Ubuntu Trusty'
-    provider_os: 'TRUSTY'
+    provider_name: Ubuntu Trusty
+    provider_os: TRUSTY
     download_timeout: 120
     update_treshold_weeks: 2
 
-- name: 'XENIAL'
-  description: 'Canonical provider'
+- name: XENIAL
+  description: Canonical provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'xenial'
+    PROVIDER: canonical
+    OS: xenial
   metadata:
-    provider_name: 'Ubuntu Xenial'
-    provider_os: 'XENIAL'
+    provider_name: Ubuntu Xenial
+    provider_os: XENIAL
     download_timeout: 120
     update_treshold_weeks: 2
 
-- name: 'BIONIC'
-  description: 'Canonical provider'
+- name: BIONIC
+  description: Canonical provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'bionic'
+    PROVIDER: canonical
+    OS: bionic
   metadata:
-    provider_name: 'Ubuntu Bionic'
+    provider_name: Ubuntu Bionic
     download_timeout: 120
-    provider_os: 'BIONIC'
+    provider_os: BIONIC
     update_treshold_weeks: 2
 
-- name: 'FOCAL'
-  description: 'Canonical provider'
+- name: FOCAL
+  description: Canonical provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'focal'
+    PROVIDER: canonical
+    OS: focal
   metadata:
-    provider_name: 'Ubuntu Focal'
+    provider_name: Ubuntu Focal
     download_timeout: 120
-    provider_os: 'FOCAL'
+    provider_os: FOCAL
     update_treshold_weeks: 2
 
-- name: 'JAMMY'
-  description: 'Canonical provider'
+- name: JAMMY
+  description: Canonical provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'jammy'
+    PROVIDER: canonical
+    OS: jammy
   metadata:
-    provider_name: 'Ubuntu Jammy'
+    provider_name: Ubuntu Jammy
     download_timeout: 120
-    provider_os: 'JAMMY'
+    provider_os: JAMMY
     update_treshold_weeks: 2
 
-- name: 'BUSTER'
-  description: 'Debian provider'
+- name: BUSTER
+  description: Debian provider
   configuration_parameters:
-    PROVIDER: 'debian'
-    OS: 'buster'
+    PROVIDER: debian
+    OS: buster
   metadata:
-    provider_name: 'Debian Buster'
-    provider_os: 'BUSTER'
-    download_timeout: 120
-    update_treshold_weeks: 2
-
-- name: 'BULLSEYE'
-  description: 'Debian provider'
-  configuration_parameters:
-    PROVIDER: 'debian'
-    OS: 'bullseye'
-  metadata:
-    provider_name: 'Debian Bullseye'
-    provider_os: 'BULLSEYE'
+    provider_name: Debian Buster
+    provider_os: BUSTER
     download_timeout: 120
     update_treshold_weeks: 2
 
-- name: 'ARCH'
-  description: 'Arch Linux provider'
+- name: BULLSEYE
+  description: Debian provider
   configuration_parameters:
-    PROVIDER: 'arch'
+    PROVIDER: debian
+    OS: bullseye
+  metadata:
+    provider_name: Debian Bullseye
+    provider_os: BULLSEYE
+    download_timeout: 120
+    update_treshold_weeks: 2
+
+- name: ARCH
+  description: Arch Linux provider
+  configuration_parameters:
+    PROVIDER: arch
     OS: ''
   metadata:
-    provider_name: 'Arch Linux'
-    provider_os: 'ARCH'
+    provider_name: Arch Linux
+    provider_os: ARCH
     download_timeout: 120
     update_treshold_weeks: 2
 
-- name: 'ALAS'
-  description: 'Amazon Linux provider'
+- name: ALAS
+  description: Amazon Linux provider
   configuration_parameters:
-    PROVIDER: 'alas'
-    OS: 'amazon-linux'
+    PROVIDER: alas
+    OS: amazon-linux
   metadata:
-    provider_name: 'Amazon Linux 1'
-    provider_os: 'Amazon-Linux'
+    provider_name: Amazon Linux 1
+    provider_os: Amazon-Linux
     download_timeout: 120
     update_treshold_weeks: 3
 
-- name: 'ALAS-2'
-  description: 'Amazon Linux provider'
+- name: ALAS-2
+  description: Amazon Linux provider
   configuration_parameters:
-    PROVIDER: 'alas'
-    OS: 'amazon-linux-2'
+    PROVIDER: alas
+    OS: amazon-linux-2
   metadata:
-    provider_name: 'Amazon Linux 2'
-    provider_os: 'Amazon-Linux-2'
+    provider_name: Amazon Linux 2
+    provider_os: Amazon-Linux-2
     download_timeout: 120
     update_treshold_weeks: 3
 
-- name: 'NVD'
-  description: 'National Vulnerability Database provider'
+- name: NVD
+  description: National Vulnerability Database provider
   configuration_parameters:
-    PROVIDER: 'nvd'
+    PROVIDER: nvd
     OS: ''
   metadata:
-    provider_name: 'National Vulnerability Database'
-    provider_os: 'NVD'
+    provider_name: National Vulnerability Database
+    provider_os: NVD
     download_timeout: 800
     update_treshold_weeks: 2
 
-- name: 'MSU'
-  description: 'Microsoft Security Update provider'
+- name: MSU
+  description: Microsoft Security Update provider
   configuration_parameters:
-    PROVIDER: 'msu'
+    PROVIDER: msu
     OS: ''
   metadata:
-    provider_name: 'Microsoft Security Update'
-    provider_os: 'MSU'
+    provider_name: Microsoft Security Update
+    provider_os: MSU
     download_timeout: 120
     update_treshold_weeks: 3
 
-- name: 'SUSE Linux Enterprise Server 11'
-  description: 'SUSE Linux Enterprise provider'
+- name: SUSE Linux Enterprise Server 11
+  description: SUSE Linux Enterprise provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '11-server'
+    PROVIDER: suse
+    OS: 11-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 11'
-    provider_os: 'SLES11'
+    provider_name: SUSE Linux Enterprise Server 11
+    provider_os: SLES11
     download_timeout: 360
     update_treshold_weeks: None
 
-- name: 'SUSE Linux Enterprise Server 12'
-  description: 'SUSE Linux Enterprise provider'
+- name: SUSE Linux Enterprise Server 12
+  description: SUSE Linux Enterprise provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '12-server'
+    PROVIDER: suse
+    OS: 12-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 12'
-    provider_os: 'SLES12'
+    provider_name: SUSE Linux Enterprise Server 12
+    provider_os: SLES12
     download_timeout: 360
     update_treshold_weeks: None
 
-- name: 'SUSE Linux Enterprise Server 15'
-  description: 'SUSE Linux Enterprise provider'
+- name: SUSE Linux Enterprise Server 15
+  description: SUSE Linux Enterprise provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '15-server'
+    PROVIDER: suse
+    OS: 15-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 15'
-    provider_os: 'SLES15'
+    provider_name: SUSE Linux Enterprise Server 15
+    provider_os: SLES15
     download_timeout: 360
     update_treshold_weeks: 2
 
-- name: 'SUSE Linux Enterprise Desktop 11'
-  description: 'SUSE Linux Enterprise provider'
+- name: SUSE Linux Enterprise Desktop 11
+  description: SUSE Linux Enterprise provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '11-desktop'
+    PROVIDER: suse
+    OS: 11-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 11'
-    provider_os: 'SLED11'
+    provider_name: SUSE Linux Enterprise Desktop 11
+    provider_os: SLED11
     download_timeout: 360
     update_treshold_weeks: None
 
-- name: 'SUSE Linux Enterprise Desktop 12'
-  description: 'SUSE Linux Enterprise provider'
+- name: SUSE Linux Enterprise Desktop 12
+  description: SUSE Linux Enterprise provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '12-desktop'
+    PROVIDER: suse
+    OS: 12-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 12'
-    provider_os: 'SLED12'
+    provider_name: SUSE Linux Enterprise Desktop 12
+    provider_os: SLED12
     download_timeout: 360
     update_treshold_weeks: None
 
-- name: 'SUSE Linux Enterprise Desktop 15'
-  description: 'SUSE Linux Enterprise provider'
+- name: SUSE Linux Enterprise Desktop 15
+  description: SUSE Linux Enterprise provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '15-desktop'
+    PROVIDER: suse
+    OS: 15-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 15'
-    provider_os: 'SLED15'
+    provider_name: SUSE Linux Enterprise Desktop 15
+    provider_os: SLED15
     download_timeout: 360
     update_treshold_weeks: 2

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -1,198 +1,198 @@
-- name: 'Red Hat Enterprise Linux'
-  description: 'Red Hat Enterprise Linux provider'
+- name: Red Hat Enterprise Linux
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 5'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/com.redhat.rhsa-RHEL5.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/rhel5.xml'
-    url: 'https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2'
+    provider_name: Red Hat Enterprise Linux 5
+    expected_format: application/x-bzip
+    path: /tmp/com.redhat.rhsa-RHEL5.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/rhel5.xml
+    url: https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2
 
-- name: 'Red Hat Enterprise Linux'
-  description: 'Red Hat Enterprise Linux provider'
+- name: Red Hat Enterprise Linux
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 6'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/rhel-6-including-unpatched.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/rhel6.xml'
-    url: 'https://www.redhat.com/security/data/oval/v2/RHEL6/rhel-6-including-unpatched.oval.xml.bz2'
+    provider_name: Red Hat Enterprise Linux 6
+    expected_format: application/x-bzip
+    path: /tmp/rhel-6-including-unpatched.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/rhel6.xml
+    url: https://www.redhat.com/security/data/oval/v2/RHEL6/rhel-6-including-unpatched.oval.xml.bz2
 
-- name: 'Red Hat Enterprise Linux'
-  description: 'Red Hat Enterprise Linux provider'
+- name: Red Hat Enterprise Linux
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 7'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/rhel-7-including-unpatched.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/rhel7.xml'
-    url: 'https://www.redhat.com/security/data/oval/v2/RHEL7/rhel-7-including-unpatched.oval.xml.bz2'
+    provider_name: Red Hat Enterprise Linux 7
+    expected_format: application/x-bzip
+    path: /tmp/rhel-7-including-unpatched.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/rhel7.xml
+    url: https://www.redhat.com/security/data/oval/v2/RHEL7/rhel-7-including-unpatched.oval.xml.bz2
 
-- name: 'Red Hat Enterprise Linux'
-  description: 'Red Hat Enterprise Linux provider'
+- name: Red Hat Enterprise Linux
+  description: Red Hat Enterprise Linux provider
   configuration_parameters:
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 8'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/rhel-8-including-unpatched.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/rhel8.xml'
-    url: 'https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8-including-unpatched.oval.xml.bz2'
+    provider_name: Red Hat Enterprise Linux 8
+    expected_format: application/x-bzip
+    path: /tmp/rhel-8-including-unpatched.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/rhel8.xml
+    url: https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8-including-unpatched.oval.xml.bz2
 
-- name: 'Canonical Jammy'
-  description: 'Canonical provider'
+- name: Canonical Jammy
+  description: Canonical provider
   configuration_parameters:
   metadata:
-    provider_name: 'Ubuntu Jammy'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/com.ubuntu.jammy.cve.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/jammy.xml'
-    url: 'https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2'
+    provider_name: Ubuntu Jammy
+    expected_format: application/x-bzip
+    path: /tmp/com.ubuntu.jammy.cve.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/jammy.xml
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2
 
-- name: 'Canonical Focal'
-  description: 'Canonical provider'
+- name: Canonical Focal
+  description: Canonical provider
   configuration_parameters:
   metadata:
-    provider_name: 'Ubuntu Focal'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/com.ubuntu.focal.cve.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/focal.xml'
-    url: 'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2'
+    provider_name: Ubuntu Focal
+    expected_format: application/x-bzip
+    path: /tmp/com.ubuntu.focal.cve.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/focal.xml
+    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
-- name: 'Canonical Bionic'
-  description: 'Canonical provider'
+- name: Canonical Bionic
+  description: Canonical provider
   configuration_parameters:
   metadata:
-    provider_name: 'Ubuntu Bionic'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/com.ubuntu.bionic.cve.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/bionic.xml'
-    url: 'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2'
+    provider_name: Ubuntu Bionic
+    expected_format: application/x-bzip
+    path: /tmp/com.ubuntu.bionic.cve.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/bionic.xml
+    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2
 
-- name: 'Canonical Xenial'
-  description: 'Canonical provider'
+- name: Canonical Xenial
+  description: Canonical provider
   configuration_parameters:
   metadata:
-    provider_name: 'Ubuntu Xenial'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/com.ubuntu.xenial.cve.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/xenial.xml'
-    url: 'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2'
+    provider_name: Ubuntu Xenial
+    expected_format: application/x-bzip
+    path: /tmp/com.ubuntu.xenial.cve.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/xenial.xml
+    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2
 
-- name: 'Canonical Trusty'
-  description: 'Canonical provider'
+- name: Canonical Trusty
+  description: Canonical provider
   configuration_parameters:
   metadata:
-    provider_name: 'Ubuntu Trusty'
-    expected_format: 'application/x-bzip2'
-    path: '/tmp/com.ubuntu.trusty.cve.oval.xml.bz2'
-    extension: 'bz2'
-    decompressed_file: '/tmp/trusty.xml'
-    url: 'https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2'
+    provider_name: Ubuntu Trusty
+    expected_format: application/x-bzip
+    path: /tmp/com.ubuntu.trusty.cve.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/trusty.xml
+    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2
 
-- name: 'Debian'
-  description: 'Debian provider'
+- name: Debian
+  description: Debian provider
   configuration_parameters:
   metadata:
-    provider_name: 'Debian Buster'
-    expected_format: 'xml'
-    path: '/tmp/oval-definitions-buster.xml'
-    extension: 'xml'
-    url: 'https://www.debian.org/security/oval/oval-definitions-buster.xml'
+    provider_name: Debian Buster
+    expected_format: xml
+    path: /tmp/oval-definitions-buster.xml
+    extension: xml
+    url: https://www.debian.org/security/oval/oval-definitions-buster.xml
 
-- name: 'Debian'
-  description: 'Debian provider'
+- name: Debian
+  description: Debian provider
   configuration_parameters:
   metadata:
-    provider_name: 'Debian Jessie'
-    expected_format: 'xml'
-    path: '/tmp/oval-definitions-jessie.xml'
-    extension: 'xml'
-    url: 'https://www.debian.org/security/oval/oval-definitions-jessie.xml'
+    provider_name: Debian Jessie
+    expected_format: xml
+    path: /tmp/oval-definitions-jessie.xml
+    extension: xml
+    url: https://www.debian.org/security/oval/oval-definitions-jessie.xml
 
-- name: 'Debian'
-  description: 'Debian provider'
+- name: Debian
+  description: Debian provider
   configuration_parameters:
   metadata:
-    provider_name: 'Debian Wheezy'
-    expected_format: 'xml'
-    path: '/tmp/oval-definitions-wheezy.xml'
-    extension: 'xml'
-    url: 'https://www.debian.org/security/oval/oval-definitions-wheezy.xml'
+    provider_name: Debian Wheezy
+    expected_format: xml
+    path: /tmp/oval-definitions-wheezy.xml
+    extension: xml
+    url: https://www.debian.org/security/oval/oval-definitions-wheezy.xml
 
-- name: 'Debian'
-  description: 'Debian provider'
+- name: Debian
+  description: Debian provider
   configuration_parameters:
   metadata:
-    provider_name: 'Debian Bullseye'
-    expected_format: 'xml'
-    path: '/tmp/oval-definitions-bullseye.xml'
-    extension: 'xml'
-    url: 'https://www.debian.org/security/oval/oval-definitions-bullseye.xml'
+    provider_name: Debian Bullseye
+    expected_format: xml
+    path: /tmp/oval-definitions-bullseye.xml
+    extension: xml
+    url: https://www.debian.org/security/oval/oval-definitions-bullseye.xml
 
-- name: 'SUSE Linux Enterprise Desktop 11'
-  description: 'SUSE Linux Enterprise Desktop 11 provider'
+- name: SUSE Linux Enterprise Desktop 11
+  description: SUSE Linux Enterprise Desktop 11 provider
   configuration_parameters:
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 11'
-    expected_format: 'xml'
-    path: '/tmp/suse.linux.enterprise.desktop.11.xml'
-    extension: 'xml'
-    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.11.xml'
+    provider_name: SUSE Linux Enterprise Desktop 11
+    expected_format: xml
+    path: /tmp/suse.linux.enterprise.desktop.11.xml
+    extension: xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.11.xml
 
-- name: 'SUSE Linux Enterprise Desktop 12'
-  description: 'SUSE Linux Enterprise Desktop 12 provider'
+- name: SUSE Linux Enterprise Desktop 12
+  description: SUSE Linux Enterprise Desktop 12 provider
   configuration_parameters:
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 12'
-    expected_format: 'xml'
-    path: '/tmp/suse.linux.enterprise.desktop.12.xml'
-    extension: 'xml'
-    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml'
+    provider_name: SUSE Linux Enterprise Desktop 12
+    expected_format: xml
+    path: /tmp/suse.linux.enterprise.desktop.12.xml
+    extension: xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml
 
-- name: 'SUSE Linux Enterprise Desktop 15'
-  description: 'SUSE Linux Enterprise Desktop 15 provider'
+- name: SUSE Linux Enterprise Desktop 15
+  description: SUSE Linux Enterprise Desktop 15 provider
   configuration_parameters:
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 15'
-    expected_format: 'xml'
-    path: '/tmp/suse.linux.enterprise.desktop.15.xml'
-    extension: 'xml'
-    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.15.xml'
+    provider_name: SUSE Linux Enterprise Desktop 15
+    expected_format: xml
+    path: /tmp/suse.linux.enterprise.desktop.15.xml
+    extension: xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.15.xml
 
-- name: 'SUSE Linux Enterprise Server 11'
-  description: 'SUSE Linux Enterprise Server 11 provider'
+- name: SUSE Linux Enterprise Server 11
+  description: SUSE Linux Enterprise Server 11 provider
   configuration_parameters:
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 11'
-    expected_format: 'xml'
-    path: '/tmp/suse.linux.enterprise.server.11.xml'
-    extension: 'xml'
-    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.11.xml'
+    provider_name: SUSE Linux Enterprise Server 11
+    expected_format: xml
+    path: /tmp/suse.linux.enterprise.server.11.xml
+    extension: xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.11.xml
 
-- name: 'SUSE Linux Enterprise Server 12'
-  description: 'SUSE Linux Enterprise Server 12 provider'
+- name: SUSE Linux Enterprise Server 12
+  description: SUSE Linux Enterprise Server 12 provider
   configuration_parameters:
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 12'
-    expected_format: 'xml'
-    path: '/tmp/suse.linux.enterprise.server.12.xml'
-    extension: 'xml'
-    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml'
+    provider_name: SUSE Linux Enterprise Server 12
+    expected_format: xml
+    path: /tmp/suse.linux.enterprise.server.12.xml
+    extension: xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml
 
-- name: 'SUSE Linux Enterprise Server 15'
-  description: 'SUSE Linux Enterprise Server 15 provider'
+- name: SUSE Linux Enterprise Server 15
+  description: SUSE Linux Enterprise Server 15 provider
   configuration_parameters:
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 15'
-    expected_format: 'xml'
-    path: '/tmp/suse.linux.enterprise.server.15.xml'
-    extension: 'xml'
-    url: 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml'
+    provider_name: SUSE Linux Enterprise Server 15
+    expected_format: xml
+    path: /tmp/suse.linux.enterprise.server.15.xml
+    extension: xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -111,26 +111,6 @@
   description: Debian provider
   configuration_parameters:
   metadata:
-    provider_name: Debian Jessie
-    expected_format: xml
-    path: /tmp/oval-definitions-jessie.xml
-    extension: xml
-    url: https://www.debian.org/security/oval/oval-definitions-jessie.xml
-
-- name: Debian
-  description: Debian provider
-  configuration_parameters:
-  metadata:
-    provider_name: Debian Wheezy
-    expected_format: xml
-    path: /tmp/oval-definitions-wheezy.xml
-    extension: xml
-    url: https://www.debian.org/security/oval/oval-definitions-wheezy.xml
-
-- name: Debian
-  description: Debian provider
-  configuration_parameters:
-  metadata:
     provider_name: Debian Bullseye
     expected_format: xml
     path: /tmp/oval-definitions-bullseye.xml

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -111,16 +111,6 @@
   description: 'Debian provider'
   configuration_parameters:
   metadata:
-    provider_name: 'Debian Stretch'
-    expected_format: 'xml'
-    path: '/tmp/oval-definitions-stretch.xml'
-    extension: 'xml'
-    url: 'https://www.debian.org/security/oval/oval-definitions-stretch.xml'
-
-- name: 'Debian'
-  description: 'Debian provider'
-  configuration_parameters:
-  metadata:
     provider_name: 'Debian Jessie'
     expected_format: 'xml'
     path: '/tmp/oval-definitions-jessie.xml'

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_retry_interval.py
@@ -38,8 +38,7 @@ os_version:
     - Ubuntu Xenial
     - Ubuntu Trusty
     - Debian Buster
-    - Debian Jessie
-    - Debian Wheezy
+    - Debian Bullseye
     - Red Hat 8
     - Red Hat 7
     - Red Hat 6

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_retry_interval.py
@@ -38,7 +38,6 @@ os_version:
     - Ubuntu Xenial
     - Ubuntu Trusty
     - Debian Buster
-    - Debian Stretch
     - Debian Jessie
     - Debian Wheezy
     - Red Hat 8

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
@@ -1,197 +1,197 @@
-- name: 'Amazon Linux 1'
-  description: 'Test disabled Amazon Linux 1'
+- name: Amazon Linux 1
+  description: Test disabled Amazon Linux 1
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'alas'
-    OS: 'amazon-linux'
+    PROVIDER: alas
+    OS: amazon-linux
   metadata:
-    provider_name: 'Amazon Linux 1'
+    provider_name: Amazon Linux 1
 
-- name: 'Amazon Linux 2'
-  description: 'Test disabled Amazon Linux 2'
+- name: Amazon Linux 2
+  description: Test disabled Amazon Linux 2
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'alas'
-    OS: 'amazon-linux-2'
+    PROVIDER: alas
+    OS: amazon-linux-2
   metadata:
-    provider_name: 'Amazon Linux 2'
+    provider_name: Amazon Linux 2
 
-- name: 'Ubuntu Focal'
-  description: 'Test disabled Ubuntu Focal'
+- name: Ubuntu Focal
+  description: Test disabled Ubuntu Focal
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'canonical'
-    OS: 'focal'
+    PROVIDER: canonical
+    OS: focal
   metadata:
-    provider_name: 'Ubuntu Focal'
+    provider_name: Ubuntu Focal
 
-- name: 'Ubuntu Bionic'
-  description: 'Test disabled Ubuntu Focal'
+- name: Ubuntu Bionic
+  description: Test disabled Ubuntu Focal
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'canonical'
-    OS: 'bionic'
+    PROVIDER: canonical
+    OS: bionic
   metadata:
-    provider_name: 'Ubuntu Bionic'
+    provider_name: Ubuntu Bionic
 
-- name: 'Ubuntu Xenial'
-  description: 'Test disabled Ubuntu Xenial'
+- name: Ubuntu Xenial
+  description: Test disabled Ubuntu Xenial
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'canonical'
-    OS: 'xenial'
+    PROVIDER: canonical
+    OS: xenial
   metadata:
-    provider_name: 'Ubuntu Xenial'
+    provider_name: Ubuntu Xenial
 
-- name: 'Ubuntu Trusty'
-  description: 'Test disabled Ubuntu Trusty'
+- name: Ubuntu Trusty
+  description: Test disabled Ubuntu Trusty
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'canonical'
-    OS: 'trusty'
+    PROVIDER: canonical
+    OS: trusty
   metadata:
-    provider_name: 'Ubuntu Trusty'
+    provider_name: Ubuntu Trusty
 
-- name: 'Ubuntu Jammy'
-  description: 'Test disabled Ubuntu 22'
+- name: Ubuntu Jammy
+  description: Test disabled Ubuntu 22
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'canonical'
-    OS: 'jammy'
+    PROVIDER: canonical
+    OS: jammy
   metadata:
-    provider_name: 'Ubuntu Jammy'
+    provider_name: Ubuntu Jammy
 
-- name: 'RHEL 8'
-  description: 'Test disabled Red Hat Enterprise Linux 8'
+- name: RHEL 8
+  description: Test disabled Red Hat Enterprise Linux 8
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '8'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 8'
+    provider_name: Red Hat Enterprise Linux 8
 
-- name: 'RHEL 7'
-  description: 'Test disabled Red Hat Enterprise Linux 7'
+- name: RHEL 7
+  description: Test disabled Red Hat Enterprise Linux 7
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '7'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 7'
+    provider_name: Red Hat Enterprise Linux 7
 
-- name: 'RHEL 6'
-  description: 'Test disabled Red Hat Enterprise Linux 6'
+- name: RHEL 6
+  description: Test disabled Red Hat Enterprise Linux 6
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '6'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 6'
+    provider_name: Red Hat Enterprise Linux 6
 
-- name: 'RHEL 5'
-  description: 'Test disabled Red Hat Enterprise Linux 5'
+- name: RHEL 5
+  description: Test disabled Red Hat Enterprise Linux 5
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '5'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 5'
+    provider_name: Red Hat Enterprise Linux 5
 
-- name: 'Debian Bullseye'
-  description: 'Test disabled Debian Bullseye'
+- name: Debian Bullseye
+  description: Test disabled Debian Bullseye
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'debian'
-    OS: 'bullseye'
+    PROVIDER: debian
+    OS: bullseye
   metadata:
-    provider_name: 'Debian Bullseye'
+    provider_name: Debian Bullseye
 
-- name: 'Debian Buster'
-  description: 'Test disabled Debian Buster'
+- name: Debian Buster
+  description: Test disabled Debian Buster
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'debian'
-    OS: 'buster'
+    PROVIDER: debian
+    OS: buster
   metadata:
-    provider_name: 'Debian Buster'
+    provider_name: Debian Buster
 
-- name: 'Arch Linux'
-  description: 'Test disabled Arch Linux'
+- name: Arch Linux
+  description: Test disabled Arch Linux
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'arch'
+    PROVIDER: arch
     OS: ''
   metadata:
-    provider_name: 'Arch Linux'
+    provider_name: Arch Linux
 
-- name: 'NVD'
-  description: 'Test disabled National Vulnerability Database'
+- name: NVD
+  description: Test disabled National Vulnerability Database
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'nvd'
+    PROVIDER: nvd
     OS: ''
   metadata:
-    provider_name: 'National Vulnerability Database'
+    provider_name: National Vulnerability Database
 
-- name: 'MSU'
-  description: 'Test disabled Microsoft Security Update'
+- name: MSU
+  description: Test disabled Microsoft Security Update
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'msu'
+    PROVIDER: msu
     OS: ''
   metadata:
-    provider_name: 'Microsoft Security Update'
+    provider_name: Microsoft Security Update
 
-- name: 'SUSE Linux Enterprise Server 11'
-  description: 'Test enabled SUSE Server 11'
+- name: SUSE Linux Enterprise Server 11
+  description: Test enabled SUSE Server 11
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'suse'
-    OS: '11-server'
+    PROVIDER: suse
+    OS: 11-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 11'
+    provider_name: SUSE Linux Enterprise Server 11
 
-- name: 'SUSE Linux Enterprise Server 12'
-  description: 'Test enabled SUSE Server 12'
+- name: SUSE Linux Enterprise Server 12
+  description: Test enabled SUSE Server 12
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'suse'
-    OS: '12-server'
+    PROVIDER: suse
+    OS: 12-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 12'
+    provider_name: SUSE Linux Enterprise Server 12
 
-- name: 'SUSE Linux Enterprise Server 15'
-  description: 'Test enabled SUSE Server 15'
+- name: SUSE Linux Enterprise Server 15
+  description: Test enabled SUSE Server 15
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'suse'
-    OS: '15-server'
+    PROVIDER: suse
+    OS: 15-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 15'
+    provider_name: SUSE Linux Enterprise Server 15
 
-- name: 'SUSE Linux Enterprise Desktop 11'
-  description: 'Test enabled SUSE Desktop 11'
+- name: SUSE Linux Enterprise Desktop 11
+  description: Test enabled SUSE Desktop 11
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'suse'
-    OS: '11-desktop'
+    PROVIDER: suse
+    OS: 11-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 11'
+    provider_name: SUSE Linux Enterprise Desktop 11
 
-- name: 'SUSE Linux Enterprise Desktop 12'
-  description: 'Test enabled SUSE Desktop 12'
+- name: SUSE Linux Enterprise Desktop 12
+  description: Test enabled SUSE Desktop 12
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'suse'
-    OS: '12-desktop'
+    PROVIDER: suse
+    OS: 12-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 12'
+    provider_name: SUSE Linux Enterprise Desktop 12
 
-- name: 'SUSE Linux Enterprise Desktop 15'
-  description: 'Test enabled SUSE Desktop 15'
+- name: SUSE Linux Enterprise Desktop 15
+  description: Test enabled SUSE Desktop 15
   configuration_parameters:
     ENABLED: 'no'
-    PROVIDER: 'suse'
-    OS: '15-desktop'
+    PROVIDER: suse
+    OS: 15-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 15'
+    provider_name: SUSE Linux Enterprise Desktop 15

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
@@ -115,15 +115,6 @@
   metadata:
     provider_name: 'Debian Buster'
 
-- name: 'Debian Stretch'
-  description: 'Test disabled Debian Stretch'
-  configuration_parameters:
-    ENABLED: 'no'
-    PROVIDER: 'debian'
-    OS: 'stretch'
-  metadata:
-    provider_name: 'Debian Stretch'
-
 - name: 'Arch Linux'
   description: 'Test disabled Arch Linux'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
@@ -115,15 +115,6 @@
   metadata:
     provider_name: 'Debian Buster'
 
-- name: 'Debian Stretch'
-  description: 'Test enabled Debian Stretch'
-  configuration_parameters:
-    ENABLED: 'yes'
-    PROVIDER: 'debian'
-    OS: 'stretch'
-  metadata:
-    provider_name: 'Debian Stretch'
-
 - name: 'Arch Linux'
   description: 'Test enabled Arch Linux'
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
@@ -1,197 +1,197 @@
-- name: 'Amazon Linux 1'
-  description: 'Test enabled Amazon Linux 1'
+- name: Amazon Linux 1
+  description: Test enabled Amazon Linux 1
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'alas'
-    OS: 'amazon-linux'
+    PROVIDER: alas
+    OS: amazon-linux
   metadata:
-    provider_name: 'Amazon Linux 1'
+    provider_name: Amazon Linux 1
 
-- name: 'Amazon Linux 2'
-  description: 'Test enabled Amazon Linux 2'
+- name: Amazon Linux 2
+  description: Test enabled Amazon Linux 2
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'alas'
-    OS: 'amazon-linux-2'
+    PROVIDER: alas
+    OS: amazon-linux-2
   metadata:
-    provider_name: 'Amazon Linux 2'
+    provider_name: Amazon Linux 2
 
-- name: 'Ubuntu Focal'
-  description: 'Test enabled Ubuntu Focal'
+- name: Ubuntu Focal
+  description: Test enabled Ubuntu Focal
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'canonical'
-    OS: 'focal'
+    PROVIDER: canonical
+    OS: focal
   metadata:
-    provider_name: 'Ubuntu Focal'
+    provider_name: Ubuntu Focal
 
-- name: 'Ubuntu Bionic'
-  description: 'Test enabled Ubuntu Focal'
+- name: Ubuntu Bionic
+  description: Test enabled Ubuntu Focal
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'canonical'
-    OS: 'bionic'
+    PROVIDER: canonical
+    OS: bionic
   metadata:
-    provider_name: 'Ubuntu Bionic'
+    provider_name: Ubuntu Bionic
 
-- name: 'Ubuntu Xenial'
-  description: 'Test enabled Ubuntu Xenial'
+- name: Ubuntu Xenial
+  description: Test enabled Ubuntu Xenial
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'canonical'
-    OS: 'xenial'
+    PROVIDER: canonical
+    OS: xenial
   metadata:
-    provider_name: 'Ubuntu Xenial'
+    provider_name: Ubuntu Xenial
 
-- name: 'Ubuntu Trusty'
-  description: 'Test enabled Ubuntu Trusty'
+- name: Ubuntu Trusty
+  description: Test enabled Ubuntu Trusty
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'canonical'
-    OS: 'trusty'
+    PROVIDER: canonical
+    OS: trusty
   metadata:
-    provider_name: 'Ubuntu Trusty'
+    provider_name: Ubuntu Trusty
 
-- name: 'Ubuntu Jammy'
-  description: 'Test enabled Ubuntu 22'
+- name: Ubuntu Jammy
+  description: Test enabled Ubuntu 22
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'canonical'
-    OS: 'jammy'
+    PROVIDER: canonical
+    OS: jammy
   metadata:
-    provider_name: 'Ubuntu Jammy'
+    provider_name: Ubuntu Jammy
 
-- name: 'RHEL 8'
-  description: 'Test enabled Red Hat Enterprise Linux 8'
+- name: RHEL 8
+  description: Test enabled Red Hat Enterprise Linux 8
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '8'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 8'
+    provider_name: Red Hat Enterprise Linux 8
 
-- name: 'RHEL 7'
-  description: 'Test enabled Red Hat Enterprise Linux 7'
+- name: RHEL 7
+  description: Test enabled Red Hat Enterprise Linux 7
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '7'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 7'
+    provider_name: Red Hat Enterprise Linux 7
 
-- name: 'RHEL 6'
-  description: 'Test enabled Red Hat Enterprise Linux 6'
+- name: RHEL 6
+  description: Test enabled Red Hat Enterprise Linux 6
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '6'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 6'
+    provider_name: Red Hat Enterprise Linux 6
 
-- name: 'RHEL 5'
-  description: 'Test enabled Red Hat Enterprise Linux 5'
+- name: RHEL 5
+  description: Test enabled Red Hat Enterprise Linux 5
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '5'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 5'
+    provider_name: Red Hat Enterprise Linux 5
 
-- name: 'Debian Bullseye'
-  description: 'Test enabled Debian Bullseye'
+- name: Debian Bullseye
+  description: Test enabled Debian Bullseye
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'debian'
-    OS: 'bullseye'
+    PROVIDER: debian
+    OS: bullseye
   metadata:
-    provider_name: 'Debian Bullseye'
+    provider_name: Debian Bullseye
 
-- name: 'Debian Buster'
-  description: 'Test enabled Debian Buster'
+- name: Debian Buster
+  description: Test enabled Debian Buster
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'debian'
-    OS: 'buster'
+    PROVIDER: debian
+    OS: buster
   metadata:
-    provider_name: 'Debian Buster'
+    provider_name: Debian Buster
 
-- name: 'Arch Linux'
-  description: 'Test enabled Arch Linux'
+- name: Arch Linux
+  description: Test enabled Arch Linux
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'arch'
+    PROVIDER: arch
     OS: ''
   metadata:
-    provider_name: 'Arch Linux'
+    provider_name: Arch Linux
 
-- name: 'NVD'
-  description: 'Test enabled National Vulnerability Database'
+- name: NVD
+  description: Test enabled National Vulnerability Database
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'nvd'
+    PROVIDER: nvd
     OS: ''
   metadata:
-    provider_name: 'National Vulnerability Database'
+    provider_name: National Vulnerability Database
 
-- name: 'MSU'
-  description: 'Test enabled Microsoft Security Update'
+- name: MSU
+  description: Test enabled Microsoft Security Update
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'msu'
+    PROVIDER: msu
     OS: ''
   metadata:
-    provider_name: 'Microsoft Security Update'
+    provider_name: Microsoft Security Update
 
-- name: 'SUSE Linux Enterprise Server 11'
-  description: 'Test enabled SUSE Server 11'
+- name: SUSE Linux Enterprise Server 11
+  description: Test enabled SUSE Server 11
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'suse'
-    OS: '11-server'
+    PROVIDER: suse
+    OS: 11-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 11'
+    provider_name: SUSE Linux Enterprise Server 11
 
-- name: 'SUSE Linux Enterprise Server 12'
-  description: 'Test enabled SUSE Server 12'
+- name: SUSE Linux Enterprise Server 12
+  description: Test enabled SUSE Server 12
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'suse'
-    OS: '12-server'
+    PROVIDER: suse
+    OS: 12-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 12'
+    provider_name: SUSE Linux Enterprise Server 12
 
-- name: 'SUSE Linux Enterprise Server 15'
-  description: 'Test enabled SUSE Server 15'
+- name: SUSE Linux Enterprise Server 15
+  description: Test enabled SUSE Server 15
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'suse'
-    OS: '15-server'
+    PROVIDER: suse
+    OS: 15-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 15'
+    provider_name: SUSE Linux Enterprise Server 15
 
-- name: 'SUSE Linux Enterprise Desktop 11'
-  description: 'Test enabled SUSE Desktop 11'
+- name: SUSE Linux Enterprise Desktop 11
+  description: Test enabled SUSE Desktop 11
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'suse'
-    OS: '11-desktop'
+    PROVIDER: suse
+    OS: 11-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 11'
+    provider_name: SUSE Linux Enterprise Desktop 11
 
-- name: 'SUSE Linux Enterprise Desktop 12'
-  description: 'Test enabled SUSE Desktop 12'
+- name: SUSE Linux Enterprise Desktop 12
+  description: Test enabled SUSE Desktop 12
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'suse'
-    OS: '12-desktop'
+    PROVIDER: suse
+    OS: 12-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 12'
+    provider_name: SUSE Linux Enterprise Desktop 12
 
-- name: 'SUSE Linux Enterprise Desktop 15'
-  description: 'Test enabled SUSE Desktop 15'
+- name: SUSE Linux Enterprise Desktop 15
+  description: Test enabled SUSE Desktop 15
   configuration_parameters:
     ENABLED: 'yes'
-    PROVIDER: 'suse'
-    OS: '15-desktop'
+    PROVIDER: suse
+    OS: 15-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 15'
+    provider_name: SUSE Linux Enterprise Desktop 15

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
@@ -1,198 +1,198 @@
-- name: 'Amazon Linux 1'
-  description: 'Amazon Linux provider'
+- name: Amazon Linux 1
+  description: Amazon Linux provider
   configuration_parameters:
-    PROVIDER: 'alas'
-    OS: 'amazon-linux'
+    PROVIDER: alas
+    OS: amazon-linux
   metadata:
-    provider_name: 'Amazon Linux 1'
-    os: 'amazon-linux'
+    provider_name: Amazon Linux 1
+    os: amazon-linux
 
-- name: 'Amazon Linux 2'
-  description: 'Amazon Linux 2 provider'
+- name: Amazon Linux 2
+  description: Amazon Linux 2 provider
   configuration_parameters:
-    PROVIDER: 'alas'
-    OS: 'amazon-linux-2'
+    PROVIDER: alas
+    OS: amazon-linux-2
   metadata:
-    provider_name: 'Amazon Linux 2'
-    os: 'amazon-linux-2'
+    provider_name: Amazon Linux 2
+    os: amazon-linux-2
 
-- name: 'Ubuntu Trusty'
-  description: 'Ubuntu Trusty provider'
+- name: Ubuntu Trusty
+  description: Ubuntu Trusty provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'trusty'
+    PROVIDER: canonical
+    OS: trusty
   metadata:
-    provider_name: 'Ubuntu Trusty'
-    os: 'trusty'
+    provider_name: Ubuntu Trusty
+    os: trusty
 
-- name: 'Ubuntu Xenial'
-  description: 'Ubuntu Xenial provider'
+- name: Ubuntu Xenial
+  description: Ubuntu Xenial provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'xenial'
+    PROVIDER: canonical
+    OS: xenial
   metadata:
-    provider_name: 'Ubuntu Xenial'
-    os: 'xenial'
+    provider_name: Ubuntu Xenial
+    os: xenial
 
-- name: 'Ubuntu Bionic'
-  description: 'Ubuntu Bionic provider'
+- name: Ubuntu Bionic
+  description: Ubuntu Bionic provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'bionic'
+    PROVIDER: canonical
+    OS: bionic
   metadata:
-    provider_name: 'Ubuntu Bionic'
-    os: 'bionic'
+    provider_name: Ubuntu Bionic
+    os: bionic
 
-- name: 'Ubuntu Focal'
-  description: 'Ubuntu Focal provider'
+- name: Ubuntu Focal
+  description: Ubuntu Focal provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'focal'
+    PROVIDER: canonical
+    OS: focal
   metadata:
-    provider_name: 'Ubuntu Focal'
-    os: 'focal'
+    provider_name: Ubuntu Focal
+    os: focal
 
-- name: 'Ubuntu Jammy'
-  description: 'Ubuntu 22 provider'
+- name: Ubuntu Jammy
+  description: Ubuntu 22 provider
   configuration_parameters:
-    PROVIDER: 'canonical'
-    OS: 'jammy'
+    PROVIDER: canonical
+    OS: jammy
   metadata:
-    provider_name: 'Ubuntu Jammy'
-    os: 'jammy'
+    provider_name: Ubuntu Jammy
+    os: jammy
 
 
-- name: 'Debian Buster'
-  description: 'Debian Buster provider'
+- name: Debian Buster
+  description: Debian Buster provider
   configuration_parameters:
-    PROVIDER: 'debian'
-    OS: 'buster'
+    PROVIDER: debian
+    OS: buster
   metadata:
-    provider_name: 'Debian Buster'
-    os: 'buster'
+    provider_name: Debian Buster
+    os: buster
 
-- name: 'Debian Bullseye'
-  description: 'Debian Bullseye provider'
+- name: Debian Bullseye
+  description: Debian Bullseye provider
   configuration_parameters:
-    PROVIDER: 'debian'
-    OS: 'bullseye'
+    PROVIDER: debian
+    OS: bullseye
   metadata:
-    provider_name: 'Debian Bullseye'
-    os: 'bullseye'
+    provider_name: Debian Bullseye
+    os: bullseye
 
-- name: 'Red Hat Enterprise Linux 5'
-  description: 'Red Hat Enterprise Linux 5 provider'
+- name: Red Hat Enterprise Linux 5
+  description: Red Hat Enterprise Linux 5 provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '5'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 5'
+    provider_name: Red Hat Enterprise Linux 5
     os: '5'
 
-- name: 'Red Hat Enterprise Linux 6'
-  description: 'Red Hat Enterprise Linux 6 provider'
+- name: Red Hat Enterprise Linux 6
+  description: Red Hat Enterprise Linux 6 provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '6'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 6'
+    provider_name: Red Hat Enterprise Linux 6
     os: '6'
 
-- name: 'Red Hat Enterprise Linux 7'
-  description: 'Red Hat Enterprise Linux 7 provider'
+- name: Red Hat Enterprise Linux 7
+  description: Red Hat Enterprise Linux 7 provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '7'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 7'
+    provider_name: Red Hat Enterprise Linux 7
     os: '7'
 
-- name: 'Red Hat Enterprise Linux 8'
-  description: 'Red Hat Enterprise Linux 8 provider'
+- name: Red Hat Enterprise Linux 8
+  description: Red Hat Enterprise Linux 8 provider
   configuration_parameters:
-    PROVIDER: 'redhat'
+    PROVIDER: redhat
     OS: '8'
   metadata:
-    provider_name: 'Red Hat Enterprise Linux 8'
+    provider_name: Red Hat Enterprise Linux 8
     os: '8'
 
-- name: 'Arch Linux'
-  description: 'Arch Linux provider'
+- name: Arch Linux
+  description: Arch Linux provider
   configuration_parameters:
-    PROVIDER: 'arch'
+    PROVIDER: arch
     OS: ''
   metadata:
-    provider_name: 'Arch Linux'
+    provider_name: Arch Linux
     os: ['']
 
-- name: 'National Vulnerability Database'
-  description: 'National Vulnerability Database provider'
+- name: National Vulnerability Database
+  description: National Vulnerability Database provider
   configuration_parameters:
-    PROVIDER: 'nvd'
+    PROVIDER: nvd
     OS: ''
   metadata:
-    provider_name: 'National Vulnerability Database'
+    provider_name: National Vulnerability Database
     os: ''
 
-- name: 'Microsoft Security Update'
-  description: 'Microsoft Security Update provider'
+- name: Microsoft Security Update
+  description: Microsoft Security Update provider
   configuration_parameters:
-    PROVIDER: 'msu'
+    PROVIDER: msu
     OS: ''
   metadata:
-    provider_name: 'Microsoft Security Update'
+    provider_name: Microsoft Security Update
     os: ''
 
-- name: 'SUSE Linux Enterprise Desktop 11'
-  description: 'SUSE Linux Enterprise Desktop 11 provider'
+- name: SUSE Linux Enterprise Desktop 11
+  description: SUSE Linux Enterprise Desktop 11 provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '11-desktop'
+    PROVIDER: suse
+    OS: 11-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 11'
-    os: '11-desktop'
+    provider_name: SUSE Linux Enterprise Desktop 11
+    os: 11-desktop
 
-- name: 'SUSE Linux Enterprise Desktop 12'
-  description: 'SUSE Linux Enterprise Desktop 12 provider'
+- name: SUSE Linux Enterprise Desktop 12
+  description: SUSE Linux Enterprise Desktop 12 provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '12-desktop'
+    PROVIDER: suse
+    OS: 12-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 12'
-    os: '12-desktop'
+    provider_name: SUSE Linux Enterprise Desktop 12
+    os: 12-desktop
 
-- name: 'SUSE Linux Enterprise Desktop 15'
-  description: 'SUSE Linux Enterprise Desktop 15 provider'
+- name: SUSE Linux Enterprise Desktop 15
+  description: SUSE Linux Enterprise Desktop 15 provider
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '15-desktop'
+    PROVIDER: suse
+    OS: 15-desktop
   metadata:
-    provider_name: 'SUSE Linux Enterprise Desktop 15'
-    os: '15-desktop'
+    provider_name: SUSE Linux Enterprise Desktop 15
+    os: 15-desktop
 
-- name: 'SUSE Linux Enterprise Server 11'
-  description: 'SUSE Linux Enterprise Server 11'
+- name: SUSE Linux Enterprise Server 11
+  description: SUSE Linux Enterprise Server 11
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '11-server'
+    PROVIDER: suse
+    OS: 11-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 11'
-    os: '11-server'
+    provider_name: SUSE Linux Enterprise Server 11
+    os: 11-server
 
-- name: 'SUSE Linux Enterprise Server 12'
-  description: 'SUSE Linux Enterprise Server 12'
+- name: SUSE Linux Enterprise Server 12
+  description: SUSE Linux Enterprise Server 12
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '12-server'
+    PROVIDER: suse
+    OS: 12-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 12'
-    os: '12-server'
+    provider_name: SUSE Linux Enterprise Server 12
+    os: 12-server
 
-- name: 'SUSE Linux Enterprise Server 15'
-  description: 'SUSE Linux Enterprise Server 15'
+- name: SUSE Linux Enterprise Server 15
+  description: SUSE Linux Enterprise Server 15
   configuration_parameters:
-    PROVIDER: 'suse'
-    OS: '15-server'
+    PROVIDER: suse
+    OS: 15-server
   metadata:
-    provider_name: 'SUSE Linux Enterprise Server 15'
-    os: '15-server'
+    provider_name: SUSE Linux Enterprise Server 15
+    os: 15-server

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
@@ -61,14 +61,6 @@
     provider_name: 'Ubuntu Jammy'
     os: 'jammy'
 
-- name: 'Debian Stretch'
-  description: 'Debian Stretch provider'
-  configuration_parameters:
-    PROVIDER: 'debian'
-    OS: 'stretch'
-  metadata:
-    provider_name: 'Debian Stretch'
-    os: 'stretch'
 
 - name: 'Debian Buster'
   description: 'Debian Buster provider'

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_os.yaml
@@ -61,7 +61,6 @@
     provider_name: Ubuntu Jammy
     os: jammy
 
-
 - name: Debian Buster
   description: Debian Buster provider
   configuration_parameters:
@@ -123,7 +122,7 @@
     OS: ''
   metadata:
     provider_name: Arch Linux
-    os: ['']
+    os: "['']"
 
 - name: National Vulnerability Database
   description: National Vulnerability Database provider


### PR DESCRIPTION
|Related issue|
|-------------|
| Closing #3167  |

## Description

This PR aims to fix  remove the support for Debian Stretch in the VDT suite from the repository.

### Removed

- test cases for the following tests:
   - test_feeds/test_download_feeds
   - test_feeds/test_validate_feed_xml_content
   - test_general_settings/test_retry_interval
   - test_providers/test_disabled
   - test_providers/test_enabled
   - test_providers/test_os

---

## Testing performed
<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09 (Developer)  |  test_vulnerability_detector/         | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/30588/) [:green_circle: ](https://ci.wazuh.info/view/Tests/job/Test_integration/30589/) [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/30590/) | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9311166/R1.zip)  |  Centos8   |   [4524430](https://github.com/wazuh/wazuh-qa/pull/3172/commits/45244301d51e515166fb0aab74d6516050f94a46)    | Nothing to highlight |
| Seyla (Reviewer)   | test_vulnerability_detector/         | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/30623/) [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/30624/) [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/30625/)   | ⚫  | Centos8   |   [4524430](https://github.com/wazuh/wazuh-qa/pull/3172/commits/45244301d51e515166fb0aab74d6516050f94a46)    | Nothing to highlight |



