### PR TITLE
Include Fragmentation information to getconfig endpoint wazuhdb IT case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Release report: TBD
 
 ### Changed
 
-- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
+- Adapt wazuhdb integration tests for auto-vacuum ([#3613](https://github.com/wazuh/wazuh-qa/issues/3613)) \- (Tests)
+- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests)
 - Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))

--- a/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
+++ b/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
@@ -31,7 +31,7 @@
     -
       input: '{"version": 1, "origin": {"module": "api"}, "command": "getconfig", "module": "api", "parameters": {
               "section": "internal"}}'
-      output: '"data":{"wazuh_db":{"commit_time_max":60,"commit_time_min":10,"open_db_limit":64,"worker_pool_size":8,"fragmentation_threshold":80,"fragmentation_delta":5,"free_pages_percentage":5,"max_fragmentation":95, "check_fragmentation_interval":43200}}'
+      output: '"data":{"wazuh_db":{"commit_time_max":60,"commit_time_min":10,"open_db_limit":64,"worker_pool_size":8,"fragmentation_threshold":80,"fragmentation_delta":5,"free_pages_percentage":5,"max_fragmentation":95,"check_fragmentation_interval":43200}}'
 -
   name: Get wdb config
   test_case:

--- a/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
+++ b/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
@@ -31,7 +31,7 @@
     -
       input: '{"version": 1, "origin": {"module": "api"}, "command": "getconfig", "module": "api", "parameters": {
               "section": "internal"}}'
-      output: '"data":{"wazuh_db":{"commit_time_max":60,"commit_time_min":10,"open_db_limit":64,"worker_pool_size":8}}'
+      output: '"data":{"wazuh_db":{"commit_time_max":60,"commit_time_min":10,"open_db_limit":64,"worker_pool_size":8,"fragmentation_threshold":80,"fragmentation_delta":5,"free_pages_percentage":5,"max_fragmentation":95, "check_fragmentation_interval":43200}}'
 -
   name: Get wdb config
   test_case:


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh-qa/issues/3613    |

## Description

Include auto-vacuum data to the getconfig WazuhDB integration tests


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Include `fragmentation_threshold`,  `free_pages_percentage` , `max_fragmentation` and `check_fragmen` to the wazuhdb getconfig test.
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Rebits (Developer)  |           | ⚫⚫⚫ | :green_circle: :green_circle: :green_circle:|         |         | https://github.com/wazuh/wazuh-qa/issues/3613#issuecomment-1319867101 |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
