### PR TITLE
Add VDT does not report updated vulnerable packages as Solved IT

### DIFF
--- a/tests/integration/test_vulnerability_detector/data/feeds/canonical/custom_feed_updated_packace_still_vulnerable.xml
+++ b/tests/integration/test_vulnerability_detector/data/feeds/canonical/custom_feed_updated_packace_still_vulnerable.xml
@@ -17,12 +17,15 @@
             <metadata>
                 <title>CVE-2023 custom-package-0</title>
                 <affected family="unix">
-                    <platform>Ubuntu 20.04</platform>
+                    <platform>Ubuntu 22.04 LTS</platform>
+                    <platform>Ubuntu 20.04 LTS</platform>
+                    <platform>Ubuntu 18.04 LTS</platform>
+                    <platform>Ubuntu 16.04 LTS</platform>
+                    <platform>Ubuntu 14.04 LTS</platform>
                 </affected>
                 <reference source="CVE" ref_id="CVE-2023" ref_url="https://github.com/wazuh/wazuh-qa" />
             </metadata>
             <criteria>
-                <extend_definition definition_ref="oval:com.ubuntu.focal:def:100" comment="Ubuntu 20.04 (focal) is installed." applicability_check="true" />
                 <criteria operator="OR">
                     <criterion test_ref="oval:com.ubuntu.focal:tst:1" comment="dummy-fixed package in focal, is related to the CVE in some way and has been fixed (note: '10.0.0')." />
                 </criteria>
@@ -37,8 +40,7 @@
     </tests>
     <objects>
         <linux-def:dpkginfo_object id="oval:com.ubuntu.focal:obj:1" version="1" comment="The 'dummy-fixed' package binary.">
-            <linux-def:name var_ref="oval:com.ubuntu.focal:var:1" var_check="at least one" />
-            <linux-def:name>dummy-fixed</linux-def:name>
+            <linux-def:name>custom-package-0</linux-def:name>
         </linux-def:dpkginfo_object>
     </objects>
     <states>
@@ -46,9 +48,4 @@
             <linux-def:evr datatype="debian_evr_string" operation="less than">10.0.0</linux-def:evr>
         </linux-def:dpkginfo_state>
     </states>
-    <variables>
-        <constant_variable id="oval:com.ubuntu.focal:var:1" version="1" datatype="string" comment="'dummy-fixed' package binaries">
-            <value>custom-package-0</value>
-        </constant_variable>
-    </variables>
 </oval_definitions>

