### PR TITLE
3928 slack integration options

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/integratord/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/integratord/__init__.py
@@ -9,8 +9,8 @@ INTEGRATORD_PREFIX = 'wazuh-integratord'
 
 # Callback Messages
 CB_VIRUSTOTAL_ENABLED = r".*(wazuh-integratord.*Enabling integration for: 'virustotal').*"
-CB_INTEGRATORD_SENDING_ALERT = r'(.*wazuh-integratord.*DEBUG: sending new alert).*'
-CB_PROCESSING_ALERT = r'.*(wazuh-integratord.*Processing alert.*)'
+CB_INTEGRATORD_SENDING_ALERT = r'(.*wazuh-integratord.*DEBUG: Sending new alert).*'
+CB_VIRUSTOTAL_INTEGRATION_RESPONSE_MSG = r'.*(wazuh-integratord.*Final message to send.*)'
 CB_INTEGRATORD_THREAD_READY = r'.*(wazuh-integratord.*DEBUG: Local requests thread ready).*'
 CB_VIRUSTOTAL_ALERT = r'.*(wazuh-integratord.*alert_id.*\"integration\": \"virustotal\").*'
 CB_VIRUSTOTAL_ALERT_JSON = r'.*(VirusTotal: Alert.*\"integration\":\"virustotal\").*'
@@ -28,4 +28,4 @@ ERR_MSG_OVERLONG_ALERT_NOT_FOUND = r'Did not recieve the expected "...Overlong J
 ERR_MSG_ALERT_INODE_CHANGED_NOT_FOUND = r'Did not recieve the expected "...Alert file inode changed..." event'
 ERR_MSG_CANNOT_RETRIEVE_MSG_NOT_FOUND = r'Did not recieve the expected "...Could not retrieve information/open file"'
 ERR_MSG_SENDING_ALERT_NOT_FOUND = r'Did not recieve the expected "...sending new alert" event'
-ERR_MSG_PROCESSING_ALERT_NOT_FOUND = r'Did not recieve the expected "...Procesing alert" event'
+ERR_MSG_VIRUSTOTAL_RESPONSE_NOT_FOUND = r'Did not recieve the expected "Final message to send..." event'

--- a/deps/wazuh_testing/wazuh_testing/modules/integratord/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/integratord/event_monitor.py
@@ -8,6 +8,11 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.monitoring import FileMonitor
 
 
+# Callback string
+CB_OPTIONS_NON_EXISTENT = ".*OS_IntegratorD.*JSON file  doesn't exist"
+
+
+# Functions
 def check_integratord_event(file_monitor=None, callback='', error_message=None, update_position=True,
                             timeout=30, accum_results=1, file_to_monitor=LOG_FILE_PATH):
     """Check if an event occurs
@@ -25,3 +30,36 @@ def check_integratord_event(file_monitor=None, callback='', error_message=None, 
 
     file_monitor.start(timeout=timeout, update_position=update_position, accum_results=accum_results,
                        callback=callback, error_message=error_message)
+
+
+
+# Callback functions
+def detect_integration_enabled(integration, file_monitor=None):
+    """Detects integration has been enabled.
+
+    Args:
+        integration (str): The integratio that is being checked. Ex: Slack, Pagerduty and Shuffle
+        file_monitor (FileMonitor): file log monitor to detect events
+    """
+    callback = fr".*Enabling integration for: '{integration}'."
+    check_integratord_event(file_monitor=file_monitor, callback=callback)
+
+
+def detect_unable_to_run_integration(integration, file_monitor=None):
+    """Detects is unable to be executed.
+
+    Args:
+        integration (str): The integration that is being checked. Ex: Slack, Pagerduty and Shuffle
+        file_monitor (FileMonitor): file log monitor to detect events
+    """
+    callback = fr".*ERROR: Unable to run integration for {integration} -> integrations"
+    check_integratord_event(file_monitor=file_monitor, callback=callback)
+
+
+def detect_options_json_file_does_not_exist(file_monitor=None):
+    """Detects if JSON options file does not exist
+
+    Args:
+        file_monitor (FileMonitor): file log monitor to detect events
+    """
+    check_integratord_event(file_monitor=file_monitor, callback=CB_OPTIONS_NON_EXISTENT)

--- a/deps/wazuh_testing/wazuh_testing/modules/integratord/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/integratord/event_monitor.py
@@ -32,7 +32,6 @@ def check_integratord_event(file_monitor=None, callback='', error_message=None, 
                        callback=callback, error_message=error_message)
 
 
-
 # Callback functions
 def detect_integration_enabled(integration, file_monitor=None):
     """Detects integration has been enabled.
