### PR TITLE
Fix analysisd windows registry test failure 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix cases yaml of the analysisd windows registry IT ([#4149](https://github.com/wazuh/wazuh-qa/pull/4149)) \- (Tests)
 - Fix a bug in on Migration tool's library ([#4106](https://github.com/wazuh/wazuh-qa/pull/4106)) \- (Framework)
 - Fix imports and add windows support for test_report_changes_and_diff IT ([#3548](https://github.com/wazuh/wazuh-qa/issues/3548)) \- (Framework + Tests)
 - Fix a regex error in the FIM integration tests ([#3061](https://github.com/wazuh/wazuh-qa/issues/3061)) \- (Framework + Tests)


### PR DESCRIPTION
|Related issue|
|-------------|
| #4112 |

## Description

The analysisd IT tests `/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py` were failing because a missing `index` key on the yaml cases.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py`

<!-- Functionalities or files that have been deleted. Remove if not applicable -->


## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @QU3B1M  (Developer)  |  `integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py`   | ⚫⚫⚫ |  [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/11402459/report.zip)[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/11402461/report2.zip)[:green_circle: ](https://github.com/wazuh/wazuh-qa/files/11402460/report1.zip)   |  Ubuntu 22.04  |https://github.com/wazuh/wazuh-qa/pull/4149/commits/3ed817e122e2152e8fa88c839acc23194f2c5e10 | Nothing to highlight |
| @damarisg (Reviewer)   |test_analysisd/  | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/38144/console)  | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |   centOS - Manager     | https://github.com/wazuh/wazuh-qa/pull/4149/commits/3ed817e122e2152e8fa88c839acc23194f2c5e10 | Tier 0, 1 |
| @damarisg (Reviewer)   |test_analysisd/  | [🟢](https://ci.wazuh.info/view/Tests/job/Test_integration/38146/)  | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |   centOS - Manager     | https://github.com/wazuh/wazuh-qa/pull/4149/commits/3ed817e122e2152e8fa88c839acc23194f2c5e10 | Tier 2 |


