### PR TITLE
Skip  test_day_wday_multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ Release report: TBD
 
 ### Changed
 
+- Skip test_day_wday ([#3523](https://github.com/wazuh/wazuh-qa/pull/3523)) \- (Tests)
 - Update cluster logs in reliability tests ([#2772](https://github.com/wazuh/wazuh-qa/pull/2772)) \- (Tests)
 - Use correct version format in agent_simulator tool ([#3198](https://github.com/wazuh/wazuh-qa/pull/3198)) \- (Tools)
 
 ### Fixed
 
-- Fix a regex error in the FIM integration tests ([#3061](https://github.com/wazuh/wazuh-qa/issues/3061)) \- (Framework + Tests) 
+- Fix a regex error in the FIM integration tests ([#3061](https://github.com/wazuh/wazuh-qa/issues/3061)) \- (Framework + Tests)
 - Fix an error in the cluster performance tests related to CSV parser ([#2999](https://github.com/wazuh/wazuh-qa/pull/2999)) \- (Framework + Tests)
 
 

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -81,7 +81,8 @@ today = datetime.date.today()
 day = today.day
 
 weekDays = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-monthDays = {"1": 31, "2": 28, "3": 31, "4": 30, "5": 31, "6": 30, "7": 31, "8": 31, "9": 30, "10": 31, "11": 30, "12": 31}
+monthDays = {"1": 31, "2": 28, "3": 31, "4": 30, "5": 31, "6": 30, "7": 31, "8": 31, "9": 30, "10": 31, "11": 30,
+             "12": 31}
 wday = weekDays[today.weekday()]
 
 now = datetime.datetime.now()
@@ -125,7 +126,8 @@ def get_configuration(request):
     ({'ossec_time_conf'})
 ])
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler, wait_for_gcp_start):
+def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler,
+                  wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module starts to pull logs according to the day of the week,
                  of the month, or time set in the configuration. For this purpose, the test will use
@@ -199,10 +201,10 @@ def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset
     ({'ossec_wday_multiple_conf'}),
     ({'ossec_time_multiple_conf'})
 ])
-
 @pytest.mark.xfail(reason="It will be blocked by wazuh/wazuh#15255, when it is resolved, we can enable the test")
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler, wait_for_gcp_start):
+def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler,
+                           wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module calculates the next scan correctly using time intervals
                  greater than one month, one week, or one day. For this purpose, the test will use different

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -200,6 +200,7 @@ def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset
     ({'ossec_time_multiple_conf'})
 ])
 
+@pytest.mark.xfail(reason="It will be blocked by wazuh/wazuh#15255, when it is resolved, we can enable the test")
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler, wait_for_gcp_start):
     '''


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3428        |

## Description

The `test_day_wday_multiple.py` present an unexpected behavior when the system time is around 23:59. For this reason, it has been skipped and created the respective wazuh/wazuh issue [#15255](https://github.com/wazuh/wazuh/issues/15255).

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fedepacher (Developer)  |           |  [:red_circle:](https://github.com/wazuh/wazuh-qa/files/9890120/manager_html_report_Test_integration_B32602_20221008004911.zip) |[ :red_circle:](https://github.com/wazuh/wazuh-qa/files/9890357/r1-pr3523.zip)  |         |         |        |
| @Rebits  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

