### PR TITLE
Remove old XFail marker (API suite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Release report: https://github.com/wazuh/wazuh/issues/17004
 
 ### Fixed
 
+- Remove old XFail marker (API suite) ([#4177](https://github.com/wazuh/wazuh-qa/pull/4177)) \- (Tests)
 - Mark VD download feeds test as xfail ([#4197](https://github.com/wazuh/wazuh-qa/pull/4197)) \- (Tests)
 - Skip test_age_datetime_changed ([#4182](https://github.com/wazuh/wazuh-qa/pull/4182)) \- (Tests)
 - Limit urllib3 major required version ([#4162](https://github.com/wazuh/wazuh-qa/pull/4162)) \- (Framework)

--- a/tests/integration/test_api/test_config/test_cors/test_cors.py
+++ b/tests/integration/test_api/test_config/test_cors/test_cors.py
@@ -76,7 +76,6 @@ def get_configuration(request):
 
 # Tests
 
-@pytest.mark.xfail(reason="Error fixed in this issue: https://github.com/wazuh/wazuh/issues/8485")
 @pytest.mark.parametrize('origin, tags_to_apply', [
     ('https://test_url.com', {'cors'}),
     ('http://other_url.com', {'cors'}),


### PR DESCRIPTION
|Related issue|
|-------------|
| #4161 |

## Description

Several test cases were marked as xfail, but only 1 of them was unstable. So, this PR removes the markers in those tests and makes some improvements in the test structure.

### Updated

- `tests/integration/test_gcloud/test_functionality/test_day_wday.py`

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  | tests/integration/test_gcloud/test_functionality/test_day_wday.py | [🟢](https://ci.wazuh.info/job/Test_integration/38812/)[🟢](https://ci.wazuh.info/job/Test_integration/38813/)[🟢](https://ci.wazuh.info/job/Test_integration/38814/) | [🟢](https://github.com/wazuh/wazuh-qa/files/11491602/Archive.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/11491603/Archive.3.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/11491604/Archive.2.zip) | | b74c4a0 | Nothing to highlight |
