### PR TITLE
E2E: Add markers linux and windows

### DIFF
--- a/tests/end_to_end/test_basic_cases/test_audit/test_audit.py
+++ b/tests/end_to_end/test_basic_cases/test_audit/test_audit.py
@@ -46,6 +46,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -56,6 +57,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_aws_infrastructure_monitoring/test_aws_infrastructure_monitoring.py
+++ b/tests/end_to_end/test_basic_cases/test_aws_infrastructure_monitoring/test_aws_infrastructure_monitoring.py
@@ -46,6 +46,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 # Test cases data
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -69,6 +70,9 @@ aws_api_script = os.path.join(test_data_path, 'configuration', 'aws_cloudtrail_e
 metadata = config.update_configuration_template(metadata, ['CUSTOM_AWS_SCRIPT_PATH'], [aws_api_script])
 bucket_name = metadata[0]['extra_vars']['bucket']
 configuration_extra_vars.update({'AWS_API_SCRIPT': aws_api_script, 'bucket': bucket_name})
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.parametrize('metadata', metadata, ids=cases_ids)

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/test_brute_force_rdp.py
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/test_brute_force_rdp.py
@@ -47,6 +47,7 @@ import wazuh_testing as fw
 from wazuh_testing.tools import configuration as config
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
+from wazuh_testing.modules import TIER0, WINDOWS
 
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -60,6 +61,9 @@ teardown_playbooks = None
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, WINDOWS]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/test_brute_force_ssh.py
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/test_brute_force_ssh.py
@@ -45,6 +45,7 @@ import wazuh_testing as fw
 from wazuh_testing.tools import configuration as config
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
+from wazuh_testing.modules import TIER0, LINUX
 
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -57,6 +58,9 @@ teardown_playbooks = None
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
+++ b/tests/end_to_end/test_basic_cases/test_detecting_suspicious_binaries/test_detecting_suspicious_binaries.py
@@ -47,6 +47,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 # Test cases data
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -63,6 +64,9 @@ configuration_extra_vars = {'trojan_script_path': trojan_script_path}
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)

