### PR TITLE
Fix AWS Parser integration test 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/aws/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/aws/event_monitor.py
@@ -79,7 +79,7 @@ def callback_detect_aws_module_warning(line):
         Optional[str]: Line if it matches.
     """
 
-    if re.match(r".*WARNING: No buckets or services definitions found at module 'aws-s3'.", line):
+    if re.match(r".*WARNING: No buckets, services or subscribers definitions found at module 'aws-s3'.", line):
         return line
 
 


### PR DESCRIPTION
|Related issue|
|-------------|
|      #4215        |

## Description

This PR fixes the `test_parser.py::test_bucket_and_service_missing[parser_bucket_and_service_missing]` test which was found to be failing due to the new AWS Security Lake integration addition (`v4.4.2`).

The other integration tests were also run and no related errors were found.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `deps/wazuh_testing/wazuh_testing/modules/aws/event_monitor.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fdalmaup (Developer)  |      `tests/integration/test_aws`     | ⚫⚫⚫ | :green_circle: :green_circle: |    Ubuntu 22.04.2 LTS     |         | Nothing to highlight |
| @GGP1 (Reviewer)   |   `tests/integration/test_aws`         | ⚫⚫⚫ | :green_circle: :green_circle: :green_circle:  |   Pop!_OS 22.04 LTS     |         | Nothing to highlight |

```
python3 -m pytest -vvx -k parser
====================================================================== test session starts ======================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-137-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.0.0'}, 'Plugins': {'html': '3.1.1', 'metadata': '2.0.4', 'testinfra': '5.0.0'}}
rootdir: /home/vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-2.0.4, testinfra-5.0.0
collected 195 items / 169 deselected / 26 selected                                                                                                              

test_parser.py::test_bucket_and_service_missing[parser_bucket_and_service_missing] PASSED                                                                 [  3%]
test_parser.py::test_type_missing_in_bucket[parser_type_missing_in_bucket] PASSED                                                                         [  7%]
test_parser.py::test_type_missing_in_service[parser_type_missing_in_service] PASSED                                                                       [ 11%]
test_parser.py::test_empty_values_in_bucket[parser_empty_type_in_bucket] PASSED                                                                           [ 15%]
test_parser.py::test_empty_values_in_bucket[parser_empty_name_in_bucket] PASSED                                                                           [ 19%]
test_parser.py::test_empty_values_in_bucket[parser_empty_only_logs_after_in_bucket] PASSED                                                                [ 23%]
test_parser.py::test_empty_values_in_bucket[parser_empty_regions_in_bucket] PASSED                                                                        [ 26%]
test_parser.py::test_empty_values_in_bucket[parser_empty_path_in_bucket] PASSED                                                                           [ 30%]
test_parser.py::test_empty_values_in_bucket[parser_empty_path_suffix_in_bucket] PASSED                                                                    [ 34%]
test_parser.py::test_empty_values_in_service[parser_empty_type_in_service] PASSED                                                                         [ 38%]
test_parser.py::test_empty_values_in_service[parser_empty_log_groups_in_service] PASSED                                                                   [ 42%]
test_parser.py::test_empty_values_in_service[parser_empty_only_logs_after_in_service] PASSED                                                              [ 46%]
test_parser.py::test_empty_values_in_service[parser_empty_regions_in_service] PASSED                                                                      [ 50%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_type_in_bucket] PASSED                                                                       [ 53%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_name_in_bucket] PASSED                                                                       [ 57%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_only_logs_after_in_bucket] PASSED                                                            [ 61%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_regions_in_bucket] PASSED                                                                    [ 65%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_path_in_bucket] PASSED                                                                       [ 69%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_path_suffix_in_bucket] PASSED                                                                [ 73%]
test_parser.py::test_invalid_values_in_bucket[parser_invalid_remove_from_bucket_in_bucket] PASSED                                                         [ 76%]
test_parser.py::test_invalid_values_in_service[parser_invalid_type_in_service] PASSED                                                                     [ 80%]
test_parser.py::test_invalid_values_in_service[parser_invalid_log_groups_in_service] PASSED                                                               [ 84%]
test_parser.py::test_invalid_values_in_service[parser_invalid_only_logs_after_in_service] PASSED                                                          [ 88%]
test_parser.py::test_invalid_values_in_service[parser_invalid_regions_in_service] PASSED                                                                  [ 92%]
test_parser.py::test_invalid_values_in_service[parser_invalid_remove_log_stream_in_service] PASSED                                                        [ 96%]
test_parser.py::test_multiple_bucket_and_service_tags[parser_mutiple_bucket_and_service_tags] PASSED                                                      [100%]

======================================================== 26 passed, 169 deselected in 294.02s (0:04:54) =========================================================
```