### PR TITLE
Fix daemons_handler fixture (GCP tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix daemons_handler fixture (fix GCP IT) ([#4134](https://github.com/wazuh/wazuh-qa/pull/4134)) \- (Tests)
 - Fix wazuhdb IT. ([#3584](https://github.com/wazuh/wazuh-qa/pull/3584)) \- (Framework + Tests)
 - Fix agentd IT for python3.10 AMI ([#3973](https://github.com/wazuh/wazuh-qa/pull/3973)) \- (Tests)
 - Fix unstable system tests ([#4080](https://github.com/wazuh/wazuh-qa/pull/4080)) \- (Tests)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -904,7 +904,7 @@ def create_file_structure_function(get_files_list):
 
 
 @pytest.fixture(scope='module')
-def daemons_handler(request):
+def daemons_handler(get_configuration, request):
     """Handler of Wazuh daemons.
 
     It uses `daemons_handler_configuration` of each module in order to configure the behavior of the fixture.
@@ -916,6 +916,7 @@ def daemons_handler(request):
         in order to use this fixture along with invalid configuration. Default `False`
 
     Args:
+        get_configuration (fixture): Get configurations from the module. Allows this fixture to be used for each param.
         request (fixture): Provide information on the executing test function.
     """
     daemons = []

--- a/tests/integration/test_gcloud/conftest.py
+++ b/tests/integration/test_gcloud/conftest.py
@@ -11,6 +11,7 @@ from wazuh_testing.tools.file import write_file, remove_file
 from wazuh_testing.gcloud import detect_gcp_start, publish_sync
 import wazuh_testing.tools.configuration as conf
 
+
 @pytest.fixture(scope='session', autouse=True)
 def handle_credentials_file():
     if global_parameters.gcp_credentials is None or global_parameters.gcp_credentials_file is None:
@@ -49,6 +50,7 @@ def wait_for_gcp_start(get_configuration, request):
     # Wait for module gpc-pubsub starts
     file_monitor = getattr(request.module, 'wazuh_log_monitor')
     detect_gcp_start(file_monitor)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def configure_internal_options():

--- a/tests/integration/test_gcloud/test_configuration/test_invalid.py
+++ b/tests/integration/test_gcloud/test_configuration/test_invalid.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 

--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 

--- a/tests/integration/test_gcloud/test_configuration/test_schedule.py
+++ b/tests/integration/test_gcloud/test_configuration/test_schedule.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 

--- a/tests/integration/test_gcloud/test_functionality/test_interval.py
+++ b/tests/integration/test_gcloud/test_functionality/test_interval.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 

--- a/tests/integration/test_gcloud/test_functionality/test_logging.py
+++ b/tests/integration/test_gcloud/test_functionality/test_logging.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 
@@ -76,7 +75,7 @@ force_restart_after_restoring = False
 
 # configurations
 
-daemons_handler_configuration = {'daemons': ['wazuh-analysisd', 'wazuh-modulesd']}
+daemons_handler_configuration = {'daemons': ['wazuh-modulesd']}
 monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
@@ -95,13 +94,13 @@ configurations = conf.load_wazuh_configurations(configurations_path, __name__,
 
 # fixtures
 @pytest.fixture(scope='package', params= [
-    {'wazuh_modules.debug': 0, 'analysisd.debug': 2,
+    {'wazuh_modules.debug': 0,
       'monitord.rotate_log': 0, 'monitord.day_wait': 0,
       'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
-    {'wazuh_modules.debug': 1, 'analysisd.debug': 2,
+    {'wazuh_modules.debug': 1,
      'monitord.rotate_log': 0, 'monitord.day_wait': 0,
      'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
-    {'wazuh_modules.debug': 2, 'analysisd.debug': 2,
+    {'wazuh_modules.debug': 2,
      'monitord.rotate_log': 0, 'monitord.day_wait': 0,
      'monitord.keep_log_days': 0, 'monitord.size_rotate': 0}
 ])

--- a/tests/integration/test_gcloud/test_functionality/test_logging.py
+++ b/tests/integration/test_gcloud/test_functionality/test_logging.py
@@ -93,7 +93,7 @@ configurations = conf.load_wazuh_configurations(configurations_path, __name__,
 
 
 # fixtures
-@pytest.fixture(scope='package', params= [
+@pytest.fixture(scope='module', params= [
     {'wazuh_modules.debug': 0,
       'monitord.rotate_log': 0, 'monitord.day_wait': 0,
       'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
@@ -109,8 +109,8 @@ def get_local_internal_options(request):
     return request.param
 
 
-@pytest.fixture(scope='package')
-def configure_local_internal_options_package(get_local_internal_options):
+@pytest.fixture(scope='module')
+def configure_local_internal_options_module(get_local_internal_options):
     """Fixture to configure the local internal options file.
 
     It uses the test fixture get_local_internal_options. This should be
@@ -144,7 +144,7 @@ def get_configuration(request):
     (['{level} GCP'.format(level=log_level) for log_level in log_levels]),
 ], indirect=True)
 def test_logging(get_configuration, configure_environment, reset_ossec_log,
-                 publish_messages, configure_local_internal_options_package,
+                 publish_messages, configure_local_internal_options_module,
                  daemons_handler, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module generates logs according to the debug level set for wazuh_modules.
@@ -166,7 +166,7 @@ def test_logging(get_configuration, configure_environment, reset_ossec_log,
         - publish_messages:
             type: list
             brief: List of testing GCP logs.
-        - configure_local_internal_options_package:
+        - configure_local_internal_options_module:
             type: fixture
             brief: Fixture to modify the local_internal_options.conf file
                    and restart modulesd.

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -61,6 +61,8 @@ from wazuh_testing.tools import LOG_FILE_PATH
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
 from wazuh_testing.tools.file import truncate_file
+from wazuh_testing.tools import get_service
+
 from google.cloud import pubsub_v1
 
 # Marks
@@ -81,7 +83,11 @@ force_restart_after_restoring = False
 
 # configurations
 
-daemons_handler_configuration = {'daemons': ['wazuh-modulesd']}
+if get_service() == 'wazuh-manager':
+    daemons_handler_configuration = {'daemons': ['wazuh-modulesd', 'wazuh-analysisd']}
+else:
+    daemons_handler_configuration = {'daemons': ['wazuh-modulesd']}
+
 monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -25,7 +25,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 
@@ -82,7 +81,7 @@ force_restart_after_restoring = False
 
 # configurations
 
-daemons_handler_configuration = {'daemons': ['wazuh-analysisd', 'wazuh-modulesd']}
+daemons_handler_configuration = {'daemons': ['wazuh-modulesd']}
 monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,

--- a/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
+++ b/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
@@ -24,7 +24,6 @@ targets:
     - manager
 
 daemons:
-    - wazuh-analysisd
     - wazuh-monitord
     - wazuh-modulesd
 


### PR DESCRIPTION
|Related issue|
|-------------|
|#4123|

## Description

After [this change](https://github.com/wazuh/wazuh-qa/commit/c14ca8b2610b27268aae5760ff9506c81b314fb1) was applied, the GCP tests started to fail. So this PR reverts that change partially (modifies the `daemons_handler` fixture).


### Updated

- `tests/integration/conftest.py`: `get_configuration` fixture added to `daemons_handler`
- `tests/integration/test_gcloud/conftest.py`: style fixed

---

## Testing performed


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  | integration/test_gcloud | 🚫🚫🚫 | [🟢](https://github.com/wazuh/wazuh-qa/files/11337181/report-test_gcloud.zip)[🟢](https://github.com/wazuh/wazuh-qa/files/11337181/report-test_gcloud.zip)[🟢](https://github.com/wazuh/wazuh-qa/files/11337181/report-test_gcloud.zip) | Ubuntu (Docker) | 10db526 | Nothing to highlight |
| @juliamagan (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
