### PR TITLE
E2E tests: Fix Emotet test

### DIFF
--- a/tests/end_to_end/pytest.ini
+++ b/tests/end_to_end/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+addopts = --strict-markers
+markers =
+    tier(level)
+    darwin
+    linux
+    sunos5
+    win32
+    server
+    agent

--- a/tests/end_to_end/test_basic_cases/test_emotet/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_emotet/data/playbooks/generate_events.yaml
@@ -20,9 +20,16 @@
   hosts: managers
   tasks:
 
-    - name: Wait for alert
-      wait_for:
-        timeout: 10
+    - name: Search alert in alerts log
+      with_items: "{{ lookup('ansible.builtin.dict', alerts) }}"
+      include_role:
+        name: manage_alerts
+        tasks_from: search_alert.yaml
+      vars:
+        timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
+        custom_regex: "{\"timestamp\":\"{{ timestamp }}\".*\"id\":\"{{ item.value.rule_id }}\".*"
+        attempts: 15
+        time_btw_attempts: 2
 
     - name: Get alert json
       include_role:

--- a/tests/end_to_end/test_basic_cases/test_emotet/data/test_cases/cases_emotet.yaml
+++ b/tests/end_to_end/test_basic_cases/test_emotet/data/test_cases/cases_emotet.yaml
@@ -14,3 +14,9 @@
       rule.description: Word Executing WScript C:\\\\\\\\Windows\\\\\\\\System32\\\\\\\\wscript.exe
       extra:
         groups: emotet
+    extra_vars:
+      alerts:
+        regsvr32:
+          rule_id: 255561
+        word_executing_script:
+          rule_id: 255926


### PR DESCRIPTION
|Related issue|
|-------------|
| #3209 |

## Description

### Added

- `pytest.ini`: used to define custom marks

### Updated

Replace fixed timeout with a dynamic search using regex and the alert data.

---

## Testing performed

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  |           | N/A | [🟢](https://github.com/wazuh/wazuh-qa/files/9472871/3209-R1-emotet.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9472872/3209-R2-emotet.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9472873/3209-R3-emotet.zip) |         |         | Nothing to highlight |