### PR TITLE
Change `test_python_flaws.py` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### Feature
+- Change test_python_flaws.py to accept branch or commit in the same argument. ([#4207](https://github.com/wazuh/wazuh-qa/pull/4207)) (Tests)
+
 ## [4.4.3] - 25-06-2023
 
 Wazuh commit: https://github.com/wazuh/wazuh/commit/f7080df56081adaeaad94529522233e2f0bbd577

--- a/tests/scans/code_analysis/conftest.py
+++ b/tests/scans/code_analysis/conftest.py
@@ -47,8 +47,6 @@ def clone_wazuh_repository(pytestconfig):
     repository_path = tempfile.mkdtemp()
 
     try:
-
-
         # Clone into temporary dir
         # depth=1 creates a shallow clone with a history truncated to 1 commit. Implies single_branch=True.
         try:

--- a/tests/scans/code_analysis/conftest.py
+++ b/tests/scans/code_analysis/conftest.py
@@ -41,27 +41,28 @@ def clone_wazuh_repository(pytestconfig):
     """
     # Get Wazuh repository and branch
     repository_name = pytestconfig.getoption('repo')
-    branch = pytestconfig.getoption('branch')
-    commit = pytestconfig.getoption('commit')
+    reference = pytestconfig.getoption('reference')
 
     # Create temporary dir
     repository_path = tempfile.mkdtemp()
 
     try:
+
+
         # Clone into temporary dir
         # depth=1 creates a shallow clone with a history truncated to 1 commit. Implies single_branch=True.
-        if not commit:
+        try:
             Repo.clone_from(f"https://github.com/wazuh/{repository_name}.git",
                             repository_path,
                             depth=1,
-                            branch=branch)
-        else:
+                            branch=reference)
+        except repo.exc.GitCommandError:
             repo = Repo.clone_from(f"https://github.com/wazuh/{repository_name}.git",
                                    repository_path, branch='master', no_single_branch=True)
 
             # Get all branches that contains the commit
             git_local = Git(repository_path)
-            commit_branch = git_local.branch('-a', '--contains', commit).split('\n')
+            commit_branch = git_local.branch('-a', '--contains', reference).split('\n')
             commit_branch_head = False
 
             for branch in commit_branch:
@@ -69,11 +70,11 @@ def clone_wazuh_repository(pytestconfig):
                 branch_name = branch.replace('*', '').strip()
                 repo.git.checkout(branch_name)
                 # Check if the commit is the head of the branch
-                if(str(repo.head.commit) == commit):
+                if(str(repo.head.commit) == reference):
                     commit_branch_head = True
                     break
             if not commit_branch_head:
-                raise Exception(f"{commit} was not found as any head branch")
+                raise Exception(f"{reference} was not found as any head branch")
 
         yield repository_path
 

--- a/tests/scans/code_analysis/conftest.py
+++ b/tests/scans/code_analysis/conftest.py
@@ -56,7 +56,7 @@ def clone_wazuh_repository(pytestconfig):
                             repository_path,
                             depth=1,
                             branch=reference)
-        except repo.exc.GitCommandError:
+        except:
             repo = Repo.clone_from(f"https://github.com/wazuh/{repository_name}.git",
                                    repository_path, branch='master', no_single_branch=True)
 

--- a/tests/scans/conftest.py
+++ b/tests/scans/conftest.py
@@ -3,9 +3,7 @@ DEFAULT_REPOSITORY = 'wazuh'
 
 
 def pytest_addoption(parser):
-    parser.addoption("--branch", action="store", default=DEFAULT_BRANCH,
-                     help=f"Set the repository used. Default: {DEFAULT_REPOSITORY}")
+    parser.addoption("--reference", action="store", default=DEFAULT_BRANCH,
+                     help=f"Set the repository reference(branch or commit). Default: {DEFAULT_REPOSITORY}")
     parser.addoption("--repo", action="store", default=DEFAULT_REPOSITORY,
-                     help=f"Set the repository branch. Default: {DEFAULT_BRANCH}")
-    parser.addoption("--commit", action="store", default=None,
-                     help=f"Set the repository commit. Default: None")
+                     help=f"Set the repository used. Default: {DEFAULT_BRANCH}")


### PR DESCRIPTION
|Related issue|
|-------------|
|https://github.com/wazuh/wazuh-jenkins/issues/5139|

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR changes the functioning of test `test_python_flaws.py` to accept just one argument `--reference` instead of `--branch` or `--commit`.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- tests/scans/code_analysis/conftest.py
- tests/scans/conftest.py

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
Two different runs of pipeline `Test_code_vulnerabilities` have been launched, one using a branch as a source reference and the other with a commit. Both appear as failures for what has been explained in https://github.com/wazuh/wazuh-jenkins/pull/5141, the vulnerabilities it has detected.

- Jenkins build with branch: https://ci.wazuh.info/job/Test_code_vulnerabilities/51
- Jenkins build with commit: https://ci.wazuh.info/job/Test_code_vulnerabilities/52