### PR TITLE
Maintenance of the Wazuh migration tool when the test try to delete an inexistent folder 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Release report: TBD
 - Fix imports and add windows support for test_report_changes_and_diff IT ([#3548](https://github.com/wazuh/wazuh-qa/issues/3548)) \- (Framework + Tests)
 - Fix a regex error in the FIM integration tests ([#3061](https://github.com/wazuh/wazuh-qa/issues/3061)) \- (Framework + Tests)
 - Fix an error in the cluster performance tests related to CSV parser ([#2999](https://github.com/wazuh/wazuh-qa/pull/2999)) \- (Framework + Tests)
+- Fix bug in the framework on migration tool ([#2999](https://github.com/wazuh/wazuh-qa/pull/4027)) \- (Framework)
 
 
 ## [4.4.0] - Development (unreleased)

--- a/deps/wazuh_testing/wazuh_testing/tools/migration_tool/utils.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/migration_tool/utils.py
@@ -178,7 +178,8 @@ def clean_migration_tool_output_files():
     for output_folder in output_folders:
         for folder in vendors_folders:
             folder = os.path.join(output_folder, folder)
-            delete_all_files_in_folder(folder)
+            if os.path.exists(folder):
+                delete_all_files_in_folder(folder)
 
 
 def drop_migration_tool_tables():


### PR DESCRIPTION
|Related issue|
|-------------|
|    https://github.com/wazuh/wazuh-qa/issues/4026         |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

Fix bug in the QA framework in https://github.com/wazuh/wazuh-qa/blob/4.5/deps/wazuh_testing/wazuh_testing/tools/migration_tool/utils.py#LL172-L181C47 where try to delete a folder that not exists
## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @BelenValdivia   |   `deps/wazuh_testing/wazuh_testing/tools/migration_tool/utils.py`      | ⚫⚫⚫ | [🟢](https://github.com/wazuh/wazuh-qa/files/10994738/R1-tests-tool.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/10994741/R2-tests-tool.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/10994742/R3-tests-tool.zip)      |   4681e765411d76f2179aa80c29e0d66a318923c8      | Nothing to highlight |



