### PR TITLE
E2E tests: Change inventory validation

### DIFF
--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -66,11 +66,12 @@ def validate_inventory(inventory_path, target_hosts):
         if host not in inventory_hosts:
             missing_hosts.extend([host])
     if missing_hosts != []:
+        readme_file = '[README.md](https://github.com/wazuh/wazuh-qa/blob/master/tests/end_to_end/README.md)'
         raise Exception(f"Not all the hosts required to run the tests are present in the inventory.\n"
                         f"Hosts in the inventory: {inventory_hosts}\n"
                         f"Expected hosts: {target_hosts}\n"
                         f"Missing hosts: {missing_hosts}\n"
-                        "Read the README.md file inside the E2E suite to build a valid inventory.")
+                        f"Read the {readme_file} file inside the E2E suite to build a valid inventory.")
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
|Related issue|
|-------------|
| #3237 |

## Description

Now the validation checks only if the required hosts are present in the inventory and groups are not checked anymore.

Example:

```
E   Exception: Not all the hosts required to run the tests are present in the inventory.
E   Hosts in the inventory: ['centos-manager']
E   Expected hosts: ['centos-manager', 'windows-agent', 'ubuntu-agent', 'centos-agent']
E   Missing hosts: ['windows-agent', 'ubuntu-agent', 'centos-agent']
E   Read the README.md file inside the E2E suite to build a valid inventory.
```

### Updated

- `conftest.py`: inventory validation changed.

---

## Testing performed

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  | tests/end_to_end/ | N/A | [🟢](https://github.com/wazuh/wazuh-qa/files/9478748/3213-R1-mauromalara.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9478749/3213-R2-mauromalara.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9478750/3213-R3-mauromalara.zip) |         |         | Nothing to highlight |