### PR TITLE
Fix `test_agent_groups`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Release report: TBD
 
 ### Changed
 
-- Fix `test_agent_groups` ([#3889]([#3769](https://github.com/wazuh/wazuh-qa/pull/3889)) \- (Tests + Framework)
+- Fix `test_agent_groups` ([#3889](https://github.com/wazuh/wazuh-qa/pull/3889)) \- (Tests + Framework)
 - Increase NVE download feed test timeout([#3769](https://github.com/wazuh/wazuh-qa/pull/3769)) \- (Tests)
 - Adapt wazuhdb integration tests for auto-vacuum ([#3613](https://github.com/wazuh/wazuh-qa/issues/3613)) \- (Tests)
 - Update logcollector format test due to audit changes ([#3641](https://github.com/wazuh/wazuh-qa/pull/3641)) \- (Framework)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix `test_agent_groups` ([#3889]([#3769](https://github.com/wazuh/wazuh-qa/pull/3889)) \- (Tests + Framework)
 - Increase NVE download feed test timeout([#3769](https://github.com/wazuh/wazuh-qa/pull/3769)) \- (Tests)
 - Adapt wazuhdb integration tests for auto-vacuum ([#3613](https://github.com/wazuh/wazuh-qa/issues/3613)) \- (Tests)
 - Update logcollector format test due to audit changes ([#3641](https://github.com/wazuh/wazuh-qa/pull/3641)) \- (Framework)

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -122,6 +122,7 @@ required an specific testing environment located in `wazuh-qa/tests/system/provi
 | test_cluster/test_agent_groups/test_agent_groups_forced_change            | basic_cluster                  |
 | test_cluster/test_agent_groups/test_agent_default_group_added             | enrollment_cluster             |
 | test_cluster/test_agent_groups/test_agent_groups_new_cluster_node         | four_manager_disconnected_node |
+| test_cluster/test_agent_groups/test_agent_groups                          | enrollment_cluster             |
 | test_cluster/test_agent_groups/test_assign_agent_group_with_enrollment    | enrollment_cluster             |
 | test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group | enrollment_cluster             |
 | test_cluster/test_agent_groups/test_assign_agent_to_a_group_api           | enrollment_cluster             |

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -128,3 +128,9 @@ def change_agent_group_with_wdb(agent_id, new_group, host, host_manager):
     group_data = host_manager.run_command(host, f"python3 {WAZUH_PATH}/bin/wdb-query.py global \
                                           'set-agent-groups {query}'")
     return group_data
+
+
+def execute_wdb_query(query, host, host_manager):
+    response = host_manager.run_command(host, f"python3 {WAZUH_PATH}/bin/wdb-query.py {query}")
+
+    return response

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -19,7 +19,10 @@ report_files = []
 
 # Clean cluster logs
 @pytest.fixture(scope='function')
-def clean_environment(test_infra_agents, test_infra_managers, host_manager):
+def clean_environment(request):
+    test_infra_agents = getattr(request.module, 'test_infra_agents')
+    test_infra_managers = getattr(request.module, 'test_infra_managers')
+    host_manager = getattr(request.module, 'host_manager')
 
     clean_cluster_logs(test_infra_agents + test_infra_managers, host_manager)
 

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/tasks/main.yml
@@ -87,3 +87,11 @@
 
 - name: Start Wazuh
   command: /var/ossec/bin/wazuh-control restart
+
+- name: Copy wdb-query.py script
+  copy:
+    src: ../../../../scripts/wdb-query.py
+    dest: /var/ossec/bin/wdb-query.py
+    owner: root
+    group: root
+    mode: '0644'

--- a/tests/system/test_cluster/test_agent_groups/data/add_messages.yml
+++ b/tests/system/test_cluster/test_agent_groups/data/add_messages.yml
@@ -1,10 +1,13 @@
 ---
 wazuh-master:
-  - regex: '.*POST /groups" with parameters {} and body {.*s: 200'
+  - regex: '.*POST /groups" with parameters {} and body {.*test_group.*s: 200'
     path: "/var/ossec/logs/api.log"
     timeout: 60
-  - regex: '.*PUT /agents.*group.*" with parameters {} and body {} done in.*200'
+  - regex: '.*PUT /agents.*group/test_group" with parameters {} and body {} done in.*200'
     path: "/var/ossec/logs/api.log"
+    timeout: 60
+  - regex: '.*SendSync.*Receiving SendSync request \(remoted\) from wazuh-worker1.*'
+    path: "/var/ossec/logs/cluster.log"
     timeout: 60
   - regex: '.*Master.*Local agent-groups.*Starting.'
     path: "/var/ossec/logs/cluster.log"
@@ -35,6 +38,9 @@ wazuh-master:
     timeout: 60
 
 wazuh-worker1:
+  - regex: ".*Command received: b'sendsync'"
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
   - regex: '.*Agent-groups recv.*Starting.'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60

--- a/tests/system/test_cluster/test_agent_groups/data/synchronization_messages.yml
+++ b/tests/system/test_cluster/test_agent_groups/data/synchronization_messages.yml
@@ -1,14 +1,12 @@
 ---
+wazuh-master:
+  - regex: '.*SendSync.*Receiving SendSync request \(authd\) from wazuh-worker1.*'
+    path: "/var/ossec/logs/cluster.log"
+    timeout: 60
 wazuh-worker1:
-  - regex: '.*Agent-groups sync.*Permission to synchronize granted.*'
+  - regex: '.*Connection received in local server*'
     path: "/var/ossec/logs/cluster.log"
-    timeout: 120
-  - regex: '.*Agent-groups sync.*Starting.*'
+    timeout: 60
+  - regex: ".*Command received: b'sendsync'"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 90
-  - regex: '.*Agent-groups sync.*Obtained.*chunks of data in.*'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 90
-  - regex: '.*Agent-groups sync.*Finished in.*Updated.*chunks.*'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 90
+    timeout: 60

--- a/tests/system/test_cluster/test_agent_groups/test_agent_default_group_added.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_default_group_added.py
@@ -65,12 +65,8 @@ timeout = 25
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_target", test_infra_managers)
-def test_agent_default_group_added(agent_target, clean_environment, test_infra_managers,
-                                   test_infra_agents, host_manager):
+def test_agent_default_group_added(agent_target, clean_environment):
     '''
     description: Check agent enrollment process and default group assignment works as expected in a cluster enviroment.
     An agent pointing to a master/worker node is registered using cli tool, and it gets assigned the default group
@@ -83,15 +79,6 @@ def test_agent_default_group_added(agent_target, clean_environment, test_infra_m
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_managers
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering the agent appears as never_connected in all nodes.

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
@@ -13,9 +13,10 @@ from wazuh_testing.tools.monitoring import HostMonitor
 from wazuh_testing.tools.system import HostManager
 
 # Hosts
-testinfra_hosts = ['wazuh-master', 'wazuh-worker1', 'wazuh-worker2']
+test_infra_managers = ['wazuh-master', 'wazuh-worker1', 'wazuh-worker2']
+test_infra_agents = ["wazuh-agent1"]
 master_host = 'wazuh-master'
-worker_host = testinfra_hosts[2]
+worker_host = test_infra_managers[1]
 pytestmark = [pytest.mark.cluster]
 
 inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
@@ -27,7 +28,6 @@ add_messages_path = os.path.join(local_path, 'data/synchronization_messages.yml'
 delete_messages_path = os.path.join(local_path, 'data/delete_messages.yml')
 sync_messages_path = os.path.join(local_path, 'data/synchronization_messages.yml')
 script_path = os.path.join(re.sub(r'^.*?wazuh-qa', '/wazuh-qa', local_path), '../utils/get_wdb_agent.py')
-
 tmp_path = os.path.join(local_path, 'tmp')
 
 test_group = 'test_group'
@@ -36,70 +36,11 @@ last_agent = 'wazuh-agent2'
 while_time = 5
 time_to_sync = 21
 time_to_agent_reconnect = 180
-
-queries = ['global sql select * from "group" where name="{name}"']
-
-
-@pytest.fixture(scope='function')
-def clean_cluster_logs():
-    """Remove old logs from all the existent managers."""
-    for host in testinfra_hosts:
-        host_manager.clear_file(host=host, file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
-        host_manager.clear_file(host=host, file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
-
-        # Its required to restart each node after clearing the log files
-        host_manager.get_host(host).ansible('command', 'service wazuh-manager restart', check=False)
+queries = ['sql select * from "group" where name="test_group"']
 
 
-def obtain_agent_id(token, agent):
-    """Obtain agent's ID.
-
-    Args:
-        token (str): the host token.
-        agent (str): agent's name.
-    """
-
-    response = host_manager.make_api_call(host=master_host, method='GET', token=token,
-                                          endpoint=f"/agents?name={agent}")
-
-    assert response['status'] == 200, f"API failure: {response}"
-    assert response['json']['data']['total_affected_items'] == 1, 'Failed while trying to obtain the agent\'s ID.'
-    agent_id = int(response['json']['data']['affected_items'][0]['id'])
-
-    return agent_id
-
-
-def check_agent_status(status, token, agent):
-    """Restart the removed agent to trigger auto-enrollment.
-
-    Args:
-        status (str): the agent status we are looking for.
-        token (str): the host token.
-        agent (str): agent's name.
-    """
-    timeout = time() + time_to_agent_reconnect
-
-    while True:
-        response = host_manager.make_api_call(host=master_host, method='GET', token=token,
-                                              endpoint=f"/agents?name={agent}")
-        assert response['status'] == 200, f"Failed when trying obtain agent's information: {response}"
-
-        if int(response['json']['data']['total_affected_items']) == 1:
-            if response['json']['data']['affected_items'][0]['status'] == status:
-                assert response['json']['data']['affected_items'][0][
-                           'name'] == agent, f"The agent's name does not correspond to the deleted one: " \
-                                             f"{response['json']['data']['affected_items'][0]['name']}"
-                assert response['json']['data']['affected_items'][0]['node_name'] in testinfra_hosts, \
-                    f"The agent is reporting to an unknown manager: " \
-                    f"{response['json']['data']['affected_items'][0]['node_name']}"
-                break
-        elif time() > timeout:
-            raise TimeoutError(f"The agent '{agent}' is not '{status}' yet.")
-        sleep(while_time)
-    sleep(time_to_sync)
-
-
-def test_agent_groups_create_remove_group(clean_cluster_logs):
+# Tests
+def test_agent_groups_create_remove_group(clean_environment):
     """Check agent agent-groups synchronization works as expected.
 
     This test will wait for the expected agent-groups messages declared in data/synchronization_messages.yml and
@@ -122,69 +63,53 @@ def test_agent_groups_create_remove_group(clean_cluster_logs):
 
     # Check if the new information is present in the master and workers dbs
     sleep(time_to_sync)
-    for host in testinfra_hosts:
-        result = host_manager.run_command(host,
-                                          f"{WAZUH_PATH}/framework/python/bin/python3.9 "
-                                          f"{script_path} '{queries[0].format(name=test_group)}'")
-        assert result, f"This db query should have returned something in {host}, but it did not: {result}"
-        assert f"'name': '{test_group}'" in result
-
-    # Obtain agent's ID
-    agent_id = obtain_agent_id(master_token, modified_agent)
-    previous_agent_id = obtain_agent_id(master_token, last_agent)
+    for host in test_infra_managers:
+        created_group = execute_wdb_query(f"global '{queries[0]}'", host, host_manager)
+        assert f'"name": "{test_group}"' in created_group
 
     # Add group to agent
     response = host_manager.make_api_call(host=master_host, method='PUT', token=master_token,
-                                          endpoint=f"/agents/{str(agent_id).zfill(3)}/group/{test_group}")
+                                          endpoint=f"/agents/{agent_id}/group/{test_group}")
 
     assert response['status'] == 200, f"API failure: {response}"
     assert response['json']['message'] == f"All selected agents were assigned to {test_group}"
 
     # Check if the new information is present in the master and workers dbs
     sleep(time_to_sync)
-    queries.append(f'global sync-agent-groups-get {"{"}"condition":"all", "last_id":{previous_agent_id}{"}"}')
-    for host in testinfra_hosts:
-        result = host_manager.run_command(host,
-                                          f"{WAZUH_PATH}/framework/python/bin/python3.9 "
-                                          f"{script_path} '{queries[1]}'")
-        assert result, f"This db query should have returned something in {host}, but it did not: {result}"
-        result = json.loads(result[1:-1].replace("'", '"'))
-        assert test_group in result['data'][0]['groups']
+    queries.append(f'sync-agent-groups-get {"{"}"condition":"all", "id":{agent_id}{"}"}')
+    for host in test_infra_managers:
+        assigned_groups = execute_wdb_query(f"global '{queries[1]}'", host, host_manager)
+        assert test_group in assigned_groups
 
     # Check whether the addition messages are present.
     HostMonitor(inventory_path=inventory_path, messages_path=add_messages_path, tmp_path=tmp_path).run()
 
     # Remove group from agent
     response = host_manager.make_api_call(host=master_host, method='DELETE', token=master_token,
-                                          endpoint=f"/agents/{str(agent_id).zfill(3)}/group/{test_group}")
+                                          endpoint=f"/agents/{agent_id}/group/{test_group}")
 
     assert response['status'] == 200, f"API failure: {response}"
-    assert response['json']['message'] == f"Agent '{str(agent_id).zfill(3)}' removed from '{test_group}'."
+    assert response['json']['message'] == f"Agent '{agent_id}' removed from '{test_group}'."
 
     # Check if the new information is present in the master and workers dbs
     sleep(time_to_sync)
-    for host in testinfra_hosts:
-        result = host_manager.run_command(host,
-                                          f"{WAZUH_PATH}/framework/python/bin/python3.9 "
-                                          f"{script_path} '{queries[1]}'")
-        assert result, f"This db query should not have returned anything in {host}, but it did: {result}"
-        result = json.loads(result[1:-1].replace("'", '"'))
-        assert test_group not in result['data'][0]['groups']
+    for host in test_infra_managers:
+        assigned_groups = execute_wdb_query(f"global '{queries[1]}'", host, host_manager)
+        assert test_group not in assigned_groups
 
     # Remove group
     response = host_manager.make_api_call(host=master_host, method='DELETE', token=master_token,
                                           endpoint=f"/groups?groups_list={test_group}")
 
     assert response['status'] == 200, f"API failure: {response}"
-    assert response['json']['message'] == f"All selected groups were deleted"
+    assert response['json']['message'] == 'All selected groups were deleted'
 
     # Check if the new information is present in the master and workers dbs
     sleep(time_to_sync)
-    for host in testinfra_hosts:
-        result = host_manager.run_command(host,
-                                          f"{WAZUH_PATH}/framework/python/bin/python3.9 "
-                                          f"{script_path} '{queries[0].format(name=test_group)}'")
-        assert not result, f"This db query should not have returned anything in {host}, but it did: {result}"
+    for host in test_infra_managers:
+        created_group = execute_wdb_query(f"global '{queries[0]}'", host, host_manager)
+        print(created_group)
+        assert created_group == '[]'
 
     # Check whether the deletion messages are present.
     HostMonitor(inventory_path=inventory_path, messages_path=delete_messages_path, tmp_path=tmp_path).run()

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
@@ -2,15 +2,15 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import json
 import os
 import re
-from time import sleep, time
+from time import sleep
 
 import pytest
-from wazuh_testing.tools import WAZUH_PATH, WAZUH_LOGS_PATH
 from wazuh_testing.tools.monitoring import HostMonitor
 from wazuh_testing.tools.system import HostManager
+from system.test_cluster.test_agent_groups.common import register_agent
+from system import AGENT_STATUS_ACTIVE, check_agent_status, restart_cluster, execute_wdb_query
 
 # Hosts
 test_infra_managers = ['wazuh-master', 'wazuh-worker1', 'wazuh-worker2']
@@ -20,19 +20,18 @@ worker_host = test_infra_managers[1]
 pytestmark = [pytest.mark.cluster]
 
 inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-                              'provisioning', 'basic_cluster', 'inventory.yml')
+                              'provisioning', 'enrollment_cluster', 'inventory.yml')
 
 host_manager = HostManager(inventory_path)
 local_path = os.path.dirname(os.path.abspath(__file__))
-add_messages_path = os.path.join(local_path, 'data/synchronization_messages.yml')
+add_messages_path = os.path.join(local_path, 'data/add_messages.yml')
 delete_messages_path = os.path.join(local_path, 'data/delete_messages.yml')
 sync_messages_path = os.path.join(local_path, 'data/synchronization_messages.yml')
 script_path = os.path.join(re.sub(r'^.*?wazuh-qa', '/wazuh-qa', local_path), '../utils/get_wdb_agent.py')
 tmp_path = os.path.join(local_path, 'tmp')
 
+# Variables
 test_group = 'test_group'
-modified_agent = 'wazuh-agent3'
-last_agent = 'wazuh-agent2'
 while_time = 5
 time_to_sync = 21
 time_to_agent_reconnect = 180

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
@@ -113,7 +113,6 @@ def test_agent_groups_create_remove_group(clean_environment):
     sleep(time_to_sync)
     for host in test_infra_managers:
         created_group = execute_wdb_query(f"global '{queries[0]}'", host, host_manager)
-        print(created_group)
         assert created_group == '[]'
 
     # Check whether the deletion messages are present.

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
@@ -50,8 +50,14 @@ def test_agent_groups_create_remove_group(clean_environment):
     # Get the token
     master_token = host_manager.get_api_token(master_host)
 
-    # Make sure that the agent is registered and active
-    check_agent_status('active', master_token, modified_agent)
+    # Register agent
+    agent_ip, agent_id, agent_name, manager_ip = register_agent(test_infra_agents[0], worker_host, host_manager)
+    restart_cluster(test_infra_agents, host_manager)
+
+    # Check that the agent is active
+    sleep(time_to_sync)
+    check_agent_status(agent_id, agent_name, agent_ip, AGENT_STATUS_ACTIVE, host_manager, test_infra_managers)
+
     HostMonitor(inventory_path=inventory_path, messages_path=sync_messages_path, tmp_path=tmp_path).run()
 
     # Create group from master

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_forced_change.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_forced_change.py
@@ -65,12 +65,8 @@ timeout = 10
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_host", test_infra_managers[0:2])
-def test_sync_when_forced_to_change_a_group(agent_host, clean_environment, test_infra_managers,
-                                            test_infra_agents, host_manager):
+def test_sync_when_forced_to_change_a_group(agent_host, clean_environment):
     '''
     description: Check that having an agent with a group assigned,
                  when the change is forced with a wdb command, the new group
@@ -83,15 +79,6 @@ def test_sync_when_forced_to_change_a_group(agent_host, clean_environment, test_
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agents appear as active in all nodes.
         - Verify that after registering and after starting the agent, the indicated group is synchronized.
@@ -130,10 +117,7 @@ def test_sync_when_forced_to_change_a_group(agent_host, clean_environment, test_
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
-def test_force_group_change_during_sync(clean_environment, test_infra_managers, test_infra_agents, host_manager):
+def test_force_group_change_during_sync(clean_environment):
     '''
     description: Check that having an agent with a group assigned, when the change is forced with a wdb command,
                  and the agent's group is changed again during the sync timeframe, the agent has the correct group
@@ -143,15 +127,6 @@ def test_force_group_change_during_sync(clean_environment, test_infra_managers, 
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agents appear as active in all nodes.
         - Verify that after registering and after starting the agent, the indicated group is synchronized.

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py
@@ -66,11 +66,7 @@ timeout = 10
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
-def test_agent_groups_sync_when_add_a_new_cluster_node(clean_environment, test_infra_managers,
-                                                       test_infra_agents, host_manager):
+def test_agent_groups_sync_when_add_a_new_cluster_node(clean_environment):
     '''
     description: Check that having a series of agents assigned with different groups, when an new node is added to
     the cluster, the group data is synchronized to the new node.
@@ -79,15 +75,6 @@ def test_agent_groups_sync_when_add_a_new_cluster_node(clean_environment, test_i
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_managers
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agents appear as active in all nodes.
         - Verify that after registering and after starting the agent, the indicated group is synchronized.
@@ -127,10 +114,7 @@ def test_agent_groups_sync_when_add_a_new_cluster_node(clean_environment, test_i
     check_agent_groups(agent3_data[1], agent_groups[2], test_infra_new_nodes, host_manager)
 
 
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
-def test_agent_groups_sync_worker_new_node(clean_environment, test_infra_managers, test_infra_agents, host_manager):
+def test_agent_groups_sync_worker_new_node(clean_environment):
     '''
     description: Having two agents assigned to different workers and different groups, check that when an new node
     is added to the cluster, the group data is synchronized to the new node.
@@ -139,15 +123,6 @@ def test_agent_groups_sync_worker_new_node(clean_environment, test_infra_manager
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_managers
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agents appear as active in all nodes.
         - Verify that after registering and after starting the agent, the indicated group is synchronized.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_group_with_enrollment.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_group_with_enrollment.py
@@ -73,11 +73,8 @@ enrollment_group = f"""
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_target", ["wazuh-worker1"])
-def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_managers, test_infra_agents, host_manager):
+def test_assign_agent_to_a_group(agent_target, clean_environment):
     '''
     description: Check race condition when an agent enrollment process with a group connects to the worker,
                  when worker no receive information about the group and when data of groups is receive,
@@ -90,15 +87,6 @@ def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_man
         - clean_enviroment:
             type: fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: list of manager hosts in enviroment
-        - test_infra_agents
-            type: List
-            brief: list of agent hosts in enviroment
-        - host_manager
-            type: HostManager object
-            brief: handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering and before receiving agent group info, it has the 'default' group assigned.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -63,11 +63,8 @@ id_group = 'group_test'
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_target", ['wazuh-master', 'wazuh-worker1'])
-def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_managers, test_infra_agents, host_manager):
+def test_assign_agent_to_a_group(agent_target, clean_environment):
     '''
     description: Check that when an agent with status never_connected, pointing to a master/worker node is
                  registered using agent-auth with a group the change is sync with the cluster.
@@ -79,15 +76,6 @@ def test_assign_agent_to_a_group(agent_target, clean_environment, test_infra_man
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering the agent appears as never_connected in all nodes.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py
@@ -70,13 +70,9 @@ timeout = 10
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("initial_status", [AGENT_STATUS_ACTIVE, AGENT_STATUS_DISCONNECTED])
 @pytest.mark.parametrize("agent_target", ["wazuh-master", "wazuh-worker1"])
-def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment, test_infra_managers,
-                                 test_infra_agents, host_manager):
+def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment):
     '''
     description: Check agent enrollment process and new group assignment works as expected in a cluster environment.
                  Check that when an agent pointing to a master/worker node is registered using CLI tool, and and then
@@ -92,15 +88,6 @@ def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering and before starting the agent, it has no groups assigned.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_api.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_api.py
@@ -67,13 +67,9 @@ test_group = 'group_test'
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("initial_status", [AGENT_STATUS_ACTIVE, AGENT_STATUS_DISCONNECTED])
 @pytest.mark.parametrize("agent_target", ["wazuh-master", "wazuh-worker1"])
-def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment, test_infra_managers,
-                                 test_infra_agents, host_manager):
+def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment):
     '''
     description: Check agent enrollment process and new group assignment works as expected in a cluster environment.
                  Check that when an agent pointing to a master/worker node is registered, and when
@@ -89,15 +85,6 @@ def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering and before starting the agent, it has no groups assigned.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_by_tool.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_by_tool.py
@@ -67,12 +67,8 @@ wait_time = 10
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_target", ['wazuh-master', 'wazuh-worker1'])
-def test_assign_agent_to_a_group_by_tool(agent_target, clean_environment, test_infra_managers,
-                                         test_infra_agents, host_manager):
+def test_assign_agent_to_a_group_by_tool(agent_target, clean_environment):
     '''
     description: Check that when an agent with status never_connected, pointing to a master/worker node is
                  registered using agent-auth and when it is assigned to a group with agent-group, the change is synced
@@ -85,15 +81,6 @@ def test_assign_agent_to_a_group_by_tool(agent_target, clean_environment, test_i
         - clean_enviroment:
             type: fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: list of manager hosts in enviroment
-        - test_infra_managers
-            type: List
-            brief: list of agent hosts in enviroment
-        - host_manager
-            type: HostManager object
-            brief: handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering the agent key file exists in all nodes.
         - Verify that after registering the agent appears as never_connected in all nodes.

--- a/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
@@ -71,13 +71,9 @@ timeout = 60
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("status_guess_agent_group", ['0', '1'])
 @pytest.mark.parametrize("agent_target", ['wazuh-master', 'wazuh-worker1'])
-def test_assign_agent_to_a_group(agent_target, status_guess_agent_group, clean_environment, test_infra_managers,
-                                 test_infra_agents, host_manager):
+def test_assign_agent_to_a_group(agent_target, status_guess_agent_group, clean_environment):
     '''
     description: Check that when an agent registered in the manager and assigned to group is removed, performs a
                  guessing operation and determinates the groups to with the agent was assigned.

--- a/tests/system/test_cluster/test_agent_groups/test_groups_sync_default.py
+++ b/tests/system/test_cluster/test_agent_groups/test_groups_sync_default.py
@@ -66,12 +66,8 @@ sync_delay = 40
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_host", test_infra_managers[0:2])
-def test_agent_groups_sync_default(agent_host, clean_environment, test_infra_managers, test_infra_agents,
-                                   host_manager):
+def test_agent_groups_sync_default(agent_host, clean_environment):
     '''
     description: Check that after a long time when the manager has been unable to synchronize de databases, because
     new agents are being continually added, database synchronization is forced and the expected information is in
@@ -86,15 +82,6 @@ def test_agent_groups_sync_default(agent_host, clean_environment, test_infra_man
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering and after starting the agent, the agent has the default group is assigned.
         - Assert that all Agents have been restarted

--- a/tests/system/test_cluster/test_agent_groups/test_groups_sync_time.py
+++ b/tests/system/test_cluster/test_agent_groups/test_groups_sync_time.py
@@ -70,12 +70,8 @@ sync_delay = 40
 
 
 # Tests
-@pytest.mark.parametrize("test_infra_managers", [test_infra_managers])
-@pytest.mark.parametrize("test_infra_agents", [test_infra_agents])
-@pytest.mark.parametrize("host_manager", [host_manager])
 @pytest.mark.parametrize("agent_host", test_infra_managers[0:2])
-def test_agent_groups_sync_time(agent_host, clean_environment, test_infra_managers, test_infra_agents,
-                                host_manager):
+def test_agent_groups_sync_time(agent_host, clean_environment):
     '''
     description: Check that after a long time when the manager has been unable to synchronize de databases, because
     new agents are being continually added, database synchronization is forced and the expected information is in
@@ -88,15 +84,6 @@ def test_agent_groups_sync_time(agent_host, clean_environment, test_infra_manage
         - clean_enviroment:
             type: Fixture
             brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
-        - test_infra_managers
-            type: List
-            brief: List of manager hosts in enviroment.
-        - test_infra_agents
-            type: List
-            brief: List of agent hosts in enviroment.
-        - host_manager
-            type: HostManager object
-            brief: Handles connection the enviroment's hosts.
     assertions:
         - Verify that after registering and after starting the agent, the indicated group is synchronized.
     expected_output:


### PR DESCRIPTION
|Related issue|
|-------------|
|      #3865       |

## Description

After the development done in https://github.com/wazuh/wazuh/pull/16050, the behavior of `agent-groups` has changed, so we needed to adapt `test_agent_groups`.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Added `execute_wdb_query` in `system/__init__.py`

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Updated `test_agent_groups.py`
- Updated `clean_environment()` from `system/conftest.py`
- Updated system tests `README.md`
- Updated `enrollment_cluster` playbook

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->

### PR test
| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_agent_groups.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10578928/R3_test_agent_groups.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/10578929/R2_test_agent_groups.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/10578930/R1_test_agent_groups.zip)       |    9494b96  | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |             | Nothing to highlight |

### Affected tests

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_agent_default_group_added.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10579049/R1_test_agent_default_group_added.zip)          |    ea98e57      | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |            | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_agent_groups_forced_change.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | ⚫ |             | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |          | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_agent_groups_new_cluster_node.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | ⚫|              | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |              | Nothing to highlight |

| Tester             | Test path | Jenkins | Local   | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_assign_agent_group_with_enrollment.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🔴 ](https://github.com/wazuh/wazuh-qa/files/10579054/R1_test_assign_agent_group_with_enrollment.zip) |    ea98e57       | The error is not due to the change affecting this test |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |             | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_aassign_agent_never_connected_to_group.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10579085/R1_test_assign_agent_never_connected_to_group.zip) |    ea98e57       | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        | Nothing to highlight |

| Tester             | Test path | Jenkins | Local   | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_assign_agent_to_a_group_api.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10579120/R1_test_assign_agent_to_a_group_api.zip)|      ea98e57     | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |         | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_assign_agent_to_a_group_by_tool.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10579204/R1_test_assign_agent_to_a_group_by_tool.zip) |      ea98e57      | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_assign_agent_to_a_group.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10579210/R1_test_assign_agent_to_a_group.zip)|        ea98e57      | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |           | Nothing to highlight |

| Tester             | Test path | Jenkins | Local | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_assign_group_guess.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | [🔴 ](https://github.com/wazuh/wazuh-qa/files/10579389/R1_test_assign_groups_guess.zip)|       ea98e57       | The error is not due to the change affecting this test |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |             | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_groups_sync_default.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | ⚫ |           | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |            | Nothing to highlight |

| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |     `test_cluster/test_agent_groups/test_groups_sync_time.py`      | :no_entry_sign: :no_entry_sign: :no_entry_sign:  | ⚫ |              | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |               | Nothing to highlight |