--- a/tests/integration/test_vulnerability_detector/data/feeds/canonical/custom_feed_updated_packace_still_vulnerable.xml
+++ b/tests/integration/test_vulnerability_detector/data/feeds/canonical/custom_feed_updated_packace_still_vulnerable.xml
@@ -1,0 +1,54 @@
+<oval_definitions
+    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+    xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+    xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
+    xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#macos linux-definitions-schema.xsd">
+
+    <generator>
+        <oval:product_name>Canonical CVE OVAL Generator</oval:product_name>
+        <oval:product_version>1.1</oval:product_version>
+        <oval:schema_version>5.11.1</oval:schema_version>
+        <oval:timestamp>2021-11-16T15:30:28</oval:timestamp>
+    </generator>
+    <definitions>
+        <definition class="vulnerability" id="oval:com.ubuntu.focal:def:1" version="1">
+            <metadata>
+                <title>CVE-2023 custom-package-0</title>
+                <affected family="unix">
+                    <platform>Ubuntu 20.04</platform>
+                </affected>
+                <reference source="CVE" ref_id="CVE-2023" ref_url="https://github.com/wazuh/wazuh-qa" />
+            </metadata>
+            <criteria>
+                <extend_definition definition_ref="oval:com.ubuntu.focal:def:100" comment="Ubuntu 20.04 (focal) is installed." applicability_check="true" />
+                <criteria operator="OR">
+                    <criterion test_ref="oval:com.ubuntu.focal:tst:1" comment="dummy-fixed package in focal, is related to the CVE in some way and has been fixed (note: '10.0.0')." />
+                </criteria>
+            </criteria>
+        </definition>
+    </definitions>
+    <tests>
+        <linux-def:dpkginfo_test id="oval:com.ubuntu.focal:tst:1" version="1" check_existence="at_least_one_exists" check="at least one" comment="Does the 'dummy-fixed' package exist and is the version less than '10.0.0'?">
+            <linux-def:object object_ref="oval:com.ubuntu.focal:obj:1"/>
+            <linux-def:state state_ref="oval:com.ubuntu.focal:ste:1" />
+        </linux-def:dpkginfo_test>
+    </tests>
+    <objects>
+        <linux-def:dpkginfo_object id="oval:com.ubuntu.focal:obj:1" version="1" comment="The 'dummy-fixed' package binary.">
+            <linux-def:name var_ref="oval:com.ubuntu.focal:var:1" var_check="at least one" />
+            <linux-def:name>dummy-fixed</linux-def:name>
+        </linux-def:dpkginfo_object>
+    </objects>
+    <states>
+        <linux-def:dpkginfo_state id="oval:com.ubuntu.focal:ste:1" version="1" comment="The package version is less than '10.0.0'.">
+            <linux-def:evr datatype="debian_evr_string" operation="less than">10.0.0</linux-def:evr>
+        </linux-def:dpkginfo_state>
+    </states>
+    <variables>
+        <constant_variable id="oval:com.ubuntu.focal:var:1" version="1" datatype="string" comment="'dummy-fixed' package binaries">
+            <value>custom-package-0</value>
+        </constant_variable>
+    </variables>
+</oval_definitions>

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_updated_package_still_vulnerable.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_updated_package_still_vulnerable.yaml
@@ -1,0 +1,59 @@
+# Redhat Configuration
+- sections:
+    - section: vulnerability-detector
+      elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: '5s'
+        - min_full_scan_interval:
+            value: '5s'
+        - run_on_start:
+            value: 'yes'
+        - provider:
+            attributes:
+              - name: canonical
+            elements:
+              - enabled:
+                  value: 'yes'
+              - os:
+                  attributes:
+                    - path: CUSTOM_OVAL_FEED
+                  value: focal
+        - provider:
+            attributes:
+              - name: 'nvd'
+            elements:
+              - enabled:
+                  value: 'yes'
+              - path:
+                  value: CUSTOM_NVD_JSON_FEED
+              - update_interval:
+                  value: '10s'
+
+    - section: sca
+      elements:
+      - enabled:
+          value: 'no'
+
+    - section: rootcheck
+      elements:
+      - disabled:
+          value: 'yes'
+
+    - section: syscheck
+      elements:
+      - disabled:
+          value: 'yes'
+
+    - section: wodle
+      attributes:
+        - name: 'syscollector'
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: auth
+      elements:
+        - disabled:
+            value: 'no'

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_updated_package_still_vulnerable.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_updated_package_still_vulnerable.yaml
@@ -5,9 +5,9 @@
         - enabled:
             value: 'yes'
         - interval:
-            value: '5s'
+            value: 5s
         - min_full_scan_interval:
-            value: '5s'
+            value: 5s
         - run_on_start:
             value: 'yes'
         - provider:
@@ -22,33 +22,33 @@
                   value: focal
         - provider:
             attributes:
-              - name: 'nvd'
+              - name: nvd
             elements:
               - enabled:
                   value: 'yes'
               - path:
                   value: CUSTOM_NVD_JSON_FEED
               - update_interval:
-                  value: '10s'
+                  value: 10s
 
     - section: sca
       elements:
-      - enabled:
-          value: 'no'
+        - enabled:
+            value: 'no'
 
     - section: rootcheck
       elements:
-      - disabled:
-          value: 'yes'
+        - disabled:
+            value: 'yes'
 
     - section: syscheck
       elements:
-      - disabled:
-          value: 'yes'
+        - disabled:
+            value: 'yes'
 
     - section: wodle
       attributes:
-        - name: 'syscollector'
+        - name: syscollector
       elements:
         - disabled:
             value: 'yes'
@@ -57,3 +57,4 @@
       elements:
         - disabled:
             value: 'no'
+  

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_updated_package_still_vulnerable.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_updated_package_still_vulnerable.yaml
@@ -1,0 +1,14 @@
+- name: 'Alert vulnerability removal'
+  description: 'Alert when a package is removed from the database'
+  configuration_parameters: null
+  metadata:
+    provider_name: 'canonical'
+    system: 'FOCAL'
+    oval_feed: 'custom_feed_updated_packace_still_vulnerable.xml'
+    nvd_feed: 'real_nvd_feed.json'
+    oval_feed_tag: CUSTOM_OVAL_FEED
+    nvd_feed_tag: CUSTOM_NVD_JSON_FEED
+    test_package_version: '1.0.0'
+    test_package_version_still_vulnerable: '9.0.0'
+    test_package_name: custom-package-0
+    cve: CVE-2023

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_updated_package_still_vulnerable.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_updated_package_still_vulnerable.yaml
@@ -1,14 +1,14 @@
-- name: 'Alert vulnerability removal'
-  description: 'Alert when a package is removed from the database'
+- name: no_alert_updated_package_still_vulnerable
+  description: When a package is updated to still vulnerable version, no alert appears showing package vuln as solved
   configuration_parameters: null
   metadata:
