### PR TITLE
E2E tests: Skip Vulnerability Detector Windows test

### DIFF
--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/test_vulnerability_detector_linux.py
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/test_vulnerability_detector_linux.py
@@ -64,6 +64,7 @@ teardown_playbooks = ['teardown.yaml']
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh/wazuh-jenkins#3897, when it is resolved, we can enable the test")
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
 def test_vulnerability_detector_linux(configure_environment, metadata, get_dashboard_credentials, get_manager_ip,

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/test_vulnerability_detector_linux.py
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/test_vulnerability_detector_linux.py
@@ -64,7 +64,6 @@ teardown_playbooks = ['teardown.yaml']
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
 
 
-@pytest.mark.skip(reason="It will be blocked by wazuh/wazuh-jenkins#3897, when it is resolved, we can enable the test")
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
 def test_vulnerability_detector_linux(configure_environment, metadata, get_dashboard_credentials, get_manager_ip,

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/test_vulnerability_detection_windows.py
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/test_vulnerability_detection_windows.py
@@ -65,7 +65,7 @@ teardown_playbooks = ['teardown.yaml']
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
 
 
-@pytest.mark.skip(reason="It will be blocked by wazuh/wazuh#14736, when it is resolved, we can enable the test")
+@pytest.mark.xfail(reason="It will be blocked by wazuh/wazuh#14736, when it is resolved, we can enable the test")
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
 def test_vulnerability_detector_windows(configure_environment, metadata, get_dashboard_credentials, get_manager_ip,

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/test_vulnerability_detection_windows.py
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/test_vulnerability_detection_windows.py
@@ -65,6 +65,7 @@ teardown_playbooks = ['teardown.yaml']
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
 
 
+@pytest.mark.skip(reason="It will be blocked by wazuh/wazuh#14736, when it is resolved, we can enable the test")
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)
 def test_vulnerability_detector_windows(configure_environment, metadata, get_dashboard_credentials, get_manager_ip,


### PR DESCRIPTION
|Related issue|
|-------------|
|    #3199          |

## Description

After some research, we found that the Vulnerability Detector tests were failing consistently. These tests cannot be implemented until the following issues are resolved:

- https://github.com/wazuh/wazuh/issues/14736

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Skipped `test_vulnerability_detector`


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @juliamagan  (Developer)  |    `end_to_end/test_basic_cases/test_vulnerability_detector/`       |:no_entry_sign: :no_entry_sign: :no_entry_sign:  |[🟢 ](https://github.com/wazuh/wazuh-qa/files/9451122/3199-R2-test-vulnerability-detector.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9451123/3199-R1-test-vulnerability-detector.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/9451121/3199-R3-test-vulnerability-detector.zip)|  CentOS, Ubuntu and Windows       |   7848975    | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
