### PR TITLE
Update EPS limits tests according to the new changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Release report: TBD
 
 ### Changed
 
-- Adapted analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
+- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
 - Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Release report: TBD
 
 ### Changed
 
+- Adapted analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
@@ -50,12 +50,12 @@ def check_analysisd_event(file_monitor=None, callback='', error_message=None, up
 
 def check_eps_disabled():
     """Check if the eps module is disabled"""
-    check_analysisd_event(callback=fr'.*INFO: EPS limit disabled.*', timeout=T_10)
+    check_analysisd_event(callback=r".*INFO: EPS limit disabled.*", timeout=T_10)
 
 
 def check_eps_missing_maximum():
     """Check if the eps block has the maximum tag"""
-    check_analysisd_event(callback=fr".*WARNING: EPS limit disabled. "
+    check_analysisd_event(callback=r".*WARNING: EPS limit disabled. "
                                    "The maximum value is missing in the configuration block.*",
                           timeout=T_10)
 

--- a/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
@@ -53,6 +53,13 @@ def check_eps_disabled():
     check_analysisd_event(callback=fr'.*INFO: EPS limit disabled.*', timeout=T_10)
 
 
+def check_eps_missing_maximum():
+    """Check if the eps block has the maximum tag"""
+    check_analysisd_event(callback=fr".*WARNING: EPS limit disabled. "
+                                     "The maximum value is missing in the configuration block.*", 
+                          timeout=T_10)
+
+
 def check_eps_enabled(maximum, timeframe):
     """Check if the eps module is enable"""
     check_analysisd_event(callback=fr".*INFO: EPS limit enabled, EPS: '{maximum}', timeframe: '{timeframe}'",

--- a/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/analysisd/event_monitor.py
@@ -56,7 +56,7 @@ def check_eps_disabled():
 def check_eps_missing_maximum():
     """Check if the eps block has the maximum tag"""
     check_analysisd_event(callback=fr".*WARNING: EPS limit disabled. "
-                                     "The maximum value is missing in the configuration block.*", 
+                                   "The maximum value is missing in the configuration block.*",
                           timeout=T_10)
 
 

--- a/tests/integration/test_analysisd/test_limit_eps/data/test_cases/configuration_test_module/cases_missing_configuration.yaml
+++ b/tests/integration/test_analysisd/test_limit_eps/data/test_cases/configuration_test_module/cases_missing_configuration.yaml
@@ -18,7 +18,7 @@
   metadata:
     maximum: 1000
     timeframe: 5
-    behavior: disabled
+    behavior: missing_maximum
     remove_tags:
       - <maximum>1000</maximum>
 

--- a/tests/integration/test_analysisd/test_limit_eps/test_configuration.py
+++ b/tests/integration/test_analysisd/test_limit_eps/test_configuration.py
@@ -248,7 +248,7 @@ def test_missing_configuration(configuration, metadata, restart_wazuh_daemon_aft
         evm.check_eps_enabled(metadata['maximum'], 10)  # 10 is the default timeframe
         assert check_if_daemons_are_running(['wazuh-analysisd'])[0], 'wazuh-analysisd is not running. Maybe it has ' \
                                                                      'crashed'
-    elif metadata['behavior'] == 'disabled':
+    elif metadata['behavior'] == 'missing_maximum':
         control_service('restart')
         evm.check_eps_missing_maximum()
         assert check_if_daemons_are_running(['wazuh-analysisd'])[0], 'wazuh-analysisd is not running. Maybe it has ' \

--- a/tests/integration/test_analysisd/test_limit_eps/test_configuration.py
+++ b/tests/integration/test_analysisd/test_limit_eps/test_configuration.py
@@ -250,7 +250,7 @@ def test_missing_configuration(configuration, metadata, restart_wazuh_daemon_aft
                                                                      'crashed'
     elif metadata['behavior'] == 'disabled':
         control_service('restart')
-        evm.check_eps_disabled()
+        evm.check_eps_missing_maximum()
         assert check_if_daemons_are_running(['wazuh-analysisd'])[0], 'wazuh-analysisd is not running. Maybe it has ' \
                                                                      'crashed'
     else:


### PR DESCRIPTION
|Related issue|
|-------------|
| #3559 |

## Description
The `analysisd` EPS tests were adapted to the new log added that helps to reduce the amount of `warnings` that were raised when a `wazuh-manager` with EPS block enabled has the <maximum> tag missing.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Added the function `check_eps_missing_maximum()` to the `analysisd` event monitor
- Updated the test `test_analysisd/test_limit_eps/test_configuration.py` to use the new `evm` function


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @QU3B1M  (Developer)  | `integration/test_analysisd/test_limit_eps/` | [:green_circle:](https://ci.wazuh.info/job/Test_integration/33540) [:green_circle:](https://ci.wazuh.info/job/Test_integration/33541/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/33542/) | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9940951/report0.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9940953/report1.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/9940954/report2.zip)| Ubuntu 20 | [227e54c](https://github.com/wazuh/wazuh-qa/pull/3564/commits/227e54ce66b02e8856b1f95aeb788529028ba5c4) | Nothing to highlight |
| @damarisg  (Reviewer)   | `integration/test_analysisd/test_limit_eps/   | [🟢](https://ci.wazuh.info/job/Test_integration/33572/)  |   | Ubuntu 20 | [227e54c](https://github.com/wazuh/wazuh-qa/pull/3564/commits/227e54ce66b02e8856b1f95aeb788529028ba5c4) | Nothing to highlight |