### PR TITLE
Update `test_api_endpoints_performance.py` xfail message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Release report: TBD
 - Fix Solaris and Macos FIM integration tests failures ([#2976](https://github.com/wazuh/wazuh-qa/pull/2976)) \- (Framework + Tests)
 - Fix the unstable FIM tests that need refactoring ([#2458](https://github.com/wazuh/wazuh-qa/pull/2458)) \- (Framework + Tests)
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
+- Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Framework + Tests)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Release report: TBD
 - Fix Solaris and Macos FIM integration tests failures ([#2976](https://github.com/wazuh/wazuh-qa/pull/2976)) \- (Framework + Tests)
 - Fix the unstable FIM tests that need refactoring ([#2458](https://github.com/wazuh/wazuh-qa/pull/2458)) \- (Framework + Tests)
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
-- Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Framework + Tests)
+- Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Tests)
 
 ### Removed
 

--- a/tests/performance/test_api/test_api_endpoints_performance.py
+++ b/tests/performance/test_api/test_api_endpoints_performance.py
@@ -16,7 +16,8 @@ xfailed_items = {
     '/active-response': {'message': 'Agent simulator not handling active-response messages: '
                                     'https://github.com/wazuh/wazuh-qa/issues/1266',
                          'method': 'put'},
-    '/agents/group': {'message': 'Slow agent-group files creation: https://github.com/wazuh/wazuh/issues/8625',
+    '/agents/group': {'message': 'Investigate performance issues with PUT /agents/group API endpoint: '
+                                 'https://github.com/wazuh/wazuh/issues/13872',
                       'method': 'put'}
 }
 


### PR DESCRIPTION
In this PR, we have updated the message received when executing the `/agents/group` endpoint flagged as `xfailed`. The issue pointed to by this message is closed, and the current issue is https://github.com/wazuh/wazuh/issues/13872.