### PR TITLE
Add `v` to agent version in `simulate_agents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release report: TBD
 ### Changed
 
 - Update cluster logs in reliability tests ([#2772](https://github.com/wazuh/wazuh-qa/pull/2772)) \- (Tests)
+- Use correct version format in agent_simulator tool ([#3198](https://github.com/wazuh/wazuh-qa/pull/3198)) \- (Tools)
 
 ### Fixed
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -49,6 +49,9 @@ def process_script_parameters(args):
         args.modules.append('receive_messages')
         args.modules_eps.append('0')
 
+    if not args.version.startswith('v'):
+        args.version = 'v' + args.version
+
 
 def set_agent_modules_and_eps(agent, active_modules, modules_eps):
     """Set active modules and EPS to an agent.


### PR DESCRIPTION
|Related issue|
|-------------|
|Closes #3197|

## Description

This PR updates the agent_simulator script so the simulated agent's version always contains a `v` in it, even if the user does not specify it in the parameters:
```
Wazuh v4.4.0
```

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py`

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @selutario (Developer)  |           | ⚫⚫⚫ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9423509/test1.txt)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/9423510/test2.txt)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/9423512/test3.txt) |         |https://github.com/wazuh/wazuh-qa/commit/1845844f3c5e85a8aa46c0d6e215cd3a4deb466d| Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |



