### PR TITLE
Fix WazuhDB IT for 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix wazuhdb IT. ([#3584](https://github.com/wazuh/wazuh-qa/pull/3584)) \- (Framework + Tests)
 - Fix agentd IT for python3.10 AMI ([#3973](https://github.com/wazuh/wazuh-qa/pull/3973)) \- (Tests)
 - Fix unstable system tests ([#4080](https://github.com/wazuh/wazuh-qa/pull/4080)) \- (Tests)
 

--- a/deps/wazuh_testing/wazuh_testing/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/event_monitor.py
@@ -14,7 +14,7 @@ def make_callback(pattern, prefix=''):
         lambda: function that returns if there's a match in the file
     """
     pattern = r'\s+'.join(pattern.split())
-    regex = re.compile(r'{}{}'.format(prefix, pattern))
+    regex = re.compile(r'{}{}'.format(prefix, pattern)) if prefix else re.compile(pattern)
 
     return lambda line: regex.match(line)
 

--- a/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
+++ b/tests/integration/test_wazuh_db/data/global/set_agent_groups.yaml
@@ -281,7 +281,7 @@
     output: err An error occurred during the set of the groups
     agent_id: 27
     expected_group: None
-    expected_warint: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
+    expected_warning: ".*WARNING: Invalid group name. 'Test,Group1' contains invalid characters"
     expected_group_sync_status: synced
 
 - name: Wrong group name format - Assign a group with an invalid group name (has invalid '@' character) - Warning
@@ -301,7 +301,7 @@
     output: err An error occurred during the set of the groups
     agent_id: 29
     expected_group: None
-    expected_warint: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
+    expected_warning: ".*WARNING: Invalid group name. '.' represents the current directory in unix systems"
     expected_group_sync_status: synced
 
 - name: Wrong group name format - Assign a group with an invalid group name (..) - Warning

--- a/tests/integration/test_wazuh_db/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_agent_database_version.py
@@ -63,3 +63,6 @@ def test_agent_database_version(restart_wazuh_daemon, remove_agents):
     assert agent_version == expected_database_version, 'The agent database version is not the expected one. \n' \
                                                        f'Expected version: {expected_database_version}\n'\
                                                        f'Obtained version: {agent_version}'
+
+    for agent in agents:
+        agent.stop_receiver()


### PR DESCRIPTION
|Related issue|
|-------------|
|       #4111       |

## Description

This PR include some fixes for WazuhDB integration tests. In addition fix a warning in the `test_agent_database_version` test.

<!-- Changes made to existing functionality or files. Remove if not applicable -->

### Updated

- Fix warning in `test_agent_database_version`
- Fix incorrect tests cases in the `test_set_agent_groups` wazuhdb test
- Fix bug in make_callback framework function

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Rebits  (Developer)  |           | [:green_circle:](https://ci.wazuh.info/job/Test_integration/38001/console) | :no_entry_sign: :no_entry_sign: :no_entry_sign: 
| @juliamagan  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
