### PR TITLE
Add E2E modules to test the new Vulnerability Detector

### DIFF
--- a/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vd_cluster_manager_down.yaml
+++ b/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vd_cluster_manager_down.yaml
@@ -1,0 +1,14 @@
+- name: cluster_manager_down
+  description: |
+    Given a manager
+    And 2 workers
+    And an indexer node
+    And a load balancer with 4 agents
+    And a existing scan result for the agent 1 in the manager
+    When the manager stops unexpectedly
+    Then the agent is reconnected to an available manager
+    And the indexer result is cleaned
+    And a new scan is triggered
+    And the result is published in the indexer
+  configuration_parameters: null
+  metadata: null

--- a/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vuln_detector.yaml
+++ b/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vuln_detector.yaml
@@ -1,0 +1,105 @@
+- name: error_while_pulling_new_content
+  description: |
+    Given a manager
+    And an agent connected to that manager
+    And the scheduled update is enabled
+    And a feed update available
+    And a problem in the content-pulling
+    When the update process is triggered
+    Then the update process fails
+    But the user is notified
+  configuration_parameters: null
+  metadata: null
+
+- name: agents_connected_for_first_time
+  description: |
+    Given a manager
+    And several agents who hasn't connected yet
+    And a feed update available
+    And the feed has a vulnerability that affects those agents
+    And the scheduled update is enabled
+    When the feed is updated
+    Then the scan is not triggered
+    When the agent is connected for the first time
+    Then a scan is triggered
+    And the result is published
+    And the vulnerability appears in the result
+  configuration_parameters: null
+  metadata: null
+
+- name: scan_when_upgrading
+  description: |
+    Given a manager
+    And a Linux-based agent connected to the manager
+    And that agent has a vulnerable package
+    When the user upgrade the package to a fixed version
+    Then a scan is triggered
+    And the result is published
+    And the package appears as "solved" in the result
+  configuration_parameters: null
+  metadata: null
+
+- name: scan_when_removing
+  description: |
+    Given a manager
+    And a Linux-based agent connected to the manager
+    And that agent has a vulnerable package
+    When the user remove that package
+    Then a scan is triggered
+    And the result is published
+    And the package does not appear in the result
+  configuration_parameters: null
+  metadata: null
+
+- name: agent_db_doesnt_exist
+  description: |
+    Given a manager
+    And an agent that is not connected to the manager
+    And the agent has syscollector disabled
+    And the agent database does not exist in the manager
+    When the agent is connected for the first time to the manager
+    Then the scan is not triggered
+  configuration_parameters: null
+  metadata: null
+
+- name: scan_when_agent_info_is_old
+  description: |
+    Given a manager
+    And an agent that is not connected to the manager
+    And the agent's last scan is old
+    When the agent is connected for the first time to the manager
+    Then a scan is triggered
+    And the result is published
+  configuration_parameters: null
+  metadata: null
+
+- name: full_scan_manager
+  description: |
+    Given a manager that has not started yet
+    When the user starts the manager for the first time
+    Then a full scan is triggered
+    And the result is published
+  configuration_parameters: null
+  metadata: null
+
+- name: full_scan_failed
+  description: |
+    Given a manager that has not started yet
+    And the vulnerability detector configuration is invalid
+    When the user starts the manager
+    Then the scan is not triggered
+    But the user is notified
+  configuration_parameters: null
+  metadata: null
+
+- name: third_party_get_result
+  description: |
+    Given a manager
+    And an agent connected to that manager
+    And a third-party subscribed to the scan results
+    When a new vulnerable package is installed in the agent
+    Then a scan is triggered
+    And the scan result is available to all subscribers
+    And the third-party can get the results of the scan
+  configuration_parameters: null
+  metadata: null

