### PR TITLE
Adapt binary to wazuh-cluster daemon rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release report: TBD
 
 ### Added
 
+- Adapt binary performance module to wazuh-cluster script renaming ([#3944](https://github.com/wazuh/wazuh-qa/pull/3944)) \- (Framework)
 - Add an option to store logs in system tests ([#2445](https://github.com/wazuh/wazuh-qa/pull/2445)) \- (Framework + Tests)
 - Add new test to check cpe_helper.json file ([#3731](https://github.com/wazuh/wazuh-qa/pull/3731))
 - Add new tests analysid handling of invalid/empty rule signature IDs ([#3649]

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/binary.py
@@ -74,7 +74,7 @@ class Monitor:
             # These two binaries are executed using the Python interpreter instead of
             # directly execute them as daemons. That's why we need to search the .py file in
             # the cmdline instead of searching it in the name
-            if process_name in ['wazuh-clusterd', 'wazuh-apid']:
+            if process_name in ['wazuh_clusterd', 'wazuh-apid']:
                 if any(filter(lambda x: f'{process_name}.py' in x, proc.cmdline())):
                     pid = proc.pid
                     break

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -139,7 +139,8 @@ def control_service(action, daemon=None, debug_mode=False):
                 delete_sockets(WAZUH_SOCKETS[daemon])
             else:
                 daemon_path = os.path.join(WAZUH_PATH, 'bin')
-                subprocess.check_call([f'{daemon_path}/{daemon}', '' if not debug_mode else '-dd'])
+                start_process = [f'{daemon_path}/{daemon}'] if not debug_mode else [f'{daemon_path}/{daemon}', '-dd']
+                subprocess.check_call(start_process)
             result = 0
 
     if result != 0:


### PR DESCRIPTION
|Related issue|
|-------------|
|        #3940     |

## Description

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Fix bug in `control_service`  at `wazuh-clusterd` start time 
- Renamed wazuh-clusterd process to `wazuh_clusterd`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | Not required | Not required |         |         | Nothing to highlight |
| @user (Reviewer)   |           | Not required | Not required  |        |         | Nothing to highlight |
