### PR TITLE
Adapt to `multi_groups` modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Release report: TBD
 - Add `monitord.rotate_log` to `local_internal_options` file for `test_macos_format_query` ([#3602](https://github.com/wazuh/wazuh-qa/pull/3602)) \- (Tests)
 - Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests)
 - Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
+- Update pattern and expected condition for multi_groups tests ([#3565](https://github.com/wazuh/wazuh-qa/pull/3565)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))
 - Update wazuhdb_getconfig and EPS limit integration tests ([#3146](https://github.com/wazuh/wazuh-qa/pull/3146)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -499,7 +499,7 @@ def wait_to_remoted_update_groups(wazuh_log_monitor):
     # The log is truncated to ensure that the information has been loaded after the agent has been registered.
     truncate_file(LOG_FILE_PATH)
 
-    callback_pattern = '.*c_files().*End updating shared files sums.'
+    callback_pattern = '.*c_files().*End updating shared files.'
     error_message = 'Could not find the groups reload log'
 
     check_remoted_log_event(wazuh_log_monitor, callback_pattern, error_message, timeout=SYNC_FILES_TIMEOUT)

--- a/deps/wazuh_testing/wazuh_testing/remote.py
+++ b/deps/wazuh_testing/wazuh_testing/remote.py
@@ -684,7 +684,7 @@ def check_push_shared_config(agent, sender, injector=None):
                                                    args=(sender,))
         keep_alive_agent.start()
 
-        log_callback = make_callback(pattern=".*End sending file '.+' to agent '\d+'\.", prefix='.*wazuh-remoted.*')
+        log_callback = make_callback(pattern=r".*End sending file '.+' to agent '\d+'\.", prefix=r'.*wazuh-remoted.*')
         log_monitor = FileMonitor(LOG_FILE_PATH)
         log_monitor.start(timeout=REMOTED_GLOBAL_TIMEOUT, callback=log_callback,
                           error_message="New shared configuration was not sent")

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -194,7 +194,7 @@ def test_merged_mg_file_content(metadata, configure_local_internal_options_modul
     else:
         raise FileNotFoundError(f"The file: {merged_mg_file} was not created.")
 
-    expected_conditions = [True, [expected_line + '\n']] if action == 'create' else [False, []]
+    expected_conditions = [False, [expected_line + '\n']] if action == 'create' else [False, []]
     assert file_exists == expected_conditions[0], f"The file was not {action}d in the multigroups directory.\n"
     if action == 'created':
         assert match_expected_line in expected_conditions[1], f"The file is not in {merged_mg_file}."


### PR DESCRIPTION
|Related issue|
|-------------|
|  #3369  |

## Description
<!-- Add a description of the context and content of all changes made in the pull request -->
This PR aims to fix future errors that will occur when the changes from [15074](https://github.com/wazuh/wazuh/pull/15074) are implemented in wazuh `master`. It does not implement any new test case, it is just a fix to avoid existing test cases to fail.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Modify `callback_pattern` in  `deps/wazuh_testing/wazuh_testing/remote.py`
- Modify expected condition in `tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @QU3B1M(Developer)  |  `integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py` | [:green_circle:](https://ci.wazuh.info/job/Test_integration/33543/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/33544/) [:green_circle:](https://ci.wazuh.info/job/Test_integration/33545/) | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9952894/report0.zip)[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9952896/report1.zip) [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/9952897/report2.zip) |    Ubuntu 20     |   [2e1d85b](https://github.com/wazuh/wazuh-qa/pull/3565/commits/2e1d85be9640f0c6b41a7ddc6196b9a6d61e6b78)      | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
