### PR TITLE
Skip unstable integration test for agentd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Release report: TBD
 
 ### Changed
 
-- Skip test_agentd_multi_server.py ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
+- Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)
 - Refactor: logcollector `test_only_future_events` according to new standard. ([3484](https://github.com/wazuh/wazuh-qa/pull/3484)) \- (Framework + Tests)
 - Change required version of urllib3 and requests dependencies ([#3315](https://github.com/wazuh/wazuh-qa/pull/3315)) \- (Framework)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Release report: TBD
 
 ### Changed
 
+- Skip test_agentd_multi_server.py ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)
 - Refactor: logcollector `test_only_future_events` according to new standard. ([3484](https://github.com/wazuh/wazuh-qa/pull/3484)) \- (Framework + Tests)
 - Change required version of urllib3 and requests dependencies ([#3315](https://github.com/wazuh/wazuh-qa/pull/3315)) \- (Framework)

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -159,7 +159,7 @@ metadata = [
                 f"Received message: '#!-agent ack '"
             ],
             [
-                #f'Lost connection with manager. Setting lock.',
+                # f'Lost connection with manager. Setting lock.',
                 f'Trying to connect to server ([{SERVER_HOSTS[0]}]:{REMOTED_PORTS[0]}',
                 f'Trying to connect to server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',
                 f'Connected to the server ([{SERVER_HOSTS[1]}]:{REMOTED_PORTS[1]}',

--- a/tests/integration/test_agentd/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server.py
@@ -386,6 +386,7 @@ def wait_until(x, log_str):
 
 
 # @pytest.mark.parametrize('test_case', [case for case in tests])
+@pytest.mark.skip(reason='https://github.com/wazuh/wazuh-qa/issues/3536')
 def test_agentd_multi_server(add_hostnames, configure_authd_server, set_authd_id, clean_keys, configure_environment,
                              get_configuration):
     '''


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3429       |

## Description

The `test_agentd_multi_server.py` presents an unexpected behavior. This PR aims to skip the test till the reactor is finished.

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fedepacher (Developer)  |           |  [:red_circle:](https://github.com/wazuh/wazuh-qa/files/9902477/agent_windows_html_report_Test_integration_B32632_20221008065327.zip) |[ :green_circle:]()  |         |         |        |
| @Rebits  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |




