### PR TITLE
Increase sleep time in `test_agent_default_group_added` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Release report: TBD
 - Fix version validation in qa-ctl config generator ([#2454](https://github.com/wazuh/wazuh-qa/pull/2454)) \- (Framework)
 - Fix invalid reference for test_api_endpoints_performance.py xfail items ([#3378](https://github.com/wazuh/wazuh-qa/pull/3378)) \- (Tests)
 - Fix undeclared API token variable in multigroups system tests ([#3674](https://github.com/wazuh/wazuh-qa/pull/3674)) \- (Framework + Tests)
+- Fix sleep time in `test_agent_default_group_added`. ([#3692](https://github.com/wazuh/wazuh-qa/pull/3692)) \- (Tests)
 
 ### Removed
 

--- a/tests/system/test_cluster/test_agent_groups/test_agent_default_group_added.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_default_group_added.py
@@ -60,7 +60,7 @@ inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os
 host_manager = HostManager(inventory_path)
 local_path = os.path.dirname(os.path.abspath(__file__))
 tmp_path = os.path.join(local_path, 'tmp')
-timeout = 5
+timeout = 25
 
 
 # Tests


### PR DESCRIPTION
|Related issue|
|-------------|
| Closes #3646 |

## Description

As reported at #3646, the `test_cluster/test_agent_groups/test_agent_default_group_added.py` test was failing. The reason seems to be that, after assigning a group and restarting the cluster, the expected state was checked without waiting long enough for its synchronization in all the nodes.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Sleep time increased from 5s to 25s.

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Selutario (Developer)  |           | ⚫⚫⚫ | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/10257946/result1.txt)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/10257947/result2.txt)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/10257945/result3.txt) |Debian|https://github.com/wazuh/wazuh-qa/commit/a01fac543f8bd18cfe981d880c292f3f376ae802| Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