--- a/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vuln_detector_cluster.yaml
+++ b/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vuln_detector_cluster.yaml
@@ -1,0 +1,28 @@
+- name: cluster_vuln_affects_all_agents
+  description: |
+    Given a manager
+    And several agents connected to the manager
+    And those have different operating systems
+    And a feed update is available
+    And the update has a vulnerability that affects all agents
+    When the feed is updated
+    Then all agents are scanned
+    And the result is published
+    And the vulnerability appears in the result affecting all agents
+  configuration_parameters: null
+  metadata: null
+
+- name: cluster_ondemand_update
+  description: |
+    Given a manager
+    And workers connected to that manager
+    And one agent connected per worker
+    And the user have disabled the scheduled update
+    And a feed update available
+    And the update has a vulnerability that affects 1 agent
+    When the user triggers an update
+    Then the affected agent is scanned
+    And the scan result is published
+    And the vulnerability appears in the result affecting that agent
+  configuration_parameters: null
+  metadata: null

--- a/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vuln_detector_windows.yaml
+++ b/tests/end_to_end/test_new_vulnerability_detector/data/test_cases/case_vuln_detector_windows.yaml
@@ -1,0 +1,14 @@
+- name: win_agent_scan_events
+  description: |
+    Given a manager
+    And a Windows agent connected
+    When a vulnerable hotfix is installed
+    Then a scan is triggered
+    And the result is published
+    And the hotfix appears in the result
+    When a hotfix is removed
+    Then a scan is triggered
+    And the result is published
+    And the hotfix does not appear in the result
+  configuration_parameters: null
+  metadata: null

--- a/tests/end_to_end/test_new_vulnerability_detector/test_vuln_detector.py
+++ b/tests/end_to_end/test_new_vulnerability_detector/test_vuln_detector.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+from wazuh_testing.tools import configuration as config
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_path = os.path.join(test_data_path, 'test_cases')
+t1_file_path = os.path.join(test_cases_path, 'case_vuln_detector.yaml')
+t2_file_path = os.path.join(test_cases_path, 'case_vuln_detector_windows.yaml')
+
+t1_config, t1_metadata, t1_ids = config.get_test_cases_data(t1_file_path)
+t2_config, t2_metadata, t2_ids = config.get_test_cases_data(t2_file_path)
+
+
+@pytest.mark.parametrize('metadata', t1_metadata, ids=t1_ids)
+def test_vuln_detector(configure_environment, metadata):
+    """
+    Steps:
+        1. Run the necessary tasks to prepare the environment
+        2. Run the necessary tasks to generate the desired result
+        3. Check the results
+        4. Clean the environment
+    """
+
+@pytest.mark.parametrize('metadata', t2_metadata, ids=t2_ids)
+def test_vuln_detector_windows(configure_environment, metadata):
+    """
+    Steps:
+        1. Run the necessary tasks to prepare the environment
+        2. Run the necessary tasks to generate the desired result
+        3. Check the results
+        4. Clean the environment
+    """

--- a/tests/end_to_end/test_new_vulnerability_detector/test_vuln_detector_cluster.py
+++ b/tests/end_to_end/test_new_vulnerability_detector/test_vuln_detector_cluster.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+from wazuh_testing.tools import configuration as config
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_cases_path = os.path.join(test_data_path, 'test_cases')
+t1_file_path = os.path.join(test_cases_path, 'case_vuln_detector_cluster.yaml')
+t2_file_path = os.path.join(test_cases_path, 'case_vd_cluster_manager_down.yaml')
+
+t1_config, t1_metadata, t1_ids = config.get_test_cases_data(t1_file_path)
+t2_config, t2_metadata, t2_ids = config.get_test_cases_data(t2_file_path)
+
+
+@pytest.mark.parametrize('metadata', t1_metadata, ids=t1_ids)
+def test_vuln_detector_cluster(configure_environment, metadata):
+    """
+    Steps:
+        1. Run the necessary tasks to prepare the environment
+        2. Run the necessary tasks to generate the desired result
+        3. Check the results
+        4. Clean the environment
+    """
+
+@pytest.mark.parametrize('metadata', t2_metadata, ids=t2_ids)
+def test_vd_cluster_manager_down(configure_environment, metadata):
+    """
+    Steps:
+        1. Run the necessary tasks to prepare the environment
+        2. Run the necessary tasks to generate the desired result
+        3. Check the results
+        4. Clean the environment
+    """


