### PR TITLE
Fix Authd IT force_options tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix Authd force_insert tests ([#3374](https://github.com/wazuh/wazuh-qa/pull/3374)) \- (Tests)
 - Update cluster logs in reliability tests ([#2772](https://github.com/wazuh/wazuh-qa/pull/2772)) \- (Tests)
 - Use correct version format in agent_simulator tool ([#3198](https://github.com/wazuh/wazuh-qa/pull/3198)) \- (Tools)
 

--- a/tests/integration/test_authd/force_options/data/test_cases/valid_config/enablement_force_options.yaml
+++ b/tests/integration/test_authd/force_options/data/test_cases/valid_config/enablement_force_options.yaml
@@ -89,7 +89,7 @@
   - force:
       elements:
       - enabled:
-          value: 'yes'
+          value: 'no'
       - key_mismatch:
           value: 'no'
       - disconnected_time:
@@ -98,15 +98,17 @@
           - enabled: 'no'
       - after_registration_time:
           value: 0
-  - force_insert :
+  - force_insert:
       value: 'no'
+  - force_time:
+      value: 0      
   pre_existent_agents:
     -
       id: '001'
       name: agent_1
   log:
-    - The <force_insert> tag is deprecated since version 4.3.0.
-    - Setting <force><enabled> tag to 'no' to comply with the legacy <force_insert> option found.
+    - The <force_insert> tag is deprecated. Use <force> instead.
+    - The <force_time> tag is deprecated. Use <force> instead.
   test_case:
   -
     description: Don´t replace an agent if force_insert disabled force options
@@ -117,33 +119,29 @@
     log:
       - Duplicate name 'agent_1', rejecting enrollment. Agent '001' won't be removed because the force option is disabled.
 -
-  name: "force_insert_enabled"
+  name: "force_insert_enabled_no_force_block"
   description: "Check that legacy force_insert overrides force.enabled"
   configuration:
-  - force:
-      elements:
-      - enabled:
-          value: 'no'
-      - key_mismatch:
-          value: 'no'
-      - disconnected_time:
-          value: 0
-          attributes:
-          - enabled: 'no'
-      - after_registration_time:
-          value:  0
-  - force_insert :
+  - force_insert:
       value: 'yes'
+  - force_time:
+      value: 5
   pre_existent_agents:
     -
       name: agent_1
       id: '001'
+      connection_status: never_connected
+      registration_time:
+        delta: -10000
+      disconnected_time:
+        delta: -3
   log:
-    - The <force_insert> tag is deprecated since version 4.3.0.
+    - The <force_insert> tag is deprecated. Use <force> instead.
     - Setting <force><enabled> tag to 'yes' to comply with the legacy <force_insert> option found.
   test_case:
   -
     description: Replace an agent if force_insert enabled force options
+    input_delay: 5
     input:
       name: 'agent_1'
     output:

--- a/tests/integration/test_authd/force_options/data/test_cases/valid_config/enablement_force_options.yaml
+++ b/tests/integration/test_authd/force_options/data/test_cases/valid_config/enablement_force_options.yaml
@@ -137,11 +137,12 @@
         delta: -3
   log:
     - The <force_insert> tag is deprecated. Use <force> instead.
+    - The <force_time> tag is deprecated. Use <force> instead.
     - Setting <force><enabled> tag to 'yes' to comply with the legacy <force_insert> option found.
+    - Setting <force><disconnected_time> tag to '5' to comply with the legacy <force_time> option found.
   test_case:
   -
     description: Replace an agent if force_insert enabled force options
-    input_delay: 5
     input:
       name: 'agent_1'
     output:

--- a/tests/integration/test_authd/force_options/test_authd_force_options.py
+++ b/tests/integration/test_authd/force_options/test_authd_force_options.py
@@ -151,8 +151,6 @@ def test_authd_force_options(get_current_test_case, configure_local_internal_opt
 
     for stage in get_current_test_case['test_case']:
         # Reopen socket (socket is closed by manager after sending message with client key)
-        if 'input_delay' in stage:
-            time.sleep(stage['input_delay'])
         authd_sock.open()
         authd_sock.send(create_authd_request(stage['input']), size=False)
         timeout = time.time() + AUTHD_KEY_REQUEST_TIMEOUT

--- a/tests/integration/test_authd/force_options/test_authd_force_options.py
+++ b/tests/integration/test_authd/force_options/test_authd_force_options.py
@@ -151,6 +151,8 @@ def test_authd_force_options(get_current_test_case, configure_local_internal_opt
 
     for stage in get_current_test_case['test_case']:
         # Reopen socket (socket is closed by manager after sending message with client key)
+        if 'input_delay' in stage:
+            time.sleep(stage['input_delay'])
         authd_sock.open()
         authd_sock.send(create_authd_request(stage['input']), size=False)
         timeout = time.time() + AUTHD_KEY_REQUEST_TIMEOUT


### PR DESCRIPTION
|Related issue|
|-------------|
| #3267 |

## Description

After a change was made in a message, we had to test cases in `test_authd/test_force/test_authd_force_options.py`

Refs: wazuh/wazuh#14549

### Updated

- `test_authd_force_options.py`: Update test cases configuration an messages being checked for `force_insert` and `force_time` options

---

## Testing performed


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  | test_authd/ | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/32221/)[:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/32222/)[:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/32223/) |[:green_circle:](https://github.com/wazuh/wazuh-qa/files/9667601/R1.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/9667602/R2.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/9667604/R3.zip)  | Centos8 | [014868d](https://github.com/wazuh/wazuh-qa/commit/014868d795c18d145da55b18124ca5a2cb2dd4a9) | Nothing to highlight |
| @damarisg (Reviewer)   |   test_authd/   | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/32232/) [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/32233/) [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/32234/)  | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | Centos8 | [014868d](https://github.com/wazuh/wazuh-qa/commit/014868d795c18d145da55b18124ca5a2cb2dd4a9) | Nothing to highlight |