### PR TITLE
5131 fix sync integrity win32

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/fim/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/fim/__init__.py
@@ -58,6 +58,7 @@ SYNCHRONIZATION_ENABLED = 'SYNCHRONIZATION_ENABLED'
 SYNCHRONIZATION_REGISTRY_ENABLED = 'SYNCHRONIZATION_REGISTRY_ENABLED'
 
 # Callbacks message
+CB_DETECT_FIM_EVENT = r".*Sending FIM event: (.+)$"
 CB_INTEGRITY_CONTROL_MESSAGE = r'.*Sending integrity control message: (.+)$'
 CB_REGISTRY_DBSYNC_NO_DATA = r'.*#!-fim_registry dbsync no_data (.+)'
 CB_MAXIMUM_FILE_SIZE = r'.*Maximum file size limit to generate diff information configured to \'(\d+) KB\'.*'
@@ -68,6 +69,7 @@ ERR_MSG_MAXIMUM_FILE_SIZE = 'Did not receive expected "Maximum file size limit c
 ERR_MSG_WRONG_VALUE_MAXIMUM_FILE_SIZE = 'Wrong value for diff_size_limit'
 ERR_MSG_AGENT_DISCONNECT = 'Agent couldn\'t connect to server.'
 ERR_MSG_INTEGRITY_CONTROL_MSG = 'Didn\'t receive control message(integrity_check_global)'
+ERR_MSG_SENDING_FIM_EVENT = 'Did not receive expected "Sending FIM event: ..." event'
 
 # Setting Local_internal_option file
 

--- a/tests/integration/test_fim/test_synchronization/data/wazuh_conf_integrity_scan_win32.yaml
+++ b/tests/integration/test_fim/test_synchronization/data/wazuh_conf_integrity_scan_win32.yaml
@@ -17,3 +17,5 @@
         value: TEST_REGS
         attributes:
         - arch: "both"
+    - frequency:
+        value: 5

--- a/tests/integration/test_fim/test_synchronization/test_synchronize_integrity_win32.py
+++ b/tests/integration/test_fim/test_synchronization/test_synchronize_integrity_win32.py
@@ -54,20 +54,19 @@ tags:
     - fim_synchronization
 '''
 import os
-from datetime import timedelta
 
 import pytest
-from wazuh_testing import global_parameters
-from wazuh_testing.fim import LOG_FILE_PATH, create_registry, generate_params, \
-    create_file, modify_registry_value, REGULAR, callback_detect_event, callback_real_time_whodata_started, \
-    KEY_WOW64_64KEY, registry_parser, REG_SZ
+from wazuh_testing import global_parameters 
+from wazuh_testing.fim import (create_registry, generate_params, LOG_FILE_PATH, REGULAR, create_file,
+    modify_registry_value, callback_real_time_whodata_started, KEY_WOW64_64KEY, registry_parser, REG_SZ)
 from wazuh_testing.tools import PREFIX
-from wazuh_testing.tools.configuration import load_wazuh_configurations, check_apply_test
+from wazuh_testing.tools.configuration import load_wazuh_configurations
 from wazuh_testing.tools.monitoring import FileMonitor
-from wazuh_testing.tools.time import TimeMachine
+from wazuh_testing.modules.fim.event_monitor import callback_detect_file_added_event, callback_detect_event
+from wazuh_testing.modules.fim import ERR_MSG_SENDING_FIM_EVENT
+
 
 # Marks
-
 pytestmark = [pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # variables
@@ -80,12 +79,12 @@ directory_str = ','.join(test_directories)
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 configurations_path = os.path.join(test_data_path, 'wazuh_conf_integrity_scan_win32.yaml')
 testdir1, testdir2 = test_directories
-conf_params = {'TEST_DIRECTORIES': test_directories,
+conf_params = {'TEST_DIRECTORIES': directory_str,
                'TEST_REGS': os.path.join(key, subkey)}
 
 file_list = []
 subkey_list = []
-for i in range(3000):
+for i in range(1000):
     file_list.append(f'regular_{i}')
     subkey_list.append(f'subkey_{i}')
 
@@ -107,7 +106,7 @@ def get_configuration(request):
 
 
 def extra_configuration_before_yield():
-    # Create 3000 files before restarting Wazuh to make sure the integrity scan will not finish before testing
+    # Create 1000 files before restarting Wazuh to make sure the integrity scan will not finish before testing
     for testdir in test_directories:
         for file, reg in zip(file_list, subkey_list):
             create_file(REGULAR, testdir, file, content='Sample content')
@@ -127,11 +126,8 @@ def callback_integrity_or_whodata(line):
         return 2
 
 
-# tests
-@pytest.mark.parametrize('tags_to_apply', [
-    {'synchronize_events_conf'}
-])
-def test_events_while_integrity_scan(tags_to_apply, get_configuration, configure_environment, restart_syscheckd):
+# Tests
+def test_events_while_integrity_scan(get_configuration, configure_environment, restart_syscheckd):
     '''
     description: Check if the 'wazuh-syscheckd' daemon detects events while the synchronization is performed
                  simultaneously. For this purpose, the test will monitor a testing directory and registry key.
