### PR TITLE
Refactor test only future events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Release report: TBD
 
 ### Changed
 
+- Refactor: logcollector `test_only_future_events` according to new standard. ([3484](https://github.com/wazuh/wazuh-qa/pull/3484)) \- (Framework + Tests)
 - Change required version of urllib3 and requests dependencies ([#3315](https://github.com/wazuh/wazuh-qa/pull/3315)) \- (Framework)
 - Skip flaky Logcollector tests ([#3218](https://github.com/wazuh/wazuh-qa/pull/3217)) \- (Tests)
 - Change how 'service_control' collects clusterd and apid pids ([#3140](https://github.com/wazuh/wazuh-qa/pull/3140)) \- (Framework)

--- a/deps/wazuh_testing/wazuh_testing/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/__init__.py
@@ -12,11 +12,13 @@ from collections import defaultdict
 
 if sys.platform == 'win32':
     WAZUH_PATH = os.path.join("C:", os.sep, "Program Files (x86)", "ossec-agent")
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'ossec.log')
 else:
     if sys.platform == 'darwin':
         WAZUH_PATH = os.path.join("/", "Library", "Ossec")
     else:
         WAZUH_PATH = os.path.join("/var", "ossec")
+    LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
 
 CLIENT_KEYS_PATH = os.path.join(WAZUH_PATH, 'etc' if platform.system() == 'Linux' else '', 'client.keys')
 DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
@@ -24,7 +26,6 @@ QUEUE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'db')
 QUEUE_SOCKETS_PATH = os.path.join(WAZUH_PATH, 'queue', 'sockets')
 WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_DB_PATH, 'wdb')
 CVE_DB_PATH = os.path.join(WAZUH_PATH, 'queue', 'vulnerabilities', 'cve.db')
-LOG_FILE_PATH = os.path.join(WAZUH_PATH, 'logs', 'ossec.log')
 ALERTS_JSON_PATH = os.path.join(WAZUH_PATH, 'logs', 'alerts', 'alerts.json')
 CPE_HELPER_PATH = os.path.join(WAZUH_PATH, 'queue', 'vulnerabilities', 'dictionaries', 'cpe_helper.json')
 WAZUH_API_CONF = os.path.join(WAZUH_PATH, 'api', 'configuration', 'api.yaml')

--- a/deps/wazuh_testing/wazuh_testing/modules/logcollector/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/logcollector/__init__.py
@@ -1,0 +1,5 @@
+
+LOG_COLLECTOR_PREFIX = r'.*wazuh-logcollector.*'
+WINDOWS_AGENT_PREFIX = r'.*wazuh-agent.*'
+MAILD_PREFIX = r'.*wazuh-maild.*'
+GENERIC_CALLBACK_ERROR_COMMAND_MONITORING = 'The expected command monitoring log has not been produced'

--- a/deps/wazuh_testing/wazuh_testing/modules/logcollector/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/logcollector/event_monitor.py
@@ -1,0 +1,83 @@
+import re
+
+from wazuh_testing import T_30
+from wazuh_testing.modules.logcollector import LOG_COLLECTOR_PREFIX
+from wazuh_testing.tools.monitoring import FileMonitor
+from wazuh_testing.tools import LOG_FILE_PATH
+
+
+def make_logcollector_callback(pattern, prefix=LOG_COLLECTOR_PREFIX, escape=False):
+    """Create a callback function from a text pattern.
+
+    It already contains the logcollector prefix.
+
+    Args:
+        pattern (str): String to match on the log.
+        prefix (str): regular expression used as a prefix before the pattern.
+        escape (bool): Flag to escape special characters in the pattern
+
+    Returns:
+        lambda: function that returns if there's a match in the file
+
+    Examples:
+        >>> callback_message = make_vuln_callback("DEBUG: Reading syslog message")
+    """
+    if escape:
+        pattern = re.escape(pattern)
+    else:
+        pattern = r'\s+'.join(pattern.split())
+    regex = re.compile(r'{}{}'.format(prefix, pattern))
+
+    return lambda line: regex.match(line) is not None
+
+
+def check_logcollector_event(file_monitor=None, callback='', error_message=None, update_position=True,
+                             timeout=T_30, prefix=LOG_COLLECTOR_PREFIX, accum_results=1, file_to_monitor=LOG_FILE_PATH,
+                             escape=False):
+    """Check if a logcollector event occurs
+
+    Args:
+        file_monitor (FileMonitor): FileMonitor object to monitor the file content.
+        callback (str): log regex to check in Wazuh log
+        error_message (str): error message to show in case of expected event does not occur
+        update_position (boolean): filter configuration parameter to search in Wazuh log
+        timeout (str): timeout to check the event in Wazuh log
+        prefix (str): log pattern regex
+        accum_results (int): Accumulation of matches.
+        escape (bool): Flag to escape special characters in the pattern
+    """
+    file_monitor = FileMonitor(file_to_monitor) if file_monitor is None else file_monitor
+    error_message = f"Could not find this event in {file_to_monitor}: {callback}" if error_message is None else \
+        error_message
+
+    file_monitor.start(timeout=timeout, update_position=update_position, accum_results=accum_results,
+                       callback=make_logcollector_callback(callback, prefix, escape), error_message=error_message)
+
+
+def check_analyzing_file(file, error_message, prefix, file_monitor=None):
+    """Create a callback to detect if logcollector is monitoring a file.
+
+    Args:
+        file (str): Name with absolute path of the analyzed file.
+        error_message (str): Error message.
+        prefix (str): Daemon that generates the error log.
+        file_monitor (FileMonitor): Log monitor.
+    """
+    check_logcollector_event(file_monitor=file_monitor, timeout=T_30,
+                             callback=fr".*Analyzing file: '{re.escape(file)}'.*",
+                             error_message=error_message, prefix=prefix)
+
+
+def check_syslog_messages(message, error_message, prefix, file_monitor=None, timeout=T_30, escape=False):
+    """Create a callback to detect "DEBUG: Read <number> lines from command <command>" debug line.
+    Args:
+        message (str): Command to be monitored.
+        error_message (str): Error message.
+        prefix (str): Daemon that generates the error log.
+        file_monitor (FileMonitor): Log monitor.
+        timeout (int): Timeout to check the log.
+        escape (bool): Flag to escape special characters in the pattern.
+    """
+    callback_msg = fr"DEBUG: Reading syslog message: '{message}'"
+    check_logcollector_event(file_monitor=file_monitor, timeout=timeout, callback=callback_msg,
+                             error_message=error_message, prefix=prefix, escape=escape)

--- a/deps/wazuh_testing/wazuh_testing/modules/logcollector/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/logcollector/event_monitor.py
@@ -3,7 +3,7 @@ import re
 from wazuh_testing import T_30
 from wazuh_testing.modules.logcollector import LOG_COLLECTOR_PREFIX
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools import LOG_FILE_PATH
+from wazuh_testing import LOG_FILE_PATH
 
 
 def make_logcollector_callback(pattern, prefix=LOG_COLLECTOR_PREFIX, escape=False):

--- a/deps/wazuh_testing/wazuh_testing/tools/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/configuration.py
@@ -690,7 +690,7 @@ def load_configuration_template(data_file_path, configuration_parameters=[], con
     configuration = file.read_yaml(data_file_path)
 
     if sys.platform == 'darwin':
-        configuration = set_correct_prefix([configuration], PREFIX)
+        configuration = set_correct_prefix(configuration, PREFIX)
 
     return [process_configuration(configuration[0], placeholders=replacement, metadata=meta)
             for replacement, meta in zip(configuration_parameters, configuration_metadata)]

--- a/tests/integration/test_logcollector/test_only_future_events/data/configuration_template/configuration_only_future_events.yaml
+++ b/tests/integration/test_logcollector/test_only_future_events/data/configuration_template/configuration_only_future_events.yaml
@@ -1,0 +1,11 @@
+- sections:
+    - section: localfile
+      elements:
+        - location:
+            value: LOCATION
+        - log_format:
+            value: LOG_FORMAT
+        - only-future-events:
+            value: ONLY_FUTURE_EVENTS
+            attributes:
+              - max-size: MAX_SIZE

--- a/tests/integration/test_logcollector/test_only_future_events/data/test_cases/cases_only_future_events.yaml
+++ b/tests/integration/test_logcollector/test_only_future_events/data/test_cases/cases_only_future_events.yaml
@@ -3,19 +3,23 @@
   configuration_parameters:
     LOCATION: ''
     LOG_FORMAT: syslog
-    ONLY_FUTURE_EVENTS: no
+    ONLY_FUTURE_EVENTS: 'no'
+    MAX_SIZE: 10MB
   metadata:
     location: ''
     log_format: syslog
-    only_future_events: no
+    only_future_events: 'no'
+    max_size: 10MB
 
 - name: rotate_TEMP_TEST_PATH_in_syslog_format
   description: rotate_TEMP_TEST_PATH_in_syslog_format
   configuration_parameters:
     LOCATION: ''
     LOG_FORMAT: syslog
-    ONLY_FUTURE_EVENTS: yes
+    ONLY_FUTURE_EVENTS: 'yes'
+    MAX_SIZE: 10MB
   metadata:
     location: ''
     log_format: syslog
-    only_future_events: yes
+    only_future_events: 'yes'
+    max_size: 10MB

--- a/tests/integration/test_logcollector/test_only_future_events/data/test_cases/cases_only_future_events.yaml
+++ b/tests/integration/test_logcollector/test_only_future_events/data/test_cases/cases_only_future_events.yaml
@@ -1,0 +1,21 @@
+- name: rotate_TEMP_TEST_PATH_in_syslog_format
+  description: rotate_TEMP_TEST_PATH_in_syslog_format
+  configuration_parameters:
+    LOCATION: ''
+    LOG_FORMAT: syslog
+    ONLY_FUTURE_EVENTS: no
+  metadata:
+    location: ''
+    log_format: syslog
+    only_future_events: no
+
+- name: rotate_TEMP_TEST_PATH_in_syslog_format
+  description: rotate_TEMP_TEST_PATH_in_syslog_format
+  configuration_parameters:
+    LOCATION: ''
+    LOG_FORMAT: syslog
+    ONLY_FUTURE_EVENTS: yes
+  metadata:
+    location: ''
+    log_format: syslog
+    only_future_events: yes

--- a/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
+++ b/tests/integration/test_logcollector/test_only_future_events/test_only_future_events.py
@@ -60,67 +60,58 @@ import sys
 import pytest
 import wazuh_testing.logcollector as logcollector
 from wazuh_testing import global_parameters
-from wazuh_testing.tools import monitoring, file
-from wazuh_testing.tools.configuration import load_wazuh_configurations
-from wazuh_testing.tools.monitoring import LOG_COLLECTOR_DETECTOR_PREFIX, WINDOWS_AGENT_DETECTOR_PREFIX
 from wazuh_testing.tools.services import control_service
+from wazuh_testing.modules.logcollector import LOG_COLLECTOR_PREFIX, WINDOWS_AGENT_PREFIX, \
+                                               GENERIC_CALLBACK_ERROR_COMMAND_MONITORING
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.modules.logcollector import event_monitor as evm
 
-
-if sys.platform == 'win32':
-    prefix = monitoring.WINDOWS_AGENT_DETECTOR_PREFIX
-else:
-    prefix = monitoring.LOG_COLLECTOR_DETECTOR_PREFIX
 
 # Marks
 pytestmark = [pytest.mark.tier(level=0)]
 
-# Configuration
-DAEMON_NAME = "wazuh-logcollector"
-test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configurations_path = os.path.join(test_data_path, 'wazuh_only_future_events_conf.yaml')
+prefix = LOG_COLLECTOR_PREFIX
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+
+# ------------------------------------------------ TEST_ACCEPTED_VALUES ------------------------------------------------
+# Configuration and cases data
+t1_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_only_future_events.yaml')
+t1_cases_path = os.path.join(TEST_CASES_PATH, 'cases_only_future_events.yaml')
+
 temp_dir = tempfile.gettempdir()
 log_test_path = os.path.join(temp_dir, 'wazuh-testing', 'test.log')
+LOG_LINE = 'Jan  1 00:00:00 localhost test[0]: line='
+
+# Accepted values test configurations (t1)
+t1_configuration_parameters, t1_configuration_metadata, t1_case_ids = get_test_cases_data(t1_cases_path)
+
+for index in range(len(t1_configuration_metadata)):
+    t1_configuration_metadata[index]['location'] = log_test_path
+    t1_configuration_parameters[index]['LOCATION'] = log_test_path
+
+t1_configurations = load_configuration_template(t1_configurations_path, t1_configuration_parameters,
+                                                t1_configuration_metadata)
+
+local_internal_options = {'logcollector.vcheck_files': '5', 'logcollector.debug': '2', 'windows.debug': '2'}
+
+if sys.platform == 'win32':
+    prefix = WINDOWS_AGENT_PREFIX
+
+# Configuration
+DAEMON_NAME = "wazuh-logcollector"
 current_line = 0
-
-local_internal_options = {'logcollector.vcheck_files': '5', 'logcollector.debug': '2', 'windows.debug': 2}
-
-parameters = [
-    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path, 'ONLY_FUTURE_EVENTS': 'no', 'MAX_SIZE': '10MB'},
-    {'LOG_FORMAT': 'syslog', 'LOCATION': log_test_path, 'ONLY_FUTURE_EVENTS': 'yes', 'MAX_SIZE': '10MB'}
-]
-metadata = [
-    {'log_format': 'syslog', 'location': log_test_path, 'only_future_events': 'no',
-     'log_line': "Jan  1 00:00:00 localhost test[0]: line="},
-    {'log_format': 'syslog', 'location': log_test_path, 'only_future_events': 'yes',
-     'log_line': "Jan  1 00:00:00 localhost test[0]: line="}
-]
-
-log_line = metadata[0]['log_line']
-
 file_structure = [
     {
         'folder_path': os.path.join(temp_dir, 'wazuh-testing'),
         'filename': ['test.log'],
-        'content': log_line,
+        'content': LOG_LINE,
         'size_kib': 10240
     }
 ]
-
-configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
-configuration_ids = [f"rotate_{x['location']}_in_{x['log_format']}_format" for x in metadata]
-
-
-# Fixtures
-@pytest.fixture(scope="module", params=configurations, ids=configuration_ids)
-def get_configuration(request):
-    """Get configurations from the module."""
-    return request.param
-
-
-@pytest.fixture(scope="module")
-def get_local_internal_options():
-    """Get internal configuration."""
-    return local_internal_options
 
 
 @pytest.fixture(scope="module")
@@ -129,8 +120,10 @@ def get_files_list():
     return file_structure
 
 
-def test_only_future_events(configure_local_internal_options_module, get_configuration, file_monitoring,
-                            configure_environment, get_files_list, create_file_structure_module, restart_logcollector):
+@pytest.mark.parametrize('configuration, metadata', zip(t1_configurations, t1_configuration_metadata), ids=t1_case_ids)
+def test_only_future_events(configuration, metadata, set_wazuh_configuration,
+                            configure_local_internal_options_module, setup_log_monitor, get_files_list,
+                            create_file_structure_module, restart_wazuh_daemon_function):
     '''
     description: Check if the 'only-future-events' option is used properly by the 'wazuh-logcollector' when
                  monitoring a log file. This option allows reading new log content since the logcollector
@@ -148,27 +141,30 @@ def test_only_future_events(configure_local_internal_options_module, get_configu
     tier: 0
 
     parameters:
-        - get_local_internal_options:
-            type: fixture
-            brief: Get local internal options from the module.
-        - configure_local_internal_options:
-            type: fixture
-            brief: Configure the Wazuh local internal options.
-        - get_configuration:
-            type: fixture
+        - configuration:
+            type: dict
             brief: Get configurations from the module.
-        - configure_environment:
+        - metadata:
+            type: dict
+            brief: Get metadata from the module.
+        - set_wazuh_configuration:
             type: fixture
-            brief: Configure a custom environment for testing.
+            brief: Apply changes to the ossec.conf configuration.
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Configure the Wazuh local internal options file.
+        - setup_log_monitor:
+            type: fixture
+            brief: Create the log monitor.
         - get_files_list:
             type: fixture
             brief: Get file list to create from the module.
         - create_file_structure_module:
             type: fixture
             brief: Create the specified file tree structure.
-        - restart_logcollector:
+        - restart_wazuh_daemon_function:
             type: fixture
-            brief: Clear the 'ossec.log' file and start a new monitor.
+            brief: Restart the wazuh service.
 
     assertions:
         - Verify that the logcollector starts monitoring the log file.
@@ -180,8 +176,8 @@ def test_only_future_events(configure_local_internal_options_module, get_configu
         - Verify that the log collector continues detecting new logs messages when it is started.
 
     input_description: A configuration template (test_only_future_events) is contained in an external YAML file
-                       (wazuh_only_future_events_conf.yaml). That template is combined with two test cases defined
-                       in the module. Those include configuration settings for the 'wazuh-logcollector' daemon.
+                       (configuration_only_future_events.yaml). That template is combined with two test cases defined
+                       in the file cases_only_future_events.yaml.
 
     expected_output:
         - r'Analyzing file.*'
@@ -190,73 +186,64 @@ def test_only_future_events(configure_local_internal_options_module, get_configu
     tags:
         - logs
     '''
-    config = get_configuration['metadata']
+    log_monitor = setup_log_monitor
+
     global current_line
 
     # Ensure that the file is being analyzed
-    message = f"Analyzing file: '{log_test_path}'."
-    callback_message = monitoring.make_callback(pattern=message, prefix=prefix, escape=True)
-    log_monitor.start(timeout=global_parameters.default_timeout,
-                      error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                      callback=callback_message)
+    evm.check_analyzing_file(file_monitor=log_monitor, file=log_test_path,
+                             error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix)
 
     # Add one KiB of data to log
-    current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
+    current_line = logcollector.add_log_data(log_path=metadata['location'], log_line_message=LOG_LINE,
                                              size_kib=1, line_start=current_line + 1, print_line_num=True)
 
-    message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
-    callback_message = monitoring.make_callback(pattern=message, prefix=prefix, escape=True)
-    log_monitor.start(timeout=global_parameters.default_timeout,
-                      error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                      callback=callback_message)
+    message = f"{LOG_LINE}{current_line}"
+    evm.check_syslog_messages(file_monitor=log_monitor, message=message,
+                              error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix,
+                              timeout=global_parameters.default_timeout, escape=True)
 
     control_service('stop', daemon=DAEMON_NAME)
 
     # Add another KiB of data to log while logcollector is stopped
     first_line = current_line + 1
-    current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
+    current_line = logcollector.add_log_data(log_path=metadata['location'], log_line_message=LOG_LINE,
                                              size_kib=1, line_start=first_line, print_line_num=True)
 
     control_service('start', daemon=DAEMON_NAME)
 
-    if config['only_future_events'] == 'no':
+    if metadata['only_future_events'] == 'no':
         # Logcollector should detect the first line written while it was stopped
         # Check first line
-        message = f"DEBUG: Reading syslog message: '{config['log_line']}{first_line}'"
-        callback_message = monitoring.make_callback(pattern=message, prefix=prefix, escape=True)
-        log_monitor.start(timeout=global_parameters.default_timeout,
-                          error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                          callback=callback_message)
+        message = f"{LOG_LINE}{first_line}"
+        evm.check_syslog_messages(file_monitor=log_monitor, message=message,
+                                  error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix,
+                                  timeout=global_parameters.default_timeout, escape=True)
         # Check last line
-        message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
-        callback_message = monitoring.make_callback(pattern=message, prefix=prefix, escape=True)
-        log_monitor.start(timeout=global_parameters.default_timeout,
-                          error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                          callback=callback_message)
+        message = f"{LOG_LINE}{current_line}"
+        evm.check_syslog_messages(file_monitor=log_monitor, message=message,
+                                  error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix,
+                                  timeout=global_parameters.default_timeout, escape=True)
     else:
         # Logcollector should NOT detect the log lines written while it was stopped
         with pytest.raises(TimeoutError):
             # Check first line
-            message = f"DEBUG: Reading syslog message: '{config['log_line']}{first_line}'"
-            callback_message = monitoring.make_callback(pattern=message, prefix=prefix,
-                                                        escape=True)
-            log_monitor.start(timeout=global_parameters.default_timeout,
-                              error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                              callback=callback_message)
+            message = f"{LOG_LINE}{first_line}"
+            evm.check_syslog_messages(file_monitor=log_monitor, message=message,
+                                      error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix,
+                                      timeout=global_parameters.default_timeout, escape=True)
             # Check last line
-            message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
-            callback_message = monitoring.make_callback(pattern=message, prefix=prefix,
-                                                        escape=True)
-            log_monitor.start(timeout=global_parameters.default_timeout,
-                              error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                              callback=callback_message)
+            message = f"{LOG_LINE}{current_line}"
+            evm.check_syslog_messages(file_monitor=log_monitor, message=message,
+                                      error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix,
+                                      timeout=global_parameters.default_timeout, escape=True)
 
     # Add another KiB of data to log (additional check)
-    current_line = logcollector.add_log_data(log_path=config['location'], log_line_message=config['log_line'],
+    current_line = logcollector.add_log_data(log_path=metadata['location'], log_line_message=LOG_LINE,
                                              size_kib=1, line_start=current_line + 1, print_line_num=True)
 
-    message = f"DEBUG: Reading syslog message: '{config['log_line']}{current_line}'"
-    callback_message = monitoring.make_callback(pattern=message, prefix=prefix, escape=True)
-    log_monitor.start(timeout=global_parameters.default_timeout,
-                      error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING,
-                      callback=callback_message)
+    # Check last line
+    message = f"{LOG_LINE}{current_line}"
+    evm.check_syslog_messages(file_monitor=log_monitor, message=message,
+                              error_message=GENERIC_CALLBACK_ERROR_COMMAND_MONITORING, prefix=prefix,
+                              timeout=global_parameters.default_timeout, escape=True)


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh-qa/issues/3430       |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
This PR aims to fix the `test_only_future_events` reported as unstable. 
A full refactor of the test with the new QA structure has been carried on.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

The following files have been added to the `test_only_future_events`
- `configuration_only_future_events.yaml`
- `cases_only_future_events.yaml`


---

## Testing performed

<!-- At most, there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fedepacher (Developer)  |           | :green_circle::green_circle:  :green_circle:    | :green_circle::green_circle:  :green_circle:  |  Windows/Linux    |   https://github.com/wazuh/wazuh-qa/commit/61a41ddb3e1ed03bf0d623c9f67bf0006206207f      | Nothing to highlight |
| @Rebits  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

Here are the links to the Jenkins execution:
 - [Launch 1](https://devel.ci.wazuh.info/job/Test_integration/1712/)
 - [Launch 2](https://devel.ci.wazuh.info/job/Test_integration/1713/)
 - [Launch 3](https://devel.ci.wazuh.info/job/Test_integration/1714/)
