### PR TITLE
Modify Github actions for edited PRs

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - ready_for_review
+      - edited
     branches:
       - master
       - '[0-9]+.[0-9]+'

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -4,7 +4,7 @@ on:
     types:
       - opened
       - ready_for_review
-      - edited
+      - synchronize
     branches:
       - master
       - '[0-9]+.[0-9]+'

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -4,7 +4,7 @@ on:
     types:
       - opened
       - ready_for_review
-      - edited
+      - synchronize
 jobs:
   Linting:
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - ready_for_review
+      - edited
 jobs:
   Linting:
     if: ${{ !github.event.pull_request.draft }}

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,0 +1,1 @@
+testing changes

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,1 +1,0 @@
-testing changes


### PR DESCRIPTION
|Related issue|
|-------------|
|   #4223           |

## Description

The type `synchronize` has been added so that every time there is a change in a PR, the expected actions are executed.