### PR TITLE
Vulnerability detector NVE test feed download fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Release report: TBD
 
 ### Changed
 
+- Increase NVE download feed test timeout([#3769](https://github.com/wazuh/wazuh-qa/pull/3769)) \- (Tests)
 - Adapt wazuhdb integration tests for auto-vacuum ([#3613](https://github.com/wazuh/wazuh-qa/issues/3613)) \- (Tests)
 - Update logcollector format test due to audit changes ([#3641](https://github.com/wazuh/wazuh-qa/pull/3641)) \- (Framework)
 - Refactor `test_basic_usage_realtime_unsupported` FIM test to avoid using time travel ([#3623](https://github.com/wazuh/wazuh-qa/pull/3623)) \- (Tests)

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -164,7 +164,7 @@
   metadata:
     provider_name: National Vulnerability Database
     provider_os: NVD
-    download_timeout: 800
+    download_timeout: 1000
     update_treshold_weeks: 2
 
 - name: MSU


### PR DESCRIPTION
|Related issue|
|-------------|
|     #3767         |

## Description

The vulnerability detector NVE download feed test timeout has been increasing to avoid false positive failures.



<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Increase NVE download feed test timeout
 
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Rebits  (Developer)  |           |  [:large_blue_circle: ](https://ci.wazuh.info/job/Test_integration/35594/console)  | Not required |         |         | Nothing to highlight |
| @jmv74211  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

> **Warning**
>  Is expected to fail the ALAS and ALAS2 download feed tests. Further information could be found in https://github.com/wazuh/wazuh-qa/issues/3767#issuecomment-1385369610