### PR TITLE
Add test to check vulnerable packages with triaged null

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/db_interface/agent_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/agent_db.py
@@ -56,7 +56,7 @@ def insert_hotfix(agent_id='000', scan_id=int(time()), scan_time=datetime.dateti
 def insert_os_info(agent_id='000', scan_id=int(time()), scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
                    hostname='centos8', architecture='x64', os_name='CentOS Linux', os_version='8.4', os_codename='',
                    os_major='8', os_minor='4', os_patch='', os_build='', os_platform='centos', sysname='Linux',
-                   release='', version='', os_release='', checksum='dummychecksum', os_display_version='', triaged=0,
+                   release='', version='', os_release='', checksum='dummychecksum', os_display_version='', triaged='0',
                    reference=''):
     """Insert the OS information in the agent database.
 
@@ -80,7 +80,7 @@ def insert_os_info(agent_id='000', scan_id=int(time()), scan_time=datetime.datet
         os_release (str): Release of the OS.
         checksum (str): Checksum of the OS.
         os_display_version (str): Os displayed version
-        triaged (int): Triaged.
+        triaged (str): Triaged.
         reference (str): OS reference.
     """
     query_string = f"agent {agent_id} sql INSERT OR REPLACE INTO sys_osinfo (scan_id, scan_time, hostname, " \
@@ -97,7 +97,7 @@ def insert_os_info(agent_id='000', scan_id=int(time()), scan_time=datetime.datet
 def insert_package(agent_id='000', scan_id=int(time()), format='rpm', name='custom-package-0',
                    priority='', section='Unspecified', size=99, vendor='wazuh-mocking', version='1.0.0-1.el7',
                    architecture='x64', multiarch='', description='Wazuh mocking packages', source='Wazuh QA tests',
-                   location='', triaged=0, install_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
+                   location='', triaged='0', install_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
                    scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"), checksum='dummychecksum',
                    item_id='dummyitemid'):
     """Insert a package in the agent DB.
@@ -117,7 +117,7 @@ def insert_package(agent_id='000', scan_id=int(time()), format='rpm', name='cust
         description (str): Package description.
         source (str): Package source.
         location (str): Package location.
-        triaged (int): Times that the package has been installed.
+        triaged (str): Times that the package has been installed.
         install_time (str): Installation timestamp.
         scan_time (str): Scan timestamp.
         checksum (str): Package checksum.
@@ -218,7 +218,7 @@ def delete_os_info(agent_id='000'):
 def update_os_info(agent_id='000', scan_id=int(time()), scan_time=datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"),
                    hostname='centos8', architecture='x64', os_name='CentOS Linux', os_version='8.4', os_codename='',
                    os_major='8', os_minor='4', os_patch='', os_build='', os_platform='centos', sysname='Linux',
-                   release='', version='', os_release='', checksum='dummychecksum', os_display_version='', triaged=0,
+                   release='', version='', os_release='', checksum='dummychecksum', os_display_version='', triaged='0',
                    reference=''):
     """Update the sys_osinfo data from a specific agent.
 
@@ -242,7 +242,7 @@ def update_os_info(agent_id='000', scan_id=int(time()), scan_time=datetime.datet
         os_release (str): Release of the OS.
         checksum (str): Checksum of the OS.
         os_display_version (str): Os displayed version
-        triaged (int): Triaged.
+        triaged (str): Triaged.
         reference (str): OS reference.
     """
     delete_os_info(agent_id)

--- a/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
@@ -150,7 +150,7 @@ def create_mocked_agent(name='centos8-agent', ip='127.0.0.1', register_ip='127.0
                         manager_host='centos-8', node_name='node01', date_add='1612942494', hostname='centos-8',
                         last_keepalive='253402300799', group='', sync_status='synced', connection_status='active',
                         client_key_secret=None, os_release='', os_patch='', release='', sysname='Linux',
-                        checksum='checksum', os_display_version='', triaged=0, reference='', disconnection_time='0',
+                        checksum='checksum', os_display_version='', triaged='0', reference='', disconnection_time='0',
                         architecture='x64'):
 
     """Mock a new agent creating a new client keys entry, adding it to the global db and creating a new agent id DB.
@@ -187,7 +187,7 @@ def create_mocked_agent(name='centos8-agent', ip='127.0.0.1', register_ip='127.0
         sysname (str): System name.
         checksum (str): Checksum.
         os_display_version (str): OS displayed version.
-        triaged (int): Triaged.
+        triaged (str): Triaged.
         reference (str): Reference.
         disconnection_time (str): Last disconnection time.
         architecture (str): Architecture.

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_vulnerabilities_triaged_null.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_vulnerabilities_triaged_null.yaml
@@ -1,0 +1,81 @@
+- sections:
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - run_on_start:
+            value: 'yes'
+        - interval:
+            value: SCAN_INTERVAL
+        - provider:
+            attributes:
+              - name: 'redhat'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: CUSTOM_REDHAT_OVAL_FEED
+                  value: OS
+              - path:
+                  value: CUSTOM_REDHAT_JSON_FEED
+        - provider:
+            attributes:
+              - name: 'canonical'
+            elements:
+              - enabled:
+                  value: 'no'
+        - provider:
+            attributes:
+              - name: 'debian'
+            elements:
+              - enabled:
+                  value: 'no'
+        - provider:
+            attributes:
+              - name: 'msu'
+            elements:
+              - enabled:
+                  value: 'no'
+        - provider:
+            attributes:
+              - name: 'alas'
+            elements:
+              - enabled:
+                  value: 'no'
+        - provider:
+            attributes:
+              - name: 'arch'
+            elements:
+              - enabled:
+                  value: 'no'
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: CUSTOM_NVD_JSON_FEED
+
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_vulnerabilities_triaged_null.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_vulnerabilities_triaged_null.yaml
@@ -1,0 +1,8 @@
+- name: 'RHEL'
+  description: 'Check that after partial scan is launched triaged status changes from NULL to 1'
+  configuration_parameters:
+    OS: '8'
+    SCAN_INTERVAL: '5'
+  metadata:
+    system: RHEL8
+    triaged: ''

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py
@@ -1,0 +1,192 @@
+'''
+copyright: Copyright (C) 2015-2021, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
+components:
+    - vulnerability_detector
+
+suite: scan_results
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - Debian Buster
+    - Red Hat 8
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - SUSE Enterprise Desktop 11
+    - SUSE Enterprise Desktop 12
+    - SUSE Enterprise Desktop 15
+    - SUSE Enterprise Server 11
+    - SUSE Enterprise Server 12
+    - SUSE Enterprise Server 15
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+    - scan_results
+'''
+import os
+import pytest
+
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.tools.configuration import update_configuration_template
+from wazuh_testing.tools.file import read_json_file, copy, write_json_file
+from wazuh_testing import CPE_HELPER_PATH
+from wazuh_testing.db_interface import agent_db
+from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
+from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.db_interface import query_wdb
+
+pytestmark = [pytest.mark.server]
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+TEST_FEEDS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+TEST_PACKAGES_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'vulnerable_packages')
+
+# Configuration and cases data
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_scan_vulnerabilities_triaged_null.yaml')
+t1_cases_path = os.path.join(TEST_CASES_PATH, 'cases_scan_vulnerabilities_triaged_null.yaml')
+
+# Custom paths
+custom_nvd_json_feed_path = os.path.join(TEST_FEEDS_PATH, 'nvd', vd.CUSTOM_NVD_FEED)
+custom_redhat_oval_feed_path = os.path.join(TEST_FEEDS_PATH, 'redhat', vd.CUSTOM_REDHAT_OVAL_FEED)
+custom_redhat_json_feed_path = os.path.join(TEST_FEEDS_PATH, 'redhat', vd.CUSTOM_REDHAT_JSON_FEED)
+
+# Scan NVD test configurations (t1)
+t1_configuration_parameters, t1_configuration_metadata, t1_case_ids = get_test_cases_data(t1_cases_path)
+t1_configurations = load_configuration_template(configurations_path, t1_configuration_parameters,
+                                                t1_configuration_metadata)
+t1_systems = [metadata['system'] for metadata in t1_configuration_metadata]
+
+# Set offline custom feeds configuration
+t1_configurations = update_configuration_template(
+    t1_configurations,  ['CUSTOM_REDHAT_OVAL_FEED', 'CUSTOM_REDHAT_JSON_FEED', 'CUSTOM_NVD_JSON_FEED'],
+    [custom_redhat_oval_feed_path, custom_redhat_json_feed_path, custom_nvd_json_feed_path])
+
+
+@pytest.fixture(scope='function')
+def prepare_scan(metadata, agent_system, mock_agent_with_custom_system):
+    """Prepare the environment to launch the vulnerability scan.
+
+    - Mock an agent with a specified system.
+    - Force full scan.
+
+    Args:
+        metadata (dict): Test case metadata.
+        agent_system (str): System to set to the mocked agent.
+        mock_agent_with_custom_system (fixture): Mock an agent with a custom system.
+    """
+    # Forcing a full-scan
+    agent_db.update_last_full_scan(1, agent_id=mock_agent_with_custom_system)
+
+    yield mock_agent_with_custom_system
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata, agent_system',
+                         zip(t1_configurations, t1_configuration_metadata, t1_systems), ids=t1_case_ids)
+def test_scan_triaged_null_vulnerabilities(configuration, metadata, agent_system, set_wazuh_configuration_vdt,
+                                           truncate_monitored_files, clean_cve_tables_func, prepare_scan,
+                                           restart_modulesd_function):
+    '''
+    description: Check if a vulnerable package with triaged NULL, is detected with the partial scan.
+
+    test_phases:
+        - Set a custom Wazuh configuration.
+        - Mock an agent.
+        - Force a full scan.
+        - Restart wazuh-modulesd.
+        - Insert a vulberable package with triaged NULL.
+        - Check that after partial scan triaged changes to 1.
+
+    wazuh_min_version: 4.4.0
+
+    tier: 1
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - metadata:
+            type: dict
+            brief: Test case metadata.
+        - agent_system:
+            type: str
+            brief: System to set to the mocked agent.
+        - set_wazuh_configuration_vdt:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - clean_cve_tables_func:
+            type: fixture
+            brief: Clean all CVE tables.
+        - prepare_scan:
+            type: fixture
+            brief: Setup the initial test state.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart wazuh-modulesd daemon before starting a test, and stop it after finishing.
+
+    assertions:
+        - Verify that the log a partial scan will be run on agent appears in ossec.log.
+        - Verify that the triaged field of sys_programs table has changed to 1.
+
+    input_description:
+        - The `configuration_scan_vulnerabilities_triaged_null.yaml` file provides the module configuration for this
+          test.
+        - The `cases_scan_vulnerabilities_triaged_null.yaml` file provides the test cases.
+
+    expected_output:
+        - f"A partial scan will be run on agent '{agent_id}'"
+    '''
+    agent_id = prepare_scan
+
+    # Insert mocked vulnerables packages.
+    agent_db.insert_package(name=vd.VULNERABLE_PACKAGES[1]['name'], version=vd.VULNERABLE_PACKAGES[1]['version'],
+                            source=vd.VULNERABLE_PACKAGES[1]['name'], agent_id=agent_id,
+                            vendor='Red Hat, Inc.', triaged=metadata['triaged'])
+
+    # Update packages sync status.
+    agent_db.update_sync_info(agent_id=agent_id, component="syscollector-packages")
+
+    # Check for the next partial scan
+    evm.check_partial_scan_start_log(agent_id=agent_id, timeout=vd.T_15)
+
+    query_string = f"agent {agent_id} sql SELECT triaged FROM sys_programs"
+
+    query_value = query_wdb(query_string)[0]
+
+    assert query_value['triaged'] == 1, f'The triaged value of sys_programs table should be 1 after a partial scan of '\
+                                        f'a vulnerable package'


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3420        |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR aims to add a test to check if vulnerability detection reads packages added with no triaged value after a partial scan.



<!-- Added functionalities or files. Remove if not applicable -->
### Added

- test_scan_vulnerabilities_triaged_null.py
- configuration_scan_vulnerabilities_triaged_null.yaml
- cases_scan_vulnerabilities_triaged_null.yaml


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/10007936/r1-3420.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10007937/r2-3420.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10007938/r3-3420.zip)  |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |



