### PR TITLE
3548 report changes win

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/file.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/file.py
@@ -28,6 +28,8 @@ from wazuh_testing import logger, REGULAR, SYMLINK, HARDLINK
 if sys.platform == 'win32':
     import win32security as win32sec
     import ntsecuritycon as ntc
+    import win32con
+    import win32api
 
 
 def read_json(file_path):
@@ -851,7 +853,6 @@ def modify_file_win_attributes(path, name):
     """
     if sys.platform != 'win32':
         return
-
     logger.info("- Changing win attributes of " + str(os.path.join(path, name)))
     path_to_file = os.path.join(path, name)
     win32api.SetFileAttributes(path_to_file, win32con.FILE_ATTRIBUTE_HIDDEN)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
@@ -77,7 +77,7 @@ from test_fim.common import make_diff_file_path
 
 # Marks
 
-pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
+pytestmark = [pytest.mark.tier(level=1)]
 
 
 # Reference paths


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/3548        |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR aims to add fix the test module `test_fime/test_files/test_report_changes/test_report_changes_and_diff.py` to allow it to work on Windows.



### Fixed

A total of 6 have been fixed in the following modules:

- test_report_changes_and_diff.py

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  |  test_fim         | :large_blue_circle::large_blue_circle::large_blue_circle:   | ⚫⚫⚫   | Centos8   |  https://github.com/wazuh/wazuh-qa/pull/3649/commits/331fd696ad1f81b082b0b8c753d5eac9fbf2766a       | Nothing to highlight |
| @damarisg   (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
