### PR TITLE
E2E tests: Fix Brute Force tests

### DIFF
--- a/tests/end_to_end/data/ansible_roles/manage_alerts/tasks/search_alert.yaml
+++ b/tests/end_to_end/data/ansible_roles/manage_alerts/tasks/search_alert.yaml
@@ -1,0 +1,12 @@
+- name: Search alert in alerts log
+  become: true
+  lineinfile:
+    path: /var/ossec/logs/alerts/alerts.json
+    regexp: "{{ custom_regex }}"
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: alert
+  until: alert.found != 0
+  retries: "{{ attempts }}"
+  delay: "{{ time_btw_attempts }}"

--- a/tests/end_to_end/data/env_requirements.json
+++ b/tests/end_to_end/data/env_requirements.json
@@ -47,7 +47,8 @@
         "agent": {
             "instances": 2,
             "distros": [
-                "Windows"
+                "Windows",
+                "Ubuntu"
             ]
         }
     },

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/playbooks/configuration.yaml
@@ -1,10 +1,10 @@
 - name: Configure local environment
-  hosts: localhost
+  hosts: ubuntu-agent
   become: true
   tasks:
 
     # Install hydra to attempt the RDP brute force attack
     - name: Install hydra
       package:
-        name: hydra
+        name: hydra=9.2-1ubuntu1
         state: present

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/playbooks/generate_events.yaml
@@ -8,7 +8,7 @@
         tasks_from: truncate_alert_json.yaml
 
 - name: Generate events
-  hosts: localhost
+  hosts: ubuntu-agent
   tasks:
 
     - name: Attempt a RDP brute force attack
@@ -22,17 +22,21 @@
         - test_user
         - test_user
         - test_user
-      register: result
-      failed_when:
-        - "'0 valid password found' not in result.stdout"
-
-    - name: Wait for alert
-      wait_for:
-        timeout: 5
 
 - name: Get alerts file
   hosts: managers
   tasks:
+
+    - name: Search alert in alerts log
+      include_role:
+        name: manage_alerts
+        tasks_from: search_alert.yaml
+      vars:
+        ts: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
+        custom_regex: "{\"timestamp\":\"{{ ts }}\",\"rule\":{\"level\":{{ rule_level }},\
+          \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*"
+        attempts: 15
+        time_btw_attempts: 2
 
     - name: Get alert json
       include_role:

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/playbooks/generate_events.yaml
@@ -32,8 +32,8 @@
         name: manage_alerts
         tasks_from: search_alert.yaml
       vars:
-        ts: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
-        custom_regex: "{\"timestamp\":\"{{ ts }}\",\"rule\":{\"level\":{{ rule_level }},\
+        timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
+        custom_regex: "{\"timestamp\":\"{{ timestamp }}\",\"rule\":{\"level\":{{ rule_level }},\
           \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*"
         attempts: 15
         time_btw_attempts: 2

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/test_cases/cases_brute_force_rdp.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_rdp/data/test_cases/cases_brute_force_rdp.yaml
@@ -7,3 +7,7 @@
     rule.description: Multiple Windows logon failures.
     extra:
       mitre_technique: Brute Force
+    extra_vars:
+      rule_id: 60204
+      rule_level: 10
+      rule_description: Multiple Windows logon failures.

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/data/playbooks/generate_events.yaml
@@ -35,8 +35,6 @@
 
 - name: Get alerts file
   hosts: managers
-  vars:
-    ts:
   tasks:
 
     - name: Search alert in alerts log
@@ -44,8 +42,8 @@
         name: manage_alerts
         tasks_from: search_alert.yaml
       vars:
-        ts: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
-        custom_regex: "{\"timestamp\":\"{{ ts }}\",\"rule\":{\"level\":{{ rule_level }},\
+        timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
+        custom_regex: "{\"timestamp\":\"{{ timestamp }}\",\"rule\":{\"level\":{{ rule_level }},\
           \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*"
         attempts: 15
         time_btw_attempts: 2

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/data/playbooks/generate_events.yaml
@@ -19,7 +19,7 @@
         responses:
           (.*)continue connecting(.*): 'yes'
           (?i)password: 1
-        timeout: 5
+        timeout: 15
       loop:
         - test_user
         - test_user
@@ -33,13 +33,22 @@
       failed_when:
         - "'Permission denied' not in result.stdout"
 
-    - name: Wait for alert
-      wait_for:
-        timeout: 5
-
 - name: Get alerts file
   hosts: managers
+  vars:
+    ts:
   tasks:
+
+    - name: Search alert in alerts log
+      include_role:
+        name: manage_alerts
+        tasks_from: search_alert.yaml
+      vars:
+        ts: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
+        custom_regex: "{\"timestamp\":\"{{ ts }}\",\"rule\":{\"level\":{{ rule_level }},\
+          \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*"
+        attempts: 15
+        time_btw_attempts: 2
 
     - name: Get alert json
       include_role:

--- a/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/data/test_cases/cases_brute_force_ssh.yaml
+++ b/tests/end_to_end/test_basic_cases/test_brute_force/test_brute_force_ssh/data/test_cases/cases_brute_force_ssh.yaml
@@ -7,3 +7,7 @@
     rule.description: "sshd: brute force trying to get access to the system. Non existent user."
     extra:
       mitre_technique: Brute Force
+    extra_vars:
+      rule_id: 5712
+      rule_level: 10
+      rule_description: "sshd: brute force trying to get access to the system. Non existent user."


### PR DESCRIPTION
|Related issue|
|-------------|
| #3208 |

## Description

I fixed the `test_brute_force_rdp` test by specifying the version of Hydra to be installed (v9.2).

Also, I added a role task to search for the alert before fetching the `alerts.json`.

### Added

- `search_alert.yaml` role task

### Updated

- "Generate events" playbooks
- Test cases files

---

## Testing performed

| Results | Note
| -- | --
| [🟢](https://github.com/wazuh/wazuh-qa/files/9470844/3208-mauromalara.zip) (6 rounds) | In R2 and R6 RDP fails, so I fixed the error by removing the `failed_when` condition because it's unnecessary (the command is executed but ansible does not wait for it to finish)
| [🟢](https://github.com/wazuh/wazuh-qa/files/9471195/3208-R6-mauromalara.zip) | 6 rounds of RDP only to check the change mentioned in the previous note.