### PR TITLE
Fix multigroups system test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Release report: TBD
 - Fix the unstable FIM tests that need refactoring ([#2458](https://github.com/wazuh/wazuh-qa/pull/2458)) \- (Framework + Tests)
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
 - Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Tests)
-- Fix undeclared API token variable in multigroups system tests ([#3674](https://github.com/wazuh/wazuh-qa/pull/3674)) \- (Tests)
+- Fix undeclared API token variable in multigroups system tests ([#3674](https://github.com/wazuh/wazuh-qa/pull/3674)) \- (Framework + Tests)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Release report: TBD
 - Fix the unstable FIM tests that need refactoring ([#2458](https://github.com/wazuh/wazuh-qa/pull/2458)) \- (Framework + Tests)
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
 - Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Tests)
+- Fix undeclared API token variable in multigroups system tests ([#3674](https://github.com/wazuh/wazuh-qa/pull/3674)) \- (Tests)
 
 ### Removed
 

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -281,19 +281,21 @@ class HostManager:
         """
         return self.get_host(host).interface(interface).addresses
 
-    def find_file(self, host: str, path: str, pattern: str, recurse: bool = False, use_regex: bool = False):
+    def find_file(self, host: str, path: str, pattern: str = '*', use_regex: bool = False, recurse: bool = False,
+                  file_type: str = 'file'):
         """Search and return information of a file inside a path.
         Args:
             host (str): Hostname
             path (str): Path in which to search for the file that matches the pattern.
             pattern (str): Restrict the files to be returned to those whose basenames match the pattern specified.
-            recurse (bool): If target is a directory, recursively descend into the directory looking for files.
             use_regex (bool): If no, the patterns are file globs (shell), if yes, they are python regexes.
+            recurse (bool): If target is a directory, recursively descend into the directory looking for files.
+            file_type (str): Type of file to select. Choices are 'any', 'directory', 'file', 'link'.
         Returns:
             Files (list): List of found files.
         """
         return self.get_host(host).ansible("find", f"paths={path} patterns={pattern} recurse={recurse} "
-                                                   f"use_regex={use_regex}")
+                                                   f"use_regex={use_regex} file_type={file_type}")
 
     def get_stats(self, host: str, path: str):
         """Retrieve file or file system status.

--- a/tests/system/test_multigroups/test_multigroups.py
+++ b/tests/system/test_multigroups/test_multigroups.py
@@ -25,18 +25,16 @@ inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__
                               'basic_cluster', 'inventory.yml')
 host_manager = HostManager(inventory_path)
 
-
 time_to_update = 10
 time_to_sync = 20
 
 
-@pytest.fixture(scope="session")
+# Functions
+
 def get_api_token():
     global host_manager
     return host_manager.get_api_token(test_hosts[0])
 
-
-# Functions
 
 def calculate_mg_name(groups_list):
     """Determine multigroup name from a list of groups.
@@ -73,7 +71,7 @@ def get_mtime(folders_to_check, hosts=None):
     return result
 
 
-def get_agent_id(token, agent_name):
+def get_agent_id(agent_name):
     """Get agent ID from its name.
 
     Args:
@@ -83,7 +81,7 @@ def get_agent_id(token, agent_name):
     Returns:
         str: Agent ID.
     """
-    agent_id = host_manager.make_api_call(host=test_hosts[0], token=token, method='GET',
+    agent_id = host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='GET',
                                           endpoint=f"/agents?name={agent_name}")
     assert agent_id['status'] == 200, f"Failed trying to get ID of agent {agent_name}"
     return agent_id['json']['data']['affected_items'][0]['id']
@@ -93,7 +91,7 @@ def delete_groups():
     """Delete all groups, except Default"""
     for agent_name, groups in agent_groups.items():
         # Remove any pre-existing group.
-        host_manager.make_api_call(host=test_hosts[0], token=host_manager.get_api_token(test_hosts[0]), method='DELETE',
+        host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='DELETE',
                                    endpoint=f"/groups?groups_list={','.join(groups[1:])}")
 
         # Remove any pre-existing multigroup (just in case they weren't removed after deleting the group).
@@ -110,7 +108,7 @@ def agent_healthcheck():
     for agent, _ in agent_groups.items():
         result = {}
         for _ in range(5):
-            result = host_manager.make_api_call(host=test_hosts[0], token=token, method='GET',
+            result = host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='GET',
                                                 endpoint=f"/agents?status=active&name={agent}")
             if result['status'] == 200 and result['json']['data']['total_affected_items'] == 1:
                 break
@@ -134,7 +132,7 @@ def create_multigroups():
         for idx, group in enumerate(groups):
             if group != 'default':
                 # Create group.
-                response = host_manager.make_api_call(host=test_hosts[0], token=token, method='POST',
+                response = host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='POST',
                                                       endpoint='/groups', request_body={'group_id': group})
                 assert response['status'] == 200, f"Failed to create {group} group: {response}"
 
@@ -146,8 +144,8 @@ def create_multigroups():
                 )['files'],  f"{os.path.join(mg_folder_path, mg_name)} should not exist."
 
                 # Assign agent to group.
-                agent_id = get_agent_id(token=token, agent_name=agent_name)
-                response = host_manager.make_api_call(host=test_hosts[0], token=token, method='PUT',
+                agent_id = get_agent_id(agent_name=agent_name)
+                response = host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='PUT',
                                                       endpoint=f"/agents/{agent_id}/group/{group}")
                 assert response['status'] == 200, f"Failed to add {agent_name} ({agent_id}) to group: {response}"
 
@@ -160,7 +158,7 @@ def create_multigroups():
 
 # Tests
 
-def test_multigroups_not_reloaded(get_api_token, clean_environment, agent_healthcheck, create_multigroups):
+def test_multigroups_not_reloaded(clean_environment, agent_healthcheck, create_multigroups):
     """Check that the files are not regenerated when there are no changes.
 
     Check and store the modification time of all group and multigroup files. Wait 10 seconds
@@ -187,7 +185,7 @@ def test_multigroups_not_reloaded(get_api_token, clean_environment, agent_health
     agent_groups['wazuh-agent1'][1],
     'default'
 ])
-def test_multigroups_updated(get_api_token, clean_environment, agent_healthcheck, create_multigroups, target_group):
+def test_multigroups_updated(clean_environment, agent_healthcheck, create_multigroups, target_group):
     """Check that only the appropriate multi-groups are regenerated when a group file is created.
 
     Check and store the modification time of all group and multigroup files. Create a new file inside
@@ -233,7 +231,7 @@ def test_multigroups_updated(get_api_token, clean_environment, agent_healthcheck
                 assert mtime == host_files[host][file], f"This file changed its modification time in {host}: {file}"
 
 
-def test_multigroups_deleted(get_api_token, clean_environment, agent_healthcheck, create_multigroups):
+def test_multigroups_deleted(clean_environment, agent_healthcheck, create_multigroups):
     """Check that multigroups are removed when expected.
 
     Unassign an agent from their groups or delete the groups. Check that the associated multigroup disappears
@@ -242,19 +240,19 @@ def test_multigroups_deleted(get_api_token, clean_environment, agent_healthcheck
     for agent_name, groups in agent_groups.items():
         # Check that multigroups exists for each agent.
         mg_name = os.path.join(mg_folder_path, calculate_mg_name(groups))
-        agent_id = get_agent_id(token=get_api_token, agent_name=agent_name)
+        agent_id = get_agent_id(agent_name=agent_name)
 
         for group in groups:
             if group != 'default':
                 if agent_name == 'wazuh-agent1':
                     # Unassign agent.
-                    response = host_manager.make_api_call(host=test_hosts[0], token=get_api_token, method='DELETE',
+                    response = host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='DELETE',
                                                           endpoint=f"/agents/{agent_id}/group/{group}")
                     assert response['status'] == 200, f"Failed when unassigning {agent_name} agent from " \
                                                       f"group {group}: {response}"
                 else:
                     # Delete group.
-                    response = host_manager.make_api_call(host=test_hosts[0], token=get_api_token, method='DELETE',
+                    response = host_manager.make_api_call(host=test_hosts[0], token=get_api_token(), method='DELETE',
                                                           endpoint=f"/groups?groups_list={group}")
                     assert response['status'] == 200, f"Failed to delete {group} group: {response}"
 


### PR DESCRIPTION
|Related issue|
|-------------|
|#3647|

## Description

As reported in #3647, the [multigroups test](https://github.com/wazuh/wazuh-qa/blob/4.4/tests/system/test_multigroups/test_multigroups.py) was failing when trying to use a non-defined API token variable. This PR applies some changes to fix the problem.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- [find_file](https://github.com/wazuh/wazuh-qa/blob/c99ef1496992b00a29c85c8f3e436325e2ed2e8f/deps/wazuh_testing/wazuh_testing/tools/system.py#L284-L296): A parameter (`file_type`) was restored. Default value for `pattern` parameter was added.
- [get_api_token](https://github.com/wazuh/wazuh-qa/blob/c99ef1496992b00a29c85c8f3e436325e2ed2e8f/tests/system/test_multigroups/test_multigroups.py#L33-L36): This fixture has been converted to a normal function. 

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Selutario (Developer)  |`tests/system/test_multigroups`| ⚫⚫⚫ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10225945/multigroups_result1.txt)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/10225946/multigroups_result2.txt)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/10226101/multigroups_result3.txt) | Debian buster |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

