### PR TITLE
Analysisd predecoder stage test failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release report: TBD
 
 ### Changed
 
+- Change expected timestamp for proftpd analysisd test predecoder test case ([#3900](https://github.com/wazuh/wazuh-qa/pull/3900)) \- (Tests)
 - Skip test_large_changes test module ([#3783](https://github.com/wazuh/wazuh-qa/pull/3783)) \- (Tests)
 - Update report_changes tests ([#3405](https://github.com/wazuh/wazuh-qa/pull/3405)) \- (Tests)
 - Update Authd force_insert tests ([#3379](https://github.com/wazuh/wazuh-qa/pull/3379)) \- (Tests)

--- a/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
+++ b/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
@@ -26,7 +26,7 @@
   test_case:
   -
     input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2015-04-16 21:51:02,805 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2015-04-16 21:51:02,80"}'
+    output: '{"program_name":"sshd","timestamp":"2015-04-16 21:51:02,805"}'
 -
   name: "Syslog date format for xferlog date format"
   description: "Check valid input"

--- a/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
+++ b/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
@@ -1,71 +1,110 @@
----
--
-  name: "Syslog date format 1"
-  description: "Check valid input"
+- name: Syslog date format 1
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"Dec 29 10:00:01","hostname":"linux-agent"}'
--
-  name: "Syslog date format 2"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"},
+        "command": "log_processing", "parameters": {"location":"master->/var/log/syslog",
+        "log_format": "syslog", "event": "Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: >-
+        {"program_name":"sshd","timestamp":"Dec 29
+        10:00:01","hostname":"linux-agent"}
+
+- name: Syslog date format 2
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2015 Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2015 Dec 29 10:00:01"}'
--
-  name: "Syslog date format for rsyslog"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2015 Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2015 Dec 29 10:00:01"}'
+
+- name: Syslog date format for rsyslog
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2009-05-22T09:36:46.214994-07:00 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2009-05-22T09:36:46.214994-07:00"}'
--
-  name: "Syslog date format for proftpd 1.3.5"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2009-05-22T09:36:46.214994-07:00 linux-agent sshd[29205]: Invalid user
+        blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2009-05-22T09:36:46.214994-07:00"}'
+
+- name: Syslog date format for proftpd 1.3.5
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2015-04-16 21:51:02,805 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2015-04-16 21:51:02,805"}'
--
-  name: "Syslog date format for xferlog date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2015-04-16 21:51:02,805 linux-agent sshd[29205]: Invalid user blimey
+        from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2015-04-16 21:51:02,805"}'
+
+- name: Syslog date format for xferlog date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "Mon Apr 17 18:27:14 2006 1 64.160.42.130 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"Mon Apr 17 18:27:14 2006"}'
--
-  name: "Syslog date format for snort date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "Mon Apr 17 18:27:14 2006 1 64.160.42.130 linux-agent sshd[29205]:
+        Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"Mon Apr 17 18:27:14 2006"}'
+
+- name: Syslog date format for snort date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "01/28-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"01/28-09:13:16.240702"}'
--
-  name: "Syslog date format for suricata date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "01/28-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"01/28-09:13:16.240702"}'
+
+- name: Syslog date format for suricata date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "01/28/1979-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"01/28/1979-09:13:16.240702"}'
--
-  name: "Syslog date format for apache log format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "01/28/1979-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey
+        from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"01/28/1979-09:13:16.240702"}'
+
+- name: Syslog date format for apache log format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "[Fri Feb 11 18:06:35 2004] [warn] linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"Fri Feb 11 18:06:35 2004"}'
--
-  name: "Syslog date format for macos ULS --syslog output"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "[Fri Feb 11 18:06:35 2004] [warn] linux-agent sshd[29205]: Invalid user
+        blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"Fri Feb 11 18:06:35 2004"}'
+
+- name: Syslog date format for macos ULS --syslog output
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2021-04-21 10:16:09.404756-0700 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2021-04-21 10:16:09.404756-0700"}'
--
-  name: "Syslog Umlaut date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2021-04-21 10:16:09.404756-0700 linux-agent sshd[29205]: Invalid user
+        blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2021-04-21 10:16:09.404756-0700"}'
+
+- name: Syslog Umlaut date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "Mär 02 17:30:52 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"Mär 02 17:30:5"}'
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "Mär 02 17:30:52 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"Mär 02 17:30:5"}'


### PR DESCRIPTION
|Related issue|
|-------------|
|        #3899     |

## Description

Fixed `test_predecoder_staged` according to https://github.com/wazuh/wazuh/pull/15826

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Changed expected proftpd timestamp

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/36337/console) | Not required |         |         | Nothing to highlight |
| @user (Reviewer)   |           | Not required | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
