### PR TITLE
Umbrella integration tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/constants.py
@@ -30,6 +30,7 @@ US_EAST_1_REGION = 'us-east-1'
 JSON_EXT = '.json'
 LOG_EXT = '.log'
 JSON_GZ_EXT = '.jsonl.gz'
+CSV_EXT = '.csv'
 
 # Bucket types
 CLOUD_TRAIL_TYPE = 'cloudtrail'
@@ -47,3 +48,4 @@ GUARD_DUTY_TYPE = 'guardduty'
 NATIVE_GUARD_DUTY_TYPE = 'native-guardduty'
 WAF_TYPE = 'waf'
 SERVER_ACCESS = 'server_access'
+CISCO_UMBRELLA_TYPE = 'cisco_umbrella'

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
@@ -1101,6 +1101,51 @@ class ServerAccessDataGenerator(DataGenerator):
         return buffer.getvalue()
 
 
+class UmbrellaDataGenerator(DataGenerator):
+    BASE_PATH = 'dnslogs'
+    BASE_FILE_NAME = ''
+
+    def get_filename(self, prefix=None, **kwargs) -> str:
+        """Return the filename in the umbrella format.
+        Example:
+            <prefix>/<year>-<month>-<day>
+        Returns:
+            str: Synthetic filename.
+        """
+        now = datetime.utcnow()
+        path = join(self.BASE_PATH, now.strftime('%Y-%m-%d'))
+        name = f"{self.BASE_FILE_NAME}{now.strftime('%Y-%m-%d')}-00-00-ioxa{cons.CSV_EXT}"
+
+        return join(path, name)
+
+    def get_data_sample(self) -> str:
+        """Return a sample of data according to the cloudtrail format.
+        Returns:
+            str: Synthetic data.
+        """
+        data = []
+
+        for _ in range(5):
+            data.append(
+                [
+                    datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
+                    'ActiveDirectoryUserName',
+                    'ActiveDirectoryUserName,ADSite,Network',
+                    get_random_ip(),
+                    get_random_ip(),
+                    'Allowed',
+                    '1 (A)',
+                    'NOERROR',
+                    'domain-visited.com.',
+                    'Chat,Photo Sharing,Social Networking,Allow List'
+                ]
+            )
+        buffer = StringIO()
+        csv.writer(buffer).writerows(data)
+
+        return buffer.getvalue()
+
+
 # Maps bucket type with corresponding data generator
 buckets_data_mapping = {
     cons.CLOUD_TRAIL_TYPE: CloudTrailDataGenerator,
@@ -1115,7 +1160,8 @@ buckets_data_mapping = {
     cons.GUARD_DUTY_TYPE: GuardDutyDataGenerator,
     cons.NATIVE_GUARD_DUTY_TYPE: NativeGuardDutyDataGenerator,
     cons.WAF_TYPE: WAFDataGenerator,
-    cons.SERVER_ACCESS: ServerAccessDataGenerator
+    cons.SERVER_ACCESS: ServerAccessDataGenerator,
+    cons.CISCO_UMBRELLA_TYPE: UmbrellaDataGenerator
 }
 
 

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/data_generator.py
@@ -1105,8 +1105,9 @@ class UmbrellaDataGenerator(DataGenerator):
     BASE_PATH = 'dnslogs'
     BASE_FILE_NAME = ''
 
-    def get_filename(self, prefix=None, **kwargs) -> str:
+    def get_filename(self) -> str:
         """Return the filename in the umbrella format.
+
         Example:
             <prefix>/<year>-<month>-<day>
         Returns:
@@ -1120,6 +1121,7 @@ class UmbrellaDataGenerator(DataGenerator):
 
     def get_data_sample(self) -> str:
         """Return a sample of data according to the cloudtrail format.
+
         Returns:
             str: Synthetic data.
         """

--- a/deps/wazuh_testing/wazuh_testing/modules/aws/db_utils.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/db_utils.py
@@ -5,16 +5,17 @@ from typing import Iterator, Type
 
 from .constants import (
     ALB_TYPE,
+    AWS_SERVICES_DB_PATH,
+    CISCO_UMBRELLA_TYPE,
     CLB_TYPE,
     CLOUD_TRAIL_TYPE,
     CUSTOM_TYPE,
     GUARD_DUTY_TYPE,
     NLB_TYPE,
     S3_CLOUDTRAIL_DB_PATH,
+    SERVER_ACCESS_TABLE_NAME,
     VPC_FLOW_TYPE,
     WAF_TYPE,
-    SERVER_ACCESS_TABLE_NAME,
-    AWS_SERVICES_DB_PATH
 )
 
 SELECT_QUERY_TEMPLATE = 'SELECT * FROM {table_name}'
@@ -55,6 +56,10 @@ ServiceCloudWatchRow = namedtuple(
     'ServiceCloudWatchRow', 'aws_region aws_log_group aws_log_stream next_token start_time end_time'
 )
 
+S3UmbrellaRow = namedtuple(
+    'S3UmbrellaRow', 'bucket_path aws_account_id log_key processed_date created_date'
+)
+
 s3_rows_map = {
     CLOUD_TRAIL_TYPE: S3CloudTrailRow,
     VPC_FLOW_TYPE: S3VPCFlowRow,
@@ -64,13 +69,13 @@ s3_rows_map = {
     CUSTOM_TYPE: S3CustomRow,
     GUARD_DUTY_TYPE: S3GuardDutyRow,
     WAF_TYPE: S3WAFRow,
-    SERVER_ACCESS_TABLE_NAME: S3ServerAccessRow
+    SERVER_ACCESS_TABLE_NAME: S3ServerAccessRow,
+    CISCO_UMBRELLA_TYPE: S3UmbrellaRow
 }
 
 service_rows_map = {
     'cloudwatch_logs': ServiceCloudWatchRow,
     'aws_services': ServiceInspectorRow
-
 }
 
 
@@ -141,7 +146,6 @@ def get_s3_db_row(table_name: str) -> S3CloudTrailRow:
     cursor = connection.cursor()
     result = cursor.execute(SELECT_QUERY_TEMPLATE.format(table_name=table_name)).fetchone()
     row_type = _get_s3_row_type(table_name)
-
     return row_type(*result)
 
 

--- a/tests/integration/test_aws/data/configuration_template/discard_regex_test_module/configuration_discard_regex.yaml
+++ b/tests/integration/test_aws/data/configuration_template/discard_regex_test_module/configuration_discard_regex.yaml
@@ -15,6 +15,8 @@
                   value: BUCKET_NAME
               - only_logs_after:
                   value: 2022-NOV-20
+              - path:
+                  value: PATH
               - discard_regex:
                   attributes:
                     - field: DISCARD_FIELD

--- a/tests/integration/test_aws/data/configuration_template/only_logs_after_test_module/bucket_configuration_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/configuration_template/only_logs_after_test_module/bucket_configuration_with_only_logs_after.yaml
@@ -15,3 +15,5 @@
                   value: BUCKET_NAME
               - only_logs_after:
                   value: ONLY_LOGS_AFTER
+              - path:
+                  value: PATH

--- a/tests/integration/test_aws/data/configuration_template/only_logs_after_test_module/bucket_configuration_without_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/configuration_template/only_logs_after_test_module/bucket_configuration_without_only_logs_after.yaml
@@ -13,3 +13,5 @@
                   value: qa
               - name:
                   value: BUCKET_NAME
+              - path:
+                  value: PATH

--- a/tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml
@@ -15,3 +15,5 @@
                   value: BUCKET_NAME
               - remove_from_bucket:
                   value: 'yes'
+              - path:
+                  value: PATH

--- a/tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml
+++ b/tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml
@@ -114,3 +114,12 @@
   metadata:
     bucket_type: server_access
     bucket_name: wazuh-server-access-integration-tests
+
+- name: cisco_umbrella_defaults
+  description: Umbrella default configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_discard_regex.yaml
@@ -5,6 +5,7 @@
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     DISCARD_FIELD: eventSource
     DISCARD_REGEX: .*ec2.amazonaws.com.*
+    PATH: ''
   metadata:
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
@@ -205,3 +206,21 @@
     discard_regex: '200'
     found_logs: 3
     skipped_logs: 1
+
+- name: cisco_umbrella_discard_regex
+  description: CloudTrail discard regex configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    DISCARD_FIELD: action
+    DISCARD_REGEX: Blocked
+    PATH: dnslogs
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    only_logs_after: 2022-NOV-20
+    discard_field: action
+    discard_regex: Blocked
+    found_logs: 5
+    skipped_logs: 1
+    path: dnslogs

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_discard_regex.yaml
@@ -221,6 +221,6 @@
     only_logs_after: 2022-NOV-20
     discard_field: action
     discard_regex: Blocked
-    found_logs: 5
+    found_logs: 3
     skipped_logs: 1
     path: dnslogs

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
@@ -98,3 +98,11 @@
   metadata:
     bucket_type: server_access
     bucket_name: wazuh-server-access-integration-tests
+
+- name: cisco_umbrella_only_logs_after_multiple_calls
+  description: Umbrella only_logs_after multiple calls configurations
+  configuration_parameters:
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    path: dnslogs

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -154,3 +154,17 @@
     only_logs_after: 2022-NOV-20
     expected_results: 3
     table_name: s3_server_access
+
+- name: cisco_umbrella_with_only_logs_after
+  description: Umbrella only logs after configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
+    PATH: dnslogs
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    only_logs_after: 2022-NOV-20
+    expected_results: 3
+    path: dnslogs

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml
@@ -128,3 +128,15 @@
     bucket_name: wazuh-server-access-integration-tests
     expected_results: 1
     table_name: s3_server_access
+
+- name: cisco_umbrella_without_only_logs_after
+  description: Umbrella only logs after configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    PATH: dnslogs
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    expected_results: 1
+    path: dnslogs

--- a/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
@@ -63,6 +63,32 @@
     path: empty_prefix
     expected_results: 0
 
+- name: cisco_umbrella_path_with_data
+  description: Umbrella path configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    PATH: test_prefix/dnslogs
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    only_logs_after: 2022-NOV-20
+    path: test_prefix/dnslogs
+    expected_results: 1
+
+- name: cisco_umbrella_path_without_data
+  description: Umbrella path configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    PATH: empty_prefix
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    only_logs_after: 2022-NOV-20
+    path: empty_prefix
+    expected_results: 0
+
 - name: vpc_inexistent_path
   description: CloudTrail path configurations
   configuration_parameters:
@@ -507,3 +533,16 @@
     path: inexistent_prefix
     expected_results: 0
     table_name: s3_server_access
+
+- name: cisco_umbrella_inexistent_path
+  description: Umbrella path configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    PATH: inexistent_prefix
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    only_logs_after: 2022-NOV-20
+    path: inexistent_prefix
+    expected_results: 0

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -3,6 +3,7 @@
   configuration_parameters:
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
+    PATH: ''
   metadata:
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
@@ -114,3 +115,14 @@
   metadata:
     bucket_type: server_access
     bucket_name: wazuh-server-access-integration-tests
+
+- name: cisco_umbrella_remove_from_bucket
+  description: CloudTrail remove from bucket configurations
+  configuration_parameters:
+    BUCKET_TYPE: cisco_umbrella
+    BUCKET_NAME: wazuh-umbrella-integration-tests
+    PATH: dnslogs
+  metadata:
+    bucket_type: cisco_umbrella
+    bucket_name: wazuh-umbrella-integration-tests
+    path: dnslogs

--- a/tests/integration/test_aws/test_discard_regex.py
+++ b/tests/integration/test_aws/test_discard_regex.py
@@ -99,6 +99,7 @@ def test_discard_regex(
     discard_regex = metadata['discard_regex']
     found_logs = metadata['found_logs']
     skipped_logs = metadata['skipped_logs']
+    path = metadata.get('path')
 
     pattern = fr'.*The "{discard_regex}" regex found a match in the "{discard_field}" field. The event will be skipped.'
 
@@ -112,6 +113,10 @@ def test_discard_regex(
         '--type', bucket_type,
         '--debug', '2'
     ]
+
+    if path is not None:
+        parameters.insert(5, path)
+        parameters.insert(5, '--trail_prefix')
 
     # Check AWS module started
     wazuh_log_monitor.start(

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -572,6 +572,7 @@ def test_bucket_multiple_calls(
 
     bucket_type = metadata['bucket_type']
     bucket_name = metadata['bucket_name']
+    path = metadata.get('path')
 
     base_parameters = [
         '--bucket', bucket_name,
@@ -580,6 +581,9 @@ def test_bucket_multiple_calls(
         '--aws_profile', 'qa',
         '--debug', '2'
     ]
+
+    if path is not None:
+        base_parameters.extend(['--trail_prefix', path])
 
     # Call the module without only_logs_after and check that no logs were processed
     last_marker_key = datetime.utcnow().strftime(cons.PATH_DATE_FORMAT)

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -110,6 +110,7 @@ def test_bucket_without_only_logs_after(
     bucket_type = metadata['bucket_type']
     expected_results = metadata['expected_results']
     table_name = metadata.get('table_name', bucket_type)
+    path = metadata.get('path')
 
     parameters = [
         'wodles/aws/aws-s3',
@@ -118,6 +119,10 @@ def test_bucket_without_only_logs_after(
         '--type', bucket_type,
         '--debug', '2'
     ]
+
+    if path is not None:
+        parameters.insert(5, path)
+        parameters.insert(5, '--trail_prefix')
 
     # Check AWS module started
     wazuh_log_monitor.start(
@@ -338,6 +343,7 @@ def test_bucket_with_only_logs_after(
     only_logs_after = metadata['only_logs_after']
     expected_results = metadata['expected_results']
     table_name = metadata.get('table_name', bucket_type)
+    path = metadata.get('path')
 
     parameters = [
         'wodles/aws/aws-s3',
@@ -347,6 +353,11 @@ def test_bucket_with_only_logs_after(
         '--type', bucket_type,
         '--debug', '2'
     ]
+
+    if path is not None:
+        parameters.insert(5, path)
+        parameters.insert(5, '--trail_prefix')
+
     # Check AWS module started
     wazuh_log_monitor.start(
         timeout=global_parameters.default_timeout,

--- a/tests/integration/test_aws/test_remove_from_bucket.py
+++ b/tests/integration/test_aws/test_remove_from_bucket.py
@@ -95,6 +95,7 @@ def test_remove_from_bucket(
         - The `cases_defaults` file provides the test cases.
     """
     bucket_name = metadata['bucket_name']
+    path = metadata.get('path')
     parameters = [
         'wodles/aws/aws-s3',
         '--bucket', bucket_name,
@@ -103,6 +104,10 @@ def test_remove_from_bucket(
         '--type', metadata['bucket_type'],
         '--debug', '2'
     ]
+
+    if path is not None:
+        parameters.insert(6, path)
+        parameters.insert(6, '--trail_prefix')
 
     # Check AWS module started
     wazuh_log_monitor.start(


### PR DESCRIPTION
|Related issue|
|-------------|
|      #3347    |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR adds tests for AWS Umbrella integration

<!-- Added functionalities or files. Remove if not applicable -->
### Added

#### Tier 0
- Default configuration tests
- `remove_from_bucket` parameter tests
- `only_logs_after` parameter tests
- `path` parameter tests
- `discard_regex` parameter tests

#### Tier 1
- `only_logs_after` parameter tests
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @nico-stefani  (Developer)  | `tests/integration/test_aws` | ⚫⚫⚫ | :green_circle: :red_circle:  | Ubuntu 22.04|  | [^1] |
| @reviewer (Reviewer)   | | ⚫⚫⚫ |  |   |      | Nothing to highlight |


### Tier 0 results
```python
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 24 items / 16 deselected / 8 selected

test_basic.py .                                                          [ 12%]
test_discard_regex.py .                                                  [ 25%]
test_only_logs_after.py ..                                               [ 50%]
test_path.py ...                                                         [ 87%]
test_remove_from_bucket.py .                                             [100%]

=============================== warnings summary ===============================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:433
  /usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:433: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/nodeids
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/stepwise.py:52
  /usr/local/lib/python3.10/dist-packages/_pytest/stepwise.py:52: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/stepwise
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 8 passed, 16 deselected, 2 warnings in 174.76s (0:02:54) ===========
```

### Tier 1 results

```python
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vagrant/qa/tests/integration, configfile: pytest.ini
plugins: metadata-2.0.2, html-3.1.1, testinfra-5.0.0
collected 24 items / 23 deselected / 1 selected

test_only_logs_after.py F                                                [100%]

=================================== FAILURES ===================================
______ test_multiple_calls[cisco_umbrella_only_logs_after_multiple_calls] ______
------------------------------ Captured log call -------------------------------
DEBUG    wazuh_testing:cli_utils.py:23 Calling AWS module with: '[PosixPath('/var/ossec/wodles/aws/aws-s3'), '--bucket', 'wazuh-umbrella-integration-tests', '--type', 'cisco_umbrella', '--regions', 'us-east-1', '--aws_profile', 'qa', '--debug', '2', '--trail_prefix', 'dnslogs']'
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Debug mode on - Level: 2
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Table does not exist; create
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: dnslogs/2023-01-20
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ No logs to process in bucket: None/None
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ DB Maintenance
DEBUG    wazuh_testing:cli_utils.py:23 Calling AWS module with: '[PosixPath('/var/ossec/wodles/aws/aws-s3'), '--bucket', 'wazuh-umbrella-integration-tests', '--type', 'cisco_umbrella', '--regions', 'us-east-1', '--aws_profile', 'qa', '--debug', '2', '--trail_prefix', 'dnslogs', '--only_logs_after', '2022-NOV-20']'
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Debug mode on - Level: 2
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: dnslogs/2022-11-20
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: ++ Found new log: dnslogs/2022-11-21/2022-11-21-00-00-ioxa.csv
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: ++ Found new log: dnslogs/2022-11-23/2022-11-23-00-00-ioxa.csv
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: ++ Found new log: dnslogs/2022-11-26/2022-11-26-00-00-ioxa.csv
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ DB Maintenance
DEBUG    wazuh_testing:cli_utils.py:23 Calling AWS module with: '[PosixPath('/var/ossec/wodles/aws/aws-s3'), '--bucket', 'wazuh-umbrella-integration-tests', '--type', 'cisco_umbrella', '--regions', 'us-east-1', '--aws_profile', 'qa', '--debug', '2', '--trail_prefix', 'dnslogs', '--only_logs_after', '2022-NOV-20']'
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Debug mode on - Level: 2
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ Marker: dnslogs/2022-11-20
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: ++ Skipping previously processed file: dnslogs/2022-11-21/2022-11-21-00-00-ioxa.csv
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: ++ Skipping previously processed file: dnslogs/2022-11-23/2022-11-23-00-00-ioxa.csv
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: ++ Skipping previously processed file: dnslogs/2022-11-26/2022-11-26-00-00-ioxa.csv
DEBUG    wazuh_testing:cli_utils.py:52 DEBUG: +++ DB Maintenance
ERROR    wazuh_testing:cli_utils.py:62 Some logs may were processed
ERROR    wazuh_testing:cli_utils.py:63 Results found: 0
ERROR    wazuh_testing:cli_utils.py:64 Results expected: 1
=============================== warnings summary ===============================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:433
  /usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:433: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/nodeids
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:387
  /usr/local/lib/python3.10/dist-packages/_pytest/cacheprovider.py:387: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/lastfailed
    config.cache.set("cache/lastfailed", self.lastfailed)

../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/stepwise.py:52
  /usr/local/lib/python3.10/dist-packages/_pytest/stepwise.py:52: PytestCacheWarning: cache could not write path /home/vagrant/qa/tests/integration/.pytest_cache/v/cache/stepwise
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED test_only_logs_after.py::test_multiple_calls[cisco_umbrella_only_logs_after_multiple_calls]
================ 1 failed, 23 deselected, 3 warnings in 26.22s =================
```
[^1]: Because the module is not showing the message about no logs to process, the `server_access_only_logs_after_multiple_calls` test is failing. This should be fixed in his respective issue.