### PR TITLE
Add test to check if syslog message are parsed correctly in the `alerts.json` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release report: TBD
 
 ### Added
 
+- Add new test to check if syslog message are parsed correctrly in the `alerts.json` file ([#3609](https://github.com/wazuh/wazuh-qa/pull/3609)) \- (Framework + Tests)
 - Add new logging tests for analysisd EPS limitation ([#3509](https://github.com/wazuh/wazuh-qa/pull/3509)) \- (Framework + Tests)
 - New testing suite for checking analysisd EPS limitation ([#2947](https://github.com/wazuh/wazuh-qa/pull/3181)) \- (Framework + Tests)
 - Add stress results comparator tool ([#3478](https://github.com/wazuh/wazuh-qa/pull/3478)) \- (Tools)
@@ -34,7 +35,7 @@ Release report: TBD
 
 ### Changed
 
-- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
+- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests)
 - Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))

--- a/deps/wazuh_testing/wazuh_testing/scripts/syslog_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/syslog_simulator.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 import logging
 import time
+from ipaddress import ip_address, IPv4Address
 
 
 TCP = 'tcp'
@@ -68,7 +69,7 @@ def get_parameters():
     return arg_parser.parse_args()
 
 
-def send_messages(message, num_messages, eps, numbered_messages=-1, address='locahost', port=514, protocol=TCP):
+def send_messages(message, num_messages, eps, numbered_messages=-1, address='localhost', port=514, protocol=TCP):
     sent_messages = 0
     custom_message = f"{message}\n" if message[-1] != '\n' not in message else message
     protocol_limit = TCP_LIMIT if protocol == TCP else UDP_LIMIT
@@ -76,8 +77,14 @@ def send_messages(message, num_messages, eps, numbered_messages=-1, address='loc
 
     LOGGER.info(f"Sending {num_messages} to {address}:{port} via {protocol.upper()} ({speed}/s)")
 
+    if 'localhost' in address or type(ip_address(address)) is IPv4Address:
+        af_inet = socket.AF_INET
+    else:
+        af_inet = socket.AF_INET6
+
     # Create socket
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM if protocol == TCP else socket.SOCK_DGRAM)
+    sock = socket.socket(af_inet, socket.SOCK_STREAM if protocol == TCP else socket.SOCK_DGRAM)
+
     if protocol == TCP:
         sock.connect((address, port))
 

--- a/deps/wazuh_testing/wazuh_testing/tools/run_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/run_simulator.py
@@ -19,6 +19,7 @@ def syslog_simulator(parameters):
     run_parameters += f"-m '{parameters['message']}' " if 'message' in parameters else ''
     run_parameters += f"--numbered-messages {parameters['numbered_messages']} " if 'numbered_messages' in parameters \
         else ''
+    run_parameters += f"-p '{parameters['port']}' " if 'port' in parameters else ''
     run_parameters = run_parameters.strip()
 
     # Run the syslog simulator tool with custom parameters

--- a/tests/integration/test_remoted/test_socket_communication/data/configuration_template/configuration_syslog_message_parser.yaml
+++ b/tests/integration/test_remoted/test_socket_communication/data/configuration_template/configuration_syslog_message_parser.yaml
@@ -1,0 +1,17 @@
+- sections:
+    - section: remote
+      elements:
+        - connection:
+            value: syslog
+        - allowed-ips:
+            value: any
+        - port:
+            value: PORT
+        - protocol:
+            value: PROTOCOL
+        - ipv6:
+            value: "yes"
+    - section: global
+      elements:
+        - logall_json:
+            value: "yes"

--- a/tests/integration/test_remoted/test_socket_communication/data/test_cases/cases_syslog_message_parser.yaml
+++ b/tests/integration/test_remoted/test_socket_communication/data/test_cases/cases_syslog_message_parser.yaml
@@ -1,0 +1,25 @@
+- name: Syslog_message_ipv6_test
+  description: Send syslog message through IPV6
+  configuration_parameters:
+    PORT: 5050
+    PROTOCOL: tcp
+  metadata:
+  # syslog simulator parameters
+    address: 0000:0000:0000:0000:0000:0000:0000:0001
+    message: 'IPv6 test msg'
+    port: 5050
+    protocol: tcp
+    messages_number: 1
+
+- name: Syslog_message_ipv4_test
+  description: Send syslog message through IPV4
+  configuration_parameters:
+    PORT: 5050
+    PROTOCOL: tcp
+  metadata:
+  # syslog simulator parameters
+    address: 127.0.0.1
+    message: 'IPv4 test msg'
+    port: 5050
+    protocol: tcp
+    messages_number: 1

--- a/tests/integration/test_remoted/test_socket_communication/data/test_cases/cases_syslog_message_parser.yaml
+++ b/tests/integration/test_remoted/test_socket_communication/data/test_cases/cases_syslog_message_parser.yaml
@@ -1,4 +1,4 @@
-- name: Syslog_message_ipv6_test
+- name: Syslog_message_ipv6
   description: Send syslog message through IPV6
   configuration_parameters:
     PORT: 5050
@@ -11,7 +11,7 @@
     protocol: tcp
     messages_number: 1
 
-- name: Syslog_message_ipv4_test
+- name: Syslog_message_ipv4
   description: Send syslog message through IPV4
   configuration_parameters:
     PORT: 5050

--- a/tests/integration/test_remoted/test_socket_communication/data/test_cases/cases_syslog_message_parser.yaml
+++ b/tests/integration/test_remoted/test_socket_communication/data/test_cases/cases_syslog_message_parser.yaml
@@ -4,9 +4,9 @@
     PORT: 5050
     PROTOCOL: tcp
   metadata:
-  # syslog simulator parameters
+    # syslog simulator parameters
     address: 0000:0000:0000:0000:0000:0000:0000:0001
-    message: 'IPv6 test msg'
+    message: IPv6 test msg
     port: 5050
     protocol: tcp
     messages_number: 1
@@ -17,9 +17,9 @@
     PORT: 5050
     PROTOCOL: tcp
   metadata:
-  # syslog simulator parameters
+    # syslog simulator parameters
     address: 127.0.0.1
-    message: 'IPv4 test msg'
+    message: IPv4 test msg
     port: 5050
     protocol: tcp
     messages_number: 1

--- a/tests/integration/test_remoted/test_socket_communication/test_syslog_message_parser.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_syslog_message_parser.py
@@ -1,0 +1,150 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-remoted' program is the server side daemon that communicates with the agents.
+       Specifically, this test will check if 'wazuh-remoted' can receive syslog messages through
+       the socket.
+
+components:
+    - remoted
+
+suite: socket_communication
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-remoted
+
+os_platform:
+    - linux
+    - windows
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - Debian Buster
+    - Red Hat 8
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Windows 10
+    - Windows Server 2019
+    - Windows Server 2016
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-remoted.html
+
+tags:
+    - remoted
+'''
+import os
+import re
+import pytest
+from time import sleep
+
+from wazuh_testing import ARCHIVES_JSON_PATH
+from wazuh_testing.tools import file
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.tools.run_simulator import syslog_simulator
+from wazuh_testing.tools.thread_executor import ThreadExecutor
+
+
+pytestmark = [pytest.mark.tier(level=0)]
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+SYSLOG_SIMULATOR_START_TIME = 2
+
+# Configuration and cases data
+t1_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_syslog_message_parser.yaml')
+t1_cases_path = os.path.join(TEST_CASES_PATH, 'cases_syslog_message_parser.yaml')
+
+# Syslog message IPV6 values test configurations (t1)
+t1_configurations_parameters, t1_configurations_metadata, t1_cases_ids = get_test_cases_data(t1_cases_path)
+t1_configurations = load_configuration_template(t1_configurations_path, t1_configurations_parameters,
+                                                t1_configurations_metadata)
+
+
+@pytest.mark.parametrize('configuration, metadata', zip(t1_configurations, t1_configurations_metadata),
+                         ids=t1_cases_ids)
+def test_syslog_message_ipv6(configuration, metadata, set_wazuh_configuration, truncate_event_logs,
+                             restart_wazuh_daemon_function):
+    '''
+    description: Check if 'wazuh-remoted' can receive syslog messages through the socket.
+
+    test_phases:
+        - setup:
+            - Apply ossec.conf configuration changes according to the configuration template and use case.
+            - Truncate wazuh event logs.
+            - Restart wazuh-manager service to apply configuration changes.
+        - test:
+            - Check that the messages are parsed correctly in the alerts.json file.
+        - tierdown:
+            - Truncate wazuh logs.
+            - Restore initial configuration, both ossec.conf and local_internal_options.conf.
+
+    wazuh_min_version: 4.4.0
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Get configurations from the module.
+        - metadata:
+            type: dict
+            brief: Get metadata from the module.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Apply changes to the ossec.conf configuration.
+        - truncate_event_logs:
+            type: fixture
+            brief: Truncate wazuh event logs.
+        - restart_wazuh_daemon_function:
+            type: fixture
+            brief: Restart the wazuh service.
+
+    assertions:
+        - Verify the syslog message is received and parsed correctly.
+
+    input_description:
+        - The `configuration_syslog_message_parser` file provides the module configuration for this
+          test.
+        - The `cases_syslog_message_parser` file provides the test cases.
+
+    expected_output:
+        - fr'"full_log":"{message}".*"location":"{location}"'
+    '''
+    # Set syslog simulator parameters according to the use case data
+    syslog_simulator_parameters = {'address': metadata['address'], 'port': metadata['port'],
+                                   'protocol': metadata['protocol'],
+                                   'messages_number': metadata['messages_number'],
+                                   'message': metadata['message']}
+
+    # Run syslog simulator thread
+    syslog_simulator_thread = ThreadExecutor(syslog_simulator, {'parameters': syslog_simulator_parameters})
+    syslog_simulator_thread.start()
+
+    # Wait until syslog simulator is started
+    sleep(SYSLOG_SIMULATOR_START_TIME)
+
+    # Read the events log data
+    events_data = file.read_file(ARCHIVES_JSON_PATH).split('\n')
+
+    message = metadata['message']
+    location = metadata['address']
+    find_msg = (fr'"full_log":"{message}".*"location":"{location}"').replace('"', r'\"')
+
+    event_msg = [event for event in events_data if bool(re.match(fr".*{find_msg}.*", event))]
+
+    assert len(event_msg) == metadata['messages_number'], f"The events were not parsed as: {find_msg}"
+
+    # Wait until syslog simulator ends
+    syslog_simulator_thread.join()

--- a/tests/integration/test_remoted/test_socket_communication/test_syslog_message_parser.py
+++ b/tests/integration/test_remoted/test_socket_communication/test_syslog_message_parser.py
@@ -76,8 +76,8 @@ t1_configurations = load_configuration_template(t1_configurations_path, t1_confi
 
 @pytest.mark.parametrize('configuration, metadata', zip(t1_configurations, t1_configurations_metadata),
                          ids=t1_cases_ids)
-def test_syslog_message_ipv6(configuration, metadata, set_wazuh_configuration, truncate_event_logs,
-                             restart_wazuh_daemon_function):
+def test_syslog_message_parser(configuration, metadata, set_wazuh_configuration, truncate_event_logs,
+                               restart_wazuh_daemon_function):
     '''
     description: Check if 'wazuh-remoted' can receive syslog messages through the socket.
 
@@ -87,7 +87,7 @@ def test_syslog_message_ipv6(configuration, metadata, set_wazuh_configuration, t
             - Truncate wazuh event logs.
             - Restart wazuh-manager service to apply configuration changes.
         - test:
-            - Check that the messages are parsed correctly in the alerts.json file.
+            - Check that the messages are parsed correctly in the archives.json file.
         - tierdown:
             - Truncate wazuh logs.
             - Restore initial configuration, both ossec.conf and local_internal_options.conf.
@@ -144,7 +144,7 @@ def test_syslog_message_ipv6(configuration, metadata, set_wazuh_configuration, t
 
     event_msg = [event for event in events_data if bool(re.match(fr".*{find_msg}.*", event))]
 
-    assert len(event_msg) == metadata['messages_number'], f"The events were not parsed as: {find_msg}"
+    assert len(event_msg) == metadata['messages_number'], "The event's format is not the expected one"
 
     # Wait until syslog simulator ends
     syslog_simulator_thread.join()


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh-qa/issues/3095      |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
This PR aims to add a new test to check that the `syslog` messages are parsed correctly in the `alerts.json` file. 

<!-- Added functionalities or files. Remove if not applicable -->
### Added

-  test_syslog_message_parser.py
- configuration_syslog_message_parser.yaml
- cases_syslog_message_parser.yaml

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- syslog_simulator.py
- run_simulaor.py

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fedepacher (Developer)  |           | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/33935/console) [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/33938/console) [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/33939/console)  | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10024908/r1-3095.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10024914/r2-3095.zip) [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10024917/r3-3095.zip)  |         |         | Nothing to highlight |
| @Rebits  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


