### PR TITLE
Fix wazuh-db integration tests for agent-groups 

### DIFF
--- a/.github/workflows/scripts/config/yaml_linter_config.yaml
+++ b/.github/workflows/scripts/config/yaml_linter_config.yaml
@@ -12,7 +12,8 @@ rules:
   quoted-strings:
     required: only-when-needed
     quote-type: any
-    ignore: syscollector_deltas_messages.yaml #https://github.com/adrienverge/yamllint/issues/275
+    ignore: syscollector_deltas_messages.yaml # https://github.com/adrienverge/yamllint/issues/275
+    ignore: set_agent_groups.yaml
   trailing-spaces: {}
   braces:
     forbid: non-empty

--- a/.github/workflows/scripts/config/yaml_linter_config.yaml
+++ b/.github/workflows/scripts/config/yaml_linter_config.yaml
@@ -9,11 +9,9 @@ rules:
     spaces: 2
     indent-sequences: true
     check-multi-line-strings: true
-  quoted-strings:
+  quoted-strings: #https://github.com/adrienverge/yamllint/issues/275
     required: only-when-needed
     quote-type: any
-    ignore: syscollector_deltas_messages.yaml # https://github.com/adrienverge/yamllint/issues/275
-    ignore: set_agent_groups.yaml
   trailing-spaces: {}
   braces:
     forbid: non-empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix wazuh-db integration tests for agent-groups ([#3926](https://github.com/wazuh/wazuh-qa/pull/3926)) \- (Tests + Framework)
 - Fix `test_set_agent_groups` ([#3920](https://github.com/wazuh/wazuh-qa/pull/3920)) \- (Tests)
 - Improve `test_assign_groups_guess` ([#3901](https://github.com/wazuh/wazuh-qa/pull/3901)) \- (Tests)
 - Update `test_cluster_worker_logs_order` test ([#3896](https://github.com/wazuh/wazuh-qa/pull/3896)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix `test_set_agent_groups` ([#3920](https://github.com/wazuh/wazuh-qa/pull/3920)) \- (Tests)
 - Improve `test_assign_groups_guess` ([#3901](https://github.com/wazuh/wazuh-qa/pull/3901)) \- (Tests)
 - Update `test_cluster_worker_logs_order` test ([#3896](https://github.com/wazuh/wazuh-qa/pull/3896)) \- (Tests)
 - Fix `test_agent_groups` ([#3889](https://github.com/wazuh/wazuh-qa/pull/3889)) \- (Tests + Framework)

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -43,8 +43,28 @@ def remove_all_agents(remove_type):
 
 
 def create_group(group):
+    """Create group with /var/ossec/bin/agent_groups
+
+    Args:
+        group (str): Group name
+
+    Returns:
+        result(str): Return code
+    """
     result = subprocess.run([f'{WAZUH_PATH}/bin/agent_groups', '-a', '-q', '-g', f'{group}']).returncode
+
+    return result
 
 
 def delete_group(group):
+    """Delete group with /var/ossec/bin/agent_groups
+
+    Args:
+        group (str): Group name
+
+    Returns:
+        result(str): Return code
+    """
     result = subprocess.run([f'{WAZUH_PATH}/bin/agent_groups', '-r', '-q', '-g', f'{group}']).returncode
+
+    return result

--- a/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/wazuh_manager.py
@@ -40,3 +40,11 @@ def remove_agents(agents_id, remove_type='wazuhdb'):
 
 def remove_all_agents(remove_type):
     remove_agents(list_agents_ids(), remove_type)
+
+
+def create_group(group):
+    result = subprocess.run([f'{WAZUH_PATH}/bin/agent_groups', '-a', '-q', '-g', f'{group}']).returncode
+
+
+def delete_group(group):
+    result = subprocess.run([f'{WAZUH_PATH}/bin/agent_groups', '-r', '-q', '-g', f'{group}']).returncode

--- a/tests/integration/test_wazuh_db/conftest.py
+++ b/tests/integration/test_wazuh_db/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+from wazuh_testing.tools.wazuh_manager import create_group, delete_group
+
+
+@pytest.fixture(scope='function')
+def create_groups(test_case):
+    if 'pre_required_group' in test_case:
+        groups = test_case['pre_required_group'].split(',')
+
+        for group in groups:
+            create_group(group)
+
+    yield
+
+    if 'pre_required_group' in test_case:
+        groups = test_case['pre_required_group'].split(',')
+
+        for group in groups:
+            delete_group(group)

--- a/tests/integration/test_wazuh_db/data/global/get_groups_integrity_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global/get_groups_integrity_messages.yaml
@@ -1,61 +1,58 @@
----
--
-  name: "No Agents Registered - No Hash - Error"
+- name: "No Agents Registered - No Hash - Error"
   test_case:
-  -
     output: "'hash': None"
     no_hash: True
     agent_ids: []
     agent_status: []
--
-  name: "Two Agents Registered - Valid Hash - Both Synced => Synced"
+
+- name: "Two Agents Registered - Valid Hash - Both Synced => Synced"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: synced
     agent_ids: [1,2]
     agent_status: ["synced", "synced"]
--
-  name: "Two Agents Registered - Valid Hash - Both Syncreq => Syncreq"
+
+- name: "Two Agents Registered - Valid Hash - Both Syncreq => Syncreq"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: syncreq
     agent_ids: [1,2]
     agent_status: ["syncreq", "syncreq"]
--
-  name: "Two Agents Registered - Valid Hash - Syncreq and Synced => Syncreq"
+
+- name: "Two Agents Registered - Valid Hash - Syncreq and Synced => Syncreq"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: syncreq
     agent_ids: [1,2]
     agent_status: ["synced", "syncreq"]
--
-  name: "Two Agents Registered - Invalid Hash length. => error hash Less than 40 chars"
+
+- name: "Two Agents Registered - Invalid Hash length. => error hash Less than 40 chars"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: err Hash hex-digest does not have the expected length. Expected (40) got (14)
     invalid_hash: "invalidhash123"
     agent_ids: [1,2]
     agent_status: ["synced", "syncreq"]
--
-  name: "Two Agents Registered - Hash param Empty. => error hash Less than 40 chars"
+
+- name: "Two Agents Registered - Hash param Empty. => error hash Less than 40 chars"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: err Hash hex-digest does not have the expected length. Expected (40) got (0)
     invalid_hash: ""
     agent_ids: [1,2]
     agent_status: ["synced", "syncreq"]
--
-  name: "Two Agents Registered - Both Synced - Hash does not match DB Hash => hash_mismatch"
+
+- name: "Two Agents Registered - Both Synced - Hash does not match DB Hash => hash_mismatch"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: hash_mismatch
     invalid_hash: "invalidhash1invalidhash1invalidhash13456"
     agent_ids: [1,2]
     agent_status: ["synced", "synced"]
--
-  name: "Two Agents Registered - Syncreq - Hash does not match DB Hash => syncreq"
+
+- name: "Two Agents Registered - Syncreq - Hash does not match DB Hash => syncreq"
   test_case:
-  -
+    pre_required_group: Test_group1,Test_group2
     output: syncreq
     invalid_hash: "invalidhash1invalidhash1invalidhash13456"
     agent_ids: [1,2]

--- a/tests/integration/test_wazuh_db/data/global/get_groups_integrity_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/global/get_groups_integrity_messages.yaml
@@ -1,59 +1,87 @@
-- name: "No Agents Registered - No Hash - Error"
+- name: No Agents Registered - No Hash - Error
   test_case:
     output: "'hash': None"
-    no_hash: True
+    no_hash: true
     agent_ids: []
     agent_status: []
 
-- name: "Two Agents Registered - Valid Hash - Both Synced => Synced"
+- name: Two Agents Registered - Valid Hash - Both Synced => Synced
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: synced
-    agent_ids: [1,2]
-    agent_status: ["synced", "synced"]
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - synced
+      - synced
 
-- name: "Two Agents Registered - Valid Hash - Both Syncreq => Syncreq"
+- name: Two Agents Registered - Valid Hash - Both Syncreq => Syncreq
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: syncreq
-    agent_ids: [1,2]
-    agent_status: ["syncreq", "syncreq"]
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - syncreq
+      - syncreq
 
-- name: "Two Agents Registered - Valid Hash - Syncreq and Synced => Syncreq"
+- name: Two Agents Registered - Valid Hash - Syncreq and Synced => Syncreq
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: syncreq
-    agent_ids: [1,2]
-    agent_status: ["synced", "syncreq"]
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - synced
+      - syncreq
 
-- name: "Two Agents Registered - Invalid Hash length. => error hash Less than 40 chars"
+- name: Two Agents Registered - Invalid Hash length. => error hash Less than 40 chars
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: err Hash hex-digest does not have the expected length. Expected (40) got (14)
-    invalid_hash: "invalidhash123"
-    agent_ids: [1,2]
-    agent_status: ["synced", "syncreq"]
+    invalid_hash: invalidhash123
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - synced
+      - syncreq
 
-- name: "Two Agents Registered - Hash param Empty. => error hash Less than 40 chars"
+- name: Two Agents Registered - Hash param Empty. => error hash Less than 40 chars
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: err Hash hex-digest does not have the expected length. Expected (40) got (0)
     invalid_hash: ""
-    agent_ids: [1,2]
-    agent_status: ["synced", "syncreq"]
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - synced
+      - syncreq
 
-- name: "Two Agents Registered - Both Synced - Hash does not match DB Hash => hash_mismatch"
+- name: Two Agents Registered - Both Synced - Hash does not match DB Hash => hash_mismatch
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: hash_mismatch
-    invalid_hash: "invalidhash1invalidhash1invalidhash13456"
-    agent_ids: [1,2]
-    agent_status: ["synced", "synced"]
+    invalid_hash: invalidhash1invalidhash1invalidhash13456
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - synced
+      - synced
 
-- name: "Two Agents Registered - Syncreq - Hash does not match DB Hash => syncreq"
+- name: Two Agents Registered - Syncreq - Hash does not match DB Hash => syncreq
   test_case:
     pre_required_group: Test_group1,Test_group2
     output: syncreq
-    invalid_hash: "invalidhash1invalidhash1invalidhash13456"
-    agent_ids: [1,2]
-    agent_status: ["synced", "syncreq"]
+    invalid_hash: invalidhash1invalidhash1invalidhash13456
+    agent_ids:
+      - 1
+      - 2
+    agent_status:
+      - synced
+      - syncreq

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -1,295 +1,338 @@
----
 -
-  name: "Group Append - Add TestGroup1"
+  name: Group Append - Add TestGroup1
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 1
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Append Empty groups - Agent has no groups - Warning - No groups added"
+  name: Group Append Empty groups - Agent has no groups - Warning - No groups added
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":\
+            []}]}"
+    output: ok
     agent_id: 2
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '002'"
     expected_group_sync_status: syncreq
 -
-  name: "Group Append Empty groups - Agent has default group - No groups affected"
+  name: Group Append Empty groups - Agent has default group - No groups affected
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"default\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\
+                \"groups\":[\"default\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":\
+            []}]}"
+    output: ok
     agent_id: 3
-    expected_group: "default"
+    expected_group: default
     expected_group_sync_status: syncreq
 -
-  name: "Group Append Add same group twice - Has only one group"
+  name: Group Append Add same group twice - Has only one group
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 4
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Append group - Agent has one group - Agent has two groups"
+  name: Group Append group - Agent has one group - Agent has two groups
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup2\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":\
+            [\"TestGroup2\"]}]}"
+    output: ok
     agent_id: 5
-    expected_group: "TestGroup1,TestGroup2"
+    expected_group: TestGroup1,TestGroup2
     expected_group_sync_status: syncreq
 -
-  name: "Group Empty-Only - Agent Has no groups. One Group is Added"
+  name: Group Empty-Only - Agent Has no groups. One Group is Added
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\
+            \"groups\":[\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 6
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Empty-Only - Agent Has one group. No new groups added"
+  name: Group Empty-Only - Agent Has one group. No new groups added
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
+            \"groups\":[\"TestGroup2\"]}]}"
+    output: ok
     agent_id: 7
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: syncreq
 -
-  name: "Group Override - Agent Has one group.  New group replaces old group"
+  name: Group Override - Agent Has one group.  New group replaces old group
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup2\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
+            \"groups\":[\"TestGroup2\"]}]}"
+    output: ok
     agent_id: 8
-    expected_group: "TestGroup2"
+    expected_group: TestGroup2
     expected_group_sync_status: syncreq
 -
-  name: "Group Override - Agent has one group - Pass no new group.  Warning - groups deleted"
+  name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
+            \"groups\":[]}]}"
+    output: ok
     agent_id: 9
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '009'"
     expected_group_sync_status: syncreq
 -
-  name: "Group Remove - Agent has one Group - Remove the group.  Agent has default assigned"
+  name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\
+                \"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 10
-    expected_group: "default"
+    expected_group: default
     expected_group_sync_status: syncreq
 -
-  name: "Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned"
+  name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,
+                \"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 11
-    expected_group: "TestGroup2"
+    expected_group: TestGroup2
     expected_group_sync_status: syncreq
 -
-  name: "Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned "
+  name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 12
-    expected_group: "default"
+    expected_group: default
     expected_group_sync_status: syncreq
 -
-  name: "Invalid Mode - use an Invalid mode - no groups added"
+  name: Invalid Mode - use an Invalid mode - no groups added
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err Invalid mode 'wrong_mode' in set_agent_groups command"
+    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\
+            \"groups\":[\"TestGroup1\"]}]}"
+    output: err Invalid mode 'wrong_mode' in set_agent_groups command
     agent_id: 13
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "No Mode - No mode is passed - no groups affected"
+  name: No Mode - No mode is passed - no groups affected
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err Invalid mode '' in set_agent_groups command"
+    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: err Invalid mode '' in set_agent_groups command
     agent_id: 14
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned"
+  name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: ok
     agent_id: 15
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: synced
 -
-  name: "Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group"
+  name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\
+            \"groups\":[\"TestGroup1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 16
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned"
+  name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without data field - agent has no group assigned
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
-    output: "err An error occurred during the set of the groups"
+    output: err An error occurred during the set of the groups
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without data id field - agent has no group assigned
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":\
+            [\"TestGroup1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
+  name: Missing Fields - Assign a group using without mode field - agent has no group assigned
   test_case:
   -
     input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
-    output: "err Invalid JSON data, missing required fields"
+    output: err Invalid JSON data, missing required fields
     agent_id: 17
-    expected_group: "None"
+    expected_group: None
     expected_group_sync_status: synced
 -
-  name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
+  name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
+    output: ok
     agent_id: 18
-    expected_group: "TestGroup1"
+    expected_group: TestGroup1
     expected_group_sync_status: synced
 -
-  name: "Valid group name format - Assign a group with a '.' character"
+  name: Valid group name format - Assign a group with a '.' character
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":[\"Test.Group1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":\
+            [\"Test.Group1\"]}]}"
+    output: ok
     agent_id: 19
     expected_group: "Test.Group1"
     expected_group_sync_status: syncreq
 -
-  name: "Valid group name format - Assign a group with a '-' character"
+  name: Valid group name format - Assign a group with a '-' character
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":[\"Test-Group1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":\
+            [\"Test-Group1\"]}]}"
+    output: ok
     agent_id: 20
     expected_group: "Test-Group1"
     expected_group_sync_status: syncreq
 -
-  name: "Valid group name format - Assign a group with a '_' character"
+  name: Valid group name format - Assign a group with a '_' character
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":[\"Test_Group1\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":\
+            [\"Test_Group1\"]}]}"
+    output: ok
     agent_id: 21
     expected_group: "Test_Group1"
     expected_group_sync_status: syncreq
 -
-  name: "Valid group name format - Assign a group with a long name"
+  name: Valid group name format - Assign a group with a long name
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
-    output: "ok"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":\
+            [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
+            cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
+            ebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
+    output: ok
     agent_id: 22
-    expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
+    expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMc\
+                     YwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxE\
+                     wgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
     expected_group_sync_status: syncreq
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":[\"Test,Group1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":\
+            [\"Test,Group1\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 23
-    expected_group: "None"
+    expected_group: None
     expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":[\"TestGroup1@\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":\
+            [\"TestGroup1@\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 24
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (.) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":[\".\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":\
+            [\".\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 25
-    expected_group: "None"
+    expected_group: None
     expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (..) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":[\"..\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
+            [\"..\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 26
-    expected_group: "None"
+    expected_group: None
     expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
     expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (too long) - Warning"
+  name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":\
+            [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
+            cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
+            ebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
+    output: err An error occurred during the set of the groups
     agent_id: 27
-    expected_group: "None"
-    expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz' exceeds the maximum length of 255 characters permitted"
+    expected_group: None
+    expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741a\
+                       jntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodO\
+                       PSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScn\
+                       ISannzT8Jz' exceeds the maximum length of 255 characters permitted"
     expected_group_sync_status: synced

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -7,166 +7,188 @@
     output: "ok"
     agent_id: 1
     expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
 -
-  name: "Group Append Empty groups - Agent has no groups - No groups added"
+  name: "Group Append Empty groups - Agent has no groups - Warning - No groups added"
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
-    output: "err An error occurred during the set of the groups"
+    output: "ok"
     agent_id: 2
     expected_group: "None"
+    expected_warning: ".*WARNING: The groups were empty right after the set for agent '002'"
+    expected_group_sync_status: syncreq
 -
   name: "Group Append Empty groups - Agent has default group - No groups affected"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[\"default\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":[]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"default\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[]}]}"
     output: "ok"
-    agent_id: 2
+    agent_id: 3
     expected_group: "default"
+    expected_group_sync_status: syncreq
 -
   name: "Group Append Add same group twice - Has only one group"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
-    agent_id: 3
-    expected_group: "TestGroup1"
--
-  name: "Group Append Two groups - Agent Has two groups"
-  test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 4
+    expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
+-
+  name: "Group Append group - Agent has one group - Agent has two groups"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 5
     expected_group: "TestGroup1,TestGroup2"
+    expected_group_sync_status: syncreq
 -
   name: "Group Empty-Only - Agent Has no groups. One Group is Added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":[\"TestGroup1\"]}]}"
-    output: "ok"
-    agent_id: 5
-    expected_group: "TestGroup1"
--
-  name: "Group Empty-Only - Agent Has no groups. No new groups added"
-  test_case:
-  -
-    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
     agent_id: 6
     expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
+-
+  name: "Group Empty-Only - Agent Has one group. No new groups added"
+  test_case:
+  -
+    pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
+    output: "ok"
+    agent_id: 7
+    expected_group: "TestGroup1"
+    expected_group_sync_status: syncreq
 -
   name: "Group Override - Agent Has one group.  New group replaces old group"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\"groups\":[\"TestGroup2\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup2\"]}]}"
     output: "ok"
-    agent_id: 7
+    agent_id: 8
     expected_group: "TestGroup2"
+    expected_group_sync_status: syncreq
 -
-  name: "Group Override - Agent has Group - Pass no new group.  Error - groups not affected"
+  name: "Group Override - Agent has one group - Pass no new group.  Warning - groups deleted"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\"groups\":[]}]}"
-    output: "err An error occurred during the set of the groups"
-    agent_id: 8
-    expected_group: "TestGroup1"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[]}]}"
+    output: "ok"
+    agent_id: 9
+    expected_group: "None"
+    expected_warning: ".*WARNING: The groups were empty right after the set for agent '009'"
+    expected_group_sync_status: syncreq
 -
   name: "Group Remove - Agent has one Group - Remove the group.  Agent has default assigned"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 9
+    agent_id: 10
     expected_group: "default"
+    expected_group_sync_status: syncreq
 -
   name: "Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned"
   test_case:
   -
-    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":[\"TestGroup1\"]}]}"
+    pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 10
+    agent_id: 11
     expected_group: "TestGroup2"
+    expected_group_sync_status: syncreq
 -
   name: "Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned "
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 11
+    agent_id: 12
     expected_group: "default"
+    expected_group_sync_status: syncreq
 -
   name: "Invalid Mode - use an Invalid mode - no groups added"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid mode 'wrong_mode' in set_agent_groups command"
-    agent_id: 12
+    agent_id: 13
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "No Mode - No mode is passed - no groups affected"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
     output: "err Invalid mode '' in set_agent_groups command"
-    agent_id: 13
+    agent_id: 14
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":014,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
     output: "ok"
-    agent_id: 14
+    agent_id: 15
     expected_group: "TestGroup1"
+    expected_group_sync_status: synced
 -
   name: "Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":015,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 15
+    agent_id: 16
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":016,\"groups\":[\"TestGroup1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without data field - agent has no group assigned"
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without data groups field - agent has no group assigned"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":016}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without data id field - agent has no group assigned"
   test_case:
   -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":[\"TestGroup1\"]}]}"
     output: "err An error occurred during the set of the groups"
-    agent_id: 16
+    agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without mode field - agent has no group assigned"
   test_case:
@@ -175,6 +197,7 @@
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
     expected_group: "None"
+    expected_group_sync_status: synced
 -
   name: "Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned"
   test_case:
@@ -183,27 +206,90 @@
     output: "ok"
     agent_id: 18
     expected_group: "TestGroup1"
+    expected_group_sync_status: synced
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '.' character)"
+  name: "Valid group name format - Assign a group with a '.' character"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"Test.Group1\"]}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":[\"Test.Group1\"]}]}"
     output: "ok"
     agent_id: 19
-    expected_group: "None"
+    expected_group: "Test.Group1"
+    expected_group_sync_status: syncreq
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid ',' character)"
+  name: "Valid group name format - Assign a group with a '-' character"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"Test,Group1\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":[\"Test-Group1\"]}]}"
+    output: "ok"
     agent_id: 20
-    expected_group: "None"
+    expected_group: "Test-Group1"
+    expected_group_sync_status: syncreq
 -
-  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '@' character)"
+  name: "Valid group name format - Assign a group with a '_' character"
   test_case:
   -
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":[\"TestGroup1@\"]}]}"
-    output: "err An error occurred during the set of the groups"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":[\"Test_Group1\"]}]}"
+    output: "ok"
     agent_id: 21
+    expected_group: "Test_Group1"
+    expected_group_sync_status: syncreq
+-
+  name: "Valid group name format - Assign a group with a long name"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
+    output: "ok"
+    agent_id: 22
+    expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
+    expected_group_sync_status: syncreq
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":[\"Test,Group1\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 23
     expected_group: "None"
+    expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":[\"TestGroup1@\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 24
+    expected_group: "None"
+    expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (.) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":[\".\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 25
+    expected_group: "None"
+    expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (..) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":[\"..\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 26
+    expected_group: "None"
+    expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
+    expected_group_sync_status: synced
+-
+  name: "Wrong group name format - Assign a group with an invalid group name (too long) - Warning"
+  test_case:
+  -
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":[\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
+    output: "err An error occurred during the set of the groups"
+    agent_id: 27
+    expected_group: "None"
+    expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz' exceeds the maximum length of 255 characters permitted"
+    expected_group_sync_status: synced

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -261,8 +261,8 @@
 - name: Valid group name format - Assign a group with a long name
   test_case:
     pre_required_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG\
-                        3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2\
-                        wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
+                         3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH\
+                         2wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -1,17 +1,14 @@
--
-  name: Group Append - Add TestGroup1
+- name: Group Append - Add TestGroup1
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: ok
     agent_id: 1
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Append Empty groups - Agent has no groups - Warning - No groups added
+
+- name: Group Append Empty groups - Agent has no groups - Warning - No groups added
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":002,\"groups\":\
             []}]}"
     output: ok
@@ -19,10 +16,9 @@
     expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '002'"
     expected_group_sync_status: syncreq
--
-  name: Group Append Empty groups - Agent has default group - No groups affected
+
+- name: Group Append Empty groups - Agent has default group - No groups affected
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\
                 \"groups\":[\"default\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":003,\"groups\":\
@@ -31,10 +27,9 @@
     agent_id: 3
     expected_group: default
     expected_group_sync_status: syncreq
--
-  name: Group Append Add same group twice - Has only one group
+
+- name: Group Append Add same group twice - Has only one group
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":\
@@ -43,10 +38,9 @@
     agent_id: 4
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Append group - Agent has one group - Agent has two groups
+
+- name: Group Append group - Agent has one group - Agent has two groups
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":\
@@ -55,20 +49,18 @@
     agent_id: 5
     expected_group: TestGroup1,TestGroup2
     expected_group_sync_status: syncreq
--
-  name: Group Empty-Only - Agent Has no groups. One Group is Added
+
+- name: Group Empty-Only - Agent Has no groups. One Group is Added
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: ok
     agent_id: 6
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Empty-Only - Agent Has one group. No new groups added
+
+- name: Group Empty-Only - Agent Has one group. No new groups added
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
@@ -77,10 +69,9 @@
     agent_id: 7
     expected_group: TestGroup1
     expected_group_sync_status: syncreq
--
-  name: Group Override - Agent Has one group.  New group replaces old group
+
+- name: Group Override - Agent Has one group.  New group replaces old group
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
@@ -89,10 +80,9 @@
     agent_id: 8
     expected_group: TestGroup2
     expected_group_sync_status: syncreq
--
-  name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
+
+- name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
@@ -102,10 +92,9 @@
     expected_group: None
     expected_warning: ".*WARNING: The groups were empty right after the set for agent '009'"
     expected_group_sync_status: syncreq
--
-  name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
+
+- name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":\
@@ -114,10 +103,9 @@
     agent_id: 10
     expected_group: default
     expected_group_sync_status: syncreq
--
-  name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
+
+- name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
   test_case:
-  -
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,
                 \"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":
@@ -126,146 +114,131 @@
     agent_id: 11
     expected_group: TestGroup2
     expected_group_sync_status: syncreq
--
-  name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
+
+- name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":
             [\"TestGroup1\"]}]}"
     output: ok
     agent_id: 12
     expected_group: default
     expected_group_sync_status: syncreq
--
-  name: Invalid Mode - use an Invalid mode - no groups added
+
+- name: Invalid Mode - use an Invalid mode - no groups added
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: err Invalid mode 'wrong_mode' in set_agent_groups command
     agent_id: 13
     expected_group: None
     expected_group_sync_status: synced
--
-  name: No Mode - No mode is passed - no groups affected
+
+- name: No Mode - No mode is passed - no groups affected
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err Invalid mode '' in set_agent_groups command
     agent_id: 14
     expected_group: None
     expected_group_sync_status: synced
--
-  name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
+
+- name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: ok
     agent_id: 15
     expected_group: TestGroup1
     expected_group_sync_status: synced
--
-  name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
+
+- name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
     agent_id: 16
     expected_group: None
     expected_group_sync_status: synced
--
-  name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
+
+- name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without data field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without data field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
     output: err An error occurred during the set of the groups
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without data id field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without data id field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without mode field - agent has no group assigned
+
+- name: Missing Fields - Assign a group using without mode field - agent has no group assigned
   test_case:
-  -
     input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
     output: err Invalid JSON data, missing required fields
     agent_id: 17
     expected_group: None
     expected_group_sync_status: synced
--
-  name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
+
+- name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
     output: ok
     agent_id: 18
     expected_group: TestGroup1
     expected_group_sync_status: synced
--
-  name: Valid group name format - Assign a group with a '.' character
+
+- name: Valid group name format - Assign a group with a '.' character
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":\
             [\"Test.Group1\"]}]}"
     output: ok
     agent_id: 19
     expected_group: "Test.Group1"
     expected_group_sync_status: syncreq
--
-  name: Valid group name format - Assign a group with a '-' character
+
+- name: Valid group name format - Assign a group with a '-' character
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":\
             [\"Test-Group1\"]}]}"
     output: ok
     agent_id: 20
     expected_group: "Test-Group1"
     expected_group_sync_status: syncreq
--
-  name: Valid group name format - Assign a group with a '_' character
+
+- name: Valid group name format - Assign a group with a '_' character
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":\
             [\"Test_Group1\"]}]}"
     output: ok
     agent_id: 21
     expected_group: "Test_Group1"
     expected_group_sync_status: syncreq
--
-  name: Valid group name format - Assign a group with a long name
+
+- name: Valid group name format - Assign a group with a long name
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
@@ -276,10 +249,9 @@
                      YwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxE\
                      wgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
     expected_group_sync_status: syncreq
--
-  name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":\
             [\"Test,Group1\"]}]}"
     output: err An error occurred during the set of the groups
@@ -287,10 +259,9 @@
     expected_group: None
     expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":\
             [\"TestGroup1@\"]}]}"
     output: err An error occurred during the set of the groups
@@ -298,10 +269,9 @@
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":\
             [\".\"]}]}"
     output: err An error occurred during the set of the groups
@@ -309,10 +279,9 @@
     expected_group: None
     expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
             [\"..\"]}]}"
     output: err An error occurred during the set of the groups
@@ -320,10 +289,9 @@
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
     expected_group_sync_status: synced
--
-  name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
+
+- name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
   test_case:
-  -
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -1,5 +1,6 @@
 - name: Group Append - Add TestGroup1
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":001,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: ok
@@ -30,6 +31,7 @@
 
 - name: Group Append Add same group twice - Has only one group
   test_case:
+    pre_required_group: TestGroup1
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":004,\"groups\":\
@@ -41,6 +43,7 @@
 
 - name: Group Append group - Agent has one group - Agent has two groups
   test_case:
+    pre_required_group: TestGroup1,TestGroup2
     pre_input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":005,\"groups\":\
@@ -52,6 +55,7 @@
 
 - name: Group Empty-Only - Agent Has no groups. One Group is Added
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":006,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: ok
@@ -61,6 +65,7 @@
 
 - name: Group Empty-Only - Agent Has one group. No new groups added
   test_case:
+    pre_required_group: TestGroup1
     pre_input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"empty_only\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":007,\
@@ -72,6 +77,7 @@
 
 - name: Group Override - Agent Has one group.  New group replaces old group
   test_case:
+    pre_required_group: TestGroup1,TestGroup2
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":008,\
@@ -83,6 +89,7 @@
 
 - name: Group Override - Agent has one group - Pass no new group.  Warning - groups deleted
   test_case:
+    pre_required_group: TestGroup1
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":009,\
@@ -95,6 +102,7 @@
 
 - name: Group Remove - Agent has one Group - Remove the group.  Agent has default assigned
   test_case:
+    pre_required_group: TestGroup1
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\
                 \"groups\":[\"TestGroup1\"]}]}"
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":010,\"groups\":\
@@ -106,6 +114,7 @@
 
 - name: Group Remove - Agent has TestGroup1 and TestGroup2 - Remove Tesgroup1.  Agent has TestGroup2 assigned
   test_case:
+    pre_required_group: TestGroup1,TestGroup2
     pre_input: "global set-agent-groups {\"mode\":\"override\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,
                 \"groups\":[\"TestGroup1\",\"TestGroup2\"]}]}"
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":011,\"groups\":
@@ -117,6 +126,7 @@
 
 - name: Group Remove - Agent has no groups - Try remove a group.  Agent has default assigned
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"remove\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":012,\"groups\":
             [\"TestGroup1\"]}]}"
     output: ok
@@ -126,6 +136,7 @@
 
 - name: Invalid Mode - use an Invalid mode - no groups added
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"wrong_mode\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":013,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: err Invalid mode 'wrong_mode' in set_agent_groups command
@@ -135,6 +146,7 @@
 
 - name: No Mode - No mode is passed - no groups affected
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":014,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err Invalid mode '' in set_agent_groups command
@@ -144,6 +156,7 @@
 
 - name: sync_status Synced - Assign a group using Synced Sync Status - agent has TestGroup1 assigned
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":015,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: ok
@@ -153,6 +166,7 @@
 
 - name: Wrong sync_status - Assign a group using and invalid Sync_Status - agent has no group
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"wrong_status\",\"data\":[{\"id\":016,\
             \"groups\":[\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
@@ -162,6 +176,7 @@
 
 - name: No sync_status - Assign a group using and empty Sync_Status field - agent has no group assigned
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"\",\"data\":[{\"id\":017,\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
@@ -173,78 +188,87 @@
   test_case:
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\"}"
     output: "err Invalid JSON data, missing required fields"
-    agent_id: 17
+    agent_id: 18
     expected_group: None
     expected_group_sync_status: synced
 
 - name: Missing Fields - Assign a group using without data groups field - agent has no group assigned
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":017}]}"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 17
+    agent_id: 19
     expected_group: None
     expected_group_sync_status: synced
 
 - name: Missing Fields - Assign a group using without data id field - agent has no group assigned
   test_case:
+    pre_required_group: TestGroup1
     input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"groups\":\
             [\"TestGroup1\"]}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 17
+    agent_id: 20
     expected_group: None
     expected_group_sync_status: synced
 
 - name: Missing Fields - Assign a group using without mode field - agent has no group assigned
   test_case:
-    input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":017,\"groups\":[\"TestGroup1\"]}]}"
+    pre_required_group: TestGroup1
+    input: "global set-agent-groups {\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":[\"TestGroup1\"]}]}"
     output: err Invalid JSON data, missing required fields
-    agent_id: 17
+    agent_id: 21
     expected_group: None
     expected_group_sync_status: synced
 
 - name: Missing Fields - Assign a group using without sync_status field - agent has TestGroup1 assigned
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":018,\"groups\":[\"TestGroup1\"]}]}"
+    pre_required_group: TestGroup1
+    input: "global set-agent-groups {\"mode\":\"append\",\"data\":[{\"id\":022,\"groups\":[\"TestGroup1\"]}]}"
     output: ok
-    agent_id: 18
+    agent_id: 22
     expected_group: TestGroup1
     expected_group_sync_status: synced
 
 - name: Valid group name format - Assign a group with a '.' character
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":019,\"groups\":\
+    pre_required_group: Test.Group1
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":\
             [\"Test.Group1\"]}]}"
     output: ok
-    agent_id: 19
+    agent_id: 23
     expected_group: "Test.Group1"
     expected_group_sync_status: syncreq
 
 - name: Valid group name format - Assign a group with a '-' character
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":020,\"groups\":\
+    pre_required_group: Test-Group1
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":\
             [\"Test-Group1\"]}]}"
     output: ok
-    agent_id: 20
+    agent_id: 24
     expected_group: "Test-Group1"
     expected_group_sync_status: syncreq
 
 - name: Valid group name format - Assign a group with a '_' character
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":021,\"groups\":\
+    pre_required_group: Test_Group1
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":\
             [\"Test_Group1\"]}]}"
     output: ok
-    agent_id: 21
+    agent_id: 25
     expected_group: "Test_Group1"
     expected_group_sync_status: syncreq
 
 - name: Valid group name format - Assign a group with a long name
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":022,\"groups\":\
+    pre_required_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG\
+                        3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2\
+                        wfIpkxEwgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
             ebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J\"]}]}"
     output: ok
-    agent_id: 22
+    agent_id: 26
     expected_group: "19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMc\
                      YwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxE\
                      wgxlj2LcLOzE4nrebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8J"
@@ -252,52 +276,52 @@
 
 - name: Wrong group name format - Assign a group with an invalid group name (has invalid ',' character) - Warning
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":023,\"groups\":\
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":\
             [\"Test,Group1\"]}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 23
+    agent_id: 27
     expected_group: None
     expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
     expected_group_sync_status: synced
 
 - name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":024,\"groups\":\
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":028,\"groups\":\
             [\"TestGroup1@\"]}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 24
+    agent_id: 28
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. 'TestGroup1@' contains invalid characters"
     expected_group_sync_status: synced
 
 - name: Wrong group name format - Assign a group with an invalid group name (.) - Warning
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":025,\"groups\":\
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":029,\"groups\":\
             [\".\"]}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 25
+    agent_id: 29
     expected_group: None
     expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
     expected_group_sync_status: synced
 
 - name: Wrong group name format - Assign a group with an invalid group name (..) - Warning
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":026,\"groups\":\
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":030,\"groups\":\
             [\"..\"]}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 26
+    agent_id: 30
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. '..' represents the parent directory in unix systems"
     expected_group_sync_status: synced
 
 - name: Wrong group name format - Assign a group with an invalid group name (too long) - Warning
   test_case:
-    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":027,\"groups\":\
+    input: "global set-agent-groups {\"mode\":\"append\",\"sync_status\":\"syncreq\",\"data\":[{\"id\":031,\"groups\":\
             [\"19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741ajntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5h\
             cwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodOPSrIL7XyDXnquqSuIaeuqY1uwcvBTlrlvRqFuH2wfIpkxEwgxlj2LcLOzE4nr\
             ebf1Ot8C0gBmVYZbjBDwUrHBHNpDL7tnScnISannzT8Jz\"]}]}"
     output: err An error occurred during the set of the groups
-    agent_id: 27
+    agent_id: 31
     expected_group: None
     expected_warning: ".*WARNING: Invalid group name. The group '19im4QM7Vn8vr4kE4YeZJ92AMvZS8bkKGrinEPSfAjNnhDgZ2a741a\
                        jntTWCaB6oJpOORSP46wLs2g14TqfbAJDmsbOxJG3xMcYwFj5hcwpABb75W0CE6EQv9cTDm0SBqZAC6PIJltof7brN0bIodO\

--- a/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
+++ b/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
@@ -8,7 +8,7 @@
   test_case:
     pre_required_group: Test_group1,Test_group2
     pre_input:
-        - global sql UPDATE agent SET group_sync_status="synced"
+      - global sql UPDATE agent SET group_sync_status="synced"
     input: global sync-agent-groups-get {"condition":"sync_status"}
     output: "[{'data': []}]"
 

--- a/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
+++ b/tests/integration/test_wazuh_db/data/global/sync_agent_groups_get.yaml
@@ -1,180 +1,159 @@
--
-  name: Test sync_status with response
+- name: Test sync_status with response
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"sync_status"}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"sync_status"}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test sync_status without response
+- name: Test sync_status without response
   test_case:
-    -
-      pre_input:
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
         - global sql UPDATE agent SET group_sync_status="synced"
-      input: global sync-agent-groups-get {"condition":"sync_status"}
-      output: "[{'data': []}]"
+    input: global sync-agent-groups-get {"condition":"sync_status"}
+    output: "[{'data': []}]"
 
--
-  name: Test 'all' condition when agent groups are in 'sync_req'
+- name: Test 'all' condition when agent groups are in 'sync_req'
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"all"}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"all"}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test 'all' condition when agent groups are in 'synced'
+- name: Test 'all' condition when agent groups are in 'synced'
   test_case:
-    -
-      pre_input:
-        - global sql UPDATE agent SET group_sync_status="synced"
-      input: global sync-agent-groups-get {"condition":"all"}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
+      - global sql UPDATE agent SET group_sync_status="synced"
+    input: global sync-agent-groups-get {"condition":"all"}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test 'sync_status' condition when one agent groups are in 'synced'
+- name: Test 'sync_status' condition when one agent groups are in 'synced'
   test_case:
-    -
-      pre_input:
-        - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
-      input: global sync-agent-groups-get {"condition":"sync_status"}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
+      - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
+    input: global sync-agent-groups-get {"condition":"sync_status"}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}]}]"
 
--
-  name: Test 'all' condition when one agent groups are in 'synced'
+- name: Test 'all' condition when one agent groups are in 'synced'
   test_case:
-    -
-      pre_input:
-        - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
-      input: global sync-agent-groups-get {"condition":"all"}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
+      - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
+    input: global sync-agent-groups-get {"condition":"all"}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test with and invalid filter in condition
+- name: Test with and invalid filter in condition
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"testinvalid"}
-      output: err Could not obtain a response from wdb_global_sync_agent_groups_get
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"testinvalid"}
+    output: err Could not obtain a response from wdb_global_sync_agent_groups_get
 
--
-  name: Test without condition
+- name: Test without condition
   test_case:
-    -
-      input: global sync-agent-groups-get {"last_id":0}
-      output: err Invalid JSON data, missing required 'condition' field
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"last_id":0}
+    output: err Invalid JSON data, missing required 'condition' field
 
--
-  name: Test set_synced in True
+- name: Test set_synced in True
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":true}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
-      new_status: synced
-      agent_id: "[1,2]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":true}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    new_status: synced
+    agent_id: "[1,2]"
 
--
-  name: Test set_synced with invalid value - false
+- name: Test set_synced with invalid value - false
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":false}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
-      new_status: syncreq
-      agent_id: "[1,2]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":false}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    new_status: syncreq
+    agent_id: "[1,2]"
 
--
-  name: Test set_synced with invalid value - String
+- name: Test set_synced with invalid value - String
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":"set"}
-      output: err Invalid JSON data, invalid alternative fields data
-      new_status: syncreq
-      agent_id: "[1,2]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":"set"}
+    output: err Invalid JSON data, invalid alternative fields data
+    new_status: syncreq
+    agent_id: "[1,2]"
 
--
-  name: Test get_global_hash in true
+- name: Test get_global_hash in true
   test_case:
-    -
-      pre_input:
-        - global sql UPDATE agent SET group_hash = "DUMMY"
-      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":true}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']},
-               {'id': 2, 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
+      - global sql UPDATE agent SET group_hash = "DUMMY"
+    input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":true}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']},
+             {'id': 2, 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"
 
--
-  name: Test get_global_hash in false
+- name: Test get_global_hash in false
   test_case:
-    -
-      pre_input:
-        - global sql UPDATE agent SET group_hash = "DUMMY"
-      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":false}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
+      - global sql UPDATE agent SET group_hash = "DUMMY"
+    input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":false}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test get_global_hash with invalid value
+- name: Test get_global_hash with invalid value
   test_case:
-    -
-      pre_input:
-        - global sql UPDATE agent SET group_hash = "DUMMY"
-      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":"set"}
-      output: err Invalid JSON data, invalid alternative fields data
+    pre_required_group: Test_group1,Test_group2
+    pre_input:
+      - global sql UPDATE agent SET group_hash = "DUMMY"
+    input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":"set"}
+    output: err Invalid JSON data, invalid alternative fields data
 
--
-  name: Test 'agent_registration_delta' in 0 and sync_status
+- name: Test 'agent_registration_delta' in 0 and sync_status
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":0}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":0}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test 'agent_registration_delta' in 0 and all condition
+- name: Test 'agent_registration_delta' in 0 and all condition
   test_case:
-    -
-      input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":0}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":0}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test 'agent_registration_delta' with delta in 10000 and sync_status
+- name: Test 'agent_registration_delta' with delta in 10000 and sync_status
   test_case:
-    -
-      pre_input:
-        - global insert-agent {"id":5,"name":"Agent-test5","date_add":1545753642}
-        - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":5,"groups":["Test_group5"]}]}
-      input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":10000}
-      output: "[{'data': [{'id': 5, 'groups': ['Test_group5']}]}]"
+    pre_required_group: Test_group1,Test_group2,Test_group5
+    pre_input:
+      - global insert-agent {"id":5,"name":"Agent-test5","date_add":1545753642}
+      - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":5,"groups":["Test_group5"]}]}
+    input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":10000}
+    output: "[{'data': [{'id': 5, 'groups': ['Test_group5']}]}]"
 
--
-  name: Test 'agent_registration_delta' with delta in 10000 and all
+- name: Test 'agent_registration_delta' with delta in 10000 and all
   test_case:
-    -
-      pre_input:
-        - global insert-agent {"id":6,"name":"Agent-test6","date_add":1545753642}
-        - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":6,"groups":["Test_group6"]}]}
-      input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":10000}
-      output: "[{'data': [{'id': 6, 'groups': ['Test_group6']}]}]"
+    pre_required_group: Test_group1,Test_group2,Test_group6
+    pre_input:
+      - global insert-agent {"id":6,"name":"Agent-test6","date_add":1545753642}
+      - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":6,"groups":["Test_group6"]}]}
+    input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":10000}
+    output: "[{'data': [{'id': 6, 'groups': ['Test_group6']}]}]"
 
--
-  name: Test last_id - by default
+- name: Test last_id - by default
   test_case:
-    -
-      input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status"}
-      output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status"}
+    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test last_id - obtain from second group
+- name: Test last_id - obtain from second group
   test_case:
-    -
-      input: global sync-agent-groups-get {"last_id":1, "condition":"sync_status"}
-      output: "[{'data': [{'id': 2, 'groups': ['Test_group2']}]}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"last_id":1, "condition":"sync_status"}
+    output: "[{'data': [{'id': 2, 'groups': ['Test_group2']}]}]"
 
--
-  name: Test last_id - with not exist id
+- name: Test last_id - with not exist id
   test_case:
-    -
-      input: global sync-agent-groups-get {"last_id":3, "condition":"sync_status"}
-      output: "[{'data': []}]"
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"last_id":3, "condition":"sync_status"}
+    output: "[{'data': []}]"
 
 -
   name: Test last_id - with negative value
   test_case:
-    -
-      input: global sync-agent-groups-get {"last_id":-3, "condition":"sync_status"}
-      output: err Invalid JSON data, invalid alternative fields data
+    pre_required_group: Test_group1,Test_group2
+    input: global sync-agent-groups-get {"last_id":-3, "condition":"sync_status"}
+    output: err Invalid JSON data, invalid alternative fields data

--- a/tests/integration/test_wazuh_db/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_agent_database_version.py
@@ -1,6 +1,7 @@
 from wazuh_testing.modules import TIER0, LINUX, SERVER
 from wazuh_testing.wazuh_db import query_wdb
 from wazuh_testing.tools import agent_simulator as ag
+from wazuh_testing.tools.wazuh_manager import remove_all_agents
 
 # Marks
 pytestmark = [TIER0, LINUX, SERVER]
@@ -53,3 +54,4 @@ def test_agent_database_version(restart_wazuh_daemon):
     assert agent_version == expected_database_version, 'The agent database version is not the expected one. \n' \
                                                        f'Expected version: {expected_database_version}\n'\
                                                        f'Obtained version: {agent_version}'
+    remove_all_agents('manage_agents')

--- a/tests/integration/test_wazuh_db/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_agent_database_version.py
@@ -1,3 +1,5 @@
+import pytest
+
 from wazuh_testing.modules import TIER0, LINUX, SERVER
 from wazuh_testing.wazuh_db import query_wdb
 from wazuh_testing.tools import agent_simulator as ag
@@ -10,8 +12,15 @@ pytestmark = [TIER0, LINUX, SERVER]
 expected_database_version = '10'
 
 
+# Fixtures
+@pytest.fixture()
+def remove_agents():
+    yield
+    remove_all_agents('manage_agents')
+
+
 # Tests
-def test_agent_database_version(restart_wazuh_daemon):
+def test_agent_database_version(restart_wazuh_daemon, remove_agents):
     '''
     description: Check that the agent database version is the expected one. To do this, it performs a query to the agent
                  database that gets the database version.
@@ -54,4 +63,3 @@ def test_agent_database_version(restart_wazuh_daemon):
     assert agent_version == expected_database_version, 'The agent database version is not the expected one. \n' \
                                                        f'Expected version: {expected_database_version}\n'\
                                                        f'Obtained version: {agent_version}'
-    remove_all_agents('manage_agents')

--- a/tests/integration/test_wazuh_db/test_get_groups_integrity.py
+++ b/tests/integration/test_wazuh_db/test_get_groups_integrity.py
@@ -71,8 +71,8 @@ module_tests = get_list_of_content_yml(messages_file)
 
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
 
-# Fixtures
 
+# Fixtures
 @pytest.fixture(scope='function')
 def create_groups(test_case):
     if 'pre_required_group' in test_case:

--- a/tests/integration/test_wazuh_db/test_get_groups_integrity.py
+++ b/tests/integration/test_wazuh_db/test_get_groups_integrity.py
@@ -59,7 +59,6 @@ import pytest
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db, remove_agent
 from wazuh_testing.tools.file import get_list_of_content_yml
-from wazuh_testing.tools.wazuh_manager import create_group, delete_group
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
@@ -70,24 +69,6 @@ messages_file = os.path.join(os.path.join(test_data_path, 'global'), 'get_groups
 module_tests = get_list_of_content_yml(messages_file)
 
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-
-
-# Fixtures
-@pytest.fixture(scope='function')
-def create_groups(test_case):
-    if 'pre_required_group' in test_case:
-        groups = test_case['pre_required_group'].split(',')
-
-        for group in groups:
-            create_group(group)
-
-    yield
-
-    if 'pre_required_group' in test_case:
-        groups = test_case['pre_required_group'].split(',')
-
-        for group in groups:
-            delete_group(group)
 
 
 # Tests

--- a/tests/integration/test_wazuh_db/test_get_groups_integrity.py
+++ b/tests/integration/test_wazuh_db/test_get_groups_integrity.py
@@ -10,7 +10,7 @@ type: integration
 brief: Wazuh-db is the daemon in charge of the databases with all the Wazuh persistent information, exposing a socket
        to receive requests and provide information. The Wazuh core uses list-based databases to store information
        related to agent keys, and FIM/Rootcheck event data.
-       This test checks the usage of the get-groups-integrity command used to determine if the agent groups are synced 
+       This test checks the usage of the get-groups-integrity command used to determine if the agent groups are synced
        or if a sync is needed.
 
 tier: 0
@@ -55,10 +55,11 @@ tags:
 import os
 import time
 import pytest
-import yaml
+
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db, remove_agent
 from wazuh_testing.tools.file import get_list_of_content_yml
+from wazuh_testing.tools.wazuh_manager import create_group, delete_group
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
@@ -68,11 +69,25 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 messages_file = os.path.join(os.path.join(test_data_path, 'global'), 'get_groups_integrity_messages.yaml')
 module_tests = get_list_of_content_yml(messages_file)
 
-log_monitor_paths = []
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
-receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
-monitored_sockets_params = [('wazuh-db', None, True)]
-receiver_sockets= None  # Set in the fixtures
+
+# Fixtures
+
+@pytest.fixture(scope='function')
+def create_groups(test_case):
+    if 'pre_required_group' in test_case:
+        groups = test_case['pre_required_group'].split(',')
+
+        for group in groups:
+            create_group(group)
+
+    yield
+
+    if 'pre_required_group' in test_case:
+        groups = test_case['pre_required_group'].split(',')
+
+        for group in groups:
+            delete_group(group)
 
 
 # Tests
@@ -82,7 +97,7 @@ receiver_sockets= None  # Set in the fixtures
                               for module_data, module_name in module_tests
                               for case in module_data]
                          )
-def test_get_groups_integrity(configure_sockets_environment, connect_to_sockets_module, test_case):
+def test_get_groups_integrity(test_case, create_groups):
     '''
     description: Check that every input message using the 'get-groups-integrity' command in wazuh-db socket generates
                  the proper output to wazuh-db socket. To do this, it performs a query to the socket with a command
@@ -92,22 +107,19 @@ def test_get_groups_integrity(configure_sockets_environment, connect_to_sockets_
     wazuh_min_version: 4.4.0
 
     parameters:
-        - configure_sockets_environment:
-            type: fixture
-            brief: Configure environment for sockets and MITM.
-        - connect_to_sockets_module:
-            type: fixture
-            brief: Module scope version of 'connect_to_sockets' fixture.
         - test_case:
             type: fixture
             brief: List of test_case stages (dicts with input, output and agent_id and expected_groups keys).
+        - create_groups:
+            type: fixture
+            brief: Create required groups
 
     assertions:
         - Verify that the socket response matches the expected output.
 
     input_description:
         - Test cases are defined in the get_groups_integrity_messages.yaml file. This file contains the agent id's to
-          register, as well as the group_sync_status that each agent will have, as well as the expected output and 
+          register, as well as the group_sync_status that each agent will have, as well as the expected output and
           result for the test.
 
     expected_output:
@@ -119,31 +131,29 @@ def test_get_groups_integrity(configure_sockets_environment, connect_to_sockets_
         - wazuh_db
         - wdb_socket
     '''
-
-    case_data = test_case[0]
-    output = case_data["output"]
-    agent_ids= case_data["agent_ids"]
-    agent_status= case_data["agent_status"]
+    output = test_case["output"]
+    agent_ids = test_case["agent_ids"]
+    agent_status = test_case["agent_status"]
 
     # Insert test Agents
     for index, id in enumerate(agent_ids):
-        response = insert_agent_in_db(id=id+1, connection_status="disconnected", 
+        response = insert_agent_in_db(id=id+1, connection_status="disconnected",
                                       registration_time=str(time.time()))
         command = f'global set-agent-groups {{"mode":"append","sync_status":"{agent_status[index]}","source":"remote",\
                     "data":[{{"id":{id},"groups":["Test_group{id}"]}}]}}'
-        response =  query_wdb(command)
+        response = query_wdb(command)
 
     # Get database hash
-    if "invalid_hash" in case_data:
-        hash = case_data["invalid_hash"]
+    if "invalid_hash" in test_case:
+        hash = test_case["invalid_hash"]
     else:
-        response = query_wdb(f'global sync-agent-groups-get {{"last_id": 0, "condition": "all", "get_global_hash": true, \
-                             "set_synced": false, "agent_delta_registration": 0}}')
+        response = query_wdb('global sync-agent-groups-get {"last_id": 0, "condition": "all", "get_global_hash": true,'
+                             '"set_synced": false, "agent_delta_registration": 0}')
         response = response[0]
         hash = response["hash"]
-        if "no_hash" in case_data:
+        if "no_hash" in test_case:
             response = str(response)
-            assert output in response , f'Unexpected response: got {response}, but expected {output}'
+            assert output in response, f'Unexpected response: got {response}, but expected {output}'
             return
 
     # Get groups integrity

--- a/tests/integration/test_wazuh_db/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups.py
@@ -55,7 +55,9 @@ tags:
 import os
 import time
 import pytest
-import yaml
+
+import wazuh_testing as fw
+from wazuh_testing import event_monitor as evm
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db
 from wazuh_testing.tools.services import delete_dbs
@@ -73,10 +75,10 @@ log_monitor_paths = []
 wdb_path = os.path.join(os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb'))
 receiver_sockets_params = [(wdb_path, 'AF_UNIX', 'TCP')]
 monitored_sockets_params = [('wazuh-db', None, True)]
-receiver_sockets= None  # Set in the fixtures
+receiver_sockets = None  # Set in the fixtures
 
 
-#Fixtures
+# Fixtures
 @pytest.fixture(scope='module')
 def remove_database(request):
     yield
@@ -92,8 +94,8 @@ def remove_database(request):
                          )
 def test_set_agent_groups(remove_database, configure_sockets_environment, connect_to_sockets_module, test_case):
     '''
-    description: Check that every input message using the 'set_agent_groups' command in wazuh-db socket generates 
-                 the proper output to wazuh-db socket. To do this, it performs a query to the socket with a command 
+    description: Check that every input message using the 'set_agent_groups' command in wazuh-db socket generates
+                 the proper output to wazuh-db socket. To do this, it performs a query to the socket with a command
                  taken from the list of test_cases's 'input' field, and compare the result with the test_case's
                  'output' and 'expected_group' fields.
 
@@ -118,7 +120,7 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
         - Verify that the agent has the expected_group assigned.
 
     input_description:
-        - Test cases are defined in the set_agent_groups.yaml file. This file contains the command to insert the agentes
+        - Test cases are defined in the set_agent_groups.yaml file. This file contains the command to insert the agents
           groups, with different modes and combinations, as well as the expected outputs and results.
 
     expected_output:
@@ -133,23 +135,31 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
 
     case_data = test_case[0]
     output = case_data["output"]
-    agent_id= case_data["agent_id"]
+    agent_id = case_data["agent_id"]
 
     # Insert test Agent
-    response = insert_agent_in_db(id=agent_id, connection_status="disconnected", registration_time=str(time.time()))
-    
+    response = insert_agent_in_db(id=agent_id, connection_status='disconnected', registration_time=str(time.time()))
+
     # Apply preconditions
     if 'pre_input' in case_data:
         query_wdb(case_data['pre_input'])
-    
+
     # Add tested group
     response = query_wdb(case_data["input"])
 
     # validate output
     assert response == output, f"Assertion Error - expected {output}, but got {response}"
 
+    # Check warnings
+    if 'expected_warning' in case_data:
+        callback = case_data['expected_warning']
+        evm.check_event(callback=callback, file_to_monitor=fw.LOG_FILE_PATH, timeout=20).result()
+
     # get agent data and validate agent's groups
     response = query_wdb(f'global get-agent-info {agent_id}')
+
+    assert case_data['expected_group_sync_status'] == response[0]['group_sync_status']
+
     if case_data["expected_group"] == 'None':
         assert 'group' not in response[0], "Agent has groups data and it was expecting no group data"
     else:

--- a/tests/integration/test_wazuh_db/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups.py
@@ -58,7 +58,6 @@ import pytest
 
 import wazuh_testing as fw
 from wazuh_testing import event_monitor as evm
-from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db
 from wazuh_testing.tools.services import delete_dbs
 from wazuh_testing.tools.file import get_list_of_content_yml
@@ -79,6 +78,7 @@ def remove_database(request):
     yield
     delete_dbs()
 
+
 @pytest.fixture(scope='function')
 def create_groups(test_case):
     if 'pre_required_group' in test_case:
@@ -94,6 +94,7 @@ def create_groups(test_case):
 
         for group in groups:
             delete_group(group)
+
 
 # Tests
 @pytest.mark.parametrize('test_case',

--- a/tests/integration/test_wazuh_db/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups.py
@@ -61,7 +61,6 @@ from wazuh_testing import event_monitor as evm
 from wazuh_testing.wazuh_db import query_wdb, insert_agent_in_db
 from wazuh_testing.tools.services import delete_dbs
 from wazuh_testing.tools.file import get_list_of_content_yml
-from wazuh_testing.tools.wazuh_manager import create_group, delete_group
 
 # Marks
 pytestmark = [pytest.mark.linux, pytest.mark.tier(level=0), pytest.mark.server]
@@ -77,23 +76,6 @@ module_tests = get_list_of_content_yml(messages_file)
 def remove_database(request):
     yield
     delete_dbs()
-
-
-@pytest.fixture(scope='function')
-def create_groups(test_case):
-    if 'pre_required_group' in test_case:
-        groups = test_case['pre_required_group'].split(',')
-
-        for group in groups:
-            create_group(group)
-
-    yield
-
-    if 'pre_required_group' in test_case:
-        groups = test_case['pre_required_group'].split(',')
-
-        for group in groups:
-            delete_group(group)
 
 
 # Tests

--- a/tests/integration/test_wazuh_db/test_set_agent_groups.py
+++ b/tests/integration/test_wazuh_db/test_set_agent_groups.py
@@ -132,35 +132,33 @@ def test_set_agent_groups(remove_database, configure_sockets_environment, connec
         - wazuh_db
         - wdb_socket
     '''
-
-    case_data = test_case[0]
-    output = case_data["output"]
-    agent_id = case_data["agent_id"]
+    output = test_case['output']
+    agent_id = test_case['agent_id']
 
     # Insert test Agent
     response = insert_agent_in_db(id=agent_id, connection_status='disconnected', registration_time=str(time.time()))
 
     # Apply preconditions
-    if 'pre_input' in case_data:
-        query_wdb(case_data['pre_input'])
+    if 'pre_input' in test_case:
+        query_wdb(test_case['pre_input'])
 
     # Add tested group
-    response = query_wdb(case_data["input"])
+    response = query_wdb(test_case["input"])
 
     # validate output
     assert response == output, f"Assertion Error - expected {output}, but got {response}"
 
     # Check warnings
-    if 'expected_warning' in case_data:
-        callback = case_data['expected_warning']
+    if 'expected_warning' in test_case:
+        callback = test_case['expected_warning']
         evm.check_event(callback=callback, file_to_monitor=fw.LOG_FILE_PATH, timeout=20).result()
 
     # get agent data and validate agent's groups
     response = query_wdb(f'global get-agent-info {agent_id}')
 
-    assert case_data['expected_group_sync_status'] == response[0]['group_sync_status']
+    assert test_case['expected_group_sync_status'] == response[0]['group_sync_status']
 
-    if case_data["expected_group"] == 'None':
+    if test_case["expected_group"] == 'None':
         assert 'group' not in response[0], "Agent has groups data and it was expecting no group data"
     else:
-        assert case_data["expected_group"] == response[0]['group'], "Did not receive the expected groups in the agent."
+        assert test_case["expected_group"] == response[0]['group'], "Did not receive the expected groups in the agent."

--- a/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
+++ b/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
@@ -50,6 +50,7 @@ from wazuh_testing.wazuh_db import query_wdb, insert_agent_into_group, clean_age
 from wazuh_testing.wazuh_db import clean_groups_from_db, clean_belongs, calculate_global_hash
 from wazuh_testing.modules import TIER0, SERVER, LINUX
 from wazuh_testing.tools.file import get_list_of_content_yml
+from wazuh_testing.tools.services import delete_dbs
 from wazuh_testing.tools.wazuh_manager import create_group, delete_group
 
 
@@ -93,6 +94,12 @@ def pre_insert_agents_into_group(test_case):
     clean_belongs()
 
 
+@pytest.fixture(scope='module')
+def clean_databases():
+    yield
+    delete_dbs()
+
+
 # Tests
 @pytest.mark.parametrize('test_case',
                          [case['test_case'] for module_data in module_tests for case in module_data[0]],
@@ -100,7 +107,7 @@ def pre_insert_agents_into_group(test_case):
                               for module_data, module_name in module_tests
                               for case in module_data]
                          )
-def test_sync_agent_groups(restart_wazuh_daemon, test_case, pre_insert_agents_into_group):
+def test_sync_agent_groups(restart_wazuh_daemon, test_case, pre_insert_agents_into_group, clean_databases):
     '''
     description: Check that commands about sync_aget_groups_get works properly.
     wazuh_min_version: 4.4.0
@@ -114,6 +121,9 @@ def test_sync_agent_groups(restart_wazuh_daemon, test_case, pre_insert_agents_in
         - pre_insert_agents_into_group:
             type: fixture
             brief: fixture in charge of insert agents and groups into DB.
+        - clean_databases:
+            type: fixture
+            brief: Delete all databases after test execution.
     assertions:
         - Verify that the socket response matches the expected output.
     input_description:

--- a/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
+++ b/tests/integration/test_wazuh_db/test_sync_agent_groups_get.py
@@ -51,7 +51,6 @@ from wazuh_testing.wazuh_db import clean_groups_from_db, clean_belongs, calculat
 from wazuh_testing.modules import TIER0, SERVER, LINUX
 from wazuh_testing.tools.file import get_list_of_content_yml
 from wazuh_testing.tools.services import delete_dbs
-from wazuh_testing.tools.wazuh_manager import create_group, delete_group
 
 
 # Marks
@@ -73,22 +72,12 @@ receiver_sockets = None  # Set in the fixtures
 
 # Insert agents into DB  and assign them into a group
 @pytest.fixture(scope='function')
-def pre_insert_agents_into_group(test_case):
-    if 'pre_required_group' in test_case:
-        groups = test_case['pre_required_group'].split(',')
-
-        for group in groups:
-            create_group(group)
+def pre_insert_agents_into_group():
 
     insert_agent_into_group(2)
 
     yield
 
-    if 'pre_required_group' in test_case:
-        groups = test_case['pre_required_group'].split(',')
-
-        for group in groups:
-            delete_group(group)
     clean_agents_from_db()
     clean_groups_from_db()
     clean_belongs()
@@ -107,7 +96,8 @@ def clean_databases():
                               for module_data, module_name in module_tests
                               for case in module_data]
                          )
-def test_sync_agent_groups(restart_wazuh_daemon, test_case, pre_insert_agents_into_group, clean_databases):
+def test_sync_agent_groups(restart_wazuh_daemon, test_case, create_groups, pre_insert_agents_into_group,
+                           clean_databases):
     '''
     description: Check that commands about sync_aget_groups_get works properly.
     wazuh_min_version: 4.4.0

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -185,7 +185,8 @@ def insert_agents_test():
 
 @pytest.fixture(scope='module')
 def restart_wazuh(request):
-    control_service('start')
+    control_service('restart')
+
     yield
 
     delete_dbs()
@@ -203,7 +204,7 @@ def execute_wazuh_db_query(command, single_response=True):
         str: A response from the socket
     """
     receiver_sockets[0].send(command, size=True)
-    if single_response == True:
+    if single_response:
         return receiver_sockets[0].receive(size=True).decode()
     else:
         response_array = []


### PR DESCRIPTION
|Related issue|
|-------------|
|    #3921          |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Added `create_group` in `wazuh_testing/tools/wazuh_manager`
- Added `delete_group` in `wazuh_testing/tools/wazuh_manager`

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Updated `test_agent_database_version`: delete simulated agent
- Updated `test_get_groups_integrity`: create groups previously
- Updated `test_set_agent_groups`: create groups previously
- Updated `test_sync_agent_groups_get`: create groups previously
- Updated `test_wazuh_db`: restart manager instead of start


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @juliamagan (Developer)  |   `test_wazuh_db/`        | [🟢 ](https://ci.wazuh.info/job/Test_integration/36602/)[🟢 ](https://ci.wazuh.info/job/Test_integration/36603/)[🟢  ](https://ci.wazuh.info/job/Test_integration/36604/)  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/10708953/R2-3926-centos-manager.tar.gz)[🟢 ](https://github.com/wazuh/wazuh-qa/files/10708952/R3-3926-centos-manager.tar.gz)[🟢 ](https://github.com/wazuh/wazuh-qa/files/10708954/R1-3926-centos-manager.tar.gz)|     CentOS    |     061630b | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


