### PR TITLE
Fix wazuh-integratord tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/integratord/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/integratord/__init__.py
@@ -17,7 +17,7 @@ CB_VIRUSTOTAL_ALERT_JSON = r'.*VirusTotal: Alert.*\"integration\":\"virustotal\"
 CB_INVALID_JSON_ALERT_READ = r'.*wazuh-integratord.*WARNING: Invalid JSON alert read.*'
 CB_OVERLONG_JSON_ALERT_READ = r'.*wazuh-integratord.*WARNING: Overlong JSON alert read.*'
 CB_ALERTS_FILE_INODE_CHANGED = r'.*wazuh-integratord.*DEBUG: jqueue_next.*Alert file inode changed.*'
-CB_CANNOT_RETRIEVE_JSON_FILE = r'.*wazuh-integratord.*ERROR.*Could not retrieve information of file.*'\
+CB_CANNOT_RETRIEVE_JSON_FILE = r'.*wazuh-integratord.*WARNING.*Could not retrieve information of file.*'\
                                r'alerts\.json.*No such file.*'
 
 # Error messages

--- a/tests/integration/test_integratord/data/test_cases/cases_integratord_change_inode_alert.yaml
+++ b/tests/integration/test_integratord/data/test_cases/cases_integratord_change_inode_alert.yaml
@@ -1,4 +1,4 @@
-- name: Cannot read alerts - Inode changed
+- name: alerts_file_inode_changed
   description: The alerts.json file inode has changed and it cannot read alerts from it until it reloads.
   configuration_parameters:
     API_KEY: Insert using --integration-api-key parameter

--- a/tests/integration/test_integratord/data/test_cases/cases_integratord_read_invalid_json_alerts.yaml
+++ b/tests/integration/test_integratord/data/test_cases/cases_integratord_read_invalid_json_alerts.yaml
@@ -1,4 +1,4 @@
-- name: Read invalid json alert
+- name: read_invalid_json_alert
   description: Read a invalid alert from alerts.json - removed rule key name - Integration fails
   configuration_parameters:
     API_KEY: Insert using --integration-api-key parameter
@@ -17,7 +17,7 @@
                    "decoder":{"name":"syscheck_new_entry"},"location":"syscheck"}'
     alert_type: invalid
 
-- name: Read Overlong json alert
+- name: read_overlong_json_alert
   description: Read a an alert that is over 64kb alert from alerts.json - Integration fails
   configuration_parameters:
     API_KEY: Insert using --integration-api-key parameter

--- a/tests/integration/test_integratord/data/test_cases/cases_integratord_read_json_file_deleted.yaml
+++ b/tests/integration/test_integratord/data/test_cases/cases_integratord_read_json_file_deleted.yaml
@@ -1,4 +1,4 @@
-- name: Cannot read alerts - Json File Deleted
+- name: alerts_json_file_deleted
   description: The alerts.json file is missing and it cannot read alerts from it.
   configuration_parameters:
     API_KEY: Insert using --integration-api-key parameter

--- a/tests/integration/test_integratord/data/test_cases/cases_integratord_read_valid_json_alerts.yaml
+++ b/tests/integration/test_integratord/data/test_cases/cases_integratord_read_valid_json_alerts.yaml
@@ -1,4 +1,4 @@
-- name: Read valid json alert
+- name: read_valid_json_alert
   description: Read a valid alert from alerts.json
   configuration_parameters:
     API_KEY: Insert using --integration-api-key parameter

--- a/tests/integration/test_integratord/test_integratord_read_json_alerts.py
+++ b/tests/integration/test_integratord/test_integratord_read_json_alerts.py
@@ -102,7 +102,7 @@ def test_integratord_read_valid_alerts(configuration, metadata, set_wazuh_config
             brief: Configure the local internal options file.
         - restart_wazuh_function:
             type: fixture
-            brief: Restart wazuh-modulesd daemon before starting a test, and stop it after finishing.
+            brief: Restart all daemons because Integratord depends on multiple daemons. Stop them after finishing.
         - wait_for_start_module:
             type: fixture
             brief: Detect the start of the Integratord module in the ossec.log

--- a/tests/integration/test_integratord/test_integratord_read_json_file_deleted.py
+++ b/tests/integration/test_integratord/test_integratord_read_json_file_deleted.py
@@ -96,7 +96,7 @@ def test_integratord_read_json_file_deleted(configuration, metadata, set_wazuh_c
             brief: Configure the local internal options file.
         - restart_wazuh_function:
             type: fixture
-            brief: Restart wazuh-modulesd daemon before starting a test, and stop it after finishing.
+            brief: Restart all daemons because Integratord depends on multiple daemons. Stop them after finishing.
         - wait_for_start_module:
             type: fixture
             brief: Detect the start of the Integratord module in the ossec.log


### PR DESCRIPTION
|Related issue|
|-------------|
| #3298 |

## Description

After a change was made in a message, we had to change a callback from ERROR to WARNING.
Also, we have to change the test case IDs to be capable of running tests and selecting them by their IDs.
Finally, we made changes to the current documentation.

Refs: wazuh/wazuh#14431

### Updated

- `test_integratord_change_json_inode`: The sleep time was reduced to 1 second because `wazuh-integratord` has a one-second delay
- `deps/wazuh_testing/wazuh_testing/modules/integratord/__init__.py`: A callback was changed.

---

## Testing performed


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  | test_integratord/ | [🟢](https://github.com/wazuh/wazuh-qa/files/9637004/manager_html_report_Test_integration_B32098_20220923145025-1.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9637005/manager_html_report_Test_integration_B32098_20220923145025-2.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9637006/manager_html_report_Test_integration_B32098_20220923145025-3.zip) | [🟢](https://github.com/wazuh/wazuh-qa/files/9637044/R1-manager-ubuntu.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9637046/R2-manager-ubuntu.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/9637047/R3-manager-ubuntu.zip)
|         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |