### PR TITLE
Fix syscollector tests failure (get_configuration fixture has different scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ### Feature
+
 - Change test_python_flaws.py to accept branch or commit in the same argument. ([#4209](https://github.com/wazuh/wazuh-qa/pull/4207)) (Tests)
 - Fix test_dependencies.py for the changes in the feature. ([#4210](https://github.com/wazuh/wazuh-qa/pull/4210)) (Tests)
 
@@ -12,6 +13,8 @@ Wazuh commit: https://github.com/wazuh/wazuh/commit/f7080df56081adaeaad945295222
 Release report: https://github.com/wazuh/wazuh/issues/17198
 
 ### Fixed
+
+- Fix syscollector tests failure (get_configuration fixture has different scope) ([#4154](https://github.com/wazuh/wazuh-qa/pull/4154)) \- (Framework + Tests)
 - Fix missing comma in setup.py. ([#4180](https://github.com/wazuh/wazuh-qa/pull/4180)) (Framework)
 - Changed the last uses of 4.4.2 in setup.py and schema.yaml. ([#4172](https://github.com/wazuh/wazuh-qa/pull/4172)) \- (Framework)
 

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -5,8 +5,8 @@ import os
 import subprocess
 import sys
 import time
-
 import psutil
+
 from wazuh_testing.tools import WAZUH_PATH, get_service, WAZUH_SOCKETS, QUEUE_DB_PATH, WAZUH_OPTIONAL_SOCKETS
 from wazuh_testing.tools.configuration import write_wazuh_conf
 from wazuh_testing.modules import WAZUH_SERVICES_START, WAZUH_SERVICES_STOP

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -903,10 +903,8 @@ def create_file_structure_function(get_files_list):
     delete_file_structure(get_files_list)
 
 
-@pytest.fixture(scope='module')
-def daemons_handler(get_configuration, request):
-    """Handler of Wazuh daemons.
-
+def daemons_handler_impl(request):
+    """Helper function to handle Wazuh daemons.
     It uses `daemons_handler_configuration` of each module in order to configure the behavior of the fixture.
     The  `daemons_handler_configuration` should be a dictionary with the following keys:
         daemons (list, optional): List with every daemon to be used by the module. In case of empty a ValueError
@@ -916,7 +914,6 @@ def daemons_handler(get_configuration, request):
         in order to use this fixture along with invalid configuration. Default `False`
 
     Args:
-        get_configuration (fixture): Get configurations from the module. Allows this fixture to be used for each param.
         request (fixture): Provide information on the executing test function.
     """
     daemons = []
@@ -974,8 +971,25 @@ def daemons_handler(get_configuration, request):
             control_service('stop', daemon=daemon)
 
 
-# Wrapper of `daemons_handler` function to change its scope from `module` to `function`
-daemons_handler_function = pytest.fixture(daemons_handler.__wrapped__, scope='function')
+@pytest.fixture(scope='module')
+def daemons_handler_module(get_configuration, request):
+    """Wrapper of `daemons_handler_impl` which contains the general implementation.
+
+    Args:
+        get_configuration (fixture): Get configurations from the module. Allows this fixture to be used for each param.
+        request (fixture): Provide information on the executing test function.
+    """
+    yield from daemons_handler_impl(request)
+
+
+@pytest.fixture(scope='function')
+def daemons_handler_function(request):
+    """Wrapper of `daemons_handler_impl` which contains the general implementation.
+
+    Args:
+        request (fixture): Provide information on the executing test function.
+    """
+    yield from daemons_handler_impl(request)
 
 
 @pytest.fixture(scope='function')

--- a/tests/integration/test_api/test_config/test_max_upload_size/test_max_upload_size.py
+++ b/tests/integration/test_api/test_config/test_max_upload_size/test_max_upload_size.py
@@ -155,7 +155,7 @@ def create_cdb_list(min_length):
     {'test_upload_size'}
 ])
 def test_max_upload_size(tags_to_apply, get_configuration, configure_api_environment, restart_required_api_wazuh,
-                         file_monitoring, daemons_handler, wait_for_start, get_api_details):
+                         file_monitoring, daemons_handler_module, wait_for_start, get_api_details):
     '''
     description: Check if a '413' HTTP status code ('Payload Too Large') is returned if the response body is
                  bigger than the value of the 'max_upload_size' tag. For this purpose, the test will call to
@@ -183,7 +183,7 @@ def test_max_upload_size(tags_to_apply, get_configuration, configure_api_environ
         - file_monitoring:
             type: fixture
             brief: Handle the monitoring of a specified file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
         - wait_for_start:

--- a/tests/integration/test_enrollment/test_agentd_server_address_configuration.py
+++ b/tests/integration/test_enrollment/test_agentd_server_address_configuration.py
@@ -145,7 +145,7 @@ def clean_client_keys(get_configuration):
 def test_agentd_server_address_configuration(configure_local_internal_options_module, clean_client_keys,
                                              get_configuration, configure_environment,
                                              configure_sockets_environment, configure_socket_listener,
-                                             create_certificates, edit_hosts, daemons_handler, file_monitoring):
+                                             create_certificates, edit_hosts, daemons_handler_module, file_monitoring):
 
     '''
     description: Check the messages produced by the agent when introducing
@@ -166,7 +166,7 @@ def test_agentd_server_address_configuration(configure_local_internal_options_mo
         - edit_hosts:
             type: fixture
             brief: Edit the hosts file to add custom hostnames for testing.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Restart the agentd daemon for restarting the agent.
         - file_monitoring:

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_basic_usage_realtime_unsupported.py
@@ -90,7 +90,7 @@ def get_configuration(request):
 
 # Tests
 def test_realtime_unsupported(get_configuration, configure_environment, file_monitoring,
-                              configure_local_internal_options_module, daemons_handler):
+                              configure_local_internal_options_module, daemons_handler_module):
     '''
     description: Check if the current OS platform falls to the 'scheduled' mode when 'realtime' is not available.
                  For this purpose, the test performs a CUD set of operations to a file with 'realtime' mode set as
@@ -116,7 +116,7 @@ def test_realtime_unsupported(get_configuration, configure_environment, file_mon
         - configure_local_internal_options_module:
             type: fixture
             brief: Configure the local internal options file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handle the Wazuh daemons.
 

--- a/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
+++ b/tests/integration/test_fim/test_registry/test_registry_basic_usage/test_basic_usage_registry_duplicated_entries.py
@@ -6,6 +6,7 @@ import wazuh_testing.fim as fim
 from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.utils import get_version
 
+
 # Helper functions
 
 def extra_configuration_after_yield():
@@ -64,7 +65,7 @@ def get_configuration(request):
 @pytest.mark.skipif(get_version() != 'v4.2.3', reason="This test fails by wazuh/wazuh#6797, It was fixed on v4.2.3")
 @pytest.mark.parametrize('key, subkey1, subkey2, arch', [(key, sub_key_1, sub_key_2, fim.KEY_WOW64_32KEY)])
 def test_registry_duplicated_entry(key, subkey1, subkey2, arch, get_configuration, configure_environment,
-                                   file_monitoring, configure_local_internal_options_module, daemons_handler,
+                                   file_monitoring, configure_local_internal_options_module, daemons_handler_module,
                                    wait_for_fim_start):
     """Two registries with capital differences must trigger just one modify the event.
 

--- a/tests/integration/test_gcloud/test_configuration/test_invalid.py
+++ b/tests/integration/test_gcloud/test_configuration/test_invalid.py
@@ -75,7 +75,7 @@ force_restart_after_restoring = False
 
 # configurations
 
-daemons_handler_configuration = {'daemons': ['wazuh-modulesd'], 'ignore_errors' : True}
+daemons_handler_configuration = {'daemons': ['wazuh-modulesd'], 'ignore_errors': True}
 monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
@@ -92,10 +92,11 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # tests
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_invalid(get_configuration, configure_environment, reset_ossec_log, daemons_handler):
+def test_invalid(get_configuration, configure_environment, reset_ossec_log, daemons_handler_module):
     '''
     description: Check if the 'gcp-pubsub' module detects invalid configurations. For this purpose, the test
                  will configure 'gcp-pubsub' using invalid configuration settings with different attributes.
@@ -115,7 +116,7 @@ def test_invalid(get_configuration, configure_environment, reset_ossec_log, daem
         - reset_ossec_log:
             type: fixture
             brief: Reset the 'ossec.log' file and start a new monitor.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 

--- a/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
+++ b/tests/integration/test_gcloud/test_configuration/test_remote_configuration.py
@@ -81,7 +81,7 @@ configurations_path = os.path.join(test_data_path, 'wazuh_remote_conf.yaml')
 
 # configurations
 
-daemons_handler_configuration = {'daemons': ['wazuh-modulesd'], 'ignore_errors' : True}
+daemons_handler_configuration = {'daemons': ['wazuh-modulesd'], 'ignore_errors': True}
 monitoring_modes = ['scheduled']
 conf_params = {'PROJECT_ID': global_parameters.gcp_project_id,
                'SUBSCRIPTION_NAME': global_parameters.gcp_subscription_name,
@@ -139,7 +139,8 @@ def get_remote_configuration(component_name, config):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_remote_configuration(get_configuration, configure_environment, reset_ossec_log, daemons_handler, wait_for_gcp_start):
+def test_remote_configuration(get_configuration, configure_environment, reset_ossec_log, daemons_handler_module,
+                              wait_for_gcp_start):
     '''
     description: Check if the remote configuration matches the local configuration of the 'gcp-pubsub' module.
                  For this purpose, the test will use different settings and get the remote configuration applied.

--- a/tests/integration/test_gcloud/test_configuration/test_schedule.py
+++ b/tests/integration/test_gcloud/test_configuration/test_schedule.py
@@ -96,7 +96,7 @@ def get_configuration(request):
 # tests
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_schedule(get_configuration, configure_environment, reset_ossec_log, daemons_handler):
+def test_schedule(get_configuration, configure_environment, reset_ossec_log, daemons_handler_module):
     '''
     description: Check if the 'gcp-pubsub' module is executed in the periods specified in the 'interval' tag.
                  For this purpose, the test will use different values for the 'interval' tag (a positive number
@@ -137,15 +137,15 @@ def test_schedule(get_configuration, configure_environment, reset_ossec_log, dae
     str_interval = get_configuration['sections'][0]['elements'][3]['interval']['value']
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
     tags_to_apply = get_configuration['tags'][0]
-    
+
     # Warning log must appear in log (cause interval is not compatible with <day/month/week>)
     if (tags_to_apply == 'schedule_day' and 'M' not in str_interval) or \
-    (tags_to_apply == 'schedule_wday' and 'w' not in str_interval) or \
-    (tags_to_apply == 'schedule_time' and ('d' not in str_interval and 'w' not in str_interval)):
+       (tags_to_apply == 'schedule_wday' and 'w' not in str_interval) or \
+       (tags_to_apply == 'schedule_time' and ('d' not in str_interval and 'w' not in str_interval)):
         wazuh_log_monitor.start(timeout=global_parameters.default_timeout + time_interval,
                                 callback=callback_detect_schedule_validate_parameters_warn,
                                 error_message='Did not receive expected '
-                                                'at _sched_scan_validate_parameters(): WARNING:').result()
+                                              'at _sched_scan_validate_parameters(): WARNING:').result()
     # Warning is not suppose to appear
     else:
         with pytest.raises(TimeoutError):

--- a/tests/integration/test_gcloud/test_functionality/test_day_wday.py
+++ b/tests/integration/test_gcloud/test_functionality/test_day_wday.py
@@ -125,7 +125,7 @@ def get_configuration(request):
     ({'ossec_time_conf'})
 ])
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler,
+def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler_module,
                   wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module starts to pull logs according to the day of the week,
@@ -202,8 +202,8 @@ def test_day_wday(tags_to_apply, get_configuration, configure_environment, reset
 ])
 @pytest.mark.xfail(reason="Blocked by wazuh/wazuh#15255")
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environment, reset_ossec_log, daemons_handler,
-                           wait_for_gcp_start):
+def test_day_wday_multiple(tags_to_apply, get_configuration, configure_environment, reset_ossec_log,
+                           daemons_handler_module, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module calculates the next scan correctly using time intervals
                  greater than one month, one week, or one day. For this purpose, the test will use different

--- a/tests/integration/test_gcloud/test_functionality/test_interval.py
+++ b/tests/integration/test_gcloud/test_functionality/test_interval.py
@@ -97,6 +97,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 truncate_file(LOG_FILE_PATH)
 
+
 # fixtures
 
 @pytest.fixture(scope='module', params=configurations)
@@ -108,7 +109,8 @@ def get_configuration(request):
 # tests
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
-def test_interval(get_configuration, configure_environment, reset_ossec_log, daemons_handler, wait_for_gcp_start):
+def test_interval(get_configuration, configure_environment, reset_ossec_log, daemons_handler_module,
+                  wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module starts to pull logs at the periods set in the configuration
                  by the 'interval' tag. For this purpose, the test will use different intervals and check if

--- a/tests/integration/test_gcloud/test_functionality/test_logging.py
+++ b/tests/integration/test_gcloud/test_functionality/test_logging.py
@@ -89,14 +89,14 @@ p, m = generate_params(extra_params=conf_params,
                        modes=monitoring_modes)
 
 configurations = conf.load_wazuh_configurations(configurations_path, __name__,
-                                           params=p, metadata=m)
+                                                params=p, metadata=m)
 
 
 # fixtures
-@pytest.fixture(scope='module', params= [
+@pytest.fixture(scope='module', params=[
     {'wazuh_modules.debug': 0,
-      'monitord.rotate_log': 0, 'monitord.day_wait': 0,
-      'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
+     'monitord.rotate_log': 0, 'monitord.day_wait': 0,
+     'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
     {'wazuh_modules.debug': 1,
      'monitord.rotate_log': 0, 'monitord.day_wait': 0,
      'monitord.keep_log_days': 0, 'monitord.size_rotate': 0},
@@ -125,7 +125,6 @@ def configure_local_internal_options_module(get_local_internal_options):
     import wazuh_testing.tools.services as services
     services.restart_wazuh_daemon('wazuh-modulesd')
 
-
     yield
 
     conf.set_local_internal_options_dict(backup_local_internal_options)
@@ -145,7 +144,7 @@ def get_configuration(request):
 ], indirect=True)
 def test_logging(get_configuration, configure_environment, reset_ossec_log,
                  publish_messages, configure_local_internal_options_module,
-                 daemons_handler, wait_for_gcp_start):
+                 daemons_handler_module, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module generates logs according to the debug level set for wazuh_modules.
                  For this purpose, the test will use different debug levels (depending on the test case) and
@@ -195,7 +194,7 @@ def test_logging(get_configuration, configure_environment, reset_ossec_log,
     '''
     str_interval = get_configuration['sections'][0]['elements'][4]['interval']['value']
     logging_opt = int([x[-2] for x in conf.get_wazuh_local_internal_options()
-                   if x.startswith('wazuh_modules.debug')][0])
+                      if x.startswith('wazuh_modules.debug')][0])
     time_interval = int(''.join(filter(str.isdigit, str_interval)))
     mandatory_keywords = {}
     if logging_opt == 0:

--- a/tests/integration/test_gcloud/test_functionality/test_max_messages.py
+++ b/tests/integration/test_gcloud/test_functionality/test_max_messages.py
@@ -122,7 +122,7 @@ def get_configuration(request):
     ['- DEBUG - GCP message' for _ in range(120)]
 ], indirect=True)
 def test_max_messages(get_configuration, configure_environment, reset_ossec_log, publish_messages,
-                      daemons_handler, wait_for_gcp_start):
+                      daemons_handler_module, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module pulls a message number less than or equal to the limit set
                  in the 'max_messages' tag. For this purpose, the test will use a fixed limit and generate a

--- a/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
+++ b/tests/integration/test_gcloud/test_functionality/test_pull_on_start.py
@@ -104,7 +104,7 @@ def get_configuration(request):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_pull_on_start(get_configuration, configure_environment,
-                       daemons_handler, wait_for_gcp_start):
+                       daemons_handler_module, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module pulls messages when starting if the 'pull_on_start' is
                  set to 'yes', or sleeps up to the next interval if that one is set to 'no'. For this

--- a/tests/integration/test_gcloud/test_functionality/test_rules.py
+++ b/tests/integration/test_gcloud/test_functionality/test_rules.py
@@ -95,6 +95,7 @@ configurations = load_wazuh_configurations(configurations_path, __name__, params
 
 truncate_file(LOG_FILE_PATH)
 
+
 # fixtures
 
 @pytest.fixture(scope='module', params=configurations)
@@ -107,7 +108,7 @@ def get_configuration(request):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have support for Google Cloud integration.")
 def test_rules(get_configuration, configure_environment,
-               daemons_handler, wait_for_gcp_start):
+               daemons_handler_module, wait_for_gcp_start):
     '''
     description: Check if the 'gcp-pubsub' module gets messages matching the GCP rules. It also checks
                  if the triggered alerts contain the proper rule ID. For this purpose, the test will

--- a/tests/integration/test_logcollector/test_localfile/test_invalid_agent_localfile_config.py
+++ b/tests/integration/test_logcollector/test_localfile/test_invalid_agent_localfile_config.py
@@ -111,12 +111,12 @@ file_structure = [
 ]
 
 parameters = [
-    { 'LOCATION': os.path.join(temp_dir, 'wazuh-testing', files[0]), 'LOG_FORMAT': None },
-    { 'LOCATION': None, 'LOG_FORMAT': 'syslog' },
+    {'LOCATION': os.path.join(temp_dir, 'wazuh-testing', files[0]), 'LOG_FORMAT': None},
+    {'LOCATION': None, 'LOG_FORMAT': 'syslog'},
 ]
 metadata = lower_case_key_dictionary_array(parameters)
 
-tcase_ids = [f"location_{'None' if param['LOCATION'] is None else files[0]}_" \
+tcase_ids = [f"location_{'None' if param['LOCATION'] is None else files[0]}_"
              f"logformat_{'None' if param['LOG_FORMAT'] is None else param['LOG_FORMAT']}" for param in parameters]
 configurations_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'invalid_agent_conf.yaml')
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -133,10 +133,11 @@ def get_configuration(request):
     """Get configurations from the module."""
     return request.param
 
+
 # Tests
 
 def test_invalid_agent_localfile_config(get_files_list, create_file_structure_module, get_configuration, set_agent_conf,
-                                        daemons_handler):
+                                        daemons_handler_module):
     '''
     description: Check if the expected message is present in the ossec.log when an invalid <localfile> configuration is
                  set and if the Wazuh continues running.
@@ -156,7 +157,7 @@ def test_invalid_agent_localfile_config(get_files_list, create_file_structure_mo
         - set_agent_conf:
             type: fixture
             brief: Set a new configuration in 'agent.conf' file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 

--- a/tests/integration/test_logcollector/test_localfile/test_invalid_wazuh_conf.py
+++ b/tests/integration/test_logcollector/test_localfile/test_invalid_wazuh_conf.py
@@ -116,12 +116,12 @@ file_structure = [
 ]
 
 parameters = [
-    { 'LOCATION': os.path.join(temp_dir, 'wazuh-testing', files[0]), 'LOG_FORMAT': None },
-    { 'LOCATION': None, 'LOG_FORMAT': 'syslog' },
+    {'LOCATION': os.path.join(temp_dir, 'wazuh-testing', files[0]), 'LOG_FORMAT': None},
+    {'LOCATION': None, 'LOG_FORMAT': 'syslog'},
 ]
 metadata = lower_case_key_dictionary_array(parameters)
 
-tcase_ids = [f"location_{'None' if param['LOCATION'] is None else files[0]}_" \
+tcase_ids = [f"location_{'None' if param['LOCATION'] is None else files[0]}_"
              f"logformat_{'None' if param['LOG_FORMAT'] is None else param['LOG_FORMAT']}" for param in parameters]
 configurations_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'invalid_wazuh_conf.yaml')
 configurations = load_wazuh_configurations(configurations_path, __name__, params=parameters, metadata=metadata)
@@ -151,7 +151,7 @@ def remove_empty_options(get_configuration):
 
 
 def test_invalid_wazuh_conf(get_files_list, create_file_structure_module, get_configuration, remove_empty_options,
-                            configure_environment, daemons_handler):
+                            configure_environment, daemons_handler_module):
     '''
     description: Check if the expected message is present in the ossec.log when an invalid <localfile> configuration is
                  set and if Wazuh refuses to restart.
@@ -174,7 +174,7 @@ def test_invalid_wazuh_conf(get_files_list, create_file_structure_module, get_co
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing. Restart Wazuh is needed for applying the configuration.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 
@@ -191,7 +191,7 @@ def test_invalid_wazuh_conf(get_files_list, create_file_structure_module, get_co
         - logcollector
     '''
     wazuh_log_monitor = FileMonitor(LOG_FILE_PATH)
-    
+
     check_daemon_status(target_daemon=LOGCOLLECTOR_DAEMON, running_condition=False)
 
     wazuh_log_monitor.start(timeout=LOG_COLLECTOR_GLOBAL_TIMEOUT, callback=callback_missing_element_error,

--- a/tests/integration/test_logcollector/test_macos/test_macos_file_status_basic.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_file_status_basic.py
@@ -95,7 +95,7 @@ def get_configuration(request):
 
 def test_macos_file_status_basic(restart_logcollector_required_daemons_package, truncate_log_file,
                                  delete_file_status_json, configure_local_internal_options_module,
-                                 get_configuration, configure_environment, file_monitoring, daemons_handler):
+                                 get_configuration, configure_environment, file_monitoring, daemons_handler_module):
     '''
     description: Check if the 'wazuh-logcollector' builds and updates the 'file_status.json' file from ULS events.
                  For this purpose, the test will configure a 'localfile' section using the macOS settings.
@@ -130,7 +130,7 @@ def test_macos_file_status_basic(restart_logcollector_required_daemons_package, 
         - file_monitoring:
             type: fixture
             brief: Handle the monitoring of a specified file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 

--- a/tests/integration/test_logcollector/test_macos/test_macos_file_status_predicate.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_file_status_predicate.py
@@ -86,7 +86,7 @@ def test_macos_file_status_predicate(restart_logcollector_required_daemons_packa
                                      delete_file_status_json,
                                      configure_local_internal_options_module,
                                      get_configuration, configure_environment,
-                                     file_monitoring, daemons_handler):
+                                     file_monitoring, daemons_handler_module):
     """
     description: Check if the 'wazuh-logcollector' does not update the 'file_status.json' file from logging
                  events when using an invalid predicate in the 'query' tag of the 'localfile' section.
@@ -124,7 +124,7 @@ def test_macos_file_status_predicate(restart_logcollector_required_daemons_packa
         - file_monitoring:
             type: fixture
             brief: Handle the monitoring of a specified file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 

--- a/tests/integration/test_logcollector/test_macos/test_macos_file_status_when_no_macos.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_file_status_when_no_macos.py
@@ -52,7 +52,7 @@ from time import sleep
 from os import remove
 if sys.platform != 'win32':
     from wazuh_testing.tools import LOGCOLLECTOR_FILE_STATUS_PATH
-    
+
 # Marks
 pytestmark = [pytest.mark.darwin, pytest.mark.tier(level=0)]
 
@@ -98,7 +98,8 @@ def get_configuration(request):
 
 def test_macos_file_status_when_no_macos(restart_logcollector_required_daemons_package, truncate_log_file, handle_files,
                                          delete_file_status_json, configure_local_internal_options_module,
-                                         get_configuration, configure_environment, file_monitoring, daemons_handler):
+                                         get_configuration, configure_environment, file_monitoring,
+                                         daemons_handler_module):
     '''
     description: Check if the 'wazuh-logcollector' does not store and removes if exists, previous
                  macos-formatted localfile data in the 'file_status.json' file when the macOS localfile
@@ -139,7 +140,7 @@ def test_macos_file_status_when_no_macos(restart_logcollector_required_daemons_p
         - file_monitoring:
             type: fixture
             brief: Handle the monitoring of a specified file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 

--- a/tests/integration/test_logcollector/test_macos/test_macos_format_basic.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_format_basic.py
@@ -99,8 +99,8 @@ def restart_logcollector_function():
 @pytest.mark.parametrize('macos_message', macos_log_messages,
                          ids=[log_message['id'] for log_message in macos_log_messages])
 def test_macos_format_basic(restart_logcollector_required_daemons_package, get_configuration, configure_environment,
-                            configure_local_internal_options_module, macos_message, file_monitoring, daemons_handler,
-                            restart_logcollector_function):
+                            configure_local_internal_options_module, macos_message, file_monitoring,
+                            daemons_handler_module, restart_logcollector_function):
     '''
     description: Check if the 'wazuh-logcollector' gathers properly macOS unified logging system (ULS) events.
                  For this purpose, the test will configure a 'localfile' section using the macOS settings.
@@ -133,7 +133,7 @@ def test_macos_format_basic(restart_logcollector_required_daemons_package, get_c
         - file_monitoring:
             type: fixture
             brief: Handle the monitoring of a specified file.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
         - restart_logcollector_function:

--- a/tests/integration/test_logcollector/test_macos/test_macos_format_only_future_events.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_format_only_future_events.py
@@ -99,7 +99,7 @@ def get_connection_configuration():
 
 def test_macos_format_only_future_events(restart_logcollector_required_daemons_package, get_configuration,
                                          configure_environment, configure_local_internal_options_module,
-                                         file_monitoring, daemons_handler):
+                                         file_monitoring, daemons_handler_module):
     """
     description: Check if the 'only-future-events' option is used properly by the 'wazuh-logcollector' when
                  using the macOS unified logging system (ULS) events. For this purpose, the test will configure
@@ -128,7 +128,7 @@ def test_macos_format_only_future_events(restart_logcollector_required_daemons_p
         - configure_local_internal_options_module:
             type: fixture
             brief: Set internal configuration for testing.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
         - file_monitoring:

--- a/tests/integration/test_logcollector/test_macos/test_macos_multiline_values.py
+++ b/tests/integration/test_logcollector/test_macos/test_macos_multiline_values.py
@@ -84,9 +84,9 @@ def get_connection_configuration():
 
 
 @pytest.mark.parametrize('macos_message', macos_log_messages)
-def test_macos_multiline_values(configure_local_internal_options_module, restart_logcollector_required_daemons_package, 
-                                get_configuration, configure_environment, macos_message, file_monitoring, 
-                                daemons_handler):
+def test_macos_multiline_values(configure_local_internal_options_module, restart_logcollector_required_daemons_package,
+                                get_configuration, configure_environment, macos_message, file_monitoring,
+                                daemons_handler_module):
     '''
     description: Check if the 'wazuh-logcollector' daemon collects multiline events from the macOS ULS
                  (unified logging system). For this purpose, the test will configure a 'localfile' section
@@ -115,7 +115,7 @@ def test_macos_multiline_values(configure_local_internal_options_module, restart
         - macos_message:
             type: dict
             brief: Dictionary with the testing macOS ULS event.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
         - file_monitoring:
@@ -146,7 +146,7 @@ def test_macos_multiline_values(configure_local_internal_options_module, restart
     multiline_message = macos_message['message'].split('\n')[:-1]
     multiline_logger = f"\"$(printf \"{macos_message['message']}\")\""
     logcollector.generate_macos_logger_log(multiline_logger)
-    
+
     for line in multiline_message:
         log_monitor.start(timeout=logcollector.LOG_COLLECTOR_GLOBAL_TIMEOUT,
                           callback=logcollector.callback_read_macos_message(line),

--- a/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
+++ b/tests/integration/test_logcollector/test_statistics/test_statistics_macos.py
@@ -82,7 +82,7 @@ def get_configuration(request):
 
 
 def test_options_state_interval_no_file(configure_local_internal_options_module, get_configuration,
-                                        configure_environment, daemons_handler):
+                                        configure_environment, daemons_handler_module):
     '''
     description: Check if the 'wazuh-logcollector' daemon updates the statistic file 'wazuh-logcollector.state'
                  when using the macOS unified logging system (ULS). For this purpose, the test will configure
@@ -105,7 +105,7 @@ def test_options_state_interval_no_file(configure_local_internal_options_module,
         - configure_environment:
             type: fixture
             brief: Configure a custom environment for testing.
-        - daemons_handler:
+        - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.
 


### PR DESCRIPTION
|Related issue|
|-------------|
|#4126|

## Description

A test that verified the syscollector configuration options used a wrapped fixture that used the `get_configuration` fixture with a "module" scope but the wrapper itself had a "function" scope, throwing an error while running the test.

**This PR proposes a solution to not repeat code while keeping 2 separate fixtures with different scopes.**

I've tried different options, but none of them fulfilled those requirements or some of them did not work as expected.

### Updated

- `deps/wazuh_testing/wazuh_testing/tools/services.py`: PEP8 corrections
- `tests/integration/conftest.py`: separate the `daemons_handler` fixture implementation from the fixture itself to create different scopes from it
- Change fixture name in multiple tests and apply linter corrections on them

---

## Testing performed

See comments below.

