### PR TITLE
Add new logging tests for analysisd EPS limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Release report: TBD
 
 ### Added
 
-- New testing suite for checking analysisd EPS limitation([#2947](https://github.com/wazuh/wazuh-qa/pull/3181)) \- (Framework + Tests)
+- Add new logging tests for analysisd EPS limitation ([#3509](https://github.com/wazuh/wazuh-qa/pull/3509)) \- (Framework + Tests)
+- New testing suite for checking analysisd EPS limitation ([#2947](https://github.com/wazuh/wazuh-qa/pull/3181)) \- (Framework + Tests)
 - Add stress results comparator tool ([#3478](https://github.com/wazuh/wazuh-qa/pull/3478)) \- (Tools)
 - Add E2E tests for demo cases ([#3293](https://github.com/wazuh/wazuh-qa/pull/3293)) \- (Framework + Tests)
 - Add configuration files for Jenkins automation of system/E2E tests ([#3221](https://github.com/wazuh/wazuh-qa/pull/3221)) \- (Framework)

--- a/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
@@ -81,3 +81,25 @@ def get_analysisd_state():
     analysisd_state = dict((a.strip(), b.strip()) for a, b in (element.split('=') for element in data.split('\n')))
 
     return analysisd_state
+
+
+def check_queues_are_full_and_no_eps_credits_log(log_level='WARNING', timeout=T_10):
+    """Check if the start dropping events log is shown.
+
+    Args:
+        log_level (str): Log level.
+        timeout (int): Timeout for checking the event in log.
+    """
+    check_analysisd_event(callback=fr'.*{log_level}: Queues are full and no EPS credits, dropping events.*',
+                          timeout=timeout)
+
+
+def check_stop_dropping_events_and_credits_available_log(log_level='WARNING', timeout=T_10):
+    """Check if the stop dropping events log is shown
+
+    Args:
+        log_level (str): Log level.
+        timeout (int): Timeout for checking the event in log.
+    """
+    check_analysisd_event(callback=fr'.*{log_level}: Queues back to normal and EPS credits, no dropping events.*',
+                          timeout=timeout)

--- a/tests/integration/test_analysisd/test_limit_eps/data/configuration_template/logging_test_module/configuration_dropping_events.yaml
+++ b/tests/integration/test_analysisd/test_limit_eps/data/configuration_template/logging_test_module/configuration_dropping_events.yaml
@@ -1,0 +1,21 @@
+- sections:
+    - section: remote
+      elements:
+        - connection:
+            value: syslog
+        - port:
+            value: PORT
+        - protocol:
+            value: PROTOCOL
+        - allowed-ips:
+            value: 0.0.0.0/0
+    - section: global
+      elements:
+        - limits:
+            elements:
+              - eps:
+                  elements:
+                    - maximum:
+                        value: MAXIMUM
+                    - timeframe:
+                        value: TIMEFRAME

--- a/tests/integration/test_analysisd/test_limit_eps/data/test_cases/logging_test_module/cases_dropping_events.yaml
+++ b/tests/integration/test_analysisd/test_limit_eps/data/test_cases/logging_test_module/cases_dropping_events.yaml
@@ -1,0 +1,15 @@
+- name: started_stopped_dropping_events
+  description: Check events are being dropped due to there are no analysis credits log and the opposite one.
+  configuration_parameters:
+    PORT: 514
+    PROTOCOL: tcp
+    MAXIMUM: '100'
+    TIMEFRAME: '10'
+  metadata:
+    maximum: 100
+    timeframe: 10
+    address: localhost
+    port: 514
+    protocol: tcp
+    messages_number: 50000
+    eps: 5000

--- a/tests/integration/test_analysisd/test_limit_eps/test_logging.py
+++ b/tests/integration/test_analysisd/test_limit_eps/test_logging.py
@@ -1,0 +1,150 @@
+
+import os
+import pytest
+import time
+
+from wazuh_testing import LOG_FILE_PATH
+from wazuh_testing import T_10
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.tools.run_simulator import syslog_simulator
+from wazuh_testing.tools.thread_executor import ThreadExecutor
+from wazuh_testing.modules.analysisd import event_monitor as evm
+
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template', 'logging_test_module')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases', 'logging_test_module')
+SYSLOG_SIMULATOR_START_TIME = 2
+local_internal_options = {'analysisd.debug': 2}
+
+
+# ------------------------------------------------ TEST_DROPPING_EVENTS ------------------------------------------------
+# Configuration and cases data
+t1_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_dropping_events.yaml')
+t1_cases_path = os.path.join(TEST_CASES_PATH, 'cases_dropping_events.yaml')
+
+# Dropping event test configurations (t1)
+t1_configuration_parameters, t1_configuration_metadata, t1_case_ids = get_test_cases_data(t1_cases_path)
+t1_configurations = load_configuration_template(t1_configurations_path, t1_configuration_parameters,
+                                                t1_configuration_metadata)
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata', zip(t1_configurations, t1_configuration_metadata), ids=t1_case_ids)
+def test_dropping_events(configuration, metadata, load_wazuh_basic_configuration, set_wazuh_configuration,
+                         configure_local_internal_options_function, truncate_monitored_files,
+                         restart_wazuh_daemon_function):
+    """
+    description: Check that after the event analysis block, if the events queue is full, the events are dropped.
+
+    test_phases:
+        - setup:
+            - Load Wazuh light configuration.
+            - Apply ossec.conf configuration changes according to the configuration template and use case.
+            - Apply custom settings in local_internal_options.conf.
+            - Truncate wazuh logs.
+            - Restart wazuh-manager service to apply configuration changes.
+        - test:
+            - Send events until queue is full and dropping events.
+            - Check that "Queues are full and no EPS credits, dropping events" log appears in WARNING mode.
+            - Wait timeframe to release the events queue usage and send an event.
+            - Check that "Queues back to normal and EPS credits, no dropping events" log appears in INFO mode.
+            - Send events until queue is full and dropping events.
+            - Check that "Queues are full and no EPS credits, dropping events" log appears in DEBUG mode.
+            - Wait timeframe to release the events queue usage and send an event.
+            - Check that "Queues back to normal and EPS credits, no dropping events" log appears in DEBUG mode.
+        - tierdown:
+            - Truncate wazuh logs.
+            - Restore initial configuration, both ossec.conf and local_internal_options.conf.
+
+    wazuh_min_version: 4.4.0
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Get configurations from the module.
+        - metadata:
+            type: dict
+            brief: Get metadata from the module.
+        - load_wazuh_basic_configuration:
+            type: fixture
+            brief: Load basic wazuh configuration.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Apply changes to the ossec.conf configuration.
+        - configure_local_internal_options_function:
+            type: fixture
+            brief: Apply changes to the local_internal_options.conf configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate wazuh logs.
+        - restart_wazuh_daemon_function:
+            type: fixture
+            brief: Restart the wazuh service.
+
+    assertions:
+        - Check that "Queues are full and no EPS credits, dropping events" log appears in WARNING mode.
+        - Check that "Queues back to normal and EPS credits, no dropping events" log appears in INFO mode.
+        - Check that "Queues are full and no EPS credits, dropping events" log appears in DEBUG mode.
+        - Check that "Queues back to normal and EPS credits, no dropping events" log appears in DEBUG mode.
+
+    input_description:
+        - The `configuration_dropping_events.yaml` file provides the module configuration for this test.
+        - The `cases_dropping_events.yaml` file provides the test cases.
+    """
+    # Set syslog simulator parameters according to the use case data
+    syslog_simulator_parameters = {'address': metadata['address'], 'port': metadata['port'],
+                                   'protocol': metadata['protocol'], 'eps': metadata['eps'],
+                                   'messages_number': metadata['messages_number']}
+
+    # Run syslog simulator thread for sending events
+    syslog_simulator_thread = ThreadExecutor(syslog_simulator, {'parameters': syslog_simulator_parameters})
+    syslog_simulator_thread.start()
+
+    # Check for dropping events WARNING log
+    evm.check_queues_are_full_and_no_eps_credits_log(log_level='WARNING', timeout=T_10)
+
+    # Wait until syslog simulator ends
+    syslog_simulator_thread.join()
+
+    # Wait until the next timeframe to release elements from the queue (as they will be processed)
+    time.sleep(metadata['timeframe'])
+
+    # Send 1 event more
+    syslog_simulator_parameters.update({'messages_number': 1, 'eps': 1})
+    syslog_simulator_thread = ThreadExecutor(syslog_simulator, {'parameters': syslog_simulator_parameters})
+    syslog_simulator_thread.start()
+
+    # Check for stop dropping events INFO log
+    evm.check_stop_dropping_events_and_credits_available_log(log_level='INFO', timeout=T_10)
+
+    # Wait until syslog simulator ends
+    syslog_simulator_thread.join()
+
+    # Stage 2: If we continue causing this situation, the following logs must be in DEBUG
+
+    # Run syslog simulator thread for sending events
+    syslog_simulator_parameters.update({'messages_number': metadata['messages_number'], 'eps': metadata['eps']})
+    syslog_simulator_thread = ThreadExecutor(syslog_simulator, {'parameters': syslog_simulator_parameters})
+    syslog_simulator_thread.start()
+
+    # Check for dropping events DEBUG log
+    evm.check_queues_are_full_and_no_eps_credits_log(log_level='DEBUG', timeout=T_10)
+
+    # Wait until syslog simulator ends
+    syslog_simulator_thread.join()
+
+    # Wait until the next timeframe to release elements from the queue (as they will be processed)
+    time.sleep(metadata['timeframe'])
+
+    # Send 1 event more
+    syslog_simulator_parameters.update({'messages_number': 1, 'eps': 1})
+    syslog_simulator_thread = ThreadExecutor(syslog_simulator, {'parameters': syslog_simulator_parameters})
+    syslog_simulator_thread.start()
+
+    # Check for stop dropping events DEBUG log
+    evm.check_stop_dropping_events_and_credits_available_log(log_level='DEBUG', timeout=T_10)
+
+    # Wait until syslog simulator ends
+    syslog_simulator_thread.join()


### PR DESCRIPTION
## Description

This PR adds a new test to check that the following logs are shown in case of dropping events when the events queue is full and there are no analysis credits due to EPS limitation.

The following tests cases have been added:

- First time that queues are full, there are no available credits, and events are being dropped:

  ```
  WARNING: Queues are full and no EPS credits, dropping events.
  ```

- First time that the queues are not full, there are available credits, so the events are not being dropped:

  ```
    INFO: Queues back to normal and EPS credits, no dropping events.
  ```

- Second time that queues are full, there are no available credits, and events are being dropped (note `DEBUG` level):

  ```
  DEBUG: Queues are full and no EPS credits, dropping events.
  ```

- Second time that the queues are not full, there are available credits, so the events are not being dropped (note `DEBUG` level):

  ```
    DEBUG: Queues back to normal and EPS credits, no dropping events.
  ```


## Testing performed

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @jmv74211  (Developer)  | `test_analysisd/test_limit_eps/test_logging.py`    | 🟢🟢🟢 | 🟢🟢🟢 |  CentOS 7       | https://github.com/wazuh/wazuh-qa/pull/3509/commits/93cea0e3f0912049a28e1fbb95c9e9af734d3518        | Nothing to highlight |

