### PR TITLE
Skip unstable FIM report changes test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release report: TBD
 
 ### Changed
 
+- Skip test_large_changes test module ([#3783](https://github.com/wazuh/wazuh-qa/pull/3783)) \- (Tests)
 - Update report_changes tests ([#3405](https://github.com/wazuh/wazuh-qa/pull/3405)) \- (Tests)
 - Update Authd force_insert tests ([#3379](https://github.com/wazuh/wazuh-qa/pull/3379)) \- (Tests)
 - Update cluster logs in reliability tests ([#2772](https://github.com/wazuh/wazuh-qa/pull/2772)) \- (Tests)

--- a/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
@@ -127,7 +127,7 @@ def extra_configuration_after_yield():
 
 
 # Tests
-@pytest.mark.skip('Test skipped for flaky behavior, after it is fixed, it will be unblocked')
+@pytest.mark.skip('Test skipped for flaky behavior, after it is fixed by Issue wazuh/wazuh#3783, it will be unblocked')
 @pytest.mark.parametrize('filename, folder, original_size, modified_size', [
     ('regular_0', testdir, 500, 500),
     ('regular_1', testdir, 30000, 30000),

--- a/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_large_changes.py
@@ -127,7 +127,7 @@ def extra_configuration_after_yield():
 
 
 # Tests
-
+@pytest.mark.skip('Test skipped for flaky behavior, after it is fixed, it will be unblocked')
 @pytest.mark.parametrize('filename, folder, original_size, modified_size', [
     ('regular_0', testdir, 500, 500),
     ('regular_1', testdir, 30000, 30000),


### PR DESCRIPTION
|Related issue|
|-------------|
| #3783             |

## Description

This PR skips the test module `test_fim/test_files/test_report_changes/test_large_changes.py` because it has flaky behavior. So it can be tracked and fixed.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Skipped `test_fim/test_files/test_report_changes/test_large_changes.py`