@@ -176,8 +172,6 @@ def test_events_while_integrity_scan(tags_to_apply, get_configuration, configure
         - realtime
         - who_data
     '''
-    check_apply_test(tags_to_apply, get_configuration['tags'])
-
     folder = testdir1 if get_configuration['metadata']['fim_mode'] == 'realtime' else testdir2
     key_h = create_registry(registry_parser[key], subkey, KEY_WOW64_64KEY)
 
@@ -209,14 +203,15 @@ def test_events_while_integrity_scan(tags_to_apply, get_configuration, configure
     create_file(REGULAR, folder, file_name, content='')
     modify_registry_value(key_h, "test_value", REG_SZ, 'added')
 
-    sending_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout*3, callback=callback_detect_event,
-                                            error_message='Did not receive expected '
-                                                          '"Sending FIM event: ..." event').result()
+    # Detect and assert the file 'added' event in realtime/whodata mode
+    sending_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout*3,
+                                            callback=callback_detect_file_added_event,
+                                            error_message=ERR_MSG_SENDING_FIM_EVENT).result()
     assert sending_event['data']['path'] == os.path.join(folder, file_name)
 
-    TimeMachine.travel_to_future(timedelta(hours=13))
-    sending_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout*3, callback=callback_detect_event,
-                                            error_message='Did not receive expected '
-                                                          '"Sending FIM event: ..." event').result()
+    # Detect and assert the value 'added' event in scheduled mode
+    sending_event = wazuh_log_monitor.start(timeout=global_parameters.default_timeout*3,
+                                            callback=callback_detect_event,
+                                            error_message=ERR_MSG_SENDING_FIM_EVENT).result()
     assert sending_event['data']['path'] == os.path.join(key, subkey)
     assert sending_event['data']['arch'] == '[x64]'


### PR DESCRIPTION
|Related issue|
|-------------|
| https://github.com/wazuh/wazuh-jenkins/issues/5131            |

## Description

This PR aims to fix the FIM module `test_synchronize_integrity_win32`.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- Added new callbacks on `modules.fim.event_monitor.py` 

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Fixed `test_synchronize_integrity_win32.py`


## Testing performed

Testing was only done on Windows endpoint since the only affected modules are only executed in Windows.

| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  |  test_fim         |[:green_circle:](https://ci.wazuh.info/job/Test_integration/38787/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/38788/)[:green_circle:](https://ci.wazuh.info/job/Test_integration/38789/) | ⚫⚫⚫ |   Windows Agent      | https://github.com/wazuh/wazuh-qa/commit/be4de34a858426956a1d292772e2ad9d4c5ddb38         | Nothing to highlight |
| @damarisg  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
