### PR TITLE
Refactor `test_remove_audit` to retry package installation if busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Release report: TBD
 
 ### Changed
 
-- Fix FIM test `test_remove_audit` to retry to execute install and remove command if fail ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
+- Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Release report: TBD
 
 ### Changed
 
-- Refactor FIM test `test_remove_audit` to retry to execute a command if fail ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
+- Fix FIM test `test_remove_audit` to retry to execute install and remove command if fail ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Release report: TBD
 
 ### Changed
 
+- Refactor FIM test `test_remove_audit` to retry to execute a command if fail ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)

--- a/tests/integration/test_fim/test_files/test_audit/test_remove_audit.py
+++ b/tests/integration/test_fim/test_files/test_audit/test_remove_audit.py
@@ -63,7 +63,6 @@ tags:
 import os
 import re
 import subprocess
-from time import sleep
 
 import pytest
 import wazuh_testing.fim as fim


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3402        |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
 This PR aims to solve the problem in the FIM test `test_remove_audit.py` when it tries to install a package and the subprocess `apt-get` is busy.

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | :green_circle:  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9923674/r1-3555.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9923677/r2-3555.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9923679/r3-3555.zip)  |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

