### PR TITLE
Fix Unstable FIM tests test_file_limit_delete_full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Release report: TBD
 
 ### Changed
 
+- Fix `test_file_limit_delete_full` module ([#3990](https://github.com/wazuh/wazuh-qa/pull/3990)) \- (Tests)
 - Improve `test_agent_groups_new_cluster_node` ([#3971](https://github.com/wazuh/wazuh-qa/pull/3971)) \- (Tests)
 - Fix Solaris agent provision schema ([#3750](https://github.com/wazuh/wazuh-qa/issues/3744)) \- (Framework)
 - Fix wazuh-db integration tests for agent-groups ([#3926](https://github.com/wazuh/wazuh-qa/pull/3926)) \- (Tests + Framework)

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_ignore_restrict.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_ignore_restrict.yaml
@@ -9,6 +9,8 @@
     elements:
     - disabled:
         value: 'no'
+    - frequency:
+        value: 2   
     - directories:
         value: "/testdir1"
         attributes:
@@ -32,6 +34,8 @@
     elements:
     - disabled:
         value: 'no'
+    - frequency:
+        value: 2   
     - directories:
         value: "/testdir1"
         attributes:

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_ignore_restrict_win32.yaml
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/data/wazuh_conf_ignore_restrict_win32.yaml
@@ -9,6 +9,8 @@
     elements:
     - disabled:
         value: 'no'
+    - frequency:
+        value: 2
     - directories:
         value: "c:\\testdir1"
         attributes:
@@ -46,6 +48,8 @@
     elements:
     - disabled:
         value: 'no'
+    - frequency:
+        value: 2        
     - directories:
         value: "c:\\testdir1"
         attributes:

--- a/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
+++ b/tests/integration/test_fim/test_files/test_ambiguous_confs/test_ignore_works_over_restrict.py
@@ -174,9 +174,6 @@ def test_ignore_works_over_restrict(folder, filename, triggers_event, tags_to_ap
     logger.info(f'Adding file {os.path.join(testdir1, filename)}, content: ""')
     create_file(REGULAR, folder, filename, content='')
 
-    # Go ahead in time to let syscheck perform a new scan if mode is scheduled
-    logger.info(f'Time travel: {scheduled}')
-    check_time_travel(scheduled, monitor=wazuh_log_monitor)
 
     if triggers_event:
         logger.info('Checking the event...')

--- a/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_delete_full.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_file_limit_delete_full.py
@@ -64,7 +64,7 @@ import os
 from time import sleep
 
 import pytest
-from wazuh_testing import global_parameters
+from wazuh_testing import T_10, T_20
 from wazuh_testing.fim import LOG_FILE_PATH, delete_file, generate_params, create_file, REGULAR
 from wazuh_testing.tools import PREFIX
 from wazuh_testing.tools.configuration import load_wazuh_configurations
@@ -176,7 +176,7 @@ def test_file_limit_delete_full(folder, file_name, get_configuration, configure_
         - who_data
     '''
     #Check that database is full and assert database usage percentage is 100%
-    database_state = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+    database_state = wazuh_log_monitor.start(timeout=T_20,
                                              callback=generate_monitoring_callback(CB_FILE_LIMIT_CAPACITY),
                                              error_message=ERR_MSG_DATABASE_FULL_ALERT_EVENT).result()
 
@@ -190,7 +190,7 @@ def test_file_limit_delete_full(folder, file_name, get_configuration, configure_
 
     # Check no Creation or Deleted event has been  generated
     with pytest.raises(TimeoutError):
-        event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+        event = wazuh_log_monitor.start(timeout=T_10,
                                         callback=callback_detect_event).result()
         assert event is None, ERR_MSG_NO_EVENTS_EXPECTED
 
@@ -198,7 +198,7 @@ def test_file_limit_delete_full(folder, file_name, get_configuration, configure_
     delete_file(folder, f'{file_name}{0}')
 
     #Get that the file deleted generetes an event and assert the event data path.
-    event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout,
+    event = wazuh_log_monitor.start(timeout=T_20,
                                     callback=callback_detect_event,
                                     error_message=ERR_MSG_DELETED_EVENT_NOT_RECIEVED).result()
 

--- a/tests/integration/test_fim/test_synchronization/test_sync_interval.py
+++ b/tests/integration/test_fim/test_synchronization/test_sync_interval.py
@@ -94,7 +94,7 @@ def get_configuration(request):
 
 
 # Tests
-
+@pytest.mark.skip(reason="It will be blocked by #3992, when it was solve we can enable again this test")
 def test_sync_interval(get_configuration, configure_environment, restart_syscheckd, wait_for_fim_start):
     '''
     description: Check if the 'wazuh-syscheckd' daemon performs the file synchronization at the intervals


### PR DESCRIPTION
|Related issue|
|-------------|
| #3643             |

## Description

This Issue aims to test the unstable test module `/test_fim/test_files/test_file_limit/test_file_limit_delete_full.py`. During testing it was found that `test_sync_interval.py` was also flaky, but required further research, so it was skipped so it can be fixed (It is also skipped in 4.5)

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Fixed `test_file_limit_delete_full.py`
- Skipped `test_sync_interval.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  |           | ⚫⚫⚫ | [:green_circle::green_circle::green_circle:](https://github.com/wazuh/wazuh-qa/files/10885375/3643-ManagerResults.zip)  | Manager         |         | Nothing to highlight |
| @Deblintrake09  (Developer)  |           | ⚫⚫⚫ | [:green_circle::green_circle::green_circle:](https://github.com/wazuh/wazuh-qa/files/10885373/3643-LinuxAgentResults.zip) | Linux Agent        |         | Nothing to highlight |
| @Deblintrake09  (Developer)  |           | ⚫⚫⚫ | :large_blue_circle:  | Windows Agent        |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
