### PR TITLE
Skip Logcollector IT `test_age_datetime_changed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Skip test_age_datetime_changed ([#4182](https://github.com/wazuh/wazuh-qa/pull/4182)) \- (Tests)
 - Limit urllib3 major required version ([#4162](https://github.com/wazuh/wazuh-qa/pull/4162)) \- (Framework)
 - Fix daemons_handler fixture (fix GCP IT) ([#4134](https://github.com/wazuh/wazuh-qa/pull/4134)) \- (Tests)
 - Fix wazuhdb IT. ([#3584](https://github.com/wazuh/wazuh-qa/pull/3584)) \- (Framework + Tests)

--- a/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
+++ b/tests/integration/test_logcollector/test_age/test_age_datetime_changed.py
@@ -82,7 +82,7 @@ configurations_path = os.path.join(test_data_path, 'wazuh_age.yaml')
 
 DAEMON_NAME = "wazuh-logcollector"
 
-local_internal_options = {'logcollector.vcheck_files': '0', 'logcollector.debug': '2', 'monitord.rotate_log': '0', 
+local_internal_options = {'logcollector.vcheck_files': '0', 'logcollector.debug': '2', 'monitord.rotate_log': '0',
                           'windows.debug': '2'}
 
 timeout_logcollector_read = 10
@@ -136,7 +136,7 @@ def restart_logcollector_function():
 
 
 @pytest.mark.parametrize('new_datetime', new_host_datetime)
-@pytest.mark.skipif(sys.platform == 'win32', reason='It will be blocked by https://github.com/wazuh/wazuh-qa/issues/2174.')
+@pytest.mark.skip("Skipped by Issue #3218")
 def test_configuration_age_datetime(get_configuration, configure_environment, configure_local_internal_options_module,
                                     restart_monitord, restart_logcollector_function, file_monitoring,
                                     new_datetime, get_files_list, create_file_structure_function):


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-jenkins/issues/4986        |

## Description

Integration test pipelie failed erratically gathering the report generated by the Logcollector IT. This was originated by the test `test_configuration_age_datetime` which change the system datetime. After system change the report and the qa repository placed in `/tmp/` were removed.

In this PR this tests has been skipped. Future refactor avoiding system date change is required.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Skipped `test_age_datetime_changed` 

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |   test_logcollector        | [:green_circle:](https://ci.wazuh.info/job/Test_integration/38804/console) [:green_circle:](https://ci.wazuh.info/job/Test_integration/38808/console) [:green_circle:](https://ci.wazuh.info/job/Test_integration/38809/)|  ⚫⚫⚫ |  Manager   |  https://github.com/wazuh/wazuh-qa/pull/4182/commits/4557c11ca64b4379ff7134ca8fc5bb7c725f2e8f | Nothing to highlight | 
