### PR TITLE
Fix Yara and Virustotal E2E tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ Release report: TBD
 
 ### Added
 
-- Increase Virustotal timeout to 90 seconds in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
-- Fix Yara installation in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
+- Fix Yara and VirusTotal E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
 - Add new test to check if syslog message are parsed correctrly in the `archives.json` file ([#3609](https://github.com/wazuh/wazuh-qa/pull/3609)) \- (Framework + Tests)
 - Add new logging tests for analysisd EPS limitation ([#3509](https://github.com/wazuh/wazuh-qa/pull/3509)) \- (Framework + Tests)
 - New testing suite for checking analysisd EPS limitation ([#2947](https://github.com/wazuh/wazuh-qa/pull/3181)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Release report: TBD
 
 ### Added
 
+- Increase Virustotal timeout to 60 seconds in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
+- Fix Yara installation in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
+- Add new test to check if syslog message are parsed correctrly in the `archives.json` file ([#3609](https://github.com/wazuh/wazuh-qa/pull/3609)) \- (Framework + Tests)
 - Add new test to check if syslog message are parsed correctrly in the `archives.json` file ([#3609](https://github.com/wazuh/wazuh-qa/pull/3609)) \- (Framework + Tests)
 - Add new logging tests for analysisd EPS limitation ([#3509](https://github.com/wazuh/wazuh-qa/pull/3509)) \- (Framework + Tests)
 - New testing suite for checking analysisd EPS limitation ([#2947](https://github.com/wazuh/wazuh-qa/pull/3181)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ Release report: TBD
 
 ### Added
 
-- Increase Virustotal timeout to 60 seconds in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
+- Increase Virustotal timeout to 90 seconds in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
 - Fix Yara installation in E2E basic usage tests ([#3660](https://github.com/wazuh/wazuh-qa/pull/3660))
-- Add new test to check if syslog message are parsed correctrly in the `archives.json` file ([#3609](https://github.com/wazuh/wazuh-qa/pull/3609)) \- (Framework + Tests)
 - Add new test to check if syslog message are parsed correctrly in the `archives.json` file ([#3609](https://github.com/wazuh/wazuh-qa/pull/3609)) \- (Framework + Tests)
 - Add new logging tests for analysisd EPS limitation ([#3509](https://github.com/wazuh/wazuh-qa/pull/3509)) \- (Framework + Tests)
 - New testing suite for checking analysisd EPS limitation ([#2947](https://github.com/wazuh/wazuh-qa/pull/3181)) \- (Framework + Tests)

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
@@ -21,7 +21,7 @@
             timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
             custom_regex: "{\"timestamp\":\"{{ timestamp }}\",\"rule\":{\"level\":{{ rule_level }},\
                            \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*}"
-            timeout: 60
+            timeout: 90
 
       always:
 

--- a/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
+++ b/tests/end_to_end/test_basic_cases/test_virustotal_integration/data/playbooks/generate_events.yaml
@@ -21,7 +21,7 @@
             timestamp: \d+-\d+-\d+T\d+:\d+:\d+\.\d+[+|-]\d+
             custom_regex: "{\"timestamp\":\"{{ timestamp }}\",\"rule\":{\"level\":{{ rule_level }},\
                            \"description\":\"{{ rule_description }}\",\"id\":\"{{ rule_id }}\".*}"
-            timeout: 30
+            timeout: 60
 
       always:
 

--- a/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
@@ -51,20 +51,20 @@
         - name: Download Yara
           become: true
           get_url:
-            url: "https://github.com/VirusTotal/yara/archive/v{{ yara_version | default('4.2.3') }}.tar.gz"
-            dest: "/tmp/v{{ yara_version | default('4.2.3')}}.tar.gz"
+            url: https://github.com/VirusTotal/yara/archive/v{{ yara_version | default('4.2.3') }}.tar.gz
+            dest: /tmp/v{{ yara_version | default('4.2.3')}}.tar.gz
 
         - name: Uncompress Yara file
           become: true
           unarchive:
-            src: "/tmp/v{{ yara_version | default('4.2.3')}}.tar.gz"
+            src: /tmp/v{{ yara_version | default('4.2.3')}}.tar.gz
             dest: /tmp
-            remote_src: yes
+            remote_src: true
 
         - name: Compile and install Yara
           become: true
-          shell: "cd /tmp/yara-{{ yara_version | default('4.2.3')}} && ./bootstrap.sh && ./configure && make &&
-                  make install"
+          shell: cd /tmp/yara-{{ yara_version | default('4.2.3')}} && ./bootstrap.sh && ./configure && make &&
+                  make install
       when: yara_check.rc != 0
 
     - name: Check if jq is installed

--- a/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
@@ -23,27 +23,48 @@
         chown root:wazuh /var/ossec/active-response/bin/yara.sh
         chmod 0750 /var/ossec/active-response/bin/yara.sh
 
-    - name: Check if epel-release is installed
-      shell: rpm -qa epel-release
-      register: check_epel_release
+    - name: Check if Yara is installed
+      become: true
+      shell: yara -v
+      register: yara_check
+      ignore_errors: true
 
-    - name: Install epel-release
-      package:
-        name:
-          - epel-release
-        state: present
-      when: '"epel" not in check_epel_release.stdout'
+    - name: Install Yara
+      block:
+        - name: Update system's packages
+          become: true
+          package:
+            name: "*"
+            state: latest
 
-    - name: Check if yara is installed
-      shell: rpm -qa yara
-      register: check_yara
+        - name: Install Yara dependencies
+          become: true
+          package:
+            name:
+              - gcc
+              - make
+              - libtool
+              - pcre-devel
+              - openssl-devel
+            state: present
 
-    - name: Install Yara on CentOS
-      package:
-        name:
-          - yara
-        state: present
-      when: '"yara" not in check_yara.stdout'
+        - name: Download Yara
+          become: true
+          get_url:
+            url: "https://github.com/VirusTotal/yara/archive/v{{ yara_version | default('4.2.3') }}.tar.gz"
+            dest: "/tmp/v{{ yara_version | default('4.2.3')}}.tar.gz"
+
+        - name: Uncompress Yara file
+          become: true
+          unarchive:
+            src: "/tmp/v{{ yara_version | default('4.2.3')}}.tar.gz"
+            dest: /tmp
+            remote_src: yes
+
+        - name: Compile Yara
+          become: true
+          shell: "cd /tmp/yara-{{ yara_version | default('4.2.3')}} && ./bootstrap.sh"
+      when: yara_check.rc != 0
 
     - name: Check if jq is installed
       shell: rpm -qa jq
@@ -110,7 +131,7 @@
           <command>
           <name>yara</name>
           <executable>yara.sh</executable>
-          <extra_args>-yara_path /usr/bin -yara_rules /tmp/yara/rules/yara_rules.yar</extra_args>
+          <extra_args>-yara_path /usr/local/bin/ -yara_rules /tmp/yara/rules/yara_rules.yar</extra_args>
           <timeout_allowed>no</timeout_allowed>
           </command>
           <active-response>

--- a/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
@@ -64,7 +64,7 @@
         - name: Compile and install Yara
           become: true
           shell: cd /tmp/yara-{{ yara_version | default('4.2.3')}} && ./bootstrap.sh && ./configure && make &&
-                  make install
+                 make install
       when: yara_check.rc != 0
 
     - name: Check if jq is installed

--- a/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_yara_integration/data/playbooks/configuration.yaml
@@ -61,9 +61,10 @@
             dest: /tmp
             remote_src: yes
 
-        - name: Compile Yara
+        - name: Compile and install Yara
           become: true
-          shell: "cd /tmp/yara-{{ yara_version | default('4.2.3')}} && ./bootstrap.sh"
+          shell: "cd /tmp/yara-{{ yara_version | default('4.2.3')}} && ./bootstrap.sh && ./configure && make &&
+                  make install"
       when: yara_check.rc != 0
 
     - name: Check if jq is installed


### PR DESCRIPTION
|Related issue|
|-------------|
|   #3657           |

## Description
This PR fix Virustotal and Yara E2E tests


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Yara E2E test configuration playbook
- Virustotal E2E test timeout

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | [:green_circle:](https://ci.wazuh.info/job/Test_e2e_system/23/consoleFull)  |Not apply |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
