### PR TITLE
Update teardown.yaml

### DIFF
--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/teardown.yaml
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/teardown.yaml
@@ -24,7 +24,7 @@
   hosts: ubuntu-manager
   tasks:
 
-    - name: Delete agent configuration
+    - name: Delete manager configuration
       become: true
       blockinfile:
         path: /var/ossec/etc/ossec.conf

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/teardown.yaml
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/teardown.yaml
@@ -19,3 +19,22 @@
         tasks_from: restart_wazuh.yaml
       vars:
         os: linux
+        
+- name: Cleanup Ubuntu manager environment
+  hosts: ubuntu-manager
+  tasks:
+
+    - name: Delete agent configuration
+      become: true
+      blockinfile:
+        path: /var/ossec/etc/ossec.conf
+        block: ''
+        marker: <!-- {mark} ANSIBLE MANAGED BLOCK -->
+
+    - name: Restart wazuh-manager
+      include_role:
+        name: manage_wazuh
+        tasks_from: restart_wazuh.yaml
+      vars:
+        os: linux
+


### PR DESCRIPTION
test_vulnerability_detector_linux is adding to ossec.conf file on wazuh-manager but it's only trying to remove from wazuh-agent configuration.

Test should clean-up from wazuh-manager ossec.conf

|Related issue|
|-------------|
|             |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Item 1
- Item n

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Item 1
- Item n

<!-- Functionalities or files that have been deleted. Remove if not applicable -->
### Deleted

- Item 1
- Item n

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
