### PR TITLE
E2E test: Fix Virustotal test

### DIFF
--- a/tests/end_to_end/pytest.ini
+++ b/tests/end_to_end/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+addopts = --strict-markers
+markers =
+    tier(level)
+    darwin
+    linux
+    sunos5
+    win32
+    server
+    agent

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
@@ -17,7 +17,7 @@
       vars:
         timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
         custom_regex: "{\"timestamp\":\"{{ timestamp }}\",\"rule\":{\"level\":{{ rule_level }},\
-          \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*}"
+                       \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*}"
         attempts: 15
         time_btw_attempts: 2
 

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
@@ -6,13 +6,20 @@
       become: true
       shell: "{{ shell }}"
 
-    - name: Wait for alert
-      wait_for:
-        timeout: 5
-
 - name: Get alerts file
   hosts: managers
   tasks:
+
+    - name: Search alert in alerts log
+      include_role:
+        name: manage_alerts
+        tasks_from: search_alert.yaml
+      vars:
+        timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
+        custom_regex: "{\"timestamp\":\"{{ timestamp }}\",\"rule\":{\"level\":{{ rule_level }},\
+          \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*}"
+        attempts: 15
+        time_btw_attempts: 2
 
     - name: Get alert json
       include_role:

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/test_cases/cases_virustotal_integration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/test_cases/cases_virustotal_integration.yaml
@@ -2,9 +2,6 @@
   description: Detecting and removing malware
   configuration_parameters: null
   metadata:
-    rule.id: 100092
-    rule.level: 12
-    rule.description: "active-response\/bin\/remove-threat.sh removed threat located at \/root\/eicar.com "
     extra_vars:
       event_description: Download malicious file
       shell: |
@@ -18,9 +15,6 @@
   description: Scanning a file and check generated alerts
   configuration_parameters: null
   metadata:
-    rule.id: 87103
-    rule.level: 3
-    rule.description: "VirusTotal: Alert - No records in VirusTotal database"
     extra_vars:
       event_description: Create harmless file
       shell: echo "Just a simple text file" > /root/harmless_file.txt

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/test_cases/cases_virustotal_integration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/test_cases/cases_virustotal_integration.yaml
@@ -2,22 +2,28 @@
   description: Detecting and removing malware
   configuration_parameters: null
   metadata:
+    rule.id: 100092
+    rule.level: 12
+    rule.description: "active-response\/bin\/remove-threat.sh removed threat located at \/root\/eicar.com "
     extra_vars:
       event_description: Download malicious file
       shell: |
         cd /root
         curl -LO http://www.eicar.org/download/eicar.com
-    rule.id: 100092
-    rule.level: 12
-    rule.description: "active-response\/bin\/remove-threat.sh removed threat located at \/root\/eicar.com "
+      rule_id: 100092
+      rule_level: 12
+      rule_description: "active-response\/bin\/remove-threat.sh removed threat located at \/root\/eicar.com "
 
 - name: harmless_file
   description: Scanning a file and check generated alerts
   configuration_parameters: null
   metadata:
-    extra_vars:
-      event_description: Create harmless file
-      shell: echo "Just a simple text file" > /root/harmless_file.txt
     rule.id: 87103
     rule.level: 3
     rule.description: "VirusTotal: Alert - No records in VirusTotal database"
+    extra_vars:
+      event_description: Create harmless file
+      shell: echo "Just a simple text file" > /root/harmless_file.txt
+      rule_id: 87103
+      rule_level: 3
+      rule_description: "VirusTotal: Alert - No records in VirusTotal database"

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/test_virustotal_integration.py
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/test_virustotal_integration.py
@@ -112,9 +112,9 @@ def test_virustotal_integration(configure_environment, metadata, get_dashboard_c
         - The `configuration.yaml` file provides the module configuration for this test.
         - The `generate_events.yaml`file provides the function configuration for this test.
     '''
-    rule_id = metadata['rule.id']
-    rule_level = metadata['rule.level']
-    rule_description = metadata['rule.description']
+    rule_id = metadata['extra_vars']['rule_id']
+    rule_level = metadata['extra_vars']['rule_level']
+    rule_description = metadata['extra_vars']['rule_description']
     timestamp_regex = r'\d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+'
 
     expected_alert_json = fr'\{{"timestamp":"({timestamp_regex})","rule"\:{{"level"\:{rule_level},' \


### PR DESCRIPTION
|Related issue|
|-------------|
| #3205 |

## Description

### Updated

- `generate_events.yaml`: Replace fixed timeout with a dynamic search using regex and the alert data.

---

## Testing performed

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  |           | N/A | [🟢](https://github.com/wazuh/wazuh-qa/files/9473006/3205-R1-mauromalara.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9473053/3205-R2-mauromalara.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9473054/3205-R3-mauromalara.zip) |         |         | Nothing to highlight |