### PR TITLE
Fix unstable logcollector test_macos_format_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Release report: TBD
 
 ### Changed
 
-- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
+- Add `monitord.rotate_log` to `local_internal_options` file for `test_macos_format_query` ([#3602](https://github.com/wazuh/wazuh-qa/pull/3602)) \- (Tests)
+- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests)
 - Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))

--- a/tests/integration/test_logcollector/test_macos/test_macos_format_query.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_format_query.py
@@ -74,7 +74,8 @@ parameters_query = []
 metadata_query = []
 
 local_internal_options = {'logcollector.debug': 2,
-                          'logcollector.sample_log_length': 200}
+                          'logcollector.sample_log_length': 200,
+                          'monitord.rotate_log': 0}
 macos_log_message_timeout = 10
 macos_log_list = [
     {
@@ -430,7 +431,6 @@ def test_macos_format_query(configure_local_internal_options_module, restart_log
             logcollector.generate_macos_custom_log(macos_log['type'], macos_log['level'], macos_log['subsystem'],
                                                    macos_log['category'], macos_log['program_name'])
 
-        log_message_command = macos_log['program_name']
         clauses_values = []
 
         same_type = True


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh-qa/issues/3487       |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
This PR aims to fix the `test_macos_format_query` test that has an unstable behavior. This fix was based on adding the `monitord.rotate_log=0` option to the `local_internal_options` file.


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fedepacher  (Developer)  |           | [:green_circle:](https://ci.wazuh.info/job/Test_integration/33889/console) [:green_circle:](https://ci.wazuh.info/job/Test_integration/33890/console) [:green_circle:](https://ci.wazuh.info/job/Test_integration/33891/console)  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10017673/r1-3487.zip) :green_circle: :green_circle:  |         |         | Nothing to highlight |
| @Rebits  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

[r1-3487.zip](https://github.com/wazuh/wazuh-qa/files/10017673/r1-3487.zip)
