### PR TITLE
Update logcollector format test due to audit changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Release report: TBD
 
 ### Changed
 
+- Update logcollector format test due to audit changes ([#3641](https://github.com/wazuh/wazuh-qa/pull/3641)) \- (Framework)
 - Refactor `test_basic_usage_realtime_unsupported` FIM test to avoid using time travel ([#3623](https://github.com/wazuh/wazuh-qa/pull/3623)) \- (Tests)
 - Add `monitord.rotate_log` to `local_internal_options` file for `test_macos_format_query` ([#3602](https://github.com/wazuh/wazuh-qa/pull/3602)) \- (Tests)
 - Adapt analysisd integration tests for EPS ([#3559](https://github.com/wazuh/wazuh-qa/issues/3559)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/logcollector.py
+++ b/deps/wazuh_testing/wazuh_testing/logcollector.py
@@ -531,7 +531,7 @@ def callback_invalid_format_value(line, option, location):
     if option == 'json':
         msg = fr"DEBUG: Line '{line}' read from '{location}' is not a JSON object."
     elif option == 'audit':
-        msg = fr"ERROR: Discarding audit message because of invalid syntax."
+        msg = "WARNING: Discarding audit message because of invalid syntax."
     elif option == 'nmapg':
         msg = fr"ERROR: Bad formated nmap grepable file."
     elif option == 'djb-multilog':


### PR DESCRIPTION
## Description

This PR makes the necessary change to update the log message when an `audit` log format message has an invalid value. 

The previous behavior was to show the following `ERROR` log:

```
ERROR: Discarding audit message because of invalid syntax
```

Now, the following `WARNING` is shown:

```
 WARNING: Discarding audit message because of invalid syntax.
```

This new behavior has been added in the following PR https://github.com/wazuh/wazuh/pull/15476

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @jmv74211  |  `test_logcollector/test_log_format/test_log_format_values.py`       |  | 🟢 🟢 🟢  | Ubuntu focal      |         | Nothing to highlight |
