### PR TITLE
Fix Windows framework installation error for python3.10 - 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release report: TBD
 
 ### Changed
 
+- Change required version of urllib3 and requests dependencies ([#3315](https://github.com/wazuh/wazuh-qa/pull/3315)) \- (Framework)
 - Skip flaky Logcollector tests ([#3218](https://github.com/wazuh/wazuh-qa/pull/3217)) \- (Tests)
 - Change how 'service_control' collects clusterd and apid pids ([#3140](https://github.com/wazuh/wazuh-qa/pull/3140)) \- (Framework)
 - Change scan test module fixtures to allow use commit instead of branches ([#3134](https://github.com/wazuh/wazuh-qa/issues/3134)) \- (Tests)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,14 +23,14 @@ pyOpenSSL==19.1.0
 pytest-html==3.1.1
 pytest==6.2.5
 pyyaml==5.4
-requests==2.23.0
+requests>=2.23.0
 scipy>=1.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 setuptools~=56.0.0
 testinfra==5.0.0
 jq>=1.1.2; platform_system == "Linux" or platform_system == "Darwin"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
-urllib3
+urllib3>=1.26.5
 numpydoc>=1.1.0
 ansible-runner>=2.0.1 ; platform_system == "Linux"
 docker>=5.0.0 ; platform_system == "Linux" or platform_system=='Windows'


### PR DESCRIPTION
|Related issue|
|-------------|
|       #3292       |

## Description

Change `urllib3` and  `requests` dependencies version to fix framework installation error in Windows hosts.

### Updated

- Change urllib3 version to >=1.26.5 
- Change requests version to >=2.23.0

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | :green_circle:  |  not apply |         |         | https://github.com/wazuh/wazuh-qa/pull/3314#issue-1377630108  |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
