### PR TITLE
AWS Config integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
@@ -14,7 +14,7 @@ CONFIG = 'Config'
 
 EVENT_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 PATH_DATE_FORMAT = '%Y/%m/%d'
-PATH_DATE_NO_PADED_FORMAT = '%Y/%-m/%d'
+PATH_DATE_NO_PADED_FORMAT = '%Y/%-m/%-d'
 FILENAME_DATE_FORMAT = '%Y%m%dT%H%MZ'
 
 US_EAST_1_REGION = 'us-east-1'

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
@@ -10,6 +10,7 @@ RANDOM_ACCOUNT_ID = '819751203818'
 CLOUDTRAIL = 'CloudTrail'
 VPC_FLOW_LOGS = "vpcflowlogs"
 FLOW_LOG_ID = "fl-0754d951c16f517fa"
+CONFIG = 'Config'
 
 EVENT_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 PATH_DATE_FORMAT = '%Y/%m/%d'
@@ -23,3 +24,4 @@ LOG_EXT = '.log'
 # Bucket types
 CLOUD_TRAIL_TYPE = 'cloudtrail'
 VPC_FLOW_TYPE = 'vpcflow'
+CONFIG_TYPE = 'config'

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
@@ -14,6 +14,7 @@ CONFIG = 'Config'
 
 EVENT_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 PATH_DATE_FORMAT = '%Y/%m/%d'
+PATH_DATE_NO_PADED_FORMAT = '%Y/%-m/%d'
 FILENAME_DATE_FORMAT = '%Y%m%dT%H%MZ'
 
 US_EAST_1_REGION = 'us-east-1'

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
@@ -156,20 +156,30 @@ class VPCDataGenerator(DataGenerator):
 
 
 class ConfigDataGenerator(DataGenerator):
-    BASE_PATH = f'{cons.AWS_LOGS}/{cons.RANDOM_ACCOUNT_ID}/{cons.CONFIG}/{cons.US_EAST_1_REGION}/'
-    BASE_FILE_NAME = f'{cons.RANDOM_ACCOUNT_ID}_{cons.CONFIG}_{cons.US_EAST_1_REGION}_ConfigHistory_AWS_'
+    BASE_PATH = join(cons.AWS_LOGS, cons.RANDOM_ACCOUNT_ID, cons.CONFIG, cons.US_EAST_1_REGION)
+    BASE_FILE_NAME = f"{cons.RANDOM_ACCOUNT_ID}_{cons.CONFIG}_{cons.US_EAST_1_REGION}_ConfigHistory_AWS_"
 
     def get_filename(self, prefix=None, **kwargs) -> str:
-        """Return the filename in the cloudtrail format
-        <prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/Config/<region>/<year>/<month>/<day>
+        """Return the filename in the Config format.
+
+        Example:
+            <prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/Config/<region>/<year>/<month>/<day>
+
+        Returns:
+            str: Syntetic filename.
         """
         now = datetime.now()
-        path = f"{self.BASE_PATH}{now.strftime(cons.PATH_DATE_NO_PADED_FORMAT)}/"
+        path = join(self.BASE_PATH, now.strftime(cons.PATH_DATE_NO_PADED_FORMAT))
         name = f"{self.BASE_FILE_NAME}{now.strftime(cons.FILENAME_DATE_FORMAT)}_{abs(hash(now))}{cons.JSON_EXT}"
 
-        return f'{path}{name}'
+        return join(path, name)
 
     def get_data_sample(self) -> str:
+        """Return a sample of data according to the Config format.
+
+        Returns:
+            str: Syntetic data.
+        """
         return json.dumps({
             'fileVersion': '1.0',
             'configurationItems': [

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
@@ -164,7 +164,7 @@ class ConfigDataGenerator(DataGenerator):
         <prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/Config/<region>/<year>/<month>/<day>
         """
         now = datetime.now()
