### PR TITLE
Fix error in requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Release report: TBD
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
 - Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Tests)
 - Fix undeclared API token variable in multigroups system tests ([#3674](https://github.com/wazuh/wazuh-qa/pull/3674)) \- (Framework + Tests)
+- Fix error in requirements.txt ([#3689](https://github.com/wazuh/wazuh-qa/pull/3689)) \- (Framework)
 
 ### Removed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or pl
 setuptools~=56.0.0
 testinfra==5.0.0
 jq==1.1.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version <= "3.9"
-jq==1.2.2 ; python_version >= "3.10"
+jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version >= "3.10"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 urllib3>=1.26.5
 numpydoc>=1.1.0


### PR DESCRIPTION
|Related issue|
|-------------|
|#3687|

## Description


An error appears while trying to install the requirements of the tests. This is caused because there is no wheel for the `jq` package in Windows (as you can check [here](https://pypi.org/project/jq/#files)).

### Updated

- `requirements.txt`: added a condition to not try installing in Windows