-    provider_name: 'canonical'
-    system: 'FOCAL'
-    oval_feed: 'custom_feed_updated_packace_still_vulnerable.xml'
-    nvd_feed: 'real_nvd_feed.json'
+    provider_name: canonical
+    system: FOCAL
+    oval_feed: custom_feed_updated_packace_still_vulnerable.xml
+    nvd_feed: real_nvd_feed.json
     oval_feed_tag: CUSTOM_OVAL_FEED
     nvd_feed_tag: CUSTOM_NVD_JSON_FEED
-    test_package_version: '1.0.0'
-    test_package_version_still_vulnerable: '9.0.0'
+    test_package_version: 1.0.0
+    test_package_version_still_vulnerable: 9.0.0
     test_package_name: custom-package-0
     cve: CVE-2023

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_updated_package_still_vulnerable.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_updated_package_still_vulnerable.py
@@ -90,7 +90,7 @@ systems = [metadata['system'] for metadata in configuration_metadata]
 @pytest.mark.parametrize('configuration, metadata, agent_system', zip(configurations, configuration_metadata, systems),
                          ids=test_case_ids)
 def test_vulnerability_updated_package_still_vulnerable(configuration, metadata, agent_system,
-                                                        set_wazuh_configuration_vdt,truncate_monitored_files,
+                                                        set_wazuh_configuration_vdt, truncate_monitored_files,
                                                         clean_cve_tables_func, setup_log_monitor,
                                                         prepare_full_scan_with_vuln_packages_and_custom_system,
                                                         restart_modulesd_function):