@@ -42,7 +41,7 @@ def detect_integration_enabled(integration, file_monitor=None):
         file_monitor (FileMonitor): file log monitor to detect events
     """
     callback = fr".*(Enabling integration for: '{integration}')."
-    check_integratord_event(file_monitor=file_monitor, callback=generate_monitoring_callback(callback), 
+    check_integratord_event(file_monitor=file_monitor, callback=generate_monitoring_callback(callback),
                             error_message="Could not find the expected 'Enabling integration for...' event")
 
 
@@ -81,7 +80,6 @@ def detect_integration_response_code(response='200', file_monitor=None):
                             error_message="Could not find the expected 'Response received...' event")
 
 
-
 def get_message_sent(integration, file_monitor):
     """Gets the message that is being sent to the integration.
 
@@ -92,8 +90,8 @@ def get_message_sent(integration, file_monitor):
         string: Returns the message JSON string that was sent.
     """
     callback = fr'.*Sending message (.*) to {integration} server'
-    
-    result = file_monitor.start(timeout=T_10, update_position=True, accum_results=1, 
+
+    result = file_monitor.start(timeout=T_10, update_position=True, accum_results=1,
                                 callback=generate_monitoring_callback(callback),
                                 error_message="Could not find the expected 'Sending message...' event").result()
     return result

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -310,7 +310,15 @@ def pytest_addoption(parser):
         type=str,
         help="pass api key required for integratord tests."
     )
-
+    parser.addoption(
+        "--slack-webhook-url",
+        action="store",
+        metavar="slack_webhook_url",
+        default=None,
+        type=str,
+        help="pass web hook url required for slack integratord tests."
+    )
+    
 
 def pytest_configure(config):
     # Register an additional marker
@@ -371,6 +379,11 @@ def pytest_configure(config):
     integration_api_key = config.getoption("--integration-api-key")
     if integration_api_key:
         global_parameters.integration_api_key = integration_api_key
+
+    # Set slack_webhook_url if it is passed through command line args
+    slack_webhook_url = config.getoption("--slack-webhook-url")
+    if slack_webhook_url:
+        global_parameters.slack_webhook_url = slack_webhook_url
 
     # Set files to add to the HTML report
     set_report_files(config.getoption("--save-file"))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -318,7 +318,7 @@ def pytest_addoption(parser):
         type=str,
         help="pass web hook url required for slack integratord tests."
     )
-    
+
 
 def pytest_configure(config):
     # Register an additional marker

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_template/config_integration_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_template/config_integration_no_option_tag.yaml
@@ -11,8 +11,6 @@
             value: HOOK_URL
         - alert_format:
             value: json
-        - options:
-            value: OPTIONS_VALUE
     - section: sca
       elements:
         - enabled:

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_template/config_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_template/config_slack_options.yaml
@@ -1,0 +1,35 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_slack_options
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: slack
+        - hook_url:
+            value: API_KEY
+        - alert_format:
+            value: json
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_integration_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_integration_no_option_tag.yaml
@@ -1,0 +1,7 @@
+- name: slack_works_with_no_option_tag_present
+  description: When the option tag is missing, the slack integration works
+  configuration_parameters:
+    HOOK_URL: Insert using --integration-api-key parameter
+  metadata:
+    integration: slack
+    response_code: '200'

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_integration_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_integration_no_option_tag.yaml
@@ -1,7 +1,7 @@
 - name: slack_works_with_no_option_tag_present
   description: When the option tag is missing, the slack integration works
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
   metadata:
     integration: slack
     response_code: '200'

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
@@ -1,0 +1,17 @@
+- name: Read valid json alert
+  description: Read a valid alert from alerts.json
+  configuration_parameters:
+    API_KEY: Insert using --integration-api-key parameter
+  metadata:
+    alert_sample: '{"timestamp":"2022-07-20T14:53:16.482+0000","rule":{"level":5,"description":
+                   "File added to the system.","id":"554","firedtimes":1,"mail":false,"groups":["ossec","syscheck",
+                   "syscheck_entry_added","syscheck_file"],"pci_dss":["11.5"],"gpg13":["4.11"],"gdpr":["II_5.1.f"],
+                   "hipaa":["164.312.c.1","164.312.c.2"],"nist_800_53":["SI.7"],"tsc":["PI1.4","PI1.5","CC6.1","CC6.8",
+                   "CC7.2","CC7.3"]},"agent":{"id":"000","name":"padding_input"},"manager":{"name":"c3"},"id":
+                   "1657551196.2754","full_log":"File /test_folder/TEST_VALID_ALERT.txt added\nMode: scheduled\n",
+                   "syscheck":{"path":"/test_folder/TEST_VALID_ALERT.txt","mode":"scheduled","size_after":"16",
+                   "perm_after":"rw-r--r--","uid_after":"0","gid_after":"0","md5_after":
+                   "2982666f29e2736e7ca0e12dd638d433","sha1_after":"49999430cc5652dedd26352b0342097e8fa3affe",
+                   "sha256_after":"32bc19c9406a98ab21e5ec79fbd5bba2cb79755607a9f382c662d37b5bf5d8ea","uname_after":
+                   "root","gname_after":"root","mtime_after":"2022-07-11T14:53:07","inode_after":9793,"event":"added"},
+                   "decoder":{"name":"syscheck_new_entry"},"location":"syscheck"}'

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
@@ -1,16 +1,16 @@
 - name: slack_option_tag_no_value
   description: When the option has no value passed, the slack integration is unable to run
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
     OPTIONS_VALUE:
   metadata:
     integration: slack
     sends_message: false
 
 - name: slack_option_empty_json_value
-  description: When the option is passed an empty JSON, the slack integration is unable to run
+  description: When the option is passed an empty JSON, the slack integration is works properly
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
     OPTIONS_VALUE: '{}'
   metadata:
     integration: slack
@@ -21,7 +21,7 @@
 - name: slack_option_custom_pretext
   description: When a custom value is added to an option, the slack integration works and the option is in the message
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
     OPTIONS_VALUE: '{"pretext":"Custom Pretext"}'
   metadata:
     integration: slack
@@ -32,7 +32,7 @@
 - name: slack_option_invalid_json
   description: When an invalid json is passed, the integration is unable to send the message
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
     OPTIONS_VALUE: '{"pretext":"Custom Pretext}'
   metadata:
     integration: slack
@@ -41,7 +41,7 @@
 - name: slack_option_invalid_value
   description: When an invalid value for an option, the message is sent to the integration endpoint
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
     OPTIONS_VALUE: '{"title_link":"invalid value - no link"}'
   metadata:
     integration: slack
@@ -52,7 +52,7 @@
 - name: slack_custom_option
   description: When a non existent option is passed, the message is sent to the integration endpoint and works properly
   configuration_parameters:
-    HOOK_URL: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --slack-webhook-url parameter
     OPTIONS_VALUE: '{"custom_option":"custom value"}'
   metadata:
     integration: slack

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
@@ -1,17 +1,61 @@
-- name: Read valid json alert
-  description: Read a valid alert from alerts.json
+- name: slack_option_tag_no_value
+  description: When the option has no value passed, the slack integration is unable to run
   configuration_parameters:
-    API_KEY: Insert using --integration-api-key parameter
+    HOOK_URL: Insert using --integration-api-key parameter
+    OPTIONS_VALUE:
   metadata:
-    alert_sample: '{"timestamp":"2022-07-20T14:53:16.482+0000","rule":{"level":5,"description":
-                   "File added to the system.","id":"554","firedtimes":1,"mail":false,"groups":["ossec","syscheck",
-                   "syscheck_entry_added","syscheck_file"],"pci_dss":["11.5"],"gpg13":["4.11"],"gdpr":["II_5.1.f"],
-                   "hipaa":["164.312.c.1","164.312.c.2"],"nist_800_53":["SI.7"],"tsc":["PI1.4","PI1.5","CC6.1","CC6.8",
-                   "CC7.2","CC7.3"]},"agent":{"id":"000","name":"padding_input"},"manager":{"name":"c3"},"id":
-                   "1657551196.2754","full_log":"File /test_folder/TEST_VALID_ALERT.txt added\nMode: scheduled\n",
-                   "syscheck":{"path":"/test_folder/TEST_VALID_ALERT.txt","mode":"scheduled","size_after":"16",
-                   "perm_after":"rw-r--r--","uid_after":"0","gid_after":"0","md5_after":
-                   "2982666f29e2736e7ca0e12dd638d433","sha1_after":"49999430cc5652dedd26352b0342097e8fa3affe",
-                   "sha256_after":"32bc19c9406a98ab21e5ec79fbd5bba2cb79755607a9f382c662d37b5bf5d8ea","uname_after":
-                   "root","gname_after":"root","mtime_after":"2022-07-11T14:53:07","inode_after":9793,"event":"added"},
-                   "decoder":{"name":"syscheck_new_entry"},"location":"syscheck"}'
+    integration: slack
+    sends_message: false
+
+- name: slack_option_empty_json_value
+  description: When the option is passed an empty JSON, the slack integration is unable to run
+  configuration_parameters:
+    HOOK_URL: Insert using --integration-api-key parameter
+    OPTIONS_VALUE: '{}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option:
+    response_code: '200'
+
+- name: slack_option_custom_pretext
+  description: When a custom value is added to an option, the slack integration works and the option is in the message
+  configuration_parameters:
+    HOOK_URL: Insert using --integration-api-key parameter
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext"}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option: '"pretext": "Custom Pretext"'
+    response_code: '200'
+
+- name: slack_option_invalid_json
+  description: When an invalid json is passed, the integration is unable to send the message
+  configuration_parameters:
+    HOOK_URL: Insert using --integration-api-key parameter
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext}'
+  metadata:
+    integration: slack
+    sends_message: false
+
+- name: slack_option_invalid_value
+  description: When an invalid value for an option, the message is sent to the integration endpoint
+  configuration_parameters:
+    HOOK_URL: Insert using --integration-api-key parameter
+    OPTIONS_VALUE: '{"title_link":"invalid value - no link"}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option: '"title_link": "invalid value - no link"'
+    response_code: '200'
+
+- name: slack_custom_option
+  description: When a non existent option is passed, the message is sent to the integration endpoint and works properly
+  configuration_parameters:
+    HOOK_URL: Insert using --integration-api-key parameter
+    OPTIONS_VALUE: '{"custom_option":"custom value"}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option: '"custom_option": "custom value"'
+    response_code: '200'

--- a/tests/integration/test_integratord/test_integration_options/test_slack_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_slack_options.py
@@ -1,0 +1,212 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Integratord manages wazuh integrations with other applications such as Yara or Virustotal, by feeding
+the integrated aplications with the alerts located in alerts.json file. This test module aims to validate that
+given a specific alert, the expected response is recieved, depending if it is a valid/invalid json alert, an
+overlong alert (64kb+) or what happens when it cannot read the file because it is missing.
+
+components:
+    - integratord
+
+suite: integratord_read_json_alerts
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-integratord
+
+os_platform:
+    - Linux
+
+os_version:
+    - Centos 8
+    - Ubuntu Focal
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/integration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-integratord.htm
+
+pytest_args:
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - virustotal
+'''
+import os
+import pytest
+import time
+
+from wazuh_testing import global_parameters
+from wazuh_testing.tools import LOG_FILE_PATH, ALERT_FILE_PATH
+from wazuh_testing.modules import integratord as integrator
+from wazuh_testing.modules.integratord.event_monitor import check_integratord_event
+from wazuh_testing.tools.local_actions import run_local_command_returning_output
+from wazuh_testing.tools.configuration import get_test_cases_data, load_configuration_template
+from wazuh_testing.tools.monitoring import FileMonitor, generate_monitoring_callback
+
+
+# Marks
+pytestmark = [pytest.mark.server]
+
+# Reference paths
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
+TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
+
+# Configuration and cases data
+configurations_path = os.path.join(CONFIGURATIONS_PATH, 'config_integratord_read_json_alerts.yaml')
+t1_cases_path = os.path.join(TEST_CASES_PATH, 'cases_integratord_read_valid_json_alerts.yaml')
+t2_cases_path = os.path.join(TEST_CASES_PATH, 'cases_integratord_read_invalid_json_alerts.yaml')
+
+
+# Configurations
+t1_configuration_parameters, t1_configuration_metadata, t1_case_ids = get_test_cases_data(t1_cases_path)
+t1_configuration_parameters[0]['API_KEY'] = global_parameters.integration_api_key
+t1_configurations = load_configuration_template(configurations_path, t1_configuration_parameters,
+                                                t1_configuration_metadata)
+t2_configuration_parameters, t2_configuration_metadata, t2_case_ids = get_test_cases_data(t2_cases_path)
+t2_configuration_parameters[0]['API_KEY'] = global_parameters.integration_api_key
+t2_configurations = load_configuration_template(configurations_path, t2_configuration_parameters,
+                                                t2_configuration_metadata)
+local_internal_options = {'integrator.debug': '2'}
+
+
+# Tests
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata',
+                         zip(t1_configurations, t1_configuration_metadata), ids=t1_case_ids)
+def test_integratord_read_valid_alerts(configuration, metadata, set_wazuh_configuration, truncate_monitored_files,
+                                       configure_local_internal_options_module, restart_wazuh_daemon_function,
+                                       wait_for_start_module):
+    '''
+    description: Check that when a given alert is inserted into alerts.json, integratord works as expected. In case
+    of a valid alert, a virustotal integration alert is expected in the alerts.json file.
+    wazuh_min_version: 4.3.7
+
+    test_phases:
+        - Insert an alert alerts.json file.
+        - Check virustotal response is added in ossec.log
+
+    tier: 1
+
+    parameters:
+        - configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Configure the local internal options file.
+        - restart_wazuh_daemon_function:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_start_module:
+            type: fixture
+            brief: Detect the start of the Integratord module in the ossec.log
+
+    assertions:
+        - Verify the expected response with for a given alert is recieved
+
+    input_description:
+        - The `config_integratord_read_json_alerts.yaml` file provides the module configuration for this test.
+        - The `cases_integratord_read_valid_json_alerts` file provides the test cases.
+
+    expected_output:
+        - r'.*wazuh-integratord.*alert_id.*\"integration\": \"virustotal\".*'
+    '''
+
+    sample = metadata['alert_sample']
+    wazuh_monitor = FileMonitor(LOG_FILE_PATH)
+    run_local_command_returning_output(f"echo '{sample}' >> {ALERT_FILE_PATH}")
+
+    # Read Response in ossec.log
+    check_integratord_event(file_monitor=wazuh_monitor, timeout=global_parameters.default_timeout,
+                            callback=generate_monitoring_callback(integrator.CB_VIRUSTOTAL_ALERT),
+                            error_message=integrator.ERR_MSG_VIRUSTOTAL_ALERT_NOT_DETECTED)
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('configuration, metadata',
+                         zip(t2_configurations, t2_configuration_metadata), ids=t2_case_ids)
+def test_integratord_read_invalid_alerts(configuration, metadata, set_wazuh_configuration, truncate_monitored_files,
+                                         configure_local_internal_options_module, restart_wazuh_daemon_function,
+                                         wait_for_start_module):
+    '''
+    description: Check that when a given alert is inserted into alerts.json, integratord works as expected. In case
+    of a valid alert, a virustotal integration alert is expected in the alerts.json file. If the alert is invalid or
+    broken, or overly long a message will appear in the ossec.log file.
+    wazuh_min_version: 4.3.7
+
+    test_phases:
+        - Insert an alert alerts.json file.
+        - Check that the expected response message is given for an invalid alert.
+
+    tier: 1
+    parameters:
+        - configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options_module:
+            type: fixture
+            brief: Configure the local internal options file.
+        - restart_wazuh_daemon_function:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_start_module:
+            type: fixture
+            brief: Detect the start of the Integratord module in the ossec.log
+    assertions:
+        - Verify the expected response with for a given alert is recieved
+    input_description:
+        - The `config_integratord_read_json_alerts.yaml` file provides the module configuration for this test.
+        - The `cases_integratord_read_invalid_json_alerts` file provides the test cases.
+    expected_output:
+        - r'.*wazuh-integratord.*WARNING: Invalid JSON alert read.*'
+        - r'.*wazuh-integratord.*WARNING: Overlong JSON alert read.*'
+
+    '''
+    sample = metadata['alert_sample']
+    wazuh_monitor = FileMonitor(LOG_FILE_PATH)
+
+    if metadata['alert_type'] == 'invalid':
+        callback = integrator.CB_INVALID_JSON_ALERT_READ
+        error_message = integrator.ERR_MSG_INVALID_ALERT_NOT_FOUND
+
+    elif metadata['alert_type'] == 'overlong':
+        callback = integrator.CB_OVERLONG_JSON_ALERT_READ
+        error_message = integrator. ERR_MSG_OVERLONG_ALERT_NOT_FOUND
+        # Add 90kb of padding to alert to make it go over the allowed value of 64KB.
+        padding = "0"*90000
+        sample = sample.replace("padding_input", "agent_" + padding)
+
+    run_local_command_returning_output(f"echo '{sample}' >> {ALERT_FILE_PATH}")
+
+    # Read Response in ossec.log
+    check_integratord_event(file_monitor=wazuh_monitor, timeout=global_parameters.default_timeout,
+                            callback=generate_monitoring_callback(callback), error_message=error_message)

--- a/tests/integration/test_integratord/test_integratord_change_inode_alert.py
+++ b/tests/integration/test_integratord/test_integratord_change_inode_alert.py
@@ -162,5 +162,5 @@ def test_integratord_change_json_inode(configuration, metadata, set_wazuh_config
 
     # Read Response in ossec.log
     check_integratord_event(file_monitor=wazuh_monitor, timeout=global_parameters.default_timeout,
-                            callback=generate_monitoring_callback(integrator.CB_PROCESSING_ALERT),
-                            error_message=integrator.ERR_MSG_VIRUSTOTAL_ALERT_NOT_DETECTED)
+                            callback=generate_monitoring_callback(integrator.CB_VIRUSTOTAL_INTEGRATION_RESPONSE_MSG),
+                            error_message=integrator.ERR_MSG_VIRUSTOTAL_RESPONSE_NOT_FOUND)


### PR DESCRIPTION
|Related issue|
|-------------|
| #3928            |

## Description

This Issue adds support for the new Slack integration `options` tag. This tag allows passing custom JSON string that will be sent as part of the message to the integration and/or replace values with the ones configured. The PR adds 7 test cases for different configurations and values.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- `test_integratord/test_integration_options/test_slack_options.py`



## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  | test_integration    | | [:green_circle::green_circle::green_circle:](https://github.com/wazuh/wazuh-qa/files/11265819/3928-integratord-results.zip)  |  Ubuntu Manager       | https://github.com/wazuh/wazuh-qa/commit/01745538afc1816638d44e84e583d75810d928e6        | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
