### PR TITLE
Change test_python_flaws.py arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### Feature
+- Change test_python_flaws.py to accept branch or commit in the same argument. ([#4209](https://github.com/wazuh/wazuh-qa/pull/4207)) (Tests)
+
 ## [4.4.3] - 25-06-2023
 
 Wazuh commit: https://github.com/wazuh/wazuh/commit/f7080df56081adaeaad94529522233e2f0bbd577

--- a/tests/scans/conftest.py
+++ b/tests/scans/conftest.py
@@ -1,11 +1,9 @@
-DEFAULT_BRANCH = 'master'
+DEFAULT_REFERENCE = 'master'
 DEFAULT_REPOSITORY = 'wazuh'
 
 
 def pytest_addoption(parser):
-    parser.addoption("--branch", action="store", default=DEFAULT_BRANCH,
-                     help=f"Set the repository used. Default: {DEFAULT_REPOSITORY}")
+    parser.addoption("--reference", action="store", default=DEFAULT_REFERENCE,
+                     help=f"Set the reference used. Default: {DEFAULT_REPOSITORY}")
     parser.addoption("--repo", action="store", default=DEFAULT_REPOSITORY,
-                     help=f"Set the repository branch. Default: {DEFAULT_BRANCH}")
-    parser.addoption("--commit", action="store", default=None,
-                     help=f"Set the repository commit. Default: None")
+                     help=f"Set the repository used. Default: {DEFAULT_REPOSITORY}")


### PR DESCRIPTION
|Related issue|
|-------------|
|https://github.com/wazuh/wazuh-jenkins/issues/5139, #4208 |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR changes the functioning of test `test_python_flaws.py` to accept just one argument `--reference` instead of `--branch` or `--commit`.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- tests/scans/code_analysis/conftest.py
- tests/scans/conftest.py

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
Two different runs of pipeline `Test_code_vulnerabilities` have been launched, one using a branch as a source reference and the other with a commit. Both appear as failures for what has been explained in https://github.com/wazuh/wazuh-jenkins/pull/5141, the vulnerabilities it has detected.

- Jenkins build with branch: https://ci.wazuh.info/job/Test_code_vulnerabilities/51
- Jenkins build with commit: https://ci.wazuh.info/job/Test_code_vulnerabilities/52