### PR TITLE
Add an integration test to check the wazuh-analysisd's decoder parser

### DIFF
--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_11.xml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/custom_decoder_11.xml
@@ -1,0 +1,6 @@
+<!-- Test: invalid regex offset-->
+<decoder name="sudo-fields">
+  <parent>sudo</parent>
+  <regex offset="after_regex">(\S+)</regex>
+  <order>boom</order>
+</decoder>

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_decoder_syntax.yaml
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/data/invalid_decoder_syntax.yaml
@@ -76,3 +76,10 @@
   output_error: 0
   output_data_msg: "(2107): Decoder configuration error: 'name'."
   output_data_codemsg: -1
+-
+  name: "Invalid decoder syntax: invalid offset"
+  decoder: "custom_decoder_11.xml"
+  input: '{"version":1,"origin":{"name":"Integration Test","module":"api"},"command":"log_processing","parameters":{"event": "dummy log","log_format": "syslog","location": "master->/var/log/syslog"}}'
+  output_error: 0
+  output_data_msg: "ERROR: (2120): Invalid offset value: 'sudo-fields'"
+  output_data_codemsg: -1


### PR DESCRIPTION
|Related issue|
|-------------|
| Closes #4281|

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
This PR adds a test to check that *wazuh-logtest* reports an error when trying to parse a decoder with a `<regex>` having `offset="after_regex"` when no previous `<regex>` is defined.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- `<regex offset="after_regex">`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | 🟢🟢🟢  | Ubuntu 22.04 |  bb56c935e24957667e4946402f5349a06f95381f       | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
