### PR TITLE
Add Logcollector milisecond timestamp Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release report: TBD
 
 ### Changed
 
+- Change expected timestamp for proftpd analysisd test predecoder test case ([#3900](https://github.com/wazuh/wazuh-qa/pull/3900)) \- (Tests)
 - Skip test_large_changes test module ([#3783](https://github.com/wazuh/wazuh-qa/pull/3783)) \- (Tests)
 - Update report_changes tests ([#3405](https://github.com/wazuh/wazuh-qa/pull/3405)) \- (Tests)
 - Update Authd force_insert tests ([#3379](https://github.com/wazuh/wazuh-qa/pull/3379)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Release report: TBD
 ### Added
 
 - Add Windows System folders FIM monitoring tests ([#3720](https://github.com/wazuh/wazuh-qa/pull/3720)) \- (Tests)
-- Add 'test_whodata_policy_changes' tests ([#3627](https://github.com/wazuh/wazuh-qa/pull/3627)) \- (Framework + Tests) 
+- Add 'test_whodata_policy_changes' tests ([#3627](https://github.com/wazuh/wazuh-qa/pull/3627)) \- (Framework + Tests)
 - Add test to check if active-response netsh generates alerts when firewall is disabled. ([#3787](https://github.com/wazuh/wazuh-qa/pull/3787)) \- (Framework + Tests)
 - Add new tests for logcollector 'ignore' and 'restrict' options ([#3582](https://github.com/wazuh/wazuh-qa/pull/3582)) \- (Tests)
 - Add 'Force reconnect' feature to agent_simulator tool. ([#3111](https://github.com/wazuh/wazuh-qa/pull/3111)) \- (Tools)
@@ -37,6 +37,7 @@ Release report: TBD
 
 ### Added
 
+- Add new test to check missing fields in `cpe_helper.json` file ([#3766](https://github.com/wazuh/wazuh-qa/pull/3766)) \- (Framework + Tests)
 - Add new test to check cpe_helper.json file ([#3731](https://github.com/wazuh/wazuh-qa/pull/3731))
 - Add new tests analysid handling of invalid/empty rule signature IDs ([#3649]
 (https://github.com/wazuh/wazuh-qa/pull/3649)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/__init__.py
@@ -19,6 +19,8 @@ T_360 = 360
 T_800 = 800
 
 CUSTOM_VULNERABLE_PACKAGES = 'custom_vulnerable_packages.json'
+CUSTOM_VULNERABLE_PKG_EMPTY_VENDOR = 'custom_vulnerable_pkg_empty_vendor.json'
+CUSTOM_VULNERABLE_PKG_EMPTY_VENDOR_VERSION = 'custom_vulnerable_pkg_empty_vendor_version.json'
 CUSTOM_NVD_FEED = 'custom_nvd_feed.json'
 CUSTOM_NVD_ALTERNATIVE_FEED = 'custom_nvd_alternative_feed.json'
 CUSTOM_REDHAT_JSON_FEED = 'custom_redhat_json_feed.json'
@@ -28,6 +30,7 @@ CUSTOM_DEBIAN_OVAL_FEED = 'custom_debian_oval_feed.xml'
 CUSTOM_DEBIAN_JSON_FEED = 'custom_debian_json_feed.json'
 CUSTOM_MSU_JSON_FEED = 'custom_msu.json'
 CUSTOM_CPE_HELPER = 'custom_cpe_helper.json'
+CUSTOM_GENERIC_CPE_HELPER = 'custom_generic_cpe_helper_one_package.json'
 CUSTOM_CPE_HELPER_TEMPLATE = 'custom_cpe_helper_template.json'
 CUSTOM_ARCHLINUX_JSON_FEED = 'custom_archlinux_feed.json'
 CUSTOM_ALAS_JSON_FEED = 'custom_alas_feed.json'

--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/event_monitor.py
@@ -510,3 +510,16 @@ def check_error_inserting_package(log_monitor=None, agent_id='000', timeout=vd.T
     check_vuln_detector_event(file_monitor=log_monitor, timeout=timeout,
                               callback=f"ERROR: .* Could not insert the CPEs from the agent '{agent_id}' "
                                        "into the database.")
+
+
+def check_version_log(package_name='', log_monitor=None, timeout=vd.T_20):
+    """Check that the version log could not be reached.
+
+    Args:
+        package_name (str): Package name.
+        log_monitor (FileMonitor): Log monitor.
+        timeout (str): timeout to check the event in Wazuh log.
+    """
+    check_vuln_detector_event(file_monitor=log_monitor, timeout=timeout,
+                              callback=fr"DEBUG: .* Couldn't get the version of the CPE for the {package_name} "
+                                       "package.")

--- a/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
+++ b/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
@@ -108,3 +108,15 @@
         "Mär 02 17:30:52 linux-agent sshd[29205]: Invalid user blimey from
         18.18.18.18 port 48928", "token": "21218e6b"}}
       output: '{"program_name":"sshd","timestamp":"Mär 02 17:30:5"}'
+
+-
+  name: "Syslog syslog-ng OSE date format"
+  description: "Check valid input"
+  test_case:
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module": 
+        "wazuh-logtest"}, "command": "log_processing", "parameters": 
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2022-12-20T15:02:53.123+00:00 localhost sshd[25474]: Accepted password for
+        rromero from 192.168.1.133 port 49765 ssh2", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2022-12-20T15:02:53.123+00:00"}'

--- a/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
+++ b/tests/integration/test_analysisd/test_predecoder_stage/data/syslog_socket_input.yaml
@@ -1,71 +1,110 @@
----
--
-  name: "Syslog date format 1"
-  description: "Check valid input"
+- name: Syslog date format 1
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"Dec 29 10:00:01","hostname":"linux-agent"}'
--
-  name: "Syslog date format 2"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"},
+        "command": "log_processing", "parameters": {"location":"master->/var/log/syslog",
+        "log_format": "syslog", "event": "Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: >-
+        {"program_name":"sshd","timestamp":"Dec 29
+        10:00:01","hostname":"linux-agent"}
+
+- name: Syslog date format 2
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2015 Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2015 Dec 29 10:00:01"}'
--
-  name: "Syslog date format for rsyslog"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2015 Dec 29 10:00:01 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2015 Dec 29 10:00:01"}'
+
+- name: Syslog date format for rsyslog
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2009-05-22T09:36:46.214994-07:00 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2009-05-22T09:36:46.214994-07:00"}'
--
-  name: "Syslog date format for proftpd 1.3.5"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2009-05-22T09:36:46.214994-07:00 linux-agent sshd[29205]: Invalid user
+        blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2009-05-22T09:36:46.214994-07:00"}'
+
+- name: Syslog date format for proftpd 1.3.5
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2015-04-16 21:51:02,805 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2015-04-16 21:51:02,80"}'
--
-  name: "Syslog date format for xferlog date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2015-04-16 21:51:02,805 linux-agent sshd[29205]: Invalid user blimey
+        from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2015-04-16 21:51:02,805"}'
+
+- name: Syslog date format for xferlog date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "Mon Apr 17 18:27:14 2006 1 64.160.42.130 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"Mon Apr 17 18:27:14 2006"}'
--
-  name: "Syslog date format for snort date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "Mon Apr 17 18:27:14 2006 1 64.160.42.130 linux-agent sshd[29205]:
+        Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"Mon Apr 17 18:27:14 2006"}'
+
+- name: Syslog date format for snort date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "01/28-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"01/28-09:13:16.240702"}'
--
-  name: "Syslog date format for suricata date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "01/28-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"01/28-09:13:16.240702"}'
+
+- name: Syslog date format for suricata date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "01/28/1979-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"01/28/1979-09:13:16.240702"}'
--
-  name: "Syslog date format for apache log format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "01/28/1979-09:13:16.240702 linux-agent sshd[29205]: Invalid user blimey
+        from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"01/28/1979-09:13:16.240702"}'
+
+- name: Syslog date format for apache log format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "[Fri Feb 11 18:06:35 2004] [warn] linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"timestamp":"Fri Feb 11 18:06:35 2004"}'
--
-  name: "Syslog date format for macos ULS --syslog output"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "[Fri Feb 11 18:06:35 2004] [warn] linux-agent sshd[29205]: Invalid user
+        blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"timestamp":"Fri Feb 11 18:06:35 2004"}'
+
+- name: Syslog date format for macos ULS --syslog output
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "2021-04-21 10:16:09.404756-0700 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"2021-04-21 10:16:09.404756-0700"}'
--
-  name: "Syslog Umlaut date format"
-  description: "Check valid input"
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "2021-04-21 10:16:09.404756-0700 linux-agent sshd[29205]: Invalid user
+        blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"2021-04-21 10:16:09.404756-0700"}'
+
+- name: Syslog Umlaut date format
+  description: Check valid input
   test_case:
-  -
-    input: '{"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location":"master->/var/log/syslog", "log_format": "syslog", "event": "Mär 02 17:30:52 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928", "token": "21218e6b"}}'
-    output: '{"program_name":"sshd","timestamp":"Mär 02 17:30:5"}'
+    - input: >-
+        {"version": 1, "origin": {"name": "wazuh-logtest", "module":
+        "wazuh-logtest"}, "command": "log_processing", "parameters":
+        {"location":"master->/var/log/syslog", "log_format": "syslog", "event":
+        "Mär 02 17:30:52 linux-agent sshd[29205]: Invalid user blimey from
+        18.18.18.18 port 48928", "token": "21218e6b"}}
+      output: '{"program_name":"sshd","timestamp":"Mär 02 17:30:5"}'

--- a/tests/integration/test_vulnerability_detector/data/feeds/cpe_helper/custom_generic_cpe_helper_one_package.json
+++ b/tests/integration/test_vulnerability_detector/data/feeds/cpe_helper/custom_generic_cpe_helper_one_package.json
@@ -1,0 +1,38 @@
+{
+    "VERSION_TAG": "VERSION_VALUE",
+    "FORMAT_TAG": "FORMAT_VALUE",
+    "UPDATE_TAG": "UPDATE_VALUE",
+    "DICTIONARY_TAG": [
+        {
+            "TARGET_TAG": "TARGET_VALUE",
+            "SOURCE_TAG": {
+                "VENDOR_S_TAG": [
+                    "VENDOR_S_VALUE"
+                ],
+                "PRODUCT_S_TAG": [
+                    "PRODUCT_S_VALUE_0"
+                ],
+                "VERSION_S_TAG": ["VERSION_S_VALUE"]
+            },
+            "TRANSLATION_TAG": {
+                "VENDOR_T_TAG": [
+                    "VENDOR_T_VALUE"
+                ],
+                "PRODUCT_T_TAG": [
+                    "PRODUCT_T_VALUE_0"
+                ],
+                "VERSION_T_TAG": ["VERSION_T_VALUE"]
+            },
+            "ACTION_TAG": [
+                "ACTION_VALUE_0",
+                "ACTION_VALUE_1"
+            ]
+        }
+      ],
+      "LICENSE_TAG": {
+          "TITLE_TAG": "TITLE_VALUE",
+          "COPYRIGHT_TAG": "COPYRIGHT_VALUE",
+          "DATE_TAG": "DATE_VALUE",
+          "TYPE_TAG" : "TYPE_VALUE"
+      }
+  }

--- a/tests/integration/test_vulnerability_detector/data/vulnerable_packages/custom_vulnerable_pkg_empty_vendor.json
+++ b/tests/integration/test_vulnerability_detector/data/vulnerable_packages/custom_vulnerable_pkg_empty_vendor.json
@@ -1,0 +1,14 @@
+[
+  {
+    "scan": {
+      "id": 0,
+      "time": "2021-11-20T12:41:27Z"
+    },
+    "architecture": "x86_64",
+    "format": "win",
+    "name": "custom-package-0 1.0.0",
+    "size": 0,
+    "vendor": "NULL",
+    "cveid": "CVE-000"
+  }
+]

--- a/tests/integration/test_vulnerability_detector/data/vulnerable_packages/custom_vulnerable_pkg_empty_vendor_version.json
+++ b/tests/integration/test_vulnerability_detector/data/vulnerable_packages/custom_vulnerable_pkg_empty_vendor_version.json
@@ -1,0 +1,15 @@
+[
+  {
+    "scan": {
+      "id": 0,
+      "time": "2021-11-20T12:41:27Z"
+    },
+    "architecture": "x86_64",
+    "format": "win",
+    "name": "custom-package-0 1.0.0",
+    "size": 0,
+    "vendor": "NULL",
+    "cveid": "CVE-000",
+    "version": "NULL"
+  }
+]

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_empty_fields.yaml
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_empty_fields.yaml
@@ -1,67 +1,11 @@
-- name: Wrong source vendor fields
-  description: Indexing CPE helper with wrong source vendor fields
+- name: Missing vendor field
+  description: Indexing CPE helper with missing vendor field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
   metadata:
     system: WINDOWS_10
-    wrong_field: vedor
+    wrong_field: null
     missing_field: []
-    expected_result: invalid_tag
-    tags:
-      VERSION_TAG: version
-      FORMAT_TAG: format_version
-      UPDATE_TAG: update_date
-      DICTIONARY_TAG: dictionary
-      TARGET_TAG: target
-      SOURCE_TAG: source
-      VENDOR_S_TAG: vedor
-      PRODUCT_S_TAG: product
-      VERSION_S_TAG: version
-      TRANSLATION_TAG: translation
-      VENDOR_T_TAG: vendor
-      PRODUCT_T_TAG: product
-      VERSION_T_TAG: version
-      ACTION_TAG: action
-      LICENSE_TAG: license
-      TITLE_TAG: title
-      COPYRIGHT_TAG: copyright
-      DATE_TAG: date
-      TYPE_TAG: type
-    values:
-      VERSION_VALUE: "1.0"
-      FORMAT_VALUE: "1.0"
-      UPDATE_VALUE: 2050-10-02T10:56Z
-      TARGET_VALUE: windows
-      VENDOR_S_VALUE: ^wazuh-mocking
-      PRODUCT_S_VALUE_0: custom-package-0
-      PRODUCT_S_VALUE_1: custom-package-1
-      PRODUCT_S_VALUE_2: custom-package-2
-      PRODUCT_S_VALUE_3: custom-package-3
-      PRODUCT_S_VALUE_4: custom-package-4
-      VERSION_S_VALUE: ""
-      VENDOR_T_VALUE: wazuh-mocking
-      PRODUCT_T_VALUE_0: custom-package-0
-      PRODUCT_T_VALUE_1: custom-package-1
-      PRODUCT_T_VALUE_2: custom-package-2
-      PRODUCT_T_VALUE_3: custom-package-3
-      PRODUCT_T_VALUE_4: custom-package-4
-      VERSION_T_VALUE: ""
-      ACTION_VALUE_0: replace_vendor
-      ACTION_VALUE_1: replace_product
-      TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
-      COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
-      DATE_VALUE: March 6, 2019.
-      TYPE_VALUE: GPLv2
-
-- name: Wrong translation product fields
-  description: Indexing CPE helper with wrong translation product fields
-  configuration_parameters:
-    NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
-  metadata:
-    system: WINDOWS_10
-    wrong_field: prouct
-    missing_field: []
-    expected_result: invalid_tag
     tags:
       VERSION_TAG: version
       FORMAT_TAG: format_version
@@ -74,61 +18,6 @@
       VERSION_S_TAG: version
       TRANSLATION_TAG: translation
       VENDOR_T_TAG: vendor
-      PRODUCT_T_TAG: prouct
-      VERSION_T_TAG: version
-      ACTION_TAG: action
-      LICENSE_TAG: license
-      TITLE_TAG: title
-      COPYRIGHT_TAG: copyright
-      DATE_TAG: date
-      TYPE_TAG: type
-    values:
-      VERSION_VALUE: "1.0"
-      FORMAT_VALUE: "1.0"
-      UPDATE_VALUE: 2050-10-02T10:56Z
-      TARGET_VALUE: windows
-      VENDOR_S_VALUE: ^wazuh-mocking
-      PRODUCT_S_VALUE_0: custom-package-0
-      PRODUCT_S_VALUE_1: custom-package-1
-      PRODUCT_S_VALUE_2: custom-package-2
-      PRODUCT_S_VALUE_3: custom-package-3
-      PRODUCT_S_VALUE_4: custom-package-4
-      VERSION_S_VALUE: ""
-      VENDOR_T_VALUE: wazuh-mocking
-      PRODUCT_T_VALUE_0: custom-package-0
-      PRODUCT_T_VALUE_1: custom-package-1
-      PRODUCT_T_VALUE_2: custom-package-2
-      PRODUCT_T_VALUE_3: custom-package-3
-      PRODUCT_T_VALUE_4: custom-package-4
-      VERSION_T_VALUE: ""
-      ACTION_VALUE_0: replace_vendor
-      ACTION_VALUE_1: replace_product
-      TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
-      COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
-      DATE_VALUE: March 6, 2019.
-      TYPE_VALUE: GPLv2
-
-- name: Wrong version field
-  description: Indexing CPE helper with wrong version field
-  configuration_parameters:
-    NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
-  metadata:
-    system: WINDOWS_10
-    wrong_field: vesion
-    missing_field: []
-    expected_result: package_indexed
-    tags:
-      VERSION_TAG: vesion
-      FORMAT_TAG: format_version
-      UPDATE_TAG: update_date
-      DICTIONARY_TAG: dictionary
-      TARGET_TAG: target
-      SOURCE_TAG: source
-      VENDOR_S_TAG: vendor
-      PRODUCT_S_TAG: product
-      VERSION_S_TAG: version
-      TRANSLATION_TAG: translation
-      VENDOR_T_TAG: vendor
       PRODUCT_T_TAG: product
       VERSION_T_TAG: version
       ACTION_TAG: action
@@ -142,96 +31,32 @@
       FORMAT_VALUE: "1.0"
       UPDATE_VALUE: 2050-10-02T10:56Z
       TARGET_VALUE: windows
-      VENDOR_S_VALUE: ^wazuh-mocking
-      PRODUCT_S_VALUE_0: custom-package-0
-      PRODUCT_S_VALUE_1: custom-package-1
-      PRODUCT_S_VALUE_2: custom-package-2
-      PRODUCT_S_VALUE_3: custom-package-3
-      PRODUCT_S_VALUE_4: custom-package-4
-      VERSION_S_VALUE: ""
+      VENDOR_S_VALUE: ""
+      PRODUCT_S_VALUE_0: ^custom-package-0.*
+      VERSION_S_VALUE: ^custom-package-0 ([0-9]+\\.*[0-9]*\\.*[0-9]*-*[0-9]*)
       VENDOR_T_VALUE: wazuh-mocking
       PRODUCT_T_VALUE_0: custom-package-0
-      PRODUCT_T_VALUE_1: custom-package-1
-      PRODUCT_T_VALUE_2: custom-package-2
-      PRODUCT_T_VALUE_3: custom-package-3
-      PRODUCT_T_VALUE_4: custom-package-4
       VERSION_T_VALUE: ""
-      ACTION_VALUE_0: replace_vendor
-      ACTION_VALUE_1: replace_product
+      ACTION_VALUE_0: replace_product
+      ACTION_VALUE_1: set_version_if_product_matches
       TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
       COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Wrong format_version fields
-  description: Indexing CPE helper with wrong format_version fields
+- name: Missing vendor and version fields
+  description: Indexing CPE helper with missing vendor and version fields
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
   metadata:
     system: WINDOWS_10
-    wrong_field: fomat_version
+    wrong_field: null
     missing_field: []
-    expected_result: nvd_update_failed
-    tags:
-      VERSION_TAG: version
-      FORMAT_TAG: fomat_version
-      UPDATE_TAG: update_date
-      DICTIONARY_TAG: dictionary
-      TARGET_TAG: target
-      SOURCE_TAG: source
-      VENDOR_S_TAG: vendor
-      PRODUCT_S_TAG: product
-      VERSION_S_TAG: version
-      TRANSLATION_TAG: translation
-      VENDOR_T_TAG: vendor
-      PRODUCT_T_TAG: product
-      VERSION_T_TAG: version
-      ACTION_TAG: action
-      LICENSE_TAG: license
-      TITLE_TAG: title
-      COPYRIGHT_TAG: copyright
-      DATE_TAG: date
-      TYPE_TAG: type
-    values:
-      VERSION_VALUE: "1.0"
-      FORMAT_VALUE: "1.0"
-      UPDATE_VALUE: 2050-10-02T10:56Z
-      TARGET_VALUE: windows
-      VENDOR_S_VALUE: ^wazuh-mocking
-      PRODUCT_S_VALUE_0: custom-package-0
-      PRODUCT_S_VALUE_1: custom-package-1
-      PRODUCT_S_VALUE_2: custom-package-2
-      PRODUCT_S_VALUE_3: custom-package-3
-      PRODUCT_S_VALUE_4: custom-package-4
-      VERSION_S_VALUE: ""
-      VENDOR_T_VALUE: wazuh-mocking
-      PRODUCT_T_VALUE_0: custom-package-0
-      PRODUCT_T_VALUE_1: custom-package-1
-      PRODUCT_T_VALUE_2: custom-package-2
-      PRODUCT_T_VALUE_3: custom-package-3
-      PRODUCT_T_VALUE_4: custom-package-4
-      VERSION_T_VALUE: ""
-      ACTION_VALUE_0: replace_vendor
-      ACTION_VALUE_1: replace_product
-      TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
-      COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
-      DATE_VALUE: March 6, 2019.
-      TYPE_VALUE: GPLv2
-
-- name: Wrong update_date fields
-  description: Indexing CPE helper with wrong update_date fields
-  configuration_parameters:
-    NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
-  metadata:
-    system: WINDOWS_10
-    wrong_field: upate_date
-    missing_field: []
-    expected_result: nvd_update_failed
     tags:
       VERSION_TAG: version
       FORMAT_TAG: format_version
-      UPDATE_TAG: upate_date
-      DICTIONARY_TAG: ditionary
+      UPDATE_TAG: update_date
+      DICTIONARY_TAG: dictionary
       TARGET_TAG: target
       SOURCE_TAG: source
       VENDOR_S_TAG: vendor
@@ -252,42 +77,33 @@
       FORMAT_VALUE: "1.0"
       UPDATE_VALUE: 2050-10-02T10:56Z
       TARGET_VALUE: windows
-      VENDOR_S_VALUE: ^wazuh-mocking
-      PRODUCT_S_VALUE_0: custom-package-0
-      PRODUCT_S_VALUE_1: custom-package-1
-      PRODUCT_S_VALUE_2: custom-package-2
-      PRODUCT_S_VALUE_3: custom-package-3
-      PRODUCT_S_VALUE_4: custom-package-4
+      VENDOR_S_VALUE: ""
+      PRODUCT_S_VALUE_0: ^custom-package-0.*
       VERSION_S_VALUE: ""
       VENDOR_T_VALUE: wazuh-mocking
       PRODUCT_T_VALUE_0: custom-package-0
-      PRODUCT_T_VALUE_1: custom-package-1
-      PRODUCT_T_VALUE_2: custom-package-2
-      PRODUCT_T_VALUE_3: custom-package-3
-      PRODUCT_T_VALUE_4: custom-package-4
-      VERSION_T_VALUE: ""
-      ACTION_VALUE_0: replace_vendor
-      ACTION_VALUE_1: replace_product
+      VERSION_T_VALUE: ^custom-package-0 ([0-9]+\\.*[0-9]*\\.*[0-9]*-*[0-9]*)
+      ACTION_VALUE_0: replace_product
+      ACTION_VALUE_1: set_version_if_product_matches
       TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
       COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Wrong target field
-  description: Indexing CPE helper with wrong target field
+- name: Missing set_version_if_product_matches action field
+  description: Indexing CPE helper with missing set_version_if_product_matches action field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
   metadata:
     system: WINDOWS_10
-    wrong_field: taget
+    wrong_field: null
     missing_field: []
-    expected_result: package_not_indexed
     tags:
-      VERSION_TAG: vesion
+      VERSION_TAG: version
       FORMAT_TAG: format_version
       UPDATE_TAG: update_date
       DICTIONARY_TAG: dictionary
-      TARGET_TAG: taget
+      TARGET_TAG: target
       SOURCE_TAG: source
       VENDOR_S_TAG: vendor
       PRODUCT_S_TAG: product
@@ -307,22 +123,106 @@
       FORMAT_VALUE: "1.0"
       UPDATE_VALUE: 2050-10-02T10:56Z
       TARGET_VALUE: windows
-      VENDOR_S_VALUE: ^wazuh-mocking
-      PRODUCT_S_VALUE_0: custom-package-0
-      PRODUCT_S_VALUE_1: custom-package-1
-      PRODUCT_S_VALUE_2: custom-package-2
-      PRODUCT_S_VALUE_3: custom-package-3
-      PRODUCT_S_VALUE_4: custom-package-4
+      VENDOR_S_VALUE: ""
+      PRODUCT_S_VALUE_0: ^custom-package-0.*
       VERSION_S_VALUE: ""
       VENDOR_T_VALUE: wazuh-mocking
       PRODUCT_T_VALUE_0: custom-package-0
-      PRODUCT_T_VALUE_1: custom-package-1
-      PRODUCT_T_VALUE_2: custom-package-2
-      PRODUCT_T_VALUE_3: custom-package-3
-      PRODUCT_T_VALUE_4: custom-package-4
-      VERSION_T_VALUE: ""
-      ACTION_VALUE_0: replace_vendor
-      ACTION_VALUE_1: replace_product
+      VERSION_T_VALUE: ^custom-package-0 ([0-9]+\\.*[0-9]*\\.*[0-9]*-*[0-9]*)
+      ACTION_VALUE_0: replace_product
+      ACTION_VALUE_1: ""
+      TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
+      COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
+      DATE_VALUE: March 6, 2019.
+      TYPE_VALUE: GPLv2
+
+- name: Replace_vendor instead of set_version_if_product_matches action fields
+  description: Indexing CPE helper with replace_vendor instead of set_version_if_product_matches action fields
+  configuration_parameters:
+    NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
+  metadata:
+    system: WINDOWS_10
+    wrong_field: null
+    missing_field: []
+    tags:
+      VERSION_TAG: version
+      FORMAT_TAG: format_version
+      UPDATE_TAG: update_date
+      DICTIONARY_TAG: dictionary
+      TARGET_TAG: target
+      SOURCE_TAG: source
+      VENDOR_S_TAG: vendor
+      PRODUCT_S_TAG: product
+      VERSION_S_TAG: version
+      TRANSLATION_TAG: translation
+      VENDOR_T_TAG: vendor
+      PRODUCT_T_TAG: product
+      VERSION_T_TAG: version
+      ACTION_TAG: action
+      LICENSE_TAG: license
+      TITLE_TAG: title
+      COPYRIGHT_TAG: copyright
+      DATE_TAG: date
+      TYPE_TAG: type
+    values:
+      VERSION_VALUE: "1.0"
+      FORMAT_VALUE: "1.0"
+      UPDATE_VALUE: 2050-10-02T10:56Z
+      TARGET_VALUE: windows
+      VENDOR_S_VALUE: ""
+      PRODUCT_S_VALUE_0: ^custom-package-0.*
+      VERSION_S_VALUE: ""
+      VENDOR_T_VALUE: wazuh-mocking
+      PRODUCT_T_VALUE_0: custom-package-0
+      VERSION_T_VALUE: ^custom-package-0 ([0-9]+\\.*[0-9]*\\.*[0-9]*-*[0-9]*)
+      ACTION_VALUE_0: replace_product
+      ACTION_VALUE_1: replace_vendor
+      TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
+      COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
+      DATE_VALUE: March 6, 2019.
+      TYPE_VALUE: GPLv2
+
+- name: Missing all source fields
+  description: Indexing CPE helper with missing all source fields
+  configuration_parameters:
+    NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
+  metadata:
+    system: WINDOWS_10
+    wrong_field: null
+    missing_field: []
+    tags:
+      VERSION_TAG: version
+      FORMAT_TAG: format_version
+      UPDATE_TAG: update_date
+      DICTIONARY_TAG: dictionary
+      TARGET_TAG: target
+      SOURCE_TAG: source
+      VENDOR_S_TAG: vendor
+      PRODUCT_S_TAG: product
+      VERSION_S_TAG: version
+      TRANSLATION_TAG: translation
+      VENDOR_T_TAG: vendor
+      PRODUCT_T_TAG: product
+      VERSION_T_TAG: version
+      ACTION_TAG: action
+      LICENSE_TAG: license
+      TITLE_TAG: title
+      COPYRIGHT_TAG: copyright
+      DATE_TAG: date
+      TYPE_TAG: type
+    values:
+      VERSION_VALUE: "1.0"
+      FORMAT_VALUE: "1.0"
+      UPDATE_VALUE: 2050-10-02T10:56Z
+      TARGET_VALUE: windows
+      VENDOR_S_VALUE: ""
+      PRODUCT_S_VALUE_0: ""
+      VERSION_S_VALUE: ""
+      VENDOR_T_VALUE: wazuh-mocking
+      PRODUCT_T_VALUE_0: custom-package-0
+      VERSION_T_VALUE: ^custom-package-0 ([0-9]+\\.*[0-9]*\\.*[0-9]*-*[0-9]*)
+      ACTION_VALUE_0: replace_product
+      ACTION_VALUE_1: replace_vendor
       TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
       COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
       DATE_VALUE: March 6, 2019.

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_empty_vendor_version.yaml
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_empty_vendor_version.yaml
@@ -1,0 +1,45 @@
+- name: Missing all the source fields and version translation field
+  description: Indexing CPE helper with missing all the source fields and version translation field
+  configuration_parameters:
+    NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
+  metadata:
+    system: WINDOWS_10
+    wrong_field: null
+    missing_field: []
+    tags:
+      VERSION_TAG: version
+      FORMAT_TAG: format_version
+      UPDATE_TAG: update_date
+      DICTIONARY_TAG: dictionary
+      TARGET_TAG: target
+      SOURCE_TAG: source
+      VENDOR_S_TAG: vendor
+      PRODUCT_S_TAG: product
+      VERSION_S_TAG: version
+      TRANSLATION_TAG: translation
+      VENDOR_T_TAG: vendor
+      PRODUCT_T_TAG: product
+      VERSION_T_TAG: version
+      ACTION_TAG: action
+      LICENSE_TAG: license
+      TITLE_TAG: title
+      COPYRIGHT_TAG: copyright
+      DATE_TAG: date
+      TYPE_TAG: type
+    values:
+      VERSION_VALUE: "1.0"
+      FORMAT_VALUE: "1.0"
+      UPDATE_VALUE: 2050-10-02T10:56Z
+      TARGET_VALUE: windows
+      VENDOR_S_VALUE: ""
+      PRODUCT_S_VALUE_0: ""
+      VERSION_S_VALUE: ""
+      VENDOR_T_VALUE: wazuh-mocking
+      PRODUCT_T_VALUE_0: custom-package-0
+      VERSION_T_VALUE: ""
+      ACTION_VALUE_0: replace_product
+      ACTION_VALUE_1: replace_vendor
+      TITLE_VALUE: Dictionary of CPEs to analyze system vulnerabilities.
+      COPYRIGHT_VALUE: Copyright (C) 2015-2019, Wazuh Inc.
+      DATE_VALUE: March 6, 2019.
+      TYPE_VALUE: GPLv2

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_missing_fields.yaml
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_missing_fields.yaml
@@ -1,4 +1,4 @@
-- name: Indexing CPE helper with missing version field
+- name: Missing version field
   description: Indexing CPE helper with missing version field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -54,7 +54,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with missing format_version field
+- name: Missing format_version field
   description: Indexing CPE helper with missing format_version field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -110,7 +110,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with missing update_date field
+- name: Missing update_date field
   description: Indexing CPE helper with missing update_date field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -166,7 +166,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with missing target field
+- name: Missing target field
   description: Indexing CPE helper with missing target field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -222,7 +222,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with missing action field
+- name: Missing action field
   description: Indexing CPE helper with missing action field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -278,7 +278,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with missing vendor field
+- name: Missing vendor field
   description: Indexing CPE helper with missing vendor field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -334,7 +334,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with missing product field
+- name: Missing product field
   description: Indexing CPE helper with missing product field
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_wrong_values.yaml
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/data/test_cases/cases_cpe_indexing_wrong_values.yaml
@@ -1,4 +1,4 @@
-- name: Indexing CPE helper with wrong version value
+- name: Wrong version value
   description: Indexing CPE helper with wrong version value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -53,7 +53,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with wrong update_date value
+- name: Wrong update_date value
   description: Indexing CPE helper with wrong update_date value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -108,7 +108,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with wrong target value
+- name: Wrong target value
   description: Indexing CPE helper with wrong target value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -163,7 +163,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with wrong format_version value
+- name: Wrong format_version value
   description: Indexing CPE helper with wrong format_version value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -218,7 +218,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with wrong source vendor value
+- name: Wrong source vendor value
   description: Indexing CPE helper with wrong source vendor value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -273,7 +273,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with wrong source product value
+- name: Wrong source product value
   description: Indexing CPE helper with wrong source product value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
@@ -328,7 +328,7 @@
       DATE_VALUE: March 6, 2019.
       TYPE_VALUE: GPLv2
 
-- name: Indexing CPE helper with wrong action value
+- name: Wrong action value
   description: Indexing CPE helper with wrong action value
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_helper.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_helper.py
@@ -46,7 +46,6 @@ tags:
 '''
 import os
 import pytest
-import json
 
 from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
 from wazuh_testing.tools.configuration import update_configuration_template
@@ -73,11 +72,19 @@ t2_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_cpe_in
 t2_cases_path = os.path.join(TEST_CASES_PATH, 'cases_cpe_indexing_wrong_values.yaml')
 t3_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_cpe_indexing.yaml')
 t3_cases_path = os.path.join(TEST_CASES_PATH, 'cases_cpe_indexing_missing_fields.yaml')
+t4_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_cpe_indexing.yaml')
+t4_cases_path = os.path.join(TEST_CASES_PATH, 'cases_cpe_indexing_empty_fields.yaml')
+t5_configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_cpe_indexing.yaml')
+t5_cases_path = os.path.join(TEST_CASES_PATH, 'cases_cpe_indexing_empty_vendor_version.yaml')
 
 # Custom paths
 custom_nvd_json_feed_path = os.path.join(TEST_FEEDS_PATH, 'nvd', vd.CUSTOM_NVD_FEED)
 custom_cpe_helper_path = os.path.join(TEST_FEEDS_PATH, 'cpe_helper', vd.CUSTOM_CPE_HELPER_TEMPLATE)
 custom_vulnerable_packages_path = os.path.join(TEST_PACKAGES_PATH, vd.CUSTOM_VULNERABLE_PACKAGES)
+custom_vulnerable_pkg_empty_vendor_path = os.path.join(TEST_PACKAGES_PATH,
+                                                       vd.CUSTOM_VULNERABLE_PKG_EMPTY_VENDOR)
+custom_vulnerable_pkg_empty_vendor_version_path = os.path.join(TEST_PACKAGES_PATH,
+                                                               vd.CUSTOM_VULNERABLE_PKG_EMPTY_VENDOR_VERSION)
 
 # CPE indexing packages test configurations (t1)
 t1_configuration_parameters, t1_configuration_metadata, t1_test_case_ids = get_test_cases_data(t1_cases_path)
@@ -97,6 +104,18 @@ t3_configurations = load_configuration_template(t3_configurations_path, t3_confi
                                                 t3_configuration_metadata)
 t3_systems = [metadata['system'] for metadata in t3_configuration_metadata]
 
+# CPE indexing packages test configurations (t4)
+t4_configuration_parameters, t4_configuration_metadata, t4_test_case_ids = get_test_cases_data(t4_cases_path)
+t4_configurations = load_configuration_template(t4_configurations_path, t4_configuration_parameters,
+                                                t4_configuration_metadata)
+t4_systems = [metadata['system'] for metadata in t4_configuration_metadata]
+
+# CPE indexing packages test configurations (t5)
+t5_configuration_parameters, t5_configuration_metadata, t5_test_case_ids = get_test_cases_data(t5_cases_path)
+t5_configurations = load_configuration_template(t5_configurations_path, t5_configuration_parameters,
+                                                t5_configuration_metadata)
+t5_systems = [metadata['system'] for metadata in t5_configuration_metadata]
+
 # Set offline custom feeds configuration
 t1_configurations = update_configuration_template(t1_configurations, ['CUSTOM_NVD_JSON_PATH'],
                                                   [custom_nvd_json_feed_path])
@@ -104,9 +123,19 @@ t2_configurations = update_configuration_template(t2_configurations, ['CUSTOM_NV
                                                   [custom_nvd_json_feed_path])
 t3_configurations = update_configuration_template(t3_configurations, ['CUSTOM_NVD_JSON_PATH'],
                                                   [custom_nvd_json_feed_path])
+t4_configurations = update_configuration_template(t4_configurations, ['CUSTOM_NVD_JSON_PATH'],
+                                                  [custom_nvd_json_feed_path])
+t5_configurations = update_configuration_template(t5_configurations, ['CUSTOM_NVD_JSON_PATH'],
+                                                  [custom_nvd_json_feed_path])
 
 # Global vars
-agent_packages = read_json_file(custom_vulnerable_packages_path)
+t1_agent_packages = [read_json_file(custom_vulnerable_packages_path) for metadata in t1_configuration_metadata]
+t2_agent_packages = [read_json_file(custom_vulnerable_packages_path) for metadata in t2_configuration_metadata]
+t3_agent_packages = [read_json_file(custom_vulnerable_packages_path) for metadata in t3_configuration_metadata]
+t4_agent_packages = [read_json_file(custom_vulnerable_pkg_empty_vendor_path)
+                     for metadata in t4_configuration_metadata]
+t5_agent_packages = [read_json_file(custom_vulnerable_pkg_empty_vendor_version_path)
+                     for metadata in t5_configuration_metadata]
 
 
 def replace_cpe_json_fields(tags=None, values=None):
@@ -169,22 +198,37 @@ def remove_cpe_json_fields(tags=None):
 
 
 @pytest.fixture(scope='function')
-def prepare_environment(request, metadata, agent_system, mock_agent_with_custom_system):
+def prepare_environment(request, metadata, agent_system, agent_packages, mock_agent_with_custom_system):
     """Prepare the environment with a mocked agent, vulnerable packages and a custom cpe_helper.
 
     - Mock an agent with a specified system.
     - Insert mocked vulnerables packages.
     - Update packages sync status.
     - Copy the custom CPE helper to the dictionaries folder.
+    - Force full scan.
 
     Args:
         metadata (dict): Test case metadata.
         agent_system (str): System to set to the mocked agent.
+        agent_packages (list): List of vulnerable packages
         mock_agent_with_custom_system (fixture): Mock an agent with a custom system.
     """
     for package in agent_packages:
-        agent_db.insert_package(name=package['name'], version=package['version'], source=package['name'],
-                                vendor=package['vendor'], agent_id=mock_agent_with_custom_system)
+        try:
+            version = package['version']
+        except KeyError:
+            version = ''
+        try:
+            format = package['format']
+        except KeyError:
+            format = 'rpm'
+        try:
+            architecture = package['architecture']
+        except KeyError:
+            architecture = 'x64'
+        agent_db.insert_package(name=package['name'], format=format, architecture=architecture,
+                                agent_id=mock_agent_with_custom_system, vendor=package['vendor'],
+                                version=version, source=package['name'])
 
     # Sync packages info
     agent_db.update_sync_info(agent_id=mock_agent_with_custom_system, component="syscollector-packages")
@@ -208,9 +252,11 @@ def prepare_environment(request, metadata, agent_system, mock_agent_with_custom_
     write_json_file(CPE_HELPER_PATH, cpe_helper_backup_data)
 
 
-@pytest.mark.parametrize('configuration, metadata, agent_system',
-                         zip(t1_configurations, t1_configuration_metadata, t1_systems), ids=t1_test_case_ids)
-def test_cpe_indexing_wrong_tags(configuration, metadata, agent_system, set_wazuh_configuration_vdt,
+@pytest.mark.tier(level=2)
+@pytest.mark.parametrize('configuration, metadata, agent_system, agent_packages',
+                         zip(t1_configurations, t1_configuration_metadata, t1_systems, t1_agent_packages),
+                         ids=t1_test_case_ids)
+def test_cpe_indexing_wrong_tags(configuration, metadata, agent_system, agent_packages, set_wazuh_configuration_vdt,
                                  truncate_monitored_files, clean_cve_tables_func, prepare_environment,
                                  restart_modulesd_function):
     '''
@@ -232,7 +278,7 @@ def test_cpe_indexing_wrong_tags(configuration, metadata, agent_system, set_wazu
         - Restore initial configuration, both ossec.conf and local_internal_options.conf.
         - Restore the original cpe_helper.json
 
-    wazuh_min_version: 4.4.0
+    wazuh_min_version: 4.5.0
 
     tier: 2
 
@@ -246,6 +292,9 @@ def test_cpe_indexing_wrong_tags(configuration, metadata, agent_system, set_wazu
         - agent_system:
             type: str
             brief: System to set to the mocked agent.
+        - agent_packages
+            type: list
+            brief: List of vulnerable packages.
         - set_wazuh_configuration_vdt:
             type: fixture
             brief: Set the wazuh configuration according to the configuration data.
@@ -293,9 +342,11 @@ def test_cpe_indexing_wrong_tags(configuration, metadata, agent_system, set_wazu
                 raise AttributeError('Unexpected log')
 
 
-@pytest.mark.parametrize('configuration, metadata, agent_system',
-                         zip(t2_configurations, t2_configuration_metadata, t2_systems), ids=t2_test_case_ids)
-def test_cpe_indexing_wrong_values(configuration, metadata, agent_system, set_wazuh_configuration_vdt,
+@pytest.mark.tier(level=2)
+@pytest.mark.parametrize('configuration, metadata, agent_system, agent_packages',
+                         zip(t2_configurations, t2_configuration_metadata, t2_systems, t2_agent_packages),
+                         ids=t2_test_case_ids)
+def test_cpe_indexing_wrong_values(configuration, metadata, agent_system, agent_packages, set_wazuh_configuration_vdt,
                                    truncate_monitored_files, clean_cve_tables_func, prepare_environment,
                                    restart_modulesd_function):
     '''
@@ -317,7 +368,7 @@ def test_cpe_indexing_wrong_values(configuration, metadata, agent_system, set_wa
         - Restore initial configuration, both ossec.conf and local_internal_options.conf.
         - Restore the original cpe_helper.json
 
-    wazuh_min_version: 4.4.0
+    wazuh_min_version: 4.5.0
 
     tier: 2
 
@@ -331,6 +382,9 @@ def test_cpe_indexing_wrong_values(configuration, metadata, agent_system, set_wa
         - agent_system:
             type: str
             brief: System to set to the mocked agent.
+        - agent_packages
+            type: list
+            brief: List of vulnerable packages.
         - set_wazuh_configuration_vdt:
             type: fixture
             brief: Set the wazuh configuration according to the configuration data.
@@ -378,9 +432,11 @@ def test_cpe_indexing_wrong_values(configuration, metadata, agent_system, set_wa
                 raise AttributeError('Unexpected log')
 
 
-@pytest.mark.parametrize('configuration, metadata, agent_system',
-                         zip(t3_configurations, t3_configuration_metadata, t3_systems), ids=t3_test_case_ids)
-def test_cpe_indexing_missing_field(configuration, metadata, agent_system, set_wazuh_configuration_vdt,
+@pytest.mark.tier(level=2)
+@pytest.mark.parametrize('configuration, metadata, agent_system, agent_packages',
+                         zip(t3_configurations, t3_configuration_metadata, t3_systems, t3_agent_packages),
+                         ids=t3_test_case_ids)
+def test_cpe_indexing_missing_field(configuration, metadata, agent_system, agent_packages, set_wazuh_configuration_vdt,
                                     truncate_monitored_files, clean_cve_tables_func, prepare_environment,
                                     restart_modulesd_function):
     '''
@@ -402,7 +458,7 @@ def test_cpe_indexing_missing_field(configuration, metadata, agent_system, set_w
         - Restore initial configuration, both ossec.conf and local_internal_options.conf.
         - Restore the original cpe_helper.json
 
-    wazuh_min_version: 4.4.0
+    wazuh_min_version: 4.5.0
 
     tier: 2
 
@@ -416,6 +472,9 @@ def test_cpe_indexing_missing_field(configuration, metadata, agent_system, set_w
         - agent_system:
             type: str
             brief: System to set to the mocked agent.
+        - agent_packages
+            type: list
+            brief: List of vulnerable packages.
         - set_wazuh_configuration_vdt:
             type: fixture
             brief: Set the wazuh configuration according to the configuration data.
@@ -460,3 +519,156 @@ def test_cpe_indexing_missing_field(configuration, metadata, agent_system, set_w
                 raise AttributeError('Unexpected log')
     elif expected_result == 'error_inserting_package':
         evm.check_error_inserting_package(agent_id=prepare_environment)
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata, agent_system, agent_packages',
+                         zip(t4_configurations, t4_configuration_metadata, t4_systems, t4_agent_packages),
+                         ids=t4_test_case_ids)
+def test_cpe_indexing_empty_fields(configuration, metadata, agent_system, agent_packages, set_wazuh_configuration_vdt,
+                                   truncate_monitored_files, clean_cve_tables_func, prepare_environment,
+                                   restart_modulesd_function):
+    '''
+    description: Check if the packages are indexed in the database by checking the respective log in the ossec.log file,
+                 and if the alert of the vulnerable package comes out when some tag are empty.
+
+    test_phases:
+    - setup:
+        - Load Wazuh light configuration, with custom feeds.
+        - Apply ossec.conf configuration changes according to the configuration template and use case.
+        - Apply custom settings in local_internal_options.conf.
+        - Mock an agent with Windows system and vulnerable packages.
+        - Backup the original cpe_helper.json and copy a custom CPE helper with new tags and values.
+        - Truncate wazuh logs.
+        - Restart wazuh-modulesd daemon to apply configuration changes.
+    - test:
+        - Check in the log and alert for specific information.
+    - teardown:
+        - Truncate wazuh logs.
+        - Restore initial configuration, both ossec.conf and local_internal_options.conf.
+        - Restore the original cpe_helper.json
+
+    wazuh_min_version: 4.5.0
+
+    tier: 1
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata.
+        - agent_system:
+            type: str
+            brief: System to set to the mocked agent.
+        - agent_packages
+            type: list
+            brief: List of vulnerable packages.
+        - set_wazuh_configuration_vdt:
+            type: fixture
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - clean_cve_tables_func:
+            type: fixture
+            brief: Clean all CVE tables.
+        - prepare_environment:
+            type: fixture
+            brief: Setup the initial test state.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
+
+    assertions:
+        - Check for a specific log and alert.
+
+    input_description:
+        - The `configuration_cpe_indexing.yaml` file provides the module configuration for this test.
+        - The `cases_cpe_indexing_missing_fields.yaml` file provides the test cases.
+
+    expected_output:
+        - r"The CPE .*a:{package_vendor}:{package_name}.* from the agent '{agent_id}' was indexed"
+        - fr".*"agent":."id":"{agent_id}".*{cve} affects {package}', prefix='.*"
+    '''
+    for package in agent_packages:
+        evm.check_cpe_helper_packages_indexed(package_name=metadata['values']['PRODUCT_T_VALUE_0'],
+                                              package_vendor=metadata['values']['VENDOR_T_VALUE'],
+                                              agent_id=prepare_environment, timeout=vd.T_20)
+
+        evm.check_vulnerability_affects_alert(agent_id=prepare_environment,
+                                              package=metadata['values']['PRODUCT_T_VALUE_0'], cve=package['cveid'])
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata, agent_system, agent_packages',
+                         zip(t5_configurations, t5_configuration_metadata, t5_systems, t5_agent_packages),
+                         ids=t5_test_case_ids)
+def test_cpe_indexing_empty_vendor_version(configuration, metadata, agent_system, agent_packages,
+                                           set_wazuh_configuration_vdt, truncate_monitored_files,
+                                           clean_cve_tables_func, prepare_environment, restart_modulesd_function):
+    '''
+    description: Check that when vendor and version tags are empty, and the action tag is not the correct to
+                 extract the version field, the package cannot be indexed.
+
+    test_phases:
+    - setup:
+        - Load Wazuh light configuration, with custom feeds.
+        - Apply ossec.conf configuration changes according to the configuration template and use case.
+        - Apply custom settings in local_internal_options.conf.
+        - Mock an agent with Windows system and vulnerable packages.
+        - Backup the original cpe_helper.json and copy a custom CPE helper with new tags and values.
+        - Truncate wazuh logs.
+        - Restart wazuh-modulesd daemon to apply configuration changes.
+    - test:
+        - Check in the log and alert for specific information.
+    - teardown:
+        - Truncate wazuh logs.
+        - Restore initial configuration, both ossec.conf and local_internal_options.conf.
+        - Restore the original cpe_helper.json
+
+    wazuh_min_version: 4.5.0
+
+    tier: 1
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata.
+        - agent_system:
+            type: str
+            brief: System to set to the mocked agent.
+        - agent_packages
+            type: list
+            brief: List of vulnerable packages.
+        - set_wazuh_configuration_vdt:
+            type: fixture
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - clean_cve_tables_func:
+            type: fixture
+            brief: Clean all CVE tables.
+        - prepare_environment:
+            type: fixture
+            brief: Setup the initial test state.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
+
+    assertions:
+        - Check for a specific log and alert.
+
+    input_description:
+        - The `configuration_cpe_indexing.yaml` file provides the module configuration for this test.
+        - The `cases_cpe_indexing_missing_vendor_version.yaml` file provides the test cases.
+
+    expected_output:
+        - fr"DEBUG: .* Couldn't get the version of the CPE for the {package_name} package."
+    '''
+    evm.check_version_log(package_name=metadata['values']['PRODUCT_T_VALUE_0'])


### PR DESCRIPTION
|Related issue|
|-------------|
| #3792            |

## Description

This PR adds new IT support for logcollector pre-decoder supporting timestamps with milisecond granularity. One test case has been added to the module `test_analysisd/test_predecoder_stage`.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- One test case to module `test_predecoder_stage.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