--- a/tests/end_to_end/test_basic_cases/test_docker_monitoring/test_docker_monitoring.py
+++ b/tests/end_to_end/test_basic_cases/test_docker_monitoring/test_docker_monitoring.py
@@ -45,6 +45,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 # Test cases data
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -59,6 +60,9 @@ teardown_playbooks = ['teardown.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)

--- a/tests/end_to_end/test_basic_cases/test_emotet/test_emotet.py
+++ b/tests/end_to_end/test_basic_cases/test_emotet/test_emotet.py
@@ -47,6 +47,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, WINDOWS
 
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -58,6 +59,9 @@ teardown_playbooks = ['teardown.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, WINDOWS]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_fim/test_fim_linux/test_fim_linux.py
+++ b/tests/end_to_end/test_basic_cases/test_fim/test_fim_linux/test_fim_linux.py
@@ -47,6 +47,8 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
+
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -56,6 +58,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_fim/test_fim_windows/test_fim_windows.py
+++ b/tests/end_to_end/test_basic_cases/test_fim/test_fim_windows/test_fim_windows.py
@@ -49,6 +49,8 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, WINDOWS
+
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -58,6 +60,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, WINDOWS]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_ip_reputation/test_ip_reputation.py
+++ b/tests/end_to_end/test_basic_cases/test_ip_reputation/test_ip_reputation.py
@@ -48,6 +48,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX, WINDOWS
 
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -58,6 +59,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX, WINDOWS]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_osquery_integration/test_osquery_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_osquery_integration/test_osquery_integration.py
@@ -46,6 +46,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -58,6 +59,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_shellshock_attack_detection/test_shellshock_attack_detection.py
+++ b/tests/end_to_end/test_basic_cases/test_shellshock_attack_detection/test_shellshock_attack_detection.py
@@ -47,6 +47,7 @@ from tempfile import gettempdir
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -57,6 +58,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_slack_integration/test_slack_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_slack_integration/test_slack_integration.py
@@ -47,6 +47,8 @@ from wazuh_testing.tools.file import remove_file
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
+
 
 # Test cases data
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -69,6 +71,9 @@ slack_api_script = os.path.join(test_data_path, 'configuration', 'slack_api_scri
 # Update configuration with custom paths
 metadata = config.update_configuration_template(metadata, ['CUSTOM_SLACK_SCRIPT_PATH'], [slack_api_script])
 configuration_extra_vars = configuration[0]
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.fixture(scope='function')

--- a/tests/end_to_end/test_basic_cases/test_sql_injection/test_sql_injection.py
+++ b/tests/end_to_end/test_basic_cases/test_sql_injection/test_sql_injection.py
@@ -45,6 +45,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -55,6 +56,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_suricata_integration/test_suricata_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_suricata_integration/test_suricata_integration.py
@@ -50,6 +50,7 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -60,6 +61,9 @@ events_playbooks = ['generate_events.yaml']
 teardown_playbooks = ['teardown.yaml']
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_unauthorized_processes_detection/test_unauthorized_processes_detection.py
+++ b/tests/end_to_end/test_basic_cases/test_unauthorized_processes_detection/test_unauthorized_processes_detection.py
@@ -45,6 +45,8 @@ from tempfile import gettempdir
 from wazuh_testing.tools import configuration as config
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
+from wazuh_testing.modules import TIER0, LINUX
+
 
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -58,6 +60,9 @@ teardown_playbooks = ['teardown.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/test_virustotal_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/test_virustotal_integration.py
@@ -52,6 +52,7 @@ from tempfile import gettempdir
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
 
 
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -64,6 +65,9 @@ remove_threat_file_path = os.path.join(test_data_path, 'active_response_script',
 configuration_extra_vars = {'active_response_script': remove_threat_file_path}
 
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/test_vulnerability_detector_linux.py
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/test_vulnerability_detector_linux.py
@@ -49,6 +49,8 @@ from tempfile import gettempdir
 from wazuh_testing.tools import configuration as config
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
+from wazuh_testing.modules import TIER0, LINUX
+
 
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -62,6 +64,9 @@ teardown_playbooks = ['teardown.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/test_vulnerability_detection_windows.py
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/test_vulnerability_detection_windows.py
@@ -50,6 +50,8 @@ from tempfile import gettempdir
 from wazuh_testing.tools import configuration as config
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
+from wazuh_testing.modules import TIER0, WINDOWS
+
 
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -63,6 +65,9 @@ teardown_playbooks = ['teardown.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, WINDOWS]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_windows_defender/test_windows_defender.py
+++ b/tests/end_to_end/test_basic_cases/test_windows_defender/test_windows_defender.py
@@ -44,6 +44,7 @@ import wazuh_testing as fw
 from wazuh_testing.tools import configuration as config
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
+from wazuh_testing.modules import TIER0, WINDOWS
 
 # Test cases data
 alerts_json = os.path.join(gettempdir(), 'alerts.json')
@@ -57,6 +58,9 @@ teardown_playbooks = ['teardown.yaml']
 
 # Configuration
 configurations, configuration_metadata, cases_ids = config.get_test_cases_data(test_cases_file_path)
+
+# Marks
+pytestmark = [TIER0, WINDOWS]
 
 
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')

--- a/tests/end_to_end/test_basic_cases/test_yara_integration/test_yara_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_yara_integration/test_yara_integration.py
@@ -47,6 +47,8 @@ import wazuh_testing as fw
 from wazuh_testing import end_to_end as e2e
 from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import configuration as config
+from wazuh_testing.modules import TIER0, LINUX
+
 
 # Test cases data
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -65,6 +67,9 @@ configurations, configuration_metadata, cases_ids = config.get_test_cases_data(t
 # Custom paths
 yara_script = os.path.join(test_data_path, 'configuration', 'yara.sh')
 configuration_extra_vars = {'yara_script': yara_script}
+
+# Marks
+pytestmark = [TIER0, LINUX]
 
 
 @pytest.mark.parametrize('metadata', configuration_metadata, ids=cases_ids)


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3204        |

## Description
### Added markers to specify supported OS
### Linux
1. Run test as follows:

```
python -m pytest tests/end_to_end/test_basic_cases/ -m linux --inventory_path=/home/belen/Repositories/wazuh-qa/tests/end_to_end/general_playbooks/inventory_jenkins.yaml --html=3204-T1-R${i}-e2e-belenvaldivia.html --self-contained-html
```

### Windows
1. Run test as follows:

```
python -m pytest tests/end_to_end/test_basic_cases/ -m win32 --inventory_path=/home/belen/Repositories/wazuh-qa/tests/end_to_end/general_playbooks/inventory_jenkins.yaml --html=3204-T1-R${i}-e2e-belenvaldivia.html --self-contained-html
```
---

## Testing performed

### Linux

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @BelenValdivia  (Developer)  |          |  ⚫⚫⚫  | [🟢](https://github.com/wazuh/wazuh-qa/files/9455468/T1-R1-3204-e2e-linux.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9455469/T1-R2-3204-e2e-linux.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9455470/T1-R3-3204-e2e-linux.zip)   |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

### Windows

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @BelenValdivia  (Developer)  |          |  ⚫⚫⚫  | [🟢](https://github.com/wazuh/wazuh-qa/files/9455479/T1-R1-3204-e2e-windows.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9455480/T1-R2-3204-e2e-windows.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9455481/T1-R3-3204-e2e-windows.zip)   |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

