### PR TITLE
Update wazuh-logtest messages for integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.3.8] - Development (unreleased)
+
+Wazuh commit: TBD \
+Release report: TBD
+
+### Changed
+
+- Update wazuh-logtest messages for integration tests \- (Tests)
+
 ## [4.3.7] - 24-08-2022
 
 Wazuh commit: https://github.com/wazuh/wazuh/commit/e2b514bef3d148acd4bcae1a1c7fa8783b82ca3a \

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_rules_syntax.yaml
@@ -53,14 +53,14 @@
   rules: "custom_rule_7.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "Signature ID '123123' was not found. Invalid 'if_sid'. Rule '100001' will be ignored."
+  output_data_msg: "Signature ID '123123' was not found and will be ignored in the 'if_sid' option of rule '100001'"
   output_data_codemsg: 1
 -
   name: "Invalid rules syntax: no existing if_matched_sid rule number attribute without frequency and timeframe"
   rules: "custom_rule_8.xml"
   input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
   output_error: 0
-  output_data_msg: "Signature ID '100005' was not found. Invalid 'if_matched_sid'. Rule '100002' will be ignored."
+  output_data_msg: "Signature ID '100005' was not found. Invalid 'if_matched_sid'.Rule '100002' will be ignored"
   output_data_codemsg: 1
 -
   name: "Invalid rules syntax: non existing/invalid attribute"


### PR DESCRIPTION
|Related issue|
|-------------|
|  #3224       |

## Description

This PR applies the necessary changes in the wazuh-logtest integration tests messages due to changes made in this PR https://github.com/wazuh/wazuh/pull/14772.


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @jmv74211 |  `test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py`  | [🟢](https://ci.wazuh.info/job/Test_integration/31627/console)  | 🟢🟢🟢 |    CentOS 7   |  a07ed0f4cf8e071cf5a30499210fd8d88c238ed5       | Nothing to highlight |
