### PR TITLE
Add system tests for groups deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release report: TBD
 
 ### Added
 
+- Add system tests for groups deletion ([#4057](https://github.com/wazuh/wazuh-qa/pull/4057)) \- (Tests)
 - Add multigroups tests cases for `test_assign_groups_guess` ([#3979](https://github.com/wazuh/wazuh-qa/pull/3979)) \- (Tests)
 - Fix test_agent_groups system test ([#3955](https://github.com/wazuh/wazuh-qa/pull/3964)) \- (Tests)
 - Add new group_hash case and update the `without condition` case output in `wazuh_db/sync_agent_groups_get` ([#3959](https://github.com/wazuh/wazuh-qa/pull/3959)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.4.2] - TBD
 
+### Added
+
+- Add system tests for groups deletion ([#4057](https://github.com/wazuh/wazuh-qa/pull/4057)) \- (Tests)
+
 ### Fixed
 
 - Fix agentd IT for python3.10 AMI ([#3973](https://github.com/wazuh/wazuh-qa/pull/3973)) \- (Tests)
@@ -21,7 +25,6 @@ Release report: https://github.com/wazuh/wazuh/issues/15504
 
 ### Added
 
-- Add system tests for groups deletion ([#4057](https://github.com/wazuh/wazuh-qa/pull/4057)) \- (Tests)
 - Add multigroups tests cases for `test_assign_groups_guess` ([#3979](https://github.com/wazuh/wazuh-qa/pull/3979)) \- (Tests)
 - Add new group_hash case and update the `without condition` case output in `wazuh_db/sync_agent_groups_get` ([#3959](https://github.com/wazuh/wazuh-qa/pull/3959)) \- (Tests)
 - Add markers for each system test environment ([#3961](https://github.com/wazuh/wazuh-qa/pull/3961)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/tools/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/__init__.py
@@ -72,6 +72,7 @@ else:
     AGENT_AUTH_BINARY_PATH = os.path.join(WAZUH_PATH, 'bin', 'agent-auth')
     ANALYSISD_BINARY_PATH = os.path.join(WAZUH_PATH, 'bin', 'wazuh-analysisd')
     ACTIVE_RESPONSE_BINARY_PATH = os.path.join(WAZUH_PATH, 'active-response', 'bin')
+    AGENT_GROUPS_BINARY_PATH = os.path.join(WAZUH_PATH, 'bin', 'agent_groups')
 
     if sys.platform == 'sunos5':
         HOSTS_FILE_PATH = os.path.join('/', 'etc', 'inet', 'hosts')

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -133,12 +133,28 @@ def change_agent_group_with_wdb(agent_id, new_group, host, host_manager):
 
 
 def execute_wdb_query(query, host, host_manager):
+    """Function to execute wdb query.
+    Args:
+        query (str): Query to execute
+        host (str): Host name where the query will be executed.
+        host_manager (obj): Instance of HostManager.
+    Returns:
+        response (str): Obtained response.
+    """
     response = host_manager.run_command(host, f"python3 {WAZUH_PATH}/bin/wdb-query.py {query}")
 
     return response
 
 
 def get_group_id(group_name, host, host_manager):
+    """Function to obtain the group ID.
+    Args:
+        group_name (str): Name of the group from which the id will be obtained.
+        host (str): Host name where the query will be executed.
+        host_manager (obj): Instance of HostManager.
+    Returns:
+        group_id (int): Obtained group ID.
+    """
     group_table_command = 'sql select * from `group`;'
     query = f"global '{group_table_command}'"
     group_table = execute_wdb_query(query, host, host_manager)

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import json
 
 from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, CLUSTER_LOGS_PATH
 
@@ -135,3 +136,14 @@ def execute_wdb_query(query, host, host_manager):
     response = host_manager.run_command(host, f"python3 {WAZUH_PATH}/bin/wdb-query.py {query}")
 
     return response
+
+
+def get_group_id(group_name, host, host_manager):
+    group_table_command = 'sql select * from `group`;'
+    query = f"global '{group_table_command}'"
+    group_table = execute_wdb_query(query, host, host_manager)
+    for group_data in json.loads(group_table):
+        if group_data['name'] == group_name:
+            group_id = group_data['id']
+
+    return group_id

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -85,7 +85,13 @@ def assign_agent_to_new_group(host, id_group, id_agent, host_manager):
 
 
 def delete_agent_group(host, id_group, host_manager, method='tool'):
-    # Delete group
+    """Function to delete a group.
+    Args:
+        host (str): Host name where the query will be executed.
+        id_group (str): Name of the group from which the id will be obtained.
+        host_manager (obj): Instance of HostManager.
+        method (str): Method to be used to delete the group. Default:  tool.
+    """
     if method == 'tool':
         host_manager.run_command(host, f"{AGENT_GROUPS_BINARY_PATH} -q -r -g {id_group}")
     elif method == 'api':

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -84,9 +84,18 @@ def assign_agent_to_new_group(host, id_group, id_agent, host_manager):
     host_manager.run_command(host, f"/var/ossec/bin/agent_groups -q -a -i {id_agent} -g {id_group}")
 
 
-def delete_group_of_agents(host, id_group, host_manager):
+def delete_agent_group(host, id_group, host_manager, method='tool'):
     # Delete group
-    host_manager.run_command(host, f"/var/ossec/bin/agent_groups -q -r -g {id_group}")
+    if method == 'tool':
+        host_manager.run_command(host, f"/var/ossec/bin/agent_groups -q -r -g {id_group}")
+    elif method == 'api':
+        master_token = host_manager.get_api_token(host)
+        host_manager.make_api_call(host=host, method='DELETE', token=master_token,
+                                   endpoint=f"/groups?groups_list={id_group}")
+    elif method == 'folder':
+        host_manager.run_command(host, f"rm -rf /var/ossec/etc/shared/{id_group}")
+    else:
+        raise ValueError(f"{method} is not a valid method, it should be tool, api or folder")
 
 
 def check_agent_groups(agent_id, group_to_check, hosts_list, host_manager):

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -5,7 +5,7 @@
 import os
 import json
 
-from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, CLUSTER_LOGS_PATH
+from wazuh_testing.tools import WAZUH_PATH, LOG_FILE_PATH, CLUSTER_LOGS_PATH, AGENT_GROUPS_BINARY_PATH
 
 # Agent Variables
 AGENT_STATUS_ACTIVE = 'active'
@@ -87,7 +87,7 @@ def assign_agent_to_new_group(host, id_group, id_agent, host_manager):
 def delete_agent_group(host, id_group, host_manager, method='tool'):
     # Delete group
     if method == 'tool':
-        host_manager.run_command(host, f"/var/ossec/bin/agent_groups -q -r -g {id_group}")
+        host_manager.run_command(host, f"{AGENT_GROUPS_BINARY_PATH} -q -r -g {id_group}")
     elif method == 'api':
         master_token = host_manager.get_api_token(host)
         host_manager.make_api_call(host=host, method='DELETE', token=master_token,

--- a/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
+++ b/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
@@ -1,7 +1,40 @@
 - name: api
-  description: remove agent with api
+  description: remove group with api
   configuration_parameters: null
   metadata:
     method: |
             master_token = host_manager.get_api_token(test_infra_managers[0])
-            response = host_manager.make_api_call(host=test_infra_managers[0], method='DELETE', token=master_token, endpoint=f"/groups?groups_list={group}")
+            host_manager.make_api_call(host=test_infra_managers[0], method='DELETE', token=master_token, endpoint=f"/groups?groups_list={group}")
+    deleted: yes
+
+- name: tool
+  description: remove group with agent_groups
+  configuration_parameters: null
+  metadata:
+    method: |
+            host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -r -g {group}")
+    deleted: yes
+
+- name: master_folder
+  description: remove group by removing its folder in master node
+  configuration_parameters: null
+  metadata:
+    method: |
+            host_manager.run_command(test_infra_managers[0], f"rm -rf /var/ossec/etc/shared/{group}")
+    deleted: yes
+
+- name: worker1_folder
+  description: remove group by removing its folder in worker node
+  configuration_parameters: null
+  metadata:
+    method: |
+            host_manager.run_command(test_infra_managers[1], f"rm -rf /var/ossec/etc/shared/{group}")
+    deleted: no
+
+- name: worker2_folder
+  description: remove group by removing its folder in worker node
+  configuration_parameters: null
+  metadata:
+    method: |
+            host_manager.run_command(test_infra_managers[2], f"rm -rf /var/ossec/etc/shared/{group}")
+    deleted: no

--- a/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
+++ b/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
@@ -1,0 +1,7 @@
+- name: api
+  description: remove agent with api
+  configuration_parameters: null
+  metadata:
+    method: |
+            master_token = host_manager.get_api_token(test_infra_managers[0])
+            response = host_manager.make_api_call(host=test_infra_managers[0], method='DELETE', token=master_token, endpoint=f"/groups?groups_list={group}")

--- a/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
+++ b/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
@@ -3,38 +3,39 @@
   configuration_parameters: null
   metadata:
     method: |
-            master_token = host_manager.get_api_token(test_infra_managers[0])
-            host_manager.make_api_call(host=test_infra_managers[0], method='DELETE', token=master_token, endpoint=f"/groups?groups_list={group}")
-    deleted: yes
+      master_token = host_manager.get_api_token(test_infra_managers[0])
+      host_manager.make_api_call(host=test_infra_managers[0], method='DELETE', token=master_token,
+      endpoint=f"/groups?groups_list={group}")
+    deleted: true
 
 - name: tool
   description: remove group with agent_groups
   configuration_parameters: null
   metadata:
     method: |
-            host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -r -g {group}")
-    deleted: yes
+      host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -r -g {group}")
+    deleted: true
 
 - name: master_folder
   description: remove group by removing its folder in master node
   configuration_parameters: null
   metadata:
     method: |
-            host_manager.run_command(test_infra_managers[0], f"rm -rf /var/ossec/etc/shared/{group}")
-    deleted: yes
+      host_manager.run_command(test_infra_managers[0], f"rm -rf /var/ossec/etc/shared/{group}")
+    deleted: true
 
 - name: worker1_folder
   description: remove group by removing its folder in worker node
   configuration_parameters: null
   metadata:
     method: |
-            host_manager.run_command(test_infra_managers[1], f"rm -rf /var/ossec/etc/shared/{group}")
-    deleted: no
+      host_manager.run_command(test_infra_managers[1], f"rm -rf /var/ossec/etc/shared/{group}")
+    deleted: false
 
 - name: worker2_folder
   description: remove group by removing its folder in worker node
   configuration_parameters: null
   metadata:
     method: |
-            host_manager.run_command(test_infra_managers[2], f"rm -rf /var/ossec/etc/shared/{group}")
-    deleted: no
+      host_manager.run_command(test_infra_managers[2], f"rm -rf /var/ossec/etc/shared/{group}")
+    deleted: false

--- a/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
+++ b/tests/system/test_cluster/test_agent_groups/data/cases_remove_group.yaml
@@ -3,9 +3,7 @@
   configuration_parameters: null
   metadata:
     method: |
-      master_token = host_manager.get_api_token(test_infra_managers[0])
-      host_manager.make_api_call(host=test_infra_managers[0], method='DELETE', token=master_token,
-      endpoint=f"/groups?groups_list={group}")
+      delete_agent_group(test_infra_managers[0], group, host_manager, 'api')
     deleted: true
 
 - name: tool
@@ -13,7 +11,7 @@
   configuration_parameters: null
   metadata:
     method: |
-      host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -r -g {group}")
+      delete_agent_group(test_infra_managers[0], group, host_manager, 'tool')
     deleted: true
 
 - name: master_folder
@@ -21,7 +19,7 @@
   configuration_parameters: null
   metadata:
     method: |
-      host_manager.run_command(test_infra_managers[0], f"rm -rf /var/ossec/etc/shared/{group}")
+      delete_agent_group(test_infra_managers[0], group, host_manager, 'folder')
     deleted: true
 
 - name: worker1_folder
@@ -29,7 +27,7 @@
   configuration_parameters: null
   metadata:
     method: |
-      host_manager.run_command(test_infra_managers[1], f"rm -rf /var/ossec/etc/shared/{group}")
+      delete_agent_group(test_infra_managers[1], group, host_manager, 'folder')
     deleted: false
 
 - name: worker2_folder
@@ -37,5 +35,5 @@
   configuration_parameters: null
   metadata:
     method: |
-      host_manager.run_command(test_infra_managers[2], f"rm -rf /var/ossec/etc/shared/{group}")
+      delete_agent_group(test_infra_managers[2], group, host_manager, 'folder')
     deleted: false

--- a/tests/system/test_cluster/test_agent_groups/data/remove_group_messages.yaml
+++ b/tests/system/test_cluster/test_agent_groups/data/remove_group_messages.yaml
@@ -1,0 +1,4 @@
+wazuh-master:
+  - regex: .*Agent-groups send full.* Finished.*
+    path: var/ossec/logs/cluster.log
+    timeout: 60

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_group_with_enrollment.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_group_with_enrollment.py
@@ -45,7 +45,7 @@ import os
 import time
 import pytest
 
-from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, restart_cluster, check_keys_file, delete_group_of_agents,
+from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, restart_cluster, check_keys_file, delete_agent_group,
                     check_agent_groups_db)
 from wazuh_testing.tools.monitoring import HostMonitor
 from wazuh_testing.tools.system import HostManager
@@ -124,4 +124,4 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
 
     finally:
         # Delete group of agent
-        delete_group_of_agents(test_infra_managers[0], id_group, host_manager)
+        delete_agent_group(test_infra_managers[0], id_group, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_never_connected_to_group.py
@@ -44,7 +44,7 @@ import os
 import pytest
 
 from system.test_cluster.test_agent_groups.common import register_agent
-from system import (check_agent_groups, check_agent_status, check_keys_file, delete_group_of_agents,
+from system import (check_agent_groups, check_agent_status, check_keys_file, delete_agent_group,
                     AGENT_STATUS_NEVER_CONNECTED, ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND)
 from wazuh_testing.tools.system import HostManager
 
@@ -105,4 +105,4 @@ def test_assign_agent_to_a_group(agent_target, clean_environment):
 
     finally:
         # Delete group of agent
-        delete_group_of_agents('wazuh-master', id_group, host_manager)
+        delete_agent_group('wazuh-master', id_group, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py
@@ -47,7 +47,7 @@ import pytest
 from system.test_cluster.test_agent_groups.common import register_agent
 from system import (AGENT_NO_GROUPS, AGENT_STATUS_ACTIVE, AGENT_STATUS_DISCONNECTED, check_agent_groups,
                     check_agent_status, restart_cluster, check_keys_file, assign_agent_to_new_group,
-                    delete_group_of_agents, ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, create_new_agent_group)
+                    delete_agent_group, ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, create_new_agent_group)
 from wazuh_testing.modules import WAZUH_SERVICE_PREFIX, WAZUH_SERVICES_STOPPED
 from wazuh_testing.tools.system import HostManager
 
@@ -128,4 +128,4 @@ def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment
 
     finally:
         # Delete group of agent
-        delete_group_of_agents('wazuh-master', test_group, host_manager)
+        delete_agent_group('wazuh-master', test_group, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_api.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_api.py
@@ -46,7 +46,7 @@ import pytest
 from system.test_cluster.test_agent_groups.common import register_agent
 from system import (AGENT_NO_GROUPS, AGENT_STATUS_ACTIVE, AGENT_STATUS_DISCONNECTED, ERR_MSG_FAILED_TO_SET_AGENT_GROUP,
                     ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_agent_status, restart_cluster,
-                    check_keys_file, delete_group_of_agents, create_new_agent_group)
+                    check_keys_file, delete_agent_group, create_new_agent_group)
 from wazuh_testing.tools.system import HostManager
 
 
@@ -131,4 +131,4 @@ def test_assign_agent_to_a_group(agent_target, initial_status, clean_environment
 
     # Delete group of agent
     finally:
-        delete_group_of_agents(test_infra_managers[0], test_group, host_manager)
+        delete_agent_group(test_infra_managers[0], test_group, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_by_tool.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group_by_tool.py
@@ -48,7 +48,7 @@ import pytest
 
 from system.test_cluster.test_agent_groups.common import register_agent
 from system import (check_agent_groups, check_agent_status, check_keys_file, create_new_agent_group,
-                    delete_group_of_agents, assign_agent_to_new_group, AGENT_NO_GROUPS, AGENT_STATUS_NEVER_CONNECTED)
+                    delete_agent_group, assign_agent_to_new_group, AGENT_NO_GROUPS, AGENT_STATUS_NEVER_CONNECTED)
 from wazuh_testing.tools.system import HostManager
 
 
@@ -117,4 +117,4 @@ def test_assign_agent_to_a_group_by_tool(agent_target, clean_environment):
 
     finally:
         # Delete group of agent
-        delete_group_of_agents(test_infra_managers[0], group_id, host_manager)
+        delete_agent_group(test_infra_managers[0], group_id, host_manager)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
@@ -46,7 +46,7 @@ import pytest
 
 from system.test_cluster.test_agent_groups.common import register_agent
 from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
-                    create_new_agent_group, delete_group_of_agents, remove_cluster_agents,
+                    create_new_agent_group, delete_agent_group, remove_cluster_agents,
                     assign_agent_to_new_group, restart_cluster)
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.tools.file import replace_regex_in_file
@@ -189,7 +189,7 @@ def test_guess_single_group(target_node, status_guess_agent_group, clean_environ
 
     finally:
         # Delete group of agent
-        delete_group_of_agents(test_infra_managers[0], group_id, host_manager)
+        delete_agent_group(test_infra_managers[0], group_id, host_manager)
         replace_regex_in_file([agent_id, expected_group], ['AGENT_ID', 'GROUP_ID'], messages_path)
 
 
@@ -285,5 +285,5 @@ def test_guess_multigroups(n_agents, target_node, status_guess_agent_group, clea
 
     finally:
         # Delete group of agent
-        delete_group_of_agents(test_infra_managers[0], group_id, host_manager)
+        delete_agent_group(test_infra_managers[0], group_id, host_manager)
         replace_regex_in_file([agent1_id, expected_group], ['AGENT_ID', 'GROUP_ID'], messages_path)

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -3,7 +3,8 @@ import pytest
 from time import sleep
 
 from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
-                    create_new_agent_group, assign_agent_to_new_group, restart_cluster, execute_wdb_query, get_group_id)
+                    create_new_agent_group, assign_agent_to_new_group, restart_cluster, execute_wdb_query, get_group_id,
+                    delete_group_of_agents)
 from wazuh_testing import T_10
 from system.test_cluster.test_agent_groups.common import register_agent
 from wazuh_testing.tools.configuration import get_test_cases_data
@@ -58,6 +59,11 @@ def pre_configured_groups(target_node, group):
 
     # Check that agent has group assigned on every node
     check_agent_groups(agent_id, group, test_infra_managers, host_manager)
+
+    yield
+
+    if group != 'default':
+        delete_group_of_agents(test_infra_managers[0], group, host_manager)
 
 
 # Tests

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -4,7 +4,7 @@ from time import sleep
 
 from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
                     create_new_agent_group, assign_agent_to_new_group, restart_cluster, execute_wdb_query, get_group_id,
-                    delete_group_of_agents)
+                    delete_agent_group)
 from wazuh_testing import T_10
 from system.test_cluster.test_agent_groups.common import register_agent
 from wazuh_testing.tools.configuration import get_test_cases_data
@@ -63,7 +63,7 @@ def pre_configured_groups(target_node, group):
     yield
 
     if group != 'default':
-        delete_group_of_agents(test_infra_managers[0], group, host_manager)
+        delete_agent_group(test_infra_managers[0], group, host_manager)
 
 
 # Tests

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -1,0 +1,78 @@
+import os
+import pytest
+
+from system.test_cluster.test_agent_groups.common import register_agent
+from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
+                    create_new_agent_group, assign_agent_to_new_group, restart_cluster, execute_wdb_query, get_group_id)
+from wazuh_testing.tools.system import HostManager
+from wazuh_testing.tools.configuration import get_test_cases_data
+
+pytestmark = [pytest.mark.cluster, pytest.mark.enrollment_cluster_env]
+
+# Hosts
+test_infra_managers = ['wazuh-master', 'wazuh-worker1', 'wazuh-worker2']
+test_infra_agents = ['wazuh-agent1', 'wazuh-agent2']
+
+inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                              'provisioning', 'enrollment_cluster', 'inventory.yml')
+data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+host_manager = HostManager(inventory_path)
+local_path = os.path.dirname(os.path.abspath(__file__))
+tmp_path = os.path.join(local_path, 'tmp')
+t1_cases_path = os.path.join(data_path, 'cases_remove_group.yaml')
+
+# Variables
+t1_configuration_parameters, t1_configuration_metadata, t1_case_ids = get_test_cases_data(t1_cases_path)
+queries = ['sql select `group` from agent;', 'sql select name from `group`;', 'sql select id_group from belongs;']
+
+
+# Fixtures
+@pytest.fixture()
+def pre_configured_groups(target_node, group):
+    """Fixture to create a group and assign an agent during the setup."""
+    # Create group
+    if group != 'default':
+        create_new_agent_group(test_infra_managers[0], group, host_manager)
+
+    # Register agent with agent-auth
+    agent_ip, agent_id, agent_name, manager_ip = register_agent(test_infra_agents[0], target_node,
+                                                                host_manager)
+
+    # Restart agent
+    restart_cluster([test_infra_agents[0]], host_manager)
+
+    # Check that agent has client key file
+    assert check_keys_file(test_infra_agents[0], host_manager), ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND
+
+    # Assign agent to group
+    if group != 'default':
+        assign_agent_to_new_group(test_infra_managers[0], group, agent_id, host_manager)
+
+    # Check that agent has group assigned on every node
+    check_agent_groups(agent_id, group, test_infra_managers, host_manager)
+
+
+# Tests
+@pytest.mark.parametrize('metadata', t1_configuration_metadata, ids=t1_case_ids)
+@pytest.mark.parametrize('group', ['group_test'])
+@pytest.mark.parametrize('target_node', ['wazuh-master'])
+def test_remove_group(metadata, group, target_node, pre_configured_groups, clean_environment):
+    '''
+    description:
+    wazuh_min_version: 4.4.0
+    parameters:
+    assertions:
+    '''
+    # Get group ID
+    group_id = get_group_id(group, test_infra_managers[0], host_manager)
+
+    # Delete group
+    exec(metadata['method'])
+
+    # Check group is deleted in agent table in every node
+    for query in queries:
+        for manager in test_infra_managers:
+            global_query = f"global '{query}'"
+            response = execute_wdb_query(global_query, manager, host_manager)
+            print(manager)
+            assert group and str(group_id) not in response, 'Group not deleted correctly'

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -1,11 +1,14 @@
 import os
 import pytest
+from time import sleep
 
-from system.test_cluster.test_agent_groups.common import register_agent
+import wazuh_testing as fw
 from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
                     create_new_agent_group, assign_agent_to_new_group, restart_cluster, execute_wdb_query, get_group_id)
-from wazuh_testing.tools.system import HostManager
+from system.test_cluster.test_agent_groups.common import register_agent
 from wazuh_testing.tools.configuration import get_test_cases_data
+from wazuh_testing.tools.monitoring import HostMonitor
+from wazuh_testing.tools.system import HostManager
 
 pytestmark = [pytest.mark.cluster, pytest.mark.enrollment_cluster_env]
 
@@ -20,6 +23,7 @@ host_manager = HostManager(inventory_path)
 local_path = os.path.dirname(os.path.abspath(__file__))
 tmp_path = os.path.join(local_path, 'tmp')
 t1_cases_path = os.path.join(data_path, 'cases_remove_group.yaml')
+messages_path = os.path.join(data_path, 'remove_group_messages.yaml')
 
 # Variables
 t1_configuration_parameters, t1_configuration_metadata, t1_case_ids = get_test_cases_data(t1_cases_path)
@@ -55,24 +59,64 @@ def pre_configured_groups(target_node, group):
 # Tests
 @pytest.mark.parametrize('metadata', t1_configuration_metadata, ids=t1_case_ids)
 @pytest.mark.parametrize('group', ['group_test'])
-@pytest.mark.parametrize('target_node', ['wazuh-master'])
+@pytest.mark.parametrize('target_node', ['wazuh-master', 'wazuh-worker1'])
 def test_remove_group(metadata, group, target_node, pre_configured_groups, clean_environment):
     '''
-    description:
+    description: Check that when a group is deleted using different methods, it is deleted on all nodes, except when
+                 the group folder is deleted in a worker.
     wazuh_min_version: 4.4.0
     parameters:
+        - metadata:
+            type: dict
+            brief: Get metadata from the module.
+        - group:
+            type: string
+            brief: Group name.
+        - target_node:
+            type: string
+            brief: Name of the host where the agent will register.
+        - pre_configured_groups:
+            type: fixture
+            brief: Create group, register and assign agent during the setup.
+        - clean_environment:
+            type: fixture
+            brief: Reset the wazuh log files at the start of the test. Remove all registered agents from master.
     assertions:
+        - Verify [Agent-groups send full] task finished when the group folder is removed in a worker node.
+        - Verify group name is present in agent table when the group folder is removed in a worker node.
+        - Verify group id is present in agent table when the group folder is removed in a worker node.
+        - Verify group name is not present in agent table when group is deleted.
+        - Verify group id is not present in agent table when group is deleted.
     '''
-    # Get group ID
-    group_id = get_group_id(group, test_infra_managers[0], host_manager)
+    # Get group IDs
+    group_ids = {}
+    for manager in test_infra_managers:
+        group_ids[manager] = str(get_group_id(group, manager, host_manager))
 
     # Delete group
     exec(metadata['method'])
+    sleep(fw.T_10)
 
-    # Check group is deleted in agent table in every node
+    if not metadata['deleted']:
+        HostMonitor(inventory_path=inventory_path,
+                    messages_path=messages_path,
+                    tmp_path=tmp_path).run(update_position=True)
+
+        for manager in test_infra_managers:
+            group_ids[manager] = str(get_group_id(group, manager, host_manager))
+
+    # Check group is deleted or not if exepceted in agent table in every node
     for query in queries:
         for manager in test_infra_managers:
             global_query = f"global '{query}'"
             response = execute_wdb_query(global_query, manager, host_manager)
-            print(manager)
-            assert group and str(group_id) not in response, 'Group not deleted correctly'
+            if metadata['deleted']:
+                if 'id_group' in query:
+                    assert group_ids[manager] not in response, f"Group not deleted correctly in {manager}"
+                else:
+                    assert group not in response, f"Group not deleted correctly in {manager}"
+            else:
+                if 'id_group' in query:
+                    assert group_ids[manager] in response, f"Group deleted in {manager}"
+                else:
+                    assert group in response, f"Group deleted in {manager}"

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -105,7 +105,7 @@ def test_remove_group(metadata, group, target_node, pre_configured_groups, clean
         for manager in test_infra_managers:
             group_ids[manager] = str(get_group_id(group, manager, host_manager))
 
-    # Check group is deleted or not if exepceted in agent table in every node
+    # Check group is deleted or not if expected in agent table in every node
     for query in queries:
         for manager in test_infra_managers:
             global_query = f"global '{query}'"

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -2,9 +2,9 @@ import os
 import pytest
 from time import sleep
 
-import wazuh_testing as fw
 from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
                     create_new_agent_group, assign_agent_to_new_group, restart_cluster, execute_wdb_query, get_group_id)
+from wazuh_testing import T_10
 from system.test_cluster.test_agent_groups.common import register_agent
 from wazuh_testing.tools.configuration import get_test_cases_data
 from wazuh_testing.tools.monitoring import HostMonitor
@@ -95,7 +95,7 @@ def test_remove_group(metadata, group, target_node, pre_configured_groups, clean
 
     # Delete group
     exec(metadata['method'])
-    sleep(fw.T_10)
+    sleep(T_10)
 
     if not metadata['deleted']:
         HostMonitor(inventory_path=inventory_path,

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -62,8 +62,8 @@ def pre_configured_groups(target_node, group):
 @pytest.mark.parametrize('target_node', ['wazuh-master', 'wazuh-worker1'])
 def test_remove_group(metadata, group, target_node, pre_configured_groups, clean_environment):
     '''
-    description: Check that when a group is deleted using different methods, it is deleted on all nodes, except when
-                 the group folder is deleted in a worker.
+    description: Check that a group is completely deleted from all nodes when using different deletion methods, with the
+                 exception of cases where the group folder is deleted on a worker node.
     wazuh_min_version: 4.4.0
     parameters:
         - metadata:

--- a/tests/system/test_cluster/test_agent_groups/test_remove_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_remove_group.py
@@ -33,7 +33,11 @@ queries = ['sql select `group` from agent;', 'sql select name from `group`;', 's
 # Fixtures
 @pytest.fixture()
 def pre_configured_groups(target_node, group):
-    """Fixture to create a group and assign an agent during the setup."""
+    """Fixture to create a group and assign an agent during the setup.
+    Args:
+        target_node (str): Name of the host where the agent will register.
+        group (str): Group name.
+    """
     # Create group
     if group != 'default':
         create_new_agent_group(test_infra_managers[0], group, host_manager)


### PR DESCRIPTION
|Related issue|
|-------------|
|   #3912           |

## Description

Add a test that checks if groups are deleted correctly.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Added `test_remove_group.py`
- Added `cases_remove_group.yaml`
- Added `remove_group_messages.yaml`
- Added `get_group_id()`
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local   | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan  (Developer)  |    `tests/system/test_cluster/test_agent_groups/test_remove_group.py`       | :no_entry_sign: :no_entry_sign: :no_entry_sign: | [🟢 ](https://github.com/wazuh/wazuh-qa/files/11221093/R1_test_remove_group.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/11221097/R2_test_remove_group.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/11221099/R3_test_remove_group.zip) |    91adbe7 | Nothing to highlight |
| @user (Reviewer)   |           | :no_entry_sign: :no_entry_sign: :no_entry_sign: | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |               | Nothing to highlight |
