### PR TITLE
Refactor `test_remove_audit` to retry package installation if busy

### DIFF
--- a/tests/integration/test_fim/test_files/test_audit/test_remove_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_remove_audit.py
@@ -63,6 +63,7 @@ tags:
 import os
 import re
 import subprocess
+from time import sleep
 
 import pytest
 import wazuh_testing.fim as fim
@@ -76,6 +77,8 @@ pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Variables
 
+RETRIES = 5
+SLEEP_TIME = 10
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf.yaml')
 test_directories = [os.path.join('/', 'testdir1'), os.path.join('/', 'testdir2'), os.path.join('/', 'testdir3')]
@@ -120,8 +123,17 @@ def uninstall_install_audit():
     yield
 
     # Install audit and start the service
-    process = subprocess.run([package_management, "install", audit, option], check=True)
-    process = subprocess.run(["service", "auditd", "start"], check=True)
+    for i in range(RETRIES):
+        try:
+            process = subprocess.run([package_management, "install", audit, option], check=True)
+            process = subprocess.run(["service", "auditd", "start"], check=True)
+        except subprocess.CalledProcessError as called_process_error:
+            if i < RETRIES - 1:
+                sleep(SLEEP_TIME)
+                continue
+            else:
+                raise called_process_error
+        break
 
 
 # Test


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3402        |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
 This PR aims to solve the problem in the FIM test `test_remove_audit.py` when it tries to install a package and the subprocess `apt-get` is busy.

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | :green_circle: :green_circle: :green_circle:  |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