-        path = f"{self.BASE_PATH}{now.strftime(cons.PATH_DATE_FORMAT)}/"
+        path = f"{self.BASE_PATH}{now.strftime(cons.PATH_DATE_NO_PADED_FORMAT)}/"
         name = f"{self.BASE_FILE_NAME}{now.strftime(cons.FILENAME_DATE_FORMAT)}_{abs(hash(now))}{cons.JSON_EXT}"
 
         return f'{path}{name}'

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
@@ -50,7 +50,7 @@ class CloudTrailDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        now = datetime.now()
+        now = datetime.utcnow()
         path = join(self.BASE_PATH, now.strftime(cons.PATH_DATE_FORMAT))
         name = f"{self.BASE_FILE_NAME}{now.strftime(cons.FILENAME_DATE_FORMAT)}_{abs(hash(now))}{cons.JSON_EXT}"
 
@@ -70,7 +70,7 @@ class CloudTrailDataGenerator(DataGenerator):
                         'type': 'AWSService',
                         'invokedBy': 'ec2.amazonaws.com'
                     },
-                    'eventTime': datetime.now().strftime(cons.EVENT_TIME_FORMAT),
+                    'eventTime': datetime.utcnow().strftime(cons.EVENT_TIME_FORMAT),
                     'eventSource': 'sts.amazonaws.com',
                     'eventName': 'AssumeRole',
                     'awsRegion': cons.US_EAST_1_REGION,
