### PR TITLE
Test Integration - fix vulnerability validate feed content test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Release report: TBD
 
 ### Fixed
 
+- Fix Vulnerability Detector IT: test_validate_feed_content yaml cases had wrong extension. ([#3299](https://github.com/wazuh/wazuh-qa/pull/3299)) \- (Tests)
 - Fix Analysisd IT: test_syscollector_events failure on wait_for_analysisd_startup. ([#3110](https://github.com/wazuh/wazuh-qa/pull/3110)) \- (Tests)
 - Fix GCloud IT: test_max_messages error not received expected messages - ([#3083](https://github.com/wazuh/wazuh-qa/pull/3083)) \- (Tests)
 - Fix Solaris and Macos FIM integration tests failures ([#2976](https://github.com/wazuh/wazuh-qa/pull/2976)) \- (Framework + Tests)

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -3,7 +3,7 @@
   configuration_parameters:
   metadata:
     provider_name: Red Hat Enterprise Linux 5
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/com.redhat.rhsa-RHEL5.xml.bz2
     extension: bz2
     decompressed_file: /tmp/rhel5.xml
@@ -14,7 +14,7 @@
   configuration_parameters:
   metadata:
     provider_name: Red Hat Enterprise Linux 6
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/rhel-6-including-unpatched.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/rhel6.xml
@@ -25,7 +25,7 @@
   configuration_parameters:
   metadata:
     provider_name: Red Hat Enterprise Linux 7
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/rhel-7-including-unpatched.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/rhel7.xml
@@ -36,7 +36,7 @@
   configuration_parameters:
   metadata:
     provider_name: Red Hat Enterprise Linux 8
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/rhel-8-including-unpatched.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/rhel8.xml
@@ -47,7 +47,7 @@
   configuration_parameters:
   metadata:
     provider_name: Ubuntu Jammy
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/com.ubuntu.jammy.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/jammy.xml
@@ -58,7 +58,7 @@
   configuration_parameters:
   metadata:
     provider_name: Ubuntu Focal
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/com.ubuntu.focal.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/focal.xml
@@ -69,7 +69,7 @@
   configuration_parameters:
   metadata:
     provider_name: Ubuntu Bionic
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/com.ubuntu.bionic.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/bionic.xml
@@ -80,7 +80,7 @@
   configuration_parameters:
   metadata:
     provider_name: Ubuntu Xenial
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/com.ubuntu.xenial.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/xenial.xml
@@ -91,7 +91,7 @@
   configuration_parameters:
   metadata:
     provider_name: Ubuntu Trusty
-    expected_format: application/x-bzip
+    expected_format: application/x-bzip2
     path: /tmp/com.ubuntu.trusty.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/trusty.xml


### PR DESCRIPTION
|Related issue|
|-------------|
|      #3282       |

## Description

In a nightly the test failed as exposed in #3282. After some research, the yaml cases have a wrong `expected_extension`. 

### Updated

- Fixed `cases_validate_xml_feed_content.yaml` used in `test_validate_feed_content`

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @roronoasins (Developer)  |  `test_vulnerability_detector/test_feeds/test_validate_feed_content.py`         | [:green_circle:](https://ci.wazuh.info/job/Test_integration/31916/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/31918/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/31920/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/31922/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/31923/)  | :green_circle: :green_circle: :green_circle: |    CentOS8     |    https://github.com/wazuh/wazuh/commit/8b4624107d36970222425dfa8336a487eee4b963     | Nothing to highlight |
| @damarisg  (Reviewer)   |     `test_vulnerability_detector/test_feeds/test_validate_feed_content.py`      | [🟢](https://ci.wazuh.info/job/Test_integration/32031/)[🟢](https://ci.wazuh.info/job/Test_integration/32032/) [🟢](https://ci.wazuh.info/job/Test_integration/32033/)   | :no_entry_sign: :no_entry_sign: :no_entry_sign:   | CentOS 8   | https://github.com/wazuh/wazuh/commit/8b4624107d36970222425dfa8336a487eee4b963        | Nothing to highlight |
