### PR TITLE
Upgrade PyYAML to 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 Wazuh commit: TBD \
 Release report: TBD
 
+### Changed
+
+- Upgrade PyYAML to 6.0.1. ([#4326](https://github.com/wazuh/wazuh-qa/pull/4326)) \- (Framework)
+
 ## [4.4.5] - 10-07-2023
 
 Wazuh commit: https://github.com/wazuh/wazuh/commit/8d17d2c9c11bc10be9a31c83bc7c17dfbac0d2a0 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pyOpenSSL==19.1.0
 pytest-html==3.1.1
 pytest==6.2.2 ; python_version <= "3.9"
 pytest==7.1.2 ; python_version >= "3.10"
-pyyaml==5.4
+pyyaml==6.0.1
 requests>=2.23.0
 scipy>=1.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'

--- a/tests/system/requirements.txt
+++ b/tests/system/requirements.txt
@@ -9,5 +9,5 @@ pandas>=1.1.5
 psutil==5.6.6
 pytest==4.5.0
 pytest-html==2.0.1
-PyYAML==5.4
+PyYAML==6.0.1
 testinfra==5.0.0

--- a/tests/system/test_jwt_invalidation/requirements.txt
+++ b/tests/system/test_jwt_invalidation/requirements.txt
@@ -8,5 +8,5 @@ lockfile==0.12.2
 psutil==5.6.6
 pytest==4.5.0
 pytest-html==2.0.1
-PyYAML==5.4
+PyYAML==6.0.1
 testinfra==5.0.0


### PR DESCRIPTION
|Related issue|
|-------------|
|Closing #4325|

## Description

This PR aims to fix #4325 by upgrading PyYAML to 6.0.1

### Updated

- Upgrade PyYAML to 6.0.1

---

## Testing performed

It was proposed to use https://ci.wazuh.info/job/Test_integration_launcher as a tier mechanism to check if this change still allows execution integration tests

- Ubuntu manager https://ci.wazuh.info/job/Test_integration_launcher/170/: Several jobs fail due to https://github.com/wazuh/wazuh-jenkins/issues/5208
- Centos manager https://ci.wazuh.info/job/Test_integration_launcher/173/ :green_circle: 

On the other hand, PyYaml is also used in system tests, and because are not integrated into Jenkins yet, manual execution shows that requirements.txt seems to be outdated and should be addressed in other issue.

