### PR TITLE
Fix `test_set_agent_groups`

### DIFF
--- a/.github/workflows/scripts/config/yaml_linter_config.yaml
+++ b/.github/workflows/scripts/config/yaml_linter_config.yaml
@@ -12,7 +12,8 @@ rules:
   quoted-strings:
     required: only-when-needed
     quote-type: any
-    ignore: syscollector_deltas_messages.yaml #https://github.com/adrienverge/yamllint/issues/275
+    ignore: syscollector_deltas_messages.yaml # https://github.com/adrienverge/yamllint/issues/275
+    ignore: set_agent_groups.yaml
   trailing-spaces: {}
   braces:
     forbid: non-empty

--- a/.github/workflows/scripts/config/yaml_linter_config.yaml
+++ b/.github/workflows/scripts/config/yaml_linter_config.yaml
@@ -9,11 +9,9 @@ rules:
     spaces: 2
     indent-sequences: true
     check-multi-line-strings: true
-  quoted-strings:
+  quoted-strings: #https://github.com/adrienverge/yamllint/issues/275
     required: only-when-needed
     quote-type: any
-    ignore: syscollector_deltas_messages.yaml # https://github.com/adrienverge/yamllint/issues/275
-    ignore: set_agent_groups.yaml
   trailing-spaces: {}
   braces:
     forbid: non-empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix `test_set_agent_groups` ([#3920](https://github.com/wazuh/wazuh-qa/pull/3920)) \- (Tests)
 - Improve `test_assign_groups_guess` ([#3901](https://github.com/wazuh/wazuh-qa/pull/3901)) \- (Tests)
 - Update `test_cluster_worker_logs_order` test ([#3896](https://github.com/wazuh/wazuh-qa/pull/3896)) \- (Tests)
 - Fix `test_agent_groups` ([#3889](https://github.com/wazuh/wazuh-qa/pull/3889)) \- (Tests + Framework)

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -1,295 +1,338 @@
----
 -
-  name: "Group Append - Add TestGroup1"
+  name: Group Append - Add TestGroup1
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 1
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Append Empty groups - Agent has no groups - Warning - No groups added"
+  name: Group Append Empty groups - Agent has no groups - Warning - No groups added
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":\
+            []}]}"
+    output: ok
     agent_id: 2
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '002'"
     expected_group_sync_status: syncreq
 -
-  name: "Group Append Empty groups - Agent has default group - No groups affected"
+  name: Group Append Empty groups - Agent has default group - No groups affected
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"default\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\
+                \"groups\":[\"default\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":\
+            []}]}"
+    output: ok
     agent_id: 3
-    expected_group: "default"
+    expected_group: default
     expected_group_sync_status: syncreq
 -
-  name: "Group Append Add same group twice - Has only one group"
+  name: Group Append Add same group twice - Has only one group
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 4
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Append group - Agent has one group - Agent has two groups"
+  name: Group Append group - Agent has one group - Agent has two groups
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup2\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":\
+            [\"TestGroup2\"]}]}"
+    output: ok
     agent_id: 5
-    expected_group: "TestGroup1,TestGroup2"
+    expected_group: TestGroup1,TestGroup2
     expected_group_sync_status: syncreq
 -
-  name: "Group Empty-Only - Agent Has no groups. One Group is Added"
+  name: Group Empty-Only - Agent Has no groups. One Group is Added
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\
+            \"groups\":[\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 6
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Empty-Only - Agent Has one group. No new groups added"
+  name: Group Empty-Only - Agent Has one group. No new groups added
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
+            \"groups\":[\"TestGroup2\"]}]}"
+    output: ok
     agent_id: 7
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Override - Agent Has one group.  New group replaces old group"
+  name: Group Override - Agent Has one group.  New group replaces old group
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup2\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
+            \"groups\":[\"TestGroup2\"]}]}"
+    output: ok
     agent_id: 8
-    expected_group: "TestGroup2"
+    expected_group: TestGroup2
     expected_group_sync_status: syncreq
 -
-  name: "Group Override - Agent has one group - Pass no new group.  Warning - groups deleted"
+  name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
+            \"groups\":[]}]}"
+    output: ok
     agent_id: 9
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '009'"
     expected_group_sync_status: syncreq
 -
-  name: "Group Remove - Agent has one Group - Remove the group.  Agent has default assigned"
+  name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 10
-    expected_group: "default"
+    expected_group: default
     expected_group_sync_status: syncreq
 -
-  name: "Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned"
+  name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,
+                \"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 11
-    expected_group: "TestGroup2"
+    expected_group: TestGroup2
     expected_group_sync_status: syncreq
 -
-  name: "Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned "
+  name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 12
-    expected_group: "default"
+    expected_group: default
     expected_group_sync_status: syncreq
 -
-  name: "Invalid Mode - use an Invalid mode - no groups added"
+  name: Invalid Mode - use an Invalid mode - no groups added
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err Invalid mode 'wrong_mode' in set_agent_groups command"
+    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\
+            \"groups\":[\"TestGroup1\"]}]}"
+    output: err Invalid mode 'wrong_mode' in set_agent_groups command
     agent_id: 13
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "No Mode - No mode is passed - no groups affected"
+  name: No Mode - No mode is passed - no groups affected
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err Invalid mode '' in set_agent_groups command"
+    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: err Invalid mode '' in set_agent_groups command
     agent_id: 14
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned"
+  name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 15
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: synced
 -
-  name: "Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group"
+  name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\
+            \"groups\":[\"TestGroup1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 16
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned"
+  name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without data field - agent has no group assigned
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
-    output: "err An error occurred during the set of the groups"
+    output: err An error occurred during the set of the groups
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without data id field - agent has no group assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without mode field - agent has no group assigned
   test_case:
   -
     input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err Invalid JSON data, missing required fields"
+    output: err Invalid JSON data, missing required fields
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
+  name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    output: ok
     agent_id: 18
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: synced
 -
-  name: "Valid group name format - Assign a group with a '.' character"
+  name: Valid group name format - Assign a group with a '.' character
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":[\"Test.Group1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":\
+            [\"Test.Group1\"]}]}"
+    output: ok
     agent_id: 19
     expected_group: "Test.Group1"
     expected_group_sync_status: syncreq
 -
-  name: "Valid group name format - Assign a group with a '-' character"
+  name: Valid group name format - Assign a group with a '-' character
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":[\"Test-Group1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":\
+            [\"Test-Group1\"]}]}"
+    output: ok
     agent_id: 20
     expected_group: "Test-Group1"
     expected_group_sync_status: syncreq
 -
-  name: "Valid group name format - Assign a group with a '_' character"
+  name: Valid group name format - Assign a group with a '_' character
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":[\"Test_Group1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":\
+            [\"Test_Group1\"]}]}"
+    output: ok
     agent_id: 21
     expected_group: "Test_Group1"
     expected_group_sync_status: syncreq
 -
-  name: "Valid group name format - Assign a group with a long name"
+  name: Valid group name format - Assign a group with a long name
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":\
+            [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
+            cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
+            ebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
+    output: ok
     agent_id: 22
-    expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
+    expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMc\
+                     YwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxE\
+                     wgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
     expected_group_sync_status: syncreq
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":[\"Test,Group1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":\
+            [\"Test,Group1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 23
-    expected_group: "None"
+    expected_group: None
     expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":[\"TestGroup1@\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":\
+            [\"TestGroup1@\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 24
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (.) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":[\".\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":\
+            [\".\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 25
-    expected_group: "None"
+    expected_group: None
     expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (..) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":[\"..\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
+            [\"..\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 26
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (too long) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":\
+            [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
+            cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
+            ebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 27
-    expected_group: "None"
-    expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz' exceeds the maximum length of 255 characters permitted"
+    expected_group: None
+    expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741a\
+                       jntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodO\
+                       PSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScn\
+                       ISannzT8Jz' exceeds the maximum length of 255 characters permitted"
     expected_group_sync_status: synced

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -7,166 +7,188 @@
     output: "ok"
     agent_id: 1
     expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
 -
-  name: "Group Append Empty groups - Agent has no groups - No groups added"
+  name: "Group Append Empty groups - Agent has no groups - Warning - No groups added"
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
-    output: "err An error occurred during the set of the groups"
+    output: "ok"
     agent_id: 2
     expected_group: "None"
+    expected_warning: ".*WARNING: The groups were empty right after the set for agent '002'"
+    expected_group_sync_status: syncreq
 -
   name: "Group Append Empty groups - Agent has default group - No groups affected"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[\"default\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"default\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[]}]}"
     output: "ok"
-    agent_id: 2
+    agent_id: 3
     expected_group: "default"
+    expected_group_sync_status: syncreq
 -
   name: "Group Append Add same group twice - Has only one group"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
-    agent_id: 3
-    expected_group: "TestGroup1"
--
-  name: "Group Append Two groups - Agent Has two groups"
-  test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 4
+    expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
+-
+  name: "Group Append group - Agent has one group - Agent has two groups"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 5
     expected_group: "TestGroup1,TestGroup2"
+    expected_group_sync_status: syncreq
 -
   name: "Group Empty-Only - Agent Has no groups. One Group is Added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
-    agent_id: 5
-    expected_group: "TestGroup1"
--
-  name: "Group Empty-Only - Agent Has no groups. No new groups added"
-  test_case:
-  -
-    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 6
     expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
+-
+  name: "Group Empty-Only - Agent Has one group. No new groups added"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 7
+    expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
 -
   name: "Group Override - Agent Has one group.  New group replaces old group"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup2\"]}]}"
     output: "ok"
-    agent_id: 7
+    agent_id: 8
     expected_group: "TestGroup2"
+    expected_group_sync_status: syncreq
 -
-  name: "Group Override - Agent has Group - Pass no new group.  Error - groups not affected"
+  name: "Group Override - Agent has one group - Pass no new group.  Warning - groups deleted"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[]}]}"
-    output: "err An error occurred during the set of the groups"
-    agent_id: 8
-    expected_group: "TestGroup1"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[]}]}"
+    output: "ok"
+    agent_id: 9
+    expected_group: "None"
+    expected_warning: ".*WARNING: The groups were empty right after the set for agent '009'"
+    expected_group_sync_status: syncreq
 -
   name: "Group Remove - Agent has one Group - Remove the group.  Agent has default assigned"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 9
+    agent_id: 10
     expected_group: "default"
+    expected_group_sync_status: syncreq
 -
   name: "Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 10
+    agent_id: 11
     expected_group: "TestGroup2"
+    expected_group_sync_status: syncreq
 -
   name: "Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned "
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 11
+    agent_id: 12
     expected_group: "default"
+    expected_group_sync_status: syncreq
 -
   name: "Invalid Mode - use an Invalid mode - no groups added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid mode 'wrong_mode' in set_agent_groups command"
-    agent_id: 12
+    agent_id: 13
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "No Mode - No mode is passed - no groups affected"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid mode '' in set_agent_groups command"
-    agent_id: 13
+    agent_id: 14
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 14
+    agent_id: 15
     expected_group: "TestGroup1"
+    expected_group_sync_status: synced
 -
   name: "Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 15
+    agent_id: 16
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":016}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
   test_case:
@@ -175,6 +197,7 @@
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
   test_case:
@@ -183,27 +206,90 @@
     output: "ok"
     agent_id: 18
     expected_group: "TestGroup1"
+    expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '.' character)"
+  name: "Valid group name format - Assign a group with a '.' character"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"Test.Group1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":[\"Test.Group1\"]}]}"
     output: "ok"
     agent_id: 19
-    expected_group: "None"
+    expected_group: "Test.Group1"
+    expected_group_sync_status: syncreq
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid ',' character)"
+  name: "Valid group name format - Assign a group with a '-' character"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"Test,Group1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":[\"Test-Group1\"]}]}"
+    output: "ok"
     agent_id: 20
-    expected_group: "None"
+    expected_group: "Test-Group1"
+    expected_group_sync_status: syncreq
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '@' character)"
+  name: "Valid group name format - Assign a group with a '_' character"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1@\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":[\"Test_Group1\"]}]}"
+    output: "ok"
     agent_id: 21
+    expected_group: "Test_Group1"
+    expected_group_sync_status: syncreq
+-
+  name: "Valid group name format - Assign a group with a long name"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
+    output: "ok"
+    agent_id: 22
+    expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
+    expected_group_sync_status: syncreq
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":[\"Test,Group1\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 23
     expected_group: "None"
+    expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":[\"TestGroup1@\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 24
+    expected_group: "None"
+    expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (.) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":[\".\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 25
+    expected_group: "None"
+    expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (..) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":[\"..\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 26
+    expected_group: "None"
+    expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (too long) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 27
+    expected_group: "None"
+    expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz' exceeds the maximum length of 255 characters permitted"
+    expected_group_sync_status: synced

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -1,17 +1,14 @@
--
-  name: Group Append - Add TestGroup1
+- name: Group Append - Add TestGroup1
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: ok
     agent_id: 1
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Append Empty groups - Agent has no groups - Warning - No groups added
+
+- name: Group Append Empty groups - Agent has no groups - Warning - No groups added
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":\
             []}]}"
     output: ok
@@ -19,10 +16,9 @@
     expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '002'"
     expected_group_sync_status: syncreq
--
-  name: Group Append Empty groups - Agent has default group - No groups affected
+
+- name: Group Append Empty groups - Agent has default group - No groups affected
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\
                 \"groups\":[\"default\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":\
@@ -31,10 +27,9 @@
     agent_id: 3
     expected_group: default
     expected_group_sync_status: syncreq
--
-  name: Group Append Add same group twice - Has only one group
+
+- name: Group Append Add same group twice - Has only one group
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":\
@@ -43,10 +38,9 @@
     agent_id: 4
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Append group - Agent has one group - Agent has two groups
+
+- name: Group Append group - Agent has one group - Agent has two groups
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":\
@@ -55,20 +49,18 @@
     agent_id: 5
     expected_group: TestGroup1,TestGroup2
     expected_group_sync_status: syncreq
--
-  name: Group Empty-Only - Agent Has no groups. One Group is Added
+
+- name: Group Empty-Only - Agent Has no groups. One Group is Added
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: ok
     agent_id: 6
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Empty-Only - Agent Has one group. No new groups added
+
+- name: Group Empty-Only - Agent Has one group. No new groups added
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
@@ -77,10 +69,9 @@
     agent_id: 7
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Override - Agent Has one group.  New group replaces old group
+
+- name: Group Override - Agent Has one group.  New group replaces old group
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
@@ -89,10 +80,9 @@
     agent_id: 8
     expected_group: TestGroup2
     expected_group_sync_status: syncreq
--
-  name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
+
+- name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
@@ -102,10 +92,9 @@
     expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '009'"
     expected_group_sync_status: syncreq
--
-  name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
+
+- name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":\
@@ -114,10 +103,9 @@
     agent_id: 10
     expected_group: default
     expected_group_sync_status: syncreq
--
-  name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
+
+- name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,
                 \"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":
@@ -126,146 +114,131 @@
     agent_id: 11
     expected_group: TestGroup2
     expected_group_sync_status: syncreq
--
-  name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
+
+- name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":
             [\"TestGroup1\"]}]}"
     output: ok
     agent_id: 12
     expected_group: default
     expected_group_sync_status: syncreq
--
-  name: Invalid Mode - use an Invalid mode - no groups added
+
+- name: Invalid Mode - use an Invalid mode - no groups added
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: err Invalid mode 'wrong_mode' in set_agent_groups command
     agent_id: 13
     expected_group: None
     expected_group_sync_status: synced
--
-  name: No Mode - No mode is passed - no groups affected
+
+- name: No Mode - No mode is passed - no groups affected
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err Invalid mode '' in set_agent_groups command
     agent_id: 14
     expected_group: None
     expected_group_sync_status: synced
--
-  name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
+
+- name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: ok
     agent_id: 15
     expected_group: TestGroup1
     expected_group_sync_status: synced
--
-  name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
+
+- name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
     agent_id: 16
     expected_group: None
     expected_group_sync_status: synced
--
-  name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
+
+- name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without data field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without data field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
     output: err An error occurred during the set of the groups
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without data id field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without data id field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without mode field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without mode field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
     output: err Invalid JSON data, missing required fields
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
+
+- name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
     output: ok
     agent_id: 18
     expected_group: TestGroup1
     expected_group_sync_status: synced
--
-  name: Valid group name format - Assign a group with a '.' character
+
+- name: Valid group name format - Assign a group with a '.' character
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":\
             [\"Test.Group1\"]}]}"
     output: ok
     agent_id: 19
     expected_group: "Test.Group1"
     expected_group_sync_status: syncreq
--
-  name: Valid group name format - Assign a group with a '-' character
+
+- name: Valid group name format - Assign a group with a '-' character
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":\
             [\"Test-Group1\"]}]}"
     output: ok
     agent_id: 20
     expected_group: "Test-Group1"
     expected_group_sync_status: syncreq
--
-  name: Valid group name format - Assign a group with a '_' character
+
+- name: Valid group name format - Assign a group with a '_' character
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":\
             [\"Test_Group1\"]}]}"
     output: ok
     agent_id: 21
     expected_group: "Test_Group1"
     expected_group_sync_status: syncreq
--
-  name: Valid group name format - Assign a group with a long name
+
+- name: Valid group name format - Assign a group with a long name
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
@@ -276,10 +249,9 @@
                      YwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxE\
                      wgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
     expected_group_sync_status: syncreq
--
-  name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":\
             [\"Test,Group1\"]}]}"
     output: err An error occurred during the set of the groups
@@ -287,10 +259,9 @@
     expected_group: None
     expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":\
             [\"TestGroup1@\"]}]}"
     output: err An error occurred during the set of the groups
@@ -298,10 +269,9 @@
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":\
             [\".\"]}]}"
     output: err An error occurred during the set of the groups
@@ -309,10 +279,9 @@
     expected_group: None
     expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
             [\"..\"]}]}"
     output: err An error occurred during the set of the groups
@@ -320,10 +289,9 @@
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\

--- a/tests/integration/test_wazuh_db/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups.py
@@ -55,7 +55,9 @@ tags:
 import os
 import time
 import pytest
-import yaml
+
+import wazuh_testing as fw
+from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db
 from wazuh_testing.tools.services import delete_dbs
@@ -73,10 +75,10 @@ log_monitor_paths = []
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
 receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
 monitored_sockets_params = [('wazuh-db', None, True)]
-receiver_sockets= None  # Set in the fixtures
+receiver_sockets = None  # Set in the fixtures
 
 
-#Fixtures
+# Fixtures
 @pytest.fixture(scope='module')
 def remove_database(request):
     yield
@@ -92,8 +94,8 @@ def remove_database(request):
                          )
 def test_set_agent_groups(remove_database, configure_sockets_environment, connect_to_sockets_module, test_case):
     '''
-    description: Check that every input message using the 'set_agent_groups' command in wazuh-db socket generates 
-                 the proper output to wazuh-db socket. To do this, it performs a query to the socket with a command 
+    description: Check that every input message using the 'set_agent_groups' command in wazuh-db socket generates
+                 the proper output to wazuh-db socket. To do this, it performs a query to the socket with a command
                  taken from the list of test_cases's 'input' field, and compare the result with the test_case's
                  'output' and 'expected_group' fields.
 
@@ -118,7 +120,7 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
         - Verify that the agent has the expected_group assigned.
 
     input_description:
-        - Test cases are defined in the set_agent_groups.yaml file. This file contains the command to insert the agentes
+        - Test cases are defined in the set_agent_groups.yaml file. This file contains the command to insert the agents
           groups, with different modes and combinations, as well as the expected outputs and results.
 
     expected_output:
@@ -133,23 +135,31 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
 
     case_data = test_case[0]
     output = case_data["output"]
-    agent_id= case_data["agent_id"]
+    agent_id = case_data["agent_id"]
 
     # Insert test Agent
-    response = insert_agent_in_db(id=agent_id, connection_status="disconnected", registration_time=str(time.time()))
-    
+    response = insert_agent_in_db(id=agent_id, connection_status='disconnected', registration_time=str(time.time()))
+
     # Apply preconditions
     if 'pre_input' in case_data:
         query_wdb(case_data['pre_input'])
-    
+
     # Add tested group
     response = query_wdb(case_data["input"])
 
     # validate output
     assert response == output, f"Assertion Error - expected {output}, but got {response}"
 
+    # Check warnings
+    if 'expected_warning' in case_data:
+        callback = case_data['expected_warning']
+        evm.check_event(callback=callback, file_to_monitor=fw.LOG_FILE_PATH, timeout=20).result()
+
     # get agent data and validate agent's groups
     response = query_wdb(f'global get-agent-info {agent_id}')
+
+    assert case_data['expected_group_sync_status'] == response[0]['group_sync_status']
+
     if case_data["expected_group"] == 'None':
         assert 'group' not in response[0], "Agent has groups data and it was expecting no group data"
     else:

--- a/tests/integration/test_wazuh_db/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups.py
@@ -132,35 +132,33 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
         - wazuh_db
         - wdb_socket
     '''
-
-    case_data = test_case[0]
-    output = case_data["output"]
-    agent_id = case_data["agent_id"]
+    output = test_case['output']
+    agent_id = test_case['agent_id']
 
     # Insert test Agent
     response = insert_agent_in_db(id=agent_id, connection_status='disconnected', registration_time=str(time.time()))
 
     # Apply preconditions
-    if 'pre_input' in case_data:
-        query_wdb(case_data['pre_input'])
+    if 'pre_input' in test_case:
+        query_wdb(test_case['pre_input'])
 
     # Add tested group
-    response = query_wdb(case_data["input"])
+    response = query_wdb(test_case["input"])
 
     # validate output
     assert response == output, f"Assertion Error - expected {output}, but got {response}"
 
     # Check warnings
-    if 'expected_warning' in case_data:
-        callback = case_data['expected_warning']
+    if 'expected_warning' in test_case:
+        callback = test_case['expected_warning']
         evm.check_event(callback=callback, file_to_monitor=fw.LOG_FILE_PATH, timeout=20).result()
 
     # get agent data and validate agent's groups
     response = query_wdb(f'global get-agent-info {agent_id}')
 
-    assert case_data['expected_group_sync_status'] == response[0]['group_sync_status']
+    assert test_case['expected_group_sync_status'] == response[0]['group_sync_status']
 
-    if case_data["expected_group"] == 'None':
+    if test_case["expected_group"] == 'None':
         assert 'group' not in response[0], "Agent has groups data and it was expecting no group data"
     else:
-        assert case_data["expected_group"] == response[0]['group'], "Did not receive the expected groups in the agent."
+        assert test_case["expected_group"] == response[0]['group'], "Did not receive the expected groups in the agent."


### PR DESCRIPTION
|Related issue|
|-------------|
|    #3902         |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Added test cases for valid and invalid group names in `set_agent_groups.yaml`
- Added check of `group_sync_status`

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Updated failing test cases in `set_agent_groups.yaml`


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @juliamagan (Developer)  |     `test_wazuh_db/`      | [🟡 ](https://ci.wazuh.info/job/Test_integration/36521/)[🟡 ](https://ci.wazuh.info/job/Test_integration/36522/)[🟡 ](https://ci.wazuh.info/job/Test_integration/36523/) | [🟡 ](https://github.com/wazuh/wazuh-qa/files/10696834/R3_test_assign_groups_guess.zip)[🟡 ](https://github.com/wazuh/wazuh-qa/files/10696835/R2_test_assign_groups_guess.zip)[🟡 ](https://github.com/wazuh/wazuh-qa/files/10696836/R1_test_assign_groups_guess.zip)|     CentOS    |    e69fa1d    | Expected error due to  [#3890](https://github.com/wazuh/wazuh-qa/pull/3895#issuecomment-1418914180) |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


