### PR TITLE
Fix rootcheck IT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix rootcheck IT tests ([#3859](https://github.com/wazuh/wazuh-qa/pull/3859)) \- (Tests)
 - Increase NVE download feed test timeout([#3769](https://github.com/wazuh/wazuh-qa/pull/3769)) \- (Tests)
 - Adapt wazuhdb integration tests for auto-vacuum ([#3613](https://github.com/wazuh/wazuh-qa/issues/3613)) \- (Tests)
 - Update logcollector format test due to audit changes ([#3641](https://github.com/wazuh/wazuh-qa/pull/3641)) \- (Framework)

--- a/tests/integration/test_rootcheck/test_rootcheck.py
+++ b/tests/integration/test_rootcheck/test_rootcheck.py
@@ -6,8 +6,8 @@ copyright: Copyright (C) 2015-2022, Wazuh Inc.
 type: integration
 
 brief: The 'rootcheck' tool allows to define policies in order to check if the agents
-       meet the requirement specified. The rootcheck engine can check if a process is running, if a file is 
-       present and if the content of a file contains a pattern, 
+       meet the requirement specified. The rootcheck engine can check if a process is running, if a file is
+       present and if the content of a file contains a pattern,
        or if a Windows registry key contains a string or is simply present.
 
 components:
@@ -271,7 +271,7 @@ def test_rootcheck(get_configuration, configure_environment, restart_service,
             logs_string = [':'.join(x.split(':')[2:]) for x in
                            agent.rootcheck.messages_list]
             for row in rows:
-                assert row[1] < update_threshold, \
+                assert row[1] > update_threshold, \
                     f'First time in log was updated after insertion'
                 assert row[2] > update_threshold, \
                     f'Updated time in log was not updated'


### PR DESCRIPTION
|Related issue|
|-------------|
| #3800     |

## Description

During testing for #3800 it was found that the related `test_rootcheck` IT suite started failing. This PR aims to fix the failing test cases.


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- fixed `test_rootcheck.py` tests module.

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Deblintrake)  | test_rootcheck    | [:large_blue_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/35976/)[:large_blue_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/35977/)[:large_blue_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/35978/)  | [:green_circle::green_circle::green_circle:](https://github.com/wazuh/wazuh-qa/files/10514074/rootcheck_results.zip)  |  Centos       |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
