### PR TITLE
fix `test_sync_agent_groups_get` and add function to calculate hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Release report: TBD
 
 ### Fixed
 
+- Fix test_sync_agent_groups_get, replace hardcoded hash to a dinamically calculated one ([#3895](https://github.com/wazuh/wazuh-qa/pull/3895)) \- (Framework + Tests)
 - Fix test_db_backup for Ubuntu OS ([#3802](https://github.com/wazuh/wazuh-qa/pull/3802)) \- (Tests)
 - Fix commit option of the scan module for master case ([#3157](https://github.com/wazuh/wazuh-qa/pull/3157)) \- (Tests)
 - Fix Vulnerability Detector IT: test_validate_feed_content yaml cases had wrong extension. ([#3299](https://github.com/wazuh/wazuh-qa/pull/3299)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/wazuh_db.py
+++ b/deps/wazuh_testing/wazuh_testing/wazuh_db.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import functools
+import hashlib
 import json
 import logging
 import socket
@@ -230,3 +231,18 @@ def remove_agent(agent_id):
     """
     data = query_wdb(f"global delete-agent {agent_id}").split()
     assert data[0] == 'ok', f"Unable to remove agent {agent_id} - {data[1]}"
+
+
+def calculate_global_hash():
+    """Function that calculates and retrieves the actual global groups hash.
+
+    Returns:
+        str: Actual global groups hash.
+    """
+    GET_GROUP_HASH = '''global sql SELECT group_hash FROM agent WHERE
+                     id > 0 AND group_hash IS NOT NULL ORDER BY id'''
+
+    result = query_wdb(GET_GROUP_HASH)
+    group_hashes = [item['group_hash'] for item in result]
+
+    return hashlib.sha1("".join(group_hashes).encode()).hexdigest()

--- a/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
+++ b/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
@@ -92,7 +92,7 @@
   -
     pre_input: ['global sql UPDATE agent SET group_hash = "DUMMY"']
     input: 'global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":true}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}], 'hash': '49087946dd7a587ae30ae89cbc8084cad2cb0bfd'}]"  
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"  
 
 -
   name: "Test get_global_hash in false"

--- a/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
+++ b/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
@@ -1,171 +1,180 @@
----
 -
-  name: "Test sync_status with response"
+  name: Test sync_status with response
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"sync_status"}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      input: global sync-agent-groups-get {"condition":"sync_status"}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test sync_status without response"
+  name: Test sync_status without response
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_sync_status="synced"']
-    input: 'global sync-agent-groups-get {"condition":"sync_status"}'
-    output: "[{'data': []}]"
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_sync_status="synced"
+      input: global sync-agent-groups-get {"condition":"sync_status"}
+      output: "[{'data': []}]"
 
 -
-  name: "Test 'all' condition when agent groups are in 'sync_req'"
+  name: Test 'all' condition when agent groups are in 'sync_req'
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"all"}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      input: global sync-agent-groups-get {"condition":"all"}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test 'all' condition when agent groups are in 'synced'"
+  name: Test 'all' condition when agent groups are in 'synced'
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_sync_status="synced"']
-    input: 'global sync-agent-groups-get {"condition":"all"}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_sync_status="synced"
+      input: global sync-agent-groups-get {"condition":"all"}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test 'sync_status' condition when one agent groups are in 'synced'"
+  name: Test 'sync_status' condition when one agent groups are in 'synced'
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2']
-    input: 'global sync-agent-groups-get {"condition":"sync_status"}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}]}]"
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
+      input: global sync-agent-groups-get {"condition":"sync_status"}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}]}]"
 
 -
-  name: "Test 'all' condition when one agent groups are in 'synced'"
+  name: Test 'all' condition when one agent groups are in 'synced'
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2']
-    input: 'global sync-agent-groups-get {"condition":"all"}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
+      input: global sync-agent-groups-get {"condition":"all"}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test with and invalid filter in condition"
+  name: Test with and invalid filter in condition
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"testinvalid"}'
-    output: 'err Could not obtain a response from wdb_global_sync_agent_groups_get'
+    -
+      input: global sync-agent-groups-get {"condition":"testinvalid"}
+      output: err Could not obtain a response from wdb_global_sync_agent_groups_get
 
 -
-  name: "Test without condition"
+  name: Test without condition
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"last_id":0}'
-    output: "err Invalid JSON data, missing required 'condition' field"
+    -
+      input: global sync-agent-groups-get {"last_id":0}
+      output: err Invalid JSON data, missing required 'condition' field
 
 -
-  name: "Test set_synced in True"
+  name: Test set_synced in True
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"sync_status", "set_synced":true}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
-    new_status:  "synced"
-    agent_id: "[1,2]"
+    -
+      input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":true}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+      new_status: synced
+      agent_id: "[1,2]"
 
 -
-  name: "Test set_synced with invalid value - false"
+  name: Test set_synced with invalid value - false
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"sync_status", "set_synced":false}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
-    new_status:  "syncreq"
-    agent_id: "[1,2]"
+    -
+      input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":false}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+      new_status: syncreq
+      agent_id: "[1,2]"
 
 -
-  name: "Test set_synced with invalid value - String"
+  name: Test set_synced with invalid value - String
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"sync_status", "set_synced":"set"}'
-    output: "err Invalid JSON data, invalid alternative fields data"
-    new_status:  "syncreq"
-    agent_id: "[1,2]"
+    -
+      input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":"set"}
+      output: err Invalid JSON data, invalid alternative fields data
+      new_status: syncreq
+      agent_id: "[1,2]"
 
 -
-  name: "Test get_global_hash in true"
+  name: Test get_global_hash in true
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_hash = "DUMMY"']
-    input: 'global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":true}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"  
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_hash = "DUMMY"
+      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":true}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']},
+               {'id': 2, 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"
 
 -
-  name: "Test get_global_hash in false"
+  name: Test get_global_hash in false
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_hash = "DUMMY"']
-    input: 'global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":false}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_hash = "DUMMY"
+      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":false}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test get_global_hash with invalid value"
+  name: Test get_global_hash with invalid value
   test_case:
-  -
-    pre_input: ['global sql UPDATE agent SET group_hash = "DUMMY"']
-    input: 'global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":"set"}'
-    output: "err Invalid JSON data, invalid alternative fields data" 
+    -
+      pre_input:
+        - global sql UPDATE agent SET group_hash = "DUMMY"
+      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":"set"}
+      output: err Invalid JSON data, invalid alternative fields data
 
 -
-  name: "Test 'agent_registration_delta' in 0 and sync_status"
+  name: Test 'agent_registration_delta' in 0 and sync_status
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":0}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":0}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test 'agent_registration_delta' in 0 and all condition "
+  name: Test 'agent_registration_delta' in 0 and all condition
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"condition":"all", "agent_registration_delta":0}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":0}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test 'agent_registration_delta' with delta in 10000 and sync_status"
+  name: Test 'agent_registration_delta' with delta in 10000 and sync_status
   test_case:
-  - 
-    pre_input: ['global insert-agent {"id":5,"name":"Agent-test5","date_add":1545753642}', 'global set-agent-groups {"mode":"append","sync_status":"syncreq",
-                  "data":[{"id":5,"groups":["Test_group5"]}]}']
-    input: 'global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":10000}'
-    output: "[{'data': [{'id': 5, 'groups': ['Test_group5']}]}]"
+    -
+      pre_input:
+        - global insert-agent {"id":5,"name":"Agent-test5","date_add":1545753642}
+        - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":5,"groups":["Test_group5"]}]}
+      input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":10000}
+      output: "[{'data': [{'id': 5, 'groups': ['Test_group5']}]}]"
 
 -
-  name: "Test 'agent_registration_delta' with delta in 10000 and all"
+  name: Test 'agent_registration_delta' with delta in 10000 and all
   test_case:
-  -
-    pre_input: ['global insert-agent {"id":6,"name":"Agent-test6","date_add":1545753642}', 'global set-agent-groups {"mode":"append","sync_status":"syncreq",
-                  "data":[{"id":6,"groups":["Test_group6"]}]}']
-    input: 'global sync-agent-groups-get {"condition":"all", "agent_registration_delta":10000}'
-    output: "[{'data': [{'id': 6, 'groups': ['Test_group6']}]}]"
+    -
+      pre_input:
+        - global insert-agent {"id":6,"name":"Agent-test6","date_add":1545753642}
+        - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":6,"groups":["Test_group6"]}]}
+      input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":10000}
+      output: "[{'data': [{'id': 6, 'groups': ['Test_group6']}]}]"
 
 -
-  name: "Test last_id - by default"
+  name: Test last_id - by default
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"last_id":0, "condition":"sync_status"}'
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status"}
+      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test last_id - obtain from second group"
+  name: Test last_id - obtain from second group
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"last_id":1, "condition":"sync_status"}'
-    output: "[{'data': [{'id': 2, 'groups': ['Test_group2']}]}]"
+    -
+      input: global sync-agent-groups-get {"last_id":1, "condition":"sync_status"}
+      output: "[{'data': [{'id': 2, 'groups': ['Test_group2']}]}]"
 
 -
-  name: "Test last_id - with not exist id"
+  name: Test last_id - with not exist id
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"last_id":3, "condition":"sync_status"}'
-    output: "[{'data': []}]"
+    -
+      input: global sync-agent-groups-get {"last_id":3, "condition":"sync_status"}
+      output: "[{'data': []}]"
 
 -
-  name: "Test last_id - with negative value"
+  name: Test last_id - with negative value
   test_case:
-  -
-    input: 'global sync-agent-groups-get {"last_id":-3, "condition":"sync_status"}'
-    output: "err Invalid JSON data, invalid alternative fields data"
+    -
+      input: global sync-agent-groups-get {"last_id":-3, "condition":"sync_status"}
+      output: err Invalid JSON data, invalid alternative fields data

--- a/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
+++ b/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
@@ -127,7 +127,7 @@ def test_sync_agent_groups(configure_sockets_environment, connect_to_sockets_mod
     # Check if it requires the global hash.
     if '[GLOBAL_HASH]' in output:
         global_hash = calculate_global_hash()
-        output = output.replace('[GLOBAL_HASH]', global_hash) 
+        output = output.replace('[GLOBAL_HASH]', global_hash)
 
     time.sleep(1)
     response = query_wdb(case_data["input"])

--- a/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
+++ b/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
@@ -41,17 +41,16 @@ tags:
     - wazuh_db
 '''
 import os
-import yaml
 import time
 import pytest
 import json
 
-
 from wazuh_testing.tools import WAZUH_PATH
-from wazuh_testing.wazuh_db import (query_wdb, insert_agent_into_group, clean_agents_from_db,
-                                    clean_groups_from_db, clean_belongs)
+from wazuh_testing.wazuh_db import query_wdb, insert_agent_into_group, clean_agents_from_db
+from wazuh_testing.wazuh_db import clean_groups_from_db, clean_belongs, calculate_global_hash
 from wazuh_testing.modules import TIER0, SERVER, LINUX
 from wazuh_testing.tools.file import get_list_of_content_yml
+
 
 # Marks
 pytestmark = [LINUX, TIER0, SERVER]
@@ -66,54 +65,6 @@ wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
 receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
 monitored_sockets_params = [('wazuh-db', None, True)]
 receiver_sockets = None  # Set in the fixtures
-
-
-
-import socket
-import struct
-import json
-import hashlib
-
-
-
-def send_msg(msg):
-
-    ADDR = '/var/ossec/queue/db/wdb'
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.connect(ADDR)
-    msg = struct.pack('<I', len(msg)) + msg.encode()
-
-    # Send msg
-    sock.send(msg)
-
-    # Receive response
-    data = sock.recv(4)
-    data_size = struct.unpack("<I", data[0:4])[0]
-    data = sock.recv(data_size).decode(encoding="utf-8", errors="ignore").split(" ", 1)
-    
-    sock.close()
-    return data
-
-
-def get_global_hash():
-    GET_GROUP_HASH = 'global sql SELECT group_hash FROM agent WHERE id > 0 AND group_hash IS NOT NULL ORDER BY id ' \
-                     'LIMIT {limit} OFFSET {offset}'
-    limit = 1000
-    offset = 0
-    group_hashes = []
-
-    while True:
-        result = send_msg(GET_GROUP_HASH.format(limit=1000, offset=offset))
-        if result[1] == '[]':
-            break
-        offset += limit
-        group_hashes.extend([item['group_hash'] for item in json.loads(result[1])])
-
-    actual_hash = hashlib.sha1("".join(group_hashes).encode()).hexdigest()
-    print(f'Global groups hash: {actual_hash}')
-
-    return actual_hash
-
 
 
 # Fixtures
@@ -173,9 +124,10 @@ def test_sync_agent_groups(configure_sockets_environment, connect_to_sockets_mod
         for command in case_data['pre_input']:
             query_wdb(command)
 
+    # Check if it requires the global hash.
     if '[GLOBAL_HASH]' in output:
-        actual_hash = get_global_hash()
-        output = output.replace('[GLOBAL_HASH]', actual_hash) 
+        global_hash = calculate_global_hash()
+        output = output.replace('[GLOBAL_HASH]', global_hash) 
 
     time.sleep(1)
     response = query_wdb(case_data["input"])


### PR DESCRIPTION
|Related issue|
|-------------|
| #3890 |

## Description
A fix on the calculation of the global groups hash made `test_sync_agent_groups_get` fail, with this modification now wazuh excludes the groups of the `agent 000` from the calculation of the `global_hash`. It was found that our test uses an hardcoded hash that was wrongly calculated (using the agent 000 group to make the hash).

A function to calculate the correct hash was added in the `wazuh_db` module

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `tests/integration/test_wazuh_db/test_sync_agent_groups_get.py`
- tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
- `deps/wazuh_testing/wazuh_testing/wazuh_db.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @QU3B1M  (Developer)  | `integration/test_wazuh_db/`  | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/36239) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/36240) [:green_circle: ](https://ci.wazuh.info/job/Test_integration/36241) |  [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/10582972/report.zip) [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/10582973/report1.zip) [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/10582974/report2.zip) | Ubuntu 22.04 |[`cf6d5ad`](https://github.com/wazuh/wazuh-qa/pull/3895/commits/cf6d5ad490980b099d7189290e6e17df512c7fab) | Nothing to highlight |
| @jmv74211 (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
