### PR TITLE
E2E tests: Change required environment for Suricata test

### DIFF
--- a/tests/end_to_end/test_basic_cases/test_suricata_integration/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_suricata_integration/data/playbooks/configuration.yaml
@@ -1,5 +1,5 @@
 - name: Prepare environment
-  hosts: wazuh-manager
+  hosts: ubuntu-agent
   become: true
   vars:
     suricata_conf_path: /etc/suricata/suricata.yaml
@@ -20,7 +20,7 @@
     - name: Restart Wazuh to apply the change
       systemd:
         state: restarted
-        name: wazuh-manager
+        name: wazuh-agent
 
     - name: Check if Suricata is installed
       shell: dpkg -l suricata | grep suricata

--- a/tests/end_to_end/test_basic_cases/test_suricata_integration/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_suricata_integration/data/playbooks/generate_events.yaml
@@ -1,4 +1,4 @@
-- name: Generate events
+- name: Truncate alerts file
   hosts: wazuh-manager
   become: true
   vars:
@@ -8,8 +8,20 @@
     - name: Truncate alerts file
       shell: echo "" > {{ alerts_path }}
 
+- name: Generate events
+  hosts: ubuntu-agent
+  become: true
+  tasks:
+
     - name: Run command to generate an alert
       shell: curl http://testmynids.org/uid/index.html
+
+- name: Get alerts
+  hosts: wazuh-manager
+  become: true
+  vars:
+    alerts_path: /var/ossec/logs/alerts/alerts.json
+  tasks:
 
     - name: Wait for alerts to be generated
       wait_for:

--- a/tests/end_to_end/test_basic_cases/test_suricata_integration/data/playbooks/teardown.yaml
+++ b/tests/end_to_end/test_basic_cases/test_suricata_integration/data/playbooks/teardown.yaml
@@ -1,5 +1,5 @@
 - name: Configure environment
-  hosts: wazuh-manager
+  hosts: ubuntu-agent
   become: true
   tasks:
 
@@ -12,4 +12,4 @@
     - name: Restart Wazuh to apply the change
       systemd:
         state: restarted
-        name: wazuh-manager
+        name: wazuh-agent

--- a/tests/end_to_end/test_basic_cases/test_suricata_integration/test_suricata_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_suricata_integration/test_suricata_integration.py
@@ -18,6 +18,7 @@ components:
 
 targets:
     - manager
+    - agent
 
 daemons:
     - wazuh-logcollector
@@ -27,6 +28,7 @@ os_platform:
     - linux
 
 os_version:
+    - CentOS 8
     - Ubuntu Focal
 
 references:


### PR DESCRIPTION
|Related issue|
|-------------|
|       #3187       |

**This PR should be merged after #3185**
## Description

<!-- Add a description of the context and content of all changes made in the pull request -->



<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Suricata playbooks: Now the configuration and the events are generated in the agent
- Suricata documentation


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @juliamagan (Developer)  |   test_suricata_integration/        | :no_entry_sign: :no_entry_sign: :no_entry_sign: | [🟢 ](https://github.com/wazuh/wazuh-qa/files/9380498/3188-R1-test-suricata-integration.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9380502/3188-R2-test-suricata-integration.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9380504/3188-R3-test-suricata-integration.zip) |  CentOS and Ubuntu       |     53a34f3    | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
