### PR TITLE
Fix FIM tests for Solaris agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Release report: TBD
 
 ### Changed
 
-- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests) 
+- Refactor `test_basic_usage_realtime_unsupported` FIM test to avoid using time travel ([#3623](https://github.com/wazuh/wazuh-qa/pull/3623)) \- (Tests)
+- Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests)
 - Improve `test_remove_audit` FIM test to retry install and remove command ([#3562](https://github.com/wazuh/wazuh-qa/pull/3562)) \- (Tests)
 - Skip unstable integration tests for gcloud ([#3531](https://github.com/wazuh/wazuh-qa/pull/3531)) \- (Tests)
 - Skip unstable integration test for agentd ([#3538](https://github.com/wazuh/wazuh-qa/pull/3538))

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_realtime.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/wazuh_conf_check_realtime.yaml
@@ -1,29 +1,31 @@
 # conf 1
 - tags:
-  - ossec_conf
+    - ossec_conf
   apply_to_modules:
-  - test_basic_usage_realtime_unsupported
+    - test_basic_usage_realtime_unsupported
   sections:
-  - section: syscheck
-    elements:
-    - disabled:
-        value: 'no'
-    - directories:
-        value: TEST_DIRECTORIES
-        attributes:
-        - check_all: 'yes'
-        - realtime: 'yes'
-  - section: sca
-    elements:
-    - enabled:
-        value: 'no'
-  - section: rootcheck
-    elements:
-    - disabled:
-        value: 'yes'
-  - section: wodle
-    attributes:
-      - name: 'syscollector'
-    elements:
-      - disabled:
-          value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'no'
+        - frequency:
+            value: 3
+        - directories:
+            value: TEST_DIRECTORIES
+            attributes:
+              - check_all: 'yes'
+              - realtime: 'yes'
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
@@ -140,6 +140,5 @@ def test_realtime_unsupported(get_configuration, configure_environment, file_mon
 
     detect_initial_scan(log_monitor)
 
-    regular_file_cud(directory_str, log_monitor, file_list=[test_file], time_travel=True, triggers_event=True,
+    regular_file_cud(directory_str, log_monitor, file_list=[test_file], time_travel=False, triggers_event=True,
                      event_mode="scheduled", min_timeout=15)
-


### PR DESCRIPTION
|Related issue|
|-------------|
|    https://github.com/wazuh/wazuh-qa/issues/3405       |

## Description

This PR aims to fix the `test_basic_usage_realtime_unsupported.py` for Solaris OS that had a random failure when creating/modifying/deleting files. In this fix, it has avoided the use of the time travel function, and it has been replaced by adding the tag `<frequency>` in order to set a frequency value instead of the default one.


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fedepacher  (Developer)  |           | ⚫⚫⚫ |  [🟢](https://github.com/wazuh/wazuh-qa/files/9954506/r1-3405.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9954508/r2-3405.zip)  [🟢](https://github.com/wazuh/wazuh-qa/files/9954510/r3-3405.zip) |         |         |  |
| @Rebits  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