@@ -179,7 +179,7 @@ def test_vulnerability_updated_package_still_vulnerable(configuration, metadata,
     # Check the new version of the package generates and alert
     evm.check_vulnerability_affects_alert(package=metadata['test_package_name'], cve=metadata['cve'],
                                           agent_id=agent_id)
-    
+
     # Check the old version of the package being removed is not shown as solved
     with pytest.raises(TimeoutError):
         evm.check_vulnerability_scan_remove_alert(metadata['test_package_name'], metadata['cve'], agent_id=agent_id)

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_updated_package_still_vulnerable.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_updated_package_still_vulnerable.py
@@ -1,0 +1,185 @@
+'''
+copyright: Copyright (C) 2015-2023, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh is able to detect vulnerabilities in the applications installed in agents using the Vulnerability Detector
+       module. This software audit is performed through the integration of vulnerability feeds indexed by Redhat,
+       Canonical, Debian, SUSE, Amazon Linux and NVD Database.
+
+components:
+    - vulnerability_detector
+
+suite: scan_results
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-modulesd
+    - wazuh-db
+    - wazuh-analysisd
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2022
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - Debian Buster
+    - Red Hat 8
+    - Ubuntu Focal
+    - Ubuntu Bionic
+    - Suse Enterprise Linux Server 15
+    - Suse Enterprise Linux Server 12
+    - Suse Enterprise Linux Server 11
+    - Suse Enterprise Linux Desktop 15
+    - Suse Enterprise Linux Desktop 12
+    - Suse Enterprise Linux Desktop 11
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/vuln-detector.html#provider
+
+tags:
+    - settings
+    - vulnerability
+    - vulnerability_detector
+    - providers
+'''
+import os
+import pytest
+import time
+
+from wazuh_testing.tools import configuration
+from wazuh_testing.tools.file import read_yaml
+from wazuh_testing.db_interface import agent_db, cve_db
+from wazuh_testing.tools.time import get_current_timestamp
+from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.vulnerability_detector import event_monitor as evm
+
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+TEST_FEEDS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'feeds')
+
+# Configuration and cases data
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_scan_updated_package_still_vulnerable.yaml')
+cases_path = os.path.join(TEST_CASES_PATH, 'cases_scan_updated_package_still_vulnerable.yaml')
+
+
+# Test configurations
+configurations = read_yaml(configurations_path)
+metadata = [item['metadata'] for item in read_yaml(cases_path)]
+configuration_parameters, configuration_metadata, test_case_ids = configuration.get_test_cases_data(cases_path)
+configurations = vd.update_feed_path_configurations(configurations, metadata, TEST_FEEDS_PATH)
+systems = [metadata['system'] for metadata in configuration_metadata]
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata, agent_system', zip(configurations, configuration_metadata, systems),
+                         ids=test_case_ids)
+def test_vulnerability_updated_package_still_vulnerable(configuration, metadata, agent_system,
+                                                        set_wazuh_configuration_vdt,truncate_monitored_files,
+                                                        clean_cve_tables_func, setup_log_monitor,
+                                                        prepare_full_scan_with_vuln_packages_and_custom_system,
+                                                        restart_modulesd_function):
+    '''
+    description: Check that the Vulnerability Detector module does not generates an alert when a vulnerability is
+                 updated to a version that is still vulnerable for a given CVE.
+
+    test_phases:
+        - Set a custom Wazuh configuration.
+        - Mock an agent with a custom system and vulnerable packages.
+        - Force a full scan.
+        - Restart wazuh-modulesd.
+        - Wait for full scan event log.
+        - Update one vulnerable package to a non-vulnerable version.
+        - Force again a full scan and wait for the full scan event log.
+        - Check that vulnerability removal has been detected (in log) and check for the removal alert.
+
+    wazuh_min_version: 4.4.0
+
+    tier: 1
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Wazuh configuration data. Needed for set_wazuh_configuration fixture.
+        - metadata:
+            type: dict
+            brief: Wazuh configuration metadata
+        - agent_system:
+            type: str
+            brief: System to set to the mocked agent.
+        - set_wazuh_configuration_vdt:
+            type: fixture
+            brief: Set the wazuh configuration according to the configuration data.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - clean_cve_tables_func:
+            type: fixture
+            brief: Clean all the vulnerabilities tables before and after running the test.
+        - prepare_full_scan_with_vuln_packages_and_custom_system:
+            type: fixture
+            brief: Insert vulnerable packages to an agent with a custom system and finally clean the database.
+        - setup_log_monitor:
+            type: fixture
+            brief: Create the log monitor.
+        - restart_modulesd_function:
+            type: fixture
+            brief: Restart the wazuh-modulesd daemon.
+
+    assertions:
+        - The full scan will start for the agent.
+        - The full scan finish for the agent.
+        - The package with new version is vulnerable.
+        - The package's older version is not shown as solved
+
+    input_description:
+        -  The `cases_scan_updated_package_still_vulnerable.yaml` file provides the module configuration for this test.
+
+    expected_output:
+        - 'A full scan will be run on agent <agent_id>'
+        - 'Finished vulnerability assessment for agent <agent_id>'
+        - '<test_package_cve> affecting <test_package_name> was eliminated'
+        - Package '<test_package_name>' not vulnerable to '<test_package_cve>'
+    '''
+    agent_id = prepare_full_scan_with_vuln_packages_and_custom_system
+    log_monitor = setup_log_monitor
+
+    # Wait for full scan event log
+    evm.check_full_scan_start_finish(log_monitor=log_monitor, agent_id=agent_id)
+
+    # Check the package has been marked as vulnerable and generated an alert
+    evm.check_vulnerability_affects_alert(package=metadata['test_package_name'], cve=metadata['cve'],
+                                          agent_id=agent_id)
+
+    # Update test package 1 to a vulnerable version 2.0.
+    agent_db.update_package(agent_id=agent_id, package=metadata['test_package_name'],
+                            version=metadata['test_package_version_still_vulnerable'])
+
+    # Force a full scan again after simulating the update the NVD feed and passing the min_full_scan_interval
+    cve_db.update_nvd_metadata_vuldet(int(get_current_timestamp()))
+
+    # Check again the full scan event
+    evm.check_full_scan_start_finish(log_monitor=log_monitor, agent_id=agent_id)
+
+    # Check the new version of the package generates and alert
+    evm.check_vulnerability_affects_alert(package=metadata['test_package_name'], cve=metadata['cve'],
+                                          agent_id=agent_id)
+    
+    # Check the old version of the package being removed is not shown as solved
+    with pytest.raises(TimeoutError):
+        evm.check_vulnerability_scan_remove_alert(metadata['test_package_name'], metadata['cve'], agent_id=agent_id)


### PR DESCRIPTION
|Related issue|
|-------------|
| #4045            |

## Description

This Issue aims to add IT support to verify when a package is vulnerable to a CVE and updated to a version that is still vulnerable, there is no alert showing the vulnerability as solved

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Test module `test_scan_updated_package_still_vulnerable.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09 (Developer)  | test_vulnerability_detector           | [:green_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/41572/)[:large_blue_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/41575/)[:large_blue_circle:](https://ci.wazuh.info/view/Tests/job/Test_integration/41576/)  | ⚫⚫⚫ | Centos manager         |  https://github.com/wazuh/wazuh-qa/pull/4060/commits/325e478d15a63702b7310fd18bea168d1ab66bcf       | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
