### PR TITLE
E2E tests: Disable AWS test

### DIFF
--- a/tests/end_to_end/test_basic_cases/test_aws_infrastructure_monitoring/test_aws_infrastructure_monitoring.py
+++ b/tests/end_to_end/test_basic_cases/test_aws_infrastructure_monitoring/test_aws_infrastructure_monitoring.py
@@ -75,6 +75,7 @@ configuration_extra_vars.update({'AWS_API_SCRIPT': aws_api_script, 'bucket': buc
 pytestmark = [TIER0, LINUX]
 
 
+@pytest.mark.skip(reason='It will be blocked by #3211, when it is resolved, we can enable the test')
 @pytest.mark.parametrize('metadata', metadata, ids=cases_ids)
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_aws_infrastructure_monitoring(metadata, configure_environment, get_dashboard_credentials, get_manager_ip,


### PR DESCRIPTION
|Related issue|
|-------------|
|        #3211      |

## Description

After configuring a trail for S3 data events and modifying the test to use this trail to generate events. No alerts are generated because the event we can generate is PutObject. The only events for which alerts are generated can be found at [ruleset/lists/amazon/aws-eventnames](https://github.com/wazuh/wazuh/blob/master/ruleset/lists/amazon/aws-eventnames).

So we need to create a trail that checks the Management events, the drawback is that it has a higher price than the Data events. We will disable this test until a decision is made.



<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Skip `test_aws_infrastructure_monitoring`



---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
