### PR TITLE
Adapt integration tests for Office365 GCC support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Release report: TBD
 
 ### Changed
 
+- Update `test_office365` to support the new tag `API_TYPE` ([#4065](https://github.com/wazuh/wazuh-qa/pull/4065)) \- (Framework + Tests)
 - Update `test_wazuh_db` & `test_enrollment` to support new column `status_code` and new value on the enrollment `payload`. ([#4021](https://github.com/wazuh/wazuh-qa/pull/4021)) \- (Tests)
 - Update FIM `test_audit` tests to new framework ([#3939](https://github.com/wazuh/wazuh-qa/pull/3939)) \- (Framework + Tests)
 - Update FIM test to new FIM DBSync process  ([#2728](https://github.com/wazuh/wazuh-qa/pull/2728)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/office365.py
+++ b/deps/wazuh_testing/wazuh_testing/office365.py
@@ -47,6 +47,12 @@ def callback_detect_client_secret_err(line):
     return None
 
 
+def callback_detect_api_type_err(line):
+    if 'wm_office365_read(): ERROR: Empty content for tag \'api_type\' at module \'office365\'.' in line:
+        return line
+    return None
+
+
 def callback_detect_subscription_err(line):
     if 'wm_office365_read(): ERROR: Empty content for tag \'subscription\' at module \'office365\'.' in line:
         return line

--- a/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
+++ b/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
@@ -16,14 +16,14 @@
         - api_auth:
             elements:
               - tenant_id:
-                value: TENANT_ID
+                  value: TENANT_ID
               - client_id:
-                value: CLIENT_ID
+                  value: CLIENT_ID
               - client_secret:
-                value: CLIENT_SECRET
+                  value: CLIENT_SECRET
               - api_type:
-                value: API_TYPE
+                  value: API_TYPE
         - subscriptions:
             elements:
               - subscription:
-                value: SUBSCRIPTION
+                  value: SUBSCRIPTION

--- a/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
+++ b/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
@@ -22,6 +22,8 @@
               value: 'CLIENT_ID'
           - client_secret:
               value: 'CLIENT_SECRET'
+          - api_type:
+              value: 'API_TYPE'
       - subscriptions:
           elements:
           - subscription:

--- a/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
+++ b/tests/integration/test_office365/test_configuration/data/wazuh_conf.yaml
@@ -1,30 +1,29 @@
----
 - tags:
-  - offic365_integration
+    - offic365_integration
   apply_to_modules:
-  - test_invalid
+    - test_invalid
   sections:
-  - section: office365
-    elements:
-      - enabled:
-          value: 'ENABLED'
-      - only_future_events:
-          value: 'ONLY_FUTURE_EVENTS'
-      - interval:
-          value: 'INTERVAL'
-      - curl_max_size:
-          value: 'CURL_MAX_SIZE'
-      - api_auth:
-          elements:
-          - tenant_id:
-              value: 'TENANT_ID'
-          - client_id:
-              value: 'CLIENT_ID'
-          - client_secret:
-              value: 'CLIENT_SECRET'
-          - api_type:
-              value: 'API_TYPE'
-      - subscriptions:
-          elements:
-          - subscription:
-              value: 'SUBSCRIPTION'
+    - section: office365
+      elements:
+        - enabled:
+            value: ENABLED
+        - only_future_events:
+            value: ONLY_FUTURE_EVENTS
+        - interval:
+            value: INTERVAL
+        - curl_max_size:
+            value: CURL_MAX_SIZE
+        - api_auth:
+            elements:
+              - tenant_id:
+                value: TENANT_ID
+              - client_id:
+                value: CLIENT_ID
+              - client_secret:
+                value: CLIENT_SECRET
+              - api_type:
+                value: API_TYPE
+        - subscriptions:
+            elements:
+              - subscription:
+                value: SUBSCRIPTION

--- a/tests/integration/test_office365/test_configuration/test_invalid.py
+++ b/tests/integration/test_office365/test_configuration/test_invalid.py
@@ -51,7 +51,8 @@ import pytest
 from wazuh_testing import global_parameters
 from wazuh_testing.office365 import callback_detect_enabled_err, callback_detect_only_future_events_err, \
     callback_detect_interval_err, callback_detect_curl_max_size_err, callback_detect_tenant_id_err, \
-    callback_detect_client_id_err, callback_detect_client_secret_err, callback_detect_subscription_err
+    callback_detect_client_id_err, callback_detect_client_secret_err, callback_detect_subscription_err, \
+    callback_detect_api_type_err
 from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
@@ -85,6 +86,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -101,6 +103,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -117,6 +120,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -133,6 +137,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -149,6 +154,7 @@ cases = [
             'TENANT_ID': '',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -165,6 +171,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': '',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -181,6 +188,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': '',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': 'test_subscription'
         },
         'metadata': {
@@ -202,6 +210,23 @@ cases = [
         'metadata': {
             'tags': 'invalid_subscription'
         }
+    },
+    # Case 9: Invalid api_type (version 4.5)
+    {
+        'params': {
+            'ENABLED': 'yes',
+            'ONLY_FUTURE_EVENTS': 'yes',
+            'INTERVAL': '1m',
+            'CURL_MAX_SIZE': '1024',
+            'TENANT_ID': 'test_tenant',
+            'CLIENT_ID': 'teat_client',
+            'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': '',
+            'SUBSCRIPTION': 'test_subscription'
+        },
+        'metadata': {
+            'tags': 'invalid_api_type'
+        }
     }
 ]
 params = [case['params'] for case in cases]
@@ -220,7 +245,8 @@ callbacks = {
                 'invalid_tenant_id': callback_detect_tenant_id_err,
                 'invalid_client_id': callback_detect_client_id_err,
                 'invalid_client_secret': callback_detect_client_secret_err,
-                'invalid_subscription': callback_detect_subscription_err
+                'invalid_subscription': callback_detect_subscription_err,
+                'invalid_api_type': callback_detect_api_type_err
             }
 
 

--- a/tests/integration/test_office365/test_configuration/test_invalid.py
+++ b/tests/integration/test_office365/test_configuration/test_invalid.py
@@ -205,6 +205,7 @@ cases = [
             'TENANT_ID': 'test_tenant',
             'CLIENT_ID': 'teat_client',
             'CLIENT_SECRET': 'test_secret',
+            'API_TYPE': 'commercial',
             'SUBSCRIPTION': ''
         },
         'metadata': {


### PR DESCRIPTION
|Related issue|
|-------------|
| https://github.com/wazuh/wazuh/issues/14029 |

## Description
Made by @S-Bryce _([original PR](https://github.com/wazuh/wazuh-qa/pull/4061))_ 

<!-- Add a description of the context and content of all changes made in the pull request -->
With the changes made to the Office365 module to meet the requirements of the related issue, a new parameter of `api_auth\api_type` has been added to the Office365 module, which now needs proper integration testing. This PR adds several minor additions/modifications to the overall IT process for the Office365 module, including handling a case where the new `api_auth\api_type` parameter may be invalid.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Case 9, testing for an invalid `api_type` where the tag is added but left empty.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- All existing Office365 test cases now explicitly specify an `api_type` value of `commerical`. This is done for clarity rather than as a strict requirement, since a lack of `api_type` being specified defaults to `commerical`.

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->

<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @QU3B1M |`test_office365/`| ⚫⚫⚫ | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/11124101/report.zip)[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/11124102/report1.zip)[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/11124106/report2.zip)| `ubuntu 22.04` |[`c199768`](https://github.com/wazuh/wazuh-qa/pull/4065/commits/c1997684dbd685584c10e0921f1e10191c8322bd) | Nothing to highlight |
