### PR TITLE
Logcollector `test_basic_configuration_alias.py`  integration test fails on winagent

### DIFF
--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_alias.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_alias.py
@@ -157,7 +157,7 @@ def test_configuration_alias(configure_local_internal_options_module,
     cfg = get_configuration['metadata']
 
     log_callback = logcollector.callback_command_alias_output(cfg['alias'])
-    log_monitor.start(timeout=10, callback=log_callback,
+    log_monitor.start(timeout=15, callback=log_callback,
                       error_message=logcollector.GENERIC_CALLBACK_ERROR_COMMAND_MONITORING)
 
     if wazuh_component == 'wazuh-manager':


### PR DESCRIPTION
|Related issue|
|-------------|
|  https://github.com/wazuh/wazuh-qa/issues/4179          |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

Increased timeout, requested [here ](https://github.com/wazuh/wazuh-qa/issues/4179#issuecomment-1558850656)

<!-- Added functionalities or files. Remove if not applicable -->


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- timeout increased from 10 to 15



---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @BelenValdivia  (Developer)  |   test_logcollector/test_configuration        | [🟢](https://ci.wazuh.info/job/Test_integration/39277/) [🟢](https://ci.wazuh.info/job/Test_integration/39281/) [🟢 ](https://ci.wazuh.info/job/Test_integration/39284/ )  | [🟢](https://github.com/wazuh/wazuh-qa/files/11557295/R1-logcollectortimeout.zip) ⚫⚫ |         |         | Nothing to highlight |
| @damarisg  (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


