### PR TITLE
Mark VD test as xfail (download feeds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Mark VD download feeds test as xfail ([#4197](https://github.com/wazuh/wazuh-qa/pull/4197)) \- (Tests)
 - Skip test_age_datetime_changed ([#4182](https://github.com/wazuh/wazuh-qa/pull/4182)) \- (Tests)
 - Limit urllib3 major required version ([#4162](https://github.com/wazuh/wazuh-qa/pull/4162)) \- (Framework)
 - Fix daemons_handler fixture (fix GCP IT) ([#4134](https://github.com/wazuh/wazuh-qa/pull/4134)) \- (Tests)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -79,8 +79,6 @@ configuration_parameters, configuration_metadata, case_ids = get_test_cases_data
 configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
 
 
-@pytest.mark.xfail(reason='The vendor did not update its feed so the test will fail: wazuh/wazuh-qa#4156',
-                   raises=AssertionError)
 @pytest.mark.tier(level=2)
 @pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=case_ids)
 def test_download_feeds(configuration, metadata, set_wazuh_configuration_vdt, truncate_monitored_files,
@@ -148,7 +146,11 @@ def test_download_feeds(configuration, metadata, set_wazuh_configuration_vdt, tr
 
     # Check that the timestamp of the feed metadata does not exceed the established threshold limit.
     if metadata['update_treshold_weeks'] != 'None':
-        assert vd.feed_is_recently_updated(provider_name=metadata['provider_name'],
-                                           provider_os=metadata['provider_os'],
-                                           threshold_weeks=metadata['update_treshold_weeks']), '' \
-                                           f"The {metadata['provider_os']} feed has not been recently updated"
+        try:
+            assert vd.feed_is_recently_updated(provider_name=metadata['provider_name'],
+                                               provider_os=metadata['provider_os'],
+                                               threshold_weeks=metadata['update_treshold_weeks']), '' \
+                                               f"The {metadata['provider_os']} feed has not been recently updated"
+        except AssertionError:
+            pytest.xfail(reason='The vendor did not update its feed so the test will fail: wazuh/wazuh-qa#4156',
+                         raises=AssertionError)

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
@@ -79,6 +79,8 @@ configuration_parameters, configuration_metadata, case_ids = get_test_cases_data
 configurations = load_configuration_template(configurations_path, configuration_parameters, configuration_metadata)
 
 
+@pytest.mark.xfail(reason='The vendor did not update its feed so the test will fail: wazuh/wazuh-qa#4156',
+                   raises=AssertionError)
 @pytest.mark.tier(level=2)
 @pytest.mark.parametrize('configuration, metadata', zip(configurations, configuration_metadata), ids=case_ids)
 def test_download_feeds(configuration, metadata, set_wazuh_configuration_vdt, truncate_monitored_files,


### PR DESCRIPTION
|Related issue|
|-------------|
|             |

## Description

The test fails because the threshold's timestamp is greater than the last update of the provider's feed.

IMHO, we cannot make a test fail for this reason (which is an indicator that something is not working as expected in our software), because we cannot predict or prevent the provider does not update its feed, and therefore, that limit is exceeded by the last date on which the provider updated its feed. So, Wazuh's not failing but the provider's feed is exceeding a defined threshold.

**Proposed solution**: Mark as "expected fail (xfail)" if the threshold exceeds the feed's last update.

### Updated

- `tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py`: marked as xfail if an assertion error is thrown when checking the threshold.


---

## Testing performed


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @mauromalara (Developer)  | test_vulnerability_detector/test_feeds/ | ⚫⚫⚫ | 🚫🚫🚫 |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | 🚫🚫🚫  |        |         | Nothing to highlight |
