### PR TITLE
Fix call to the python test from `test_dependencies.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ### Feature
 - Change test_python_flaws.py to accept branch or commit in the same argument. ([#4209](https://github.com/wazuh/wazuh-qa/pull/4207)) (Tests)
+- Fix test_dependencies.py for the changes in the feature. ([#4210](https://github.com/wazuh/wazuh-qa/pull/4210)) (Tests)
 
 ## [4.4.3] - 25-06-2023
 

--- a/tests/scans/dependencies/test_dependencies.py
+++ b/tests/scans/dependencies/test_dependencies.py
@@ -17,7 +17,7 @@ def test_python_dependencies_vuln_scan(pytestconfig):
     Args:
         pytestconfig (fixture): Fixture that returns the :class:`_pytest.config.Config` object.
     """
-    branch = pytestconfig.getoption('--branch')
+    branch = pytestconfig.getoption('--reference')
     repo = pytestconfig.getoption('--repo')
     requirements_path = pytestconfig.getoption('--requirements-path')
     report_path = pytestconfig.getoption('--report-path')


### PR DESCRIPTION
|Related issue|
|-------------|
| #4208 , https://github.com/wazuh/wazuh-jenkins/issues/5139|

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

After changing `test_python_flaws.py` in https://github.com/wazuh/wazuh-qa/pull/4209, when testing for https://github.com/wazuh/wazuh-jenkins/pull/5141, build https://ci.wazuh.info/job/Test_dependencies_vulnerabilities/46/console has failed because the script was called with the previous arguments.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- tests/scans/dependencies/test_dependencies.py

---

## Testing performed

Two Jenkins builds have been done, one using a branch and another using a commit:

- Jenkins build using branch: https://ci.wazuh.info/job/Test_dependencies_vulnerabilities/49
- Jenkins build using commit: https://ci.wazuh.info/job/Test_dependencies_vulnerabilities/50