### PR TITLE
Add MSU Catalog Patches IT test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release report: TBD
 
 ### Added
 
+- Add tests for msu patches with no associated CVE . ([#4009](https://github.com/wazuh/wazuh-qa/pull/4009)) \- (Framework + tests)
 - Add tests with new options to avoid FIM synchronization overlapping. ([#3318](https://github.com/wazuh/wazuh-qa/pull/3318)) \- (Framework + tests)
 - Add Logcollector millisecond granularity support test case ([#3910](https://github.com/wazuh/wazuh-qa/pull/3910)) \- (Tests)
 - Add Windows System folders FIM monitoring tests ([#3720](https://github.com/wazuh/wazuh-qa/pull/3720)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Release report: TBD
 
 ### Added
 
-- Add tests for msu patches with no associated CVE . ([#4009](https://github.com/wazuh/wazuh-qa/pull/4009)) \- (Framework + tests)
+- Add tests for msu patches with no associated CVE . ([#4009](https://github.com/wazuh/wazuh-qa/pull/4009)) \- (Framework + Tests)
 - Add tests with new options to avoid FIM synchronization overlapping. ([#3318](https://github.com/wazuh/wazuh-qa/pull/3318)) \- (Framework + tests)
 - Add Logcollector millisecond granularity support test case ([#3910](https://github.com/wazuh/wazuh-qa/pull/3910)) \- (Tests)
 - Add Windows System folders FIM monitoring tests ([#3720](https://github.com/wazuh/wazuh-qa/pull/3720)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/db_interface/cve_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/cve_db.py
@@ -228,3 +228,27 @@ def get_nvd_metadata_timestamp(year):
         return None
 
     return result[0]
+
+
+def get_rows_from_table(value, column, table, limit=None):
+    """
+    Args:
+        value (str): value that user wants to find in query
+        column (str): Name of the column where the value will be searched for.
+        table (str): Name of the table where the value will be searched for.
+        limit (int) - Optional: Maximum amount of results to look for. Default None (No Limit used).
+
+    Returns:
+        List (str): List with each instance of the value found
+    """
+
+    query_string = f"SELECT * FROM {table} WHERE {column} LIKE '{value}'"
+    
+    if limit is not None:
+        query_string = query_string + f"LIMIT {limit}"
+
+    result = get_sqlite_query_result(CVE_DB_PATH, query_string)
+    if len(result) == 0:
+        return None
+
+    return result[0]

--- a/deps/wazuh_testing/wazuh_testing/db_interface/cve_db.py
+++ b/deps/wazuh_testing/wazuh_testing/db_interface/cve_db.py
@@ -243,7 +243,7 @@ def get_rows_from_table(value, column, table, limit=None):
     """
 
     query_string = f"SELECT * FROM {table} WHERE {column} LIKE '{value}'"
-    
+
     if limit is not None:
         query_string = query_string + f"LIMIT {limit}"
 

--- a/deps/wazuh_testing/wazuh_testing/modules/fim/classes.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/fim/classes.py
@@ -460,7 +460,7 @@ class RegistryEventChecker:
                 if self.is_value:
                     validate_registry_event(ev, options, mode, is_key=False)
                 else:
-                    validate_registry_event(ev, options, mode , is_key=False)
+                    validate_registry_event(ev, options, mode, is_key=False)
 
         def check_events_type(events, ev_type, reg_list=['testkey0']):
             """Checks the event type of each events in a list.

--- a/deps/wazuh_testing/wazuh_testing/modules/fim/classes.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/fim/classes.py
@@ -460,7 +460,7 @@ class RegistryEventChecker:
                 if self.is_value:
                     validate_registry_event(ev, options, mode, is_key=False)
                 else:
-                    validate_registry_event(ev, options, mode, is_key=False)
+                    validate_registry_event(ev, options, mode, is_key=True)
 
         def check_events_type(events, ev_type, reg_list=['testkey0']):
             """Checks the event type of each events in a list.

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_msu_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_msu_inventory.yaml
@@ -1,0 +1,47 @@
+- sections:
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: PROVIDER
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  value: OS
+
+    - section: sca
+      elements:
+      - enabled:
+          value: 'no'
+
+    - section: rootcheck
+      elements:
+      - disabled:
+          value: 'yes'
+
+    - section: syscheck
+      elements:
+      - disabled:
+          value: 'yes'
+
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: rule_test
+      elements:
+        - enabled:
+            value: 'no'

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_msu_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_msu_inventory.yaml
@@ -16,22 +16,22 @@
 
     - section: sca
       elements:
-      - enabled:
-          value: 'no'
+        - enabled:
+            value: 'no'
 
     - section: rootcheck
       elements:
-      - disabled:
-          value: 'yes'
+        - disabled:
+            value: 'yes'
 
     - section: syscheck
       elements:
-      - disabled:
-          value: 'yes'
+        - disabled:
+            value: 'yes'
 
     - section: wodle
       attributes:
-        - name: 'syscollector'
+        - name: syscollector
       elements:
         - disabled:
             value: 'yes'

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_msu_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_msu_inventory.yaml
@@ -1,0 +1,8 @@
+- name: Check Patches with no CVE present
+  description: Test patches with no associated CVE are added from the catalog
+  configuration_parameters:
+    PROVIDER: msu
+    OS: ''
+  metadata:
+    provider_name: Microsoft Security Update
+    download_timeout: 120

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_msu_inventory.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_msu_inventory.yaml
@@ -1,4 +1,4 @@
-- name: Check Patches with no CVE present
+- name: check_patches_with_no_cve_present
   description: Test patches with no associated CVE are added from the catalog
   configuration_parameters:
     PROVIDER: msu

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
@@ -82,10 +82,11 @@ configurations = load_configuration_template(configurations_path, configuration_
 # Variables
 patch_references = ['4465477', '5003711', '4470788']
 
+
 @pytest.mark.tier(level=2)
 @pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=case_ids)
 def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vdt, truncate_monitored_files,
-                        clean_cve_tables_func, restart_modulesd_function):
+                             clean_cve_tables_func, restart_modulesd_function):
     '''
     description: Check that patch information is added to the feed from the catalog for patches not directly related
                  to a Vulnerability.
@@ -101,8 +102,6 @@ def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vd
         Teardown:
             - Clean the database.
             - Stop wazuh-modulesd.
-
-        
 
     wazuh_min_version: 4.5.0
 
@@ -143,7 +142,7 @@ def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vd
     # Check that the feed has been updated successfully
     evm.check_provider_database_update_finish_log(provider_name=metadata['provider_name'],
                                                   timeout=metadata['download_timeout'])
-    
+
     for patch in patch_references:
         # Check that patch is present in MSU_SUPERSEDENCE table
         result = get_rows_from_table(patch, 'patch', 'MSU_SUPERSEDENCE')

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
@@ -1,0 +1,154 @@
+'''
+copyright: Copyright (C) 2015-2023, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, Amazon Linux and NVD Database.
+
+components:
+    - vulnerability_detector
+
+suite: feeds
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2022
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - Debian Buster
+    - Red Hat 8
+    - Ubuntu Trusty
+    - Ubuntu Xenial
+    - Ubuntu Bionic
+    - Ubuntu Focal
+    - Ubuntu Jammy
+    - SUSE Linux Enterprise Desktop 11
+    - SUSE Linux Enterprise Desktop 12
+    - SUSE Linux Enterprise Desktop 15
+    - SUSE Linux Enterprise Server 11
+    - SUSE Linux Enterprise Server 12
+    - SUSE Linux Enterprise Server 15
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/
+    - https://documentation.wazuh.com/current/user-manual/capabilities/syscollector.html
+
+tags:
+    - vulnerability
+    - vulnerability_detector
+    - download
+    - feeds
+'''
+import os
+import pytest
+
+from wazuh_testing.db_interface.cve_db import get_rows_from_table
+from wazuh_testing.tools.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
+
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+
+# Configuration and cases data
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_msu_inventory.yaml')
+cases_path = os.path.join(TEST_CASES_PATH, 'cases_msu_inventory.yaml')
+
+# Test configurations
+configuration_parameters, configuration_metadata, case_ids = get_test_cases_data(cases_path)
+configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
+
+# Variables
+patch_references = ['4465477', '5003711', '4470788']
+
+@pytest.mark.tier(level=2)
+@pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=case_ids)
+def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vdt, truncate_monitored_files,
+                        clean_cve_tables_func, restart_modulesd_function):
+    '''
+    description: Check that patch information is added to the feed from the catalog for patches not directly related
+                 to a Vulnerability.
+
+    test_phases:
+        Setup:
+            - Set a custom Wazuh configuration.
+            - Restart wazuh-modulesd.
+        Test:
+            - Check in log that the database provider has been updated successfully.
+            - Query the DB to check patch is found in MSU_SUPERSEDENSE table
+            - Query the DB to check patch is not foundin MSU table (Has not Vulnerability linked to it).
+        Teardown:
+            - Clean the database.
+            - Stop wazuh-modulesd.
+
+        
+
+    wazuh_min_version: 4.5.0
+
+    tier: 2
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata
+        - set_wazuh_configuration_vdt:
+            type: fixture
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - clean_cve_tables_func:
+            type: fixture
+            brief: Clean all the CVE tables before and after running the test.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
+
+    assertions:
+        - Check that the feed is downloaded successfully.
+        - Check that the referenced patch is found in MSU_SUPERSEDENSE table
+        - Check that the referenced patch is not foundin MSU table (Has not Vulnerability linked to it).
+
+    input_description:
+        - The `configuration_msu_inventory.yaml` file provides the module configuration for this test.
+        - The `cases_msu_inventory.yaml` file provides the test cases.
+
+    expected_output:
+        - r'The update of the .* feed finished successfully'
+    '''
+    # Check that the feed has been updated successfully
+    evm.check_provider_database_update_finish_log(provider_name=metadata['provider_name'],
+                                                  timeout=metadata['download_timeout'])
+    
+    for patch in patch_references:
+        # Check that patch is present in MSU_SUPERSEDENCE table
+        result = get_rows_from_table(patch, 'patch', 'MSU_SUPERSEDENCE')
+        assert result is not None, f"The Expected data for KB{patch} was not found in MSU_SUPERSEDENCE Table"
+
+        # Check that patch is not present in MSU table
+        result = get_rows_from_table(patch, 'patch', 'MSU')
+        assert result is None, f"Unexpected data found for KB{patch} in MSU Table"

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
@@ -99,7 +99,7 @@ def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vd
         Test:
             - Check in log that the database provider has been updated successfully.
             - Query the DB to check patch is found in MSU_SUPERSEDENSE table
-            - Query the DB to check patch is not found in MSU table (Has not Vulnerability linked to it).
+            - Query the DB to check patch is not found in MSU table (has no Vulnerability linked to it).
         Teardown:
             - Clean the database.
             - Stop wazuh-modulesd.
@@ -131,7 +131,7 @@ def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vd
     assertions:
         - Check that the feed is downloaded successfully.
         - Check that the referenced patch is found in MSU_SUPERSEDENSE table
-        - Check that the referenced patch is not foundin MSU table (Has not Vulnerability linked to it).
+        - Check that the referenced patch is not foundin MSU table (has no Vulnerability linked to it).
 
     input_description:
         - The `configuration_msu_inventory.yaml` file provides the module configuration for this test.
@@ -146,9 +146,9 @@ def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vd
 
     for patch in patch_references:
         # Check that patch is present in MSU_SUPERSEDENCE table
-        result = get_rows_from_table(patch, 'patch', 'MSU_SUPERSEDENCE')
-        assert result is not None, f"The Expected data for KB{patch} was not found in MSU_SUPERSEDENCE Table"
+        patch_found = get_rows_from_table(patch, 'patch', 'MSU_SUPERSEDENCE')
+        assert patch_found is not None, f"The Expected data for KB{patch} was not found in MSU_SUPERSEDENCE Table"
 
         # Check that patch is not present in MSU table
-        result = get_rows_from_table(patch, 'patch', 'MSU')
-        assert result is None, f"Unexpected data found for KB{patch} in MSU Table"
+        patch_in_table = get_rows_from_table(patch, 'patch', 'MSU')
+        assert patch_in_table is None, f"Unexpected data found for KB{patch} in MSU Table"

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
@@ -81,7 +81,7 @@ configurations = load_configuration_template(configurations_path, configuration_
 
 # Variables
 # This patches are searched for to verify they are added correctly from the Catalog even if not associated to a CVE
-patch_references = ['4465477', '5003711', '4470788'] 
+patch_references = ['4465477', '5003711', '4470788']
 
 
 @pytest.mark.tier(level=2)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
@@ -80,7 +80,8 @@ configuration_parameters, configuration_metadata, case_ids = get_test_cases_data
 configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
 
 # Variables
-patch_references = ['4465477', '5003711', '4470788']
+# This patches are searched for to verify they are added correctly from the Catalog even if not associated to a CVE
+patch_references = ['4465477', '5003711', '4470788'] 
 
 
 @pytest.mark.tier(level=2)
@@ -98,7 +99,7 @@ def test_msu_catalog_patches(configuration, metadata, set_wazuh_configuration_vd
         Test:
             - Check in log that the database provider has been updated successfully.
             - Query the DB to check patch is found in MSU_SUPERSEDENSE table
-            - Query the DB to check patch is not foundin MSU table (Has not Vulnerability linked to it).
+            - Query the DB to check patch is not found in MSU table (Has not Vulnerability linked to it).
         Teardown:
             - Clean the database.
             - Stop wazuh-modulesd.


### PR DESCRIPTION
|Related issue|
|-------------|
| #3361     |

## Description

This PR adds IT support for MSU patch information being added to the feed from the catalog for patches that have no CVE or vulnerability associated.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Added `test_msu_inventory.py` module and test cases
- Added the `get_rows_from_table` to the `cve_db.py` module. It returns each row of a given table that has a value searched by the user.

## Testing performed


<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  | test_vulnerability_detector          | ⚫⚫⚫ | [:yellow_circle::yellow_circle::yellow_circle:](https://github.com/wazuh/wazuh-qa/files/10935544/VDT_Results.zip)  | Centos8        |  https://github.com/wazuh/wazuh-qa/pull/4009/commits/c5bfb92b0cfee7e92a93f6d729fdc57ff2c566b1       | Failing tests are caused by Jenkins being down, so the latest feeds are older than the Tests allow.  |
| @damarisg  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