### PR DESCRIPTION
|Related issue|
|-------------|
|closes #3456|

## Description

The Vulnerability Detector module is being refactored. The following tests test the new flow of said module from end to end.

<details><summary>Test case analysis and design</summary>

![Vulnerability Detector](https://user-images.githubusercontent.com/39094716/197623664-e81c19f1-202b-4a65-adae-7f5b72c84eb8.png)


</details>

<details><summary>Finished all test cases</summary>

<br>

```
Given a manager
And 2 workers
And an indexer node
And a load balancer with 4 agents
And existing scan result for agent 1 in the manager
When the manager stops unexpectedly
Then the agent is reconnected to an available manager
And the indexer result is cleaned
And a new scan is triggered
And the result is published in the indexer

Given a manager
And several agents connected to the manager
And those have different operating systems
And a feed update is available
And the update has a vulnerability that affects all agents
When the feed is updated
Then all agents are scanned
And the result is published
And the vulnerability appears in the result affecting all agents

Given a manager
And workers connected to that manager
And one agent connected per worker
And the user has disabled the scheduled update
And a feed update is available
And the update has a vulnerability that affects 1 agent
When the user triggers an update
Then the affected agent is scanned
And the scan result is published
And the vulnerability appears in the result affecting that agent

Given a manager
And an agent connected to that manager
And the scheduled update is enabled
And a feed update is available
And a problem in the content-pulling
When the update process is triggered
Then the update process fails
But the user is notified

Given a manager
And an agent who hasn't connected yet
And a feed update is available
And the feed has a vulnerability that affects the agent
And the scheduled update is enabled
When the feed is updated
Then the scan is not triggered
When the agent is connected for the first time
Then a scan is triggered
And the result is published
And the vulnerability appears in the result

Given a manager
And a Windows agent connected
When a vulnerable hotfix is installed
Then a scan is triggered
And the result is published
And the hotfix appears in the result
When a hotfix is removed
Then a scan is triggered
And the result is published
And the hotfix does not appear in the result

Given a manager
And a Linux-based agent connected to the manager
And that agent has a vulnerable package
When the user upgrades the package to a fixed version
Then a scan is triggered
And the result is published
And the package appears as "solved" in the result

Given a manager
And a Linux-based agent connected to the manager
And that agent has a vulnerable package
When the user removes that package
Then a scan is triggered
And the result is published
And the package does not appear in the result

Given a manager
And an agent that is not connected to the manager
And the agent has syscollector disabled
And the agent database does not exist in the manager
When the agent is connected for the first time to the manager
Then the scan is not triggered

Given a manager
And an agent that is not connected to the manager
And the agent's last scan is old
When the agent is connected for the first time to the manager
Then a scan is triggered
And the result is published

Given a manager that has not started yet
When the user starts the manager for the first time
Then a full scan is triggered
And the result is published

Given a manager that has not started yet
And the vulnerability detector configuration is invalid
When the user starts the manager
Then the scan is not triggered
But the user is notified

Given a manager
And an agent connected to that manager
And a third party subscribed to the scan results
When a new vulnerable package is installed in the agent
Then a scan is triggered
And the scan result is available to all subscribers
And the third party can get the results of the scan
```

</details>

### Added

- `test_vuln_detector_cluster.py`: Contains test cases related to tests that verify the VD functionality under a cluster architecture.
- `test_vuln_detector.py`: Contains test cases related to tests that verify the expected results of VD in a basic installation of Wazuh.

---

## Testing performed

WIP.