@@ -120,7 +120,7 @@ class VPCDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        now = datetime.now()
+        now = datetime.utcnow()
         path = join(self.BASE_PATH, now.strftime(cons.PATH_DATE_FORMAT))
         name = (
             f'{self.BASE_FILE_NAME}{cons.FLOW_LOG_ID}_{now.strftime(cons.FILENAME_DATE_FORMAT)}_{abs(hash(now))}'
@@ -166,9 +166,9 @@ class ConfigDataGenerator(DataGenerator):
             <prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/Config/<region>/<year>/<month>/<day>
 
         Returns:
-            str: Syntetic filename.
+            str: Synthetic filename.
         """
-        now = datetime.now()
+        now = datetime.utcnow()
         path = join(self.BASE_PATH, now.strftime(cons.PATH_DATE_NO_PADED_FORMAT))
         name = f"{self.BASE_FILE_NAME}{now.strftime(cons.FILENAME_DATE_FORMAT)}_{abs(hash(now))}{cons.JSON_EXT}"
 
@@ -178,7 +178,7 @@ class ConfigDataGenerator(DataGenerator):
         """Return a sample of data according to the Config format.
 
         Returns:
-            str: Syntetic data.
+            str: Synthetic data.
         """
         return json.dumps({
             'fileVersion': '1.0',

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
@@ -155,10 +155,69 @@ class VPCDataGenerator(DataGenerator):
         return buffer.getvalue()
 
 
+class ConfigDataGenerator(DataGenerator):
+    BASE_PATH = f'{cons.AWS_LOGS}/{cons.RANDOM_ACCOUNT_ID}/{cons.CONFIG}/{cons.US_EAST_1_REGION}/'
+    BASE_FILE_NAME = f'{cons.RANDOM_ACCOUNT_ID}_{cons.CONFIG}_{cons.US_EAST_1_REGION}_ConfigHistory_AWS_'
+
+    def get_filename(self, prefix=None, **kwargs) -> str:
+        """Return the filename in the cloudtrail format
+        <prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/Config/<region>/<year>/<month>/<day>
+        """
+        now = datetime.now()
+        path = f"{self.BASE_PATH}{now.strftime(cons.PATH_DATE_FORMAT)}/"
+        name = f"{self.BASE_FILE_NAME}{now.strftime(cons.FILENAME_DATE_FORMAT)}_{abs(hash(now))}{cons.JSON_EXT}"
+
+        return f'{path}{name}'
+
+    def get_data_sample(self) -> str:
+        return json.dumps({
+            'fileVersion': '1.0',
+            'configurationItems': [
+                {
+                    'relatedEvents': [],
+                    'relationships': [
+                        {
+                            'resourceId': f"vol-{get_random_string(17)}",
+                            'resourceType': 'AWS::EC2::Volume',
+                            'name': 'Is associated with '
+                        }
+                    ],
+                    'configuration': {
+                        'complianceType': 'NON_COMPLIANT',
+                        'targetResourceId': f"vol-{get_random_string(17)}",
+                        'targetResourceType': 'AWS::EC2::Volume',
+                        'configRuleList': [
+                            {
+                                'configRuleArn': (
+                                    f"arn:aws:config:us-east-1:{cons.RANDOM_ACCOUNT_ID}:config-rule/"
+                                    'config-rule-b1eqqf'),
+                                'configRuleId': 'config-rule-b1eqqf',
+                                'configRuleName': 'encrypted-volumes',
+                                'complianceType': 'NON_COMPLIANT'
+                            }
+                        ]
+                    },
+                    'supplementaryConfiguration': {},
+                    'tags': {},
+                    'configurationItemVersion': '1.3',
+                    'configurationItemCaptureTime': '2020-06-01T02:12:37.713Z',
+                    'configurationStateId': 1590977557713,
+                    'awsAccountId': cons.RANDOM_ACCOUNT_ID,
+                    'configurationItemStatus': 'ResourceDiscovered',
+                    'resourceType': 'AWS::Config::ResourceCompliance',
+                    'resourceId': f"AWS::EC2::Volume/vol-{get_random_string(17)}",
+                    'awsRegion': 'us-east-1',
+                    'configurationStateMd5Hash': ''
+                }
+            ]
+        })
+
+
 # Maps bucket type with corresponding data generator
 buckets_data_mapping = {
     cons.CLOUD_TRAIL_TYPE: CloudTrailDataGenerator,
-    cons.VPC_FLOW_TYPE: VPCDataGenerator
+    cons.VPC_FLOW_TYPE: VPCDataGenerator,
+    cons.CONFIG_TYPE: ConfigDataGenerator
 }
 
 

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/event_monitor.py
@@ -95,7 +95,7 @@ def check_non_processed_logs_from_output(command_output: str, bucket_type: str, 
         command_output,
         callback=make_aws_callback(pattern),
         expected_results=expected_results,
-        error_message='Some logs may were processed'
+        error_message='Some logs may were processed or the results found are more than expected'
     )
 
 

--- a/tests/integration/test_aws/data/test_cases/basic_test_module/cases_defaults.yaml
+++ b/tests/integration/test_aws/data/test_cases/basic_test_module/cases_defaults.yaml
@@ -15,3 +15,12 @@
   metadata:
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
+
+- name: config_defaults
+  description: Config default configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_discard_regex.yaml
@@ -29,3 +29,19 @@
     discard_regex: "5319"
     found_logs: 5
     skipped_logs: 1
+
+- name: config_discard_regex
+  description: Config discard regex configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    DISCARD_FIELD: configuration.complianceType
+    DISCARD_REGEX: .*COMPLIANT.*
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    discard_field: configuration.complianceType
+    discard_regex: .*COMPLIANT.*
+    found_logs: 5
+    skipped_logs: 1

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_multiple_calls.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_multiple_calls.yaml
@@ -11,3 +11,10 @@
   metadata:
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
+
+- name: config_only_logs_after_multiple_calls
+  description: Config only_logs_after multiple calls configurations
+  configuration_parameters:
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_with_only_logs_after.yaml
@@ -21,3 +21,15 @@
     bucket_name: wazuh-vpcflow-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 3
+
+- name: config_with_only_logs_after
+  description: Config only logs after configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    expected_results: 5

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_without_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_without_only_logs_after.yaml
@@ -17,3 +17,13 @@
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
     expected_results: 1
+
+- name: config_without_only_logs_after
+  description: Config only logs after configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    expected_results: 1

--- a/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
@@ -50,6 +50,19 @@
     path_suffix: test_suffix
     expected_results: 1
 
+- name: config_path_suffix_with_data
+  description: Config path_suffix configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    PATH_SUFFIX: test_suffix
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    path_suffix: test_suffix
+    expected_results: 1
+
 - name: vpc_path_suffix_without_data
   description: VPC path_suffix configurations
   configuration_parameters:
@@ -63,6 +76,19 @@
     path_suffix: empty_suffix
     expected_results: 0
 
+- name: config_path_suffix_without_data
+  description: Config path_suffix configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    PATH_SUFFIX: empty_suffix
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    path_suffix: empty_suffix
+    expected_results: 0
+
 - name: vpc_inexistent_path_suffix
   description: VPC path_suffix configurations
   configuration_parameters:
@@ -72,6 +98,19 @@
   metadata:
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
+    only_logs_after: 2022-NOV-20
+    path_suffix: inexistent_suffix
+    expected_results: 0
+
+- name: config_inexistent_path_suffix
+  description: Config path_suffix configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    PATH_SUFFIX: inexistent_suffix
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: inexistent_suffix
     expected_results: 0

--- a/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
@@ -50,6 +50,19 @@
     path: test_prefix
     expected_results: 1
 
+- name: config_path_with_data
+  description: Config path configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    PATH: test_prefix
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    path: test_prefix
+    expected_results: 1
+
 - name: vpc_path_without_data
   description: VPC path configurations
   configuration_parameters:
@@ -63,6 +76,19 @@
     path: empty_prefix
     expected_results: 0
 
+- name: config_path_without_data
+  description: Config path configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    PATH: empty_prefix
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    path: empty_prefix
+    expected_results: 0
+
 - name: vpc_inexistent_path
   description: CloudTrail path configurations
   configuration_parameters:
@@ -72,6 +98,19 @@
   metadata:
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
+    only_logs_after: 2022-NOV-20
+    path: inexistent_prefix
+    expected_results: 0
+
+- name: config_inexistent_path
+  description: Config path configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    PATH: inexistent_prefix
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
     only_logs_after: 2022-NOV-20
     path: inexistent_prefix
     expected_results: 0

--- a/tests/integration/test_aws/data/test_cases/regions_test_module/cases_regions.yaml
+++ b/tests/integration/test_aws/data/test_cases/regions_test_module/cases_regions.yaml
@@ -50,6 +50,19 @@
     regions: us-east-1
     expected_results: 3
 
+- name: config_region_with_data
+  description: Config regions configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    REGIONS: us-east-1
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    regions: us-east-1
+    expected_results: 3
+
 - name: vpc_regions_with_data
   description: VPC regions configurations
   configuration_parameters:
@@ -63,6 +76,19 @@
     regions: us-east-1,us-east-2
     expected_results: 5
 
+- name: config_regions_with_data
+  description: Config regions configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    REGIONS: us-east-1,us-east-2
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
+    regions: us-east-1,us-east-2
+    expected_results: 5
+
 - name: vpc_inexistent_region
   description: VPC regions configurations
   configuration_parameters:
@@ -72,6 +98,19 @@
   metadata:
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
+    only_logs_after: 2022-NOV-20
+    regions: us-fake-1
+    expected_results: 0
+
+- name: config_inexistent_region
+  description: Config regions configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+    REGIONS: us-fake-1
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-fake-1
     expected_results: 0

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -15,3 +15,12 @@
   metadata:
     bucket_type: vpcflow
     bucket_name: wazuh-vpcflow-integration-tests
+
+- name: config_remove_from_bucket
+  description: Config remove from bucket configurations
+  configuration_parameters:
+    BUCKET_TYPE: config
+    BUCKET_NAME: wazuh-config-integration-tests
+  metadata:
+    bucket_type: config
+    bucket_name: wazuh-config-integration-tests

--- a/tests/integration/test_aws/test_discard_regex.py
+++ b/tests/integration/test_aws/test_discard_regex.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from wazuh_testing import global_parameters, T_20
+from wazuh_testing import T_20, global_parameters
 from wazuh_testing.modules.aws import event_monitor
 from wazuh_testing.modules.aws.db_utils import s3_db_exists
 from wazuh_testing.tools.configuration import (

--- a/tests/integration/test_aws/test_path.py
+++ b/tests/integration/test_aws/test_path.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from wazuh_testing import T_10, global_parameters
+from wazuh_testing import T_10, T_20, global_parameters
 from wazuh_testing.modules.aws import event_monitor
 from wazuh_testing.modules.aws.db_utils import get_s3_db_row, s3_db_exists, table_exists
 from wazuh_testing.tools.configuration import (
@@ -126,7 +126,7 @@ def test_path(
 
     if expected_results:
         wazuh_log_monitor.start(
-            timeout=T_10,
+            timeout=T_20,
             callback=event_monitor.callback_detect_event_processed,
             error_message='The AWS module did not process the expected number of events',
         ).result()

--- a/tests/integration/test_aws/test_regions.py
+++ b/tests/integration/test_aws/test_regions.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from wazuh_testing import T_10, T_20, global_parameters
+from wazuh_testing import T_20, global_parameters
 from wazuh_testing.modules.aws import event_monitor
 from wazuh_testing.modules.aws.constants import RANDOM_ACCOUNT_ID
 from wazuh_testing.modules.aws.db_utils import (


### PR DESCRIPTION
|Related issue|
|-------------|
|      #3337       |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR adds tests for AWS Config integration

<!-- Added functionalities or files. Remove if not applicable -->
### Added

#### Tier 0
- Default configuration tests
- `remove_from_bucket` parameter tests
- `only_logs_after` parameter tests
- `path` parameter tests
- `path_suffix` parameter tests
- `regions` parameter tests
- `discard_regex` parameter tests

#### Tier 1
- `only_logs_after` parameter tests
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @nico-stefani (Developer)  |           | ⚫⚫⚫ | :red_circle: :red_circle:   |         |         |  [^1] [^2]|
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

[^1]: Because the module is iterating over all days from `only_logs_after` to the day of execution, all *tier 0* tests are falling giving timeout. This should be fixed in his respective issue.
[^2]: Because the module is showing the message `No logs to process in bucket: ...` multiple times, the *tier 1* test is falling. This should be fixed in his respective issue.

### Tier 0 results
```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k config --tier 0
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 30 items / 16 deselected / 14 selected

test_basic.py .                                                          [  7%]
test_discard_regex.py F                                                  [ 14%]
test_only_logs_after.py .F                                               [ 28%]
test_path.py F..                                                         [ 50%]
test_path_suffix.py ...                                                  [ 71%]
test_regions.py .FF                                                      [ 92%]
test_remove_from_bucket.py .                                             [100%]
=========================== short test summary info ============================
FAILED test_discard_regex.py::test_discard_regex[config_discard_regex] - Time...
FAILED test_only_logs_after.py::test_with_only_logs_after[config_with_only_logs_after]
FAILED test_path.py::test_path[config_path_with_data] - TimeoutError: The AWS...
FAILED test_regions.py::test_regions[config_regions_with_data] - TimeoutError...
FAILED test_regions.py::test_regions[config_inexistent_region] - TimeoutError...
====== 5 failed, 9 passed, 16 deselected, 3 warnings in 389.85s (0:06:29) ======
```

### Tier 1 results

```python
root@ubuntu-jammy:/home/vagrant/qa/tests/integration/test_aws# pytest -k config --tier 1
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 30 items / 29 deselected / 1 selected

test_only_logs_after.py F                                                [100%]

=================================== FAILURES ===================================
------------------------------ Captured log call -------------------------------
DEBUG    wazuh_testing:cli_utils.py:23 Calling AWS module with: '[PosixPath('/var/ossec/wodles/aws/aws-s3'), '--bucket', 'wazuh-config-integration-tests', '--type', 'config', '--regions', 'us-east-1', '--aws_profile', 'qa', '--debug', '2', '--only_logs_after', '2022-NOV-20']'
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Debug mode on - Level: 2
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Working on 819751203818 - us-east-1
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: AWSLogs/819751203818/Config/us-east-1/2022/11/26/819751203818_Config_us-east-1_ConfigHistory_AWS_20221126T1419Z_9135633071561314633.json
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ No logs to process in bucket: 819751203818/us-east-1
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: AWSLogs/819751203818/Config/us-east-1/2022/11/27
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ No logs to process in bucket: 819751203818/us-east-1
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: AWSLogs/819751203818/Config/us-east-1/2022/11/28
...
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: AWSLogs/819751203818/Config/us-east-1/2023/1/12
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ No logs to process in bucket: 819751203818/us-east-1
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ DB Maintenance
ERROR    wazuh_testing:cli_utils.py:62 Some logs may were processed or the results found are more than expected
ERROR    wazuh_testing:cli_utils.py:63 Results found: 48
ERROR    wazuh_testing:cli_utils.py:64 Results expected: 1
=============================== warnings summary ===============================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:433
  /usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:433: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/nodeids
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:387
  /usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:387: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/lastfailed
    config.cache.set("cache/lastfailed", self.lastfailed)

../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/stepwise.py:52
  /usr/local/lib/python3.10/dist-packages/_pytest/stepwise.py:52: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/stepwise
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED test_only_logs_after.py::test_multiple_calls[config_only_logs_after_multiple_calls]
================ 1 failed, 29 deselected, 3 warnings in 48.67s =================

```
