### PR TITLE
Fix boto3 version requirement for legacy OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix boto3 version requirement for legacy OS ([#4150](https://github.com/wazuh/wazuh-qa/pull/4150)) \- (Framework)
 - Fix cases yaml of the analysisd windows registry IT ([#4149](https://github.com/wazuh/wazuh-qa/pull/4149)) \- (Tests)
 - Fix a bug in on Migration tool's library ([#4106](https://github.com/wazuh/wazuh-qa/pull/4106)) \- (Framework)
 - Fix imports and add windows support for test_report_changes_and_diff IT ([#3548](https://github.com/wazuh/wazuh-qa/issues/3548)) \- (Framework + Tests)

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,4 @@ treelib==1.6.1
 prettytable; platform_system == "Linux"
 mysql-connector-python==8.0.32; platform_system == 'Linux' and python_version >= '3.7'
 protobuf>=3.11.0,<=3.20.3; platform_system == 'Linux' and python_version >= '3.7'
-boto3==1.26.11; platform_system == 'Linux'
+boto3>=1.17.85; platform_system == 'Linux'


### PR DESCRIPTION
|Related issue|
|-------------|
|#4152|

## Description

Since Wazuh 4.5 and the [Add AWS integration tests #3333](https://github.com/wazuh/wazuh-qa/issues/3333) implementation, `boto3` python dependencies were added requesting a specific version that is not available on older/legacy OS

This PR aims to pair, at least, the requested version with the one integrated with the Wazuh Manager embedded Python interpreter

### Added

- None

### Updated

- requirements.txt: change `boto3` version to be at least 1.17.85, the current version used here https://github.com/wazuh/wazuh/blob/4.5/framework/requirements.txt#L13-L14

<!-- Functionalities or files that have been deleted. Remove if not applicable -->
### Deleted

- None

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @jnasselle (Developer)  |           | ⚫⚫⚫ | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
