### PR TITLE
Fix flaky test in AR suite (excecd)

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/execd.py
+++ b/deps/wazuh_testing/wazuh_testing/execd.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 
 from wazuh_testing.tools import LOG_FILE_PATH, WAZUH_PATH
 from wazuh_testing.tools.file import truncate_file
@@ -16,14 +17,38 @@ def clean_logs():
 
 def wait_ended_message_line(line):
     """Callback function to wait for the Ended Active Response message."""
-    return True if "Ended" in line else None
+    regex = r'.*active-response\/bin\/\S+: Ended$'
+    match = re.match(regex, line)
+
+    return None if not match else line
 
 
 def wait_received_message_line(line):
     """Callback function to wait for the Received Active Response message."""
-    return True if "DEBUG: Received message: " in line else None
+    regex = r'.*wazuh-execd.+ExecdStart\(\): DEBUG: Received message: \S+'
+    match = re.match(regex, line)
+
+    return None if not match else line
 
 
 def wait_start_message_line(line):
     """Callback function to wait for the Starting Active Response message."""
-    return True if "Starting" in line else None
+    regex = r'.*active-response\/bin\/\S+: Starting$'
+    match = re.match(regex, line)
+
+    return None if not match else line
+
+
+def wait_firewall_drop_msg(line):
+    """Callback function to wait for a JSON message with the AR command.
+
+    Args:
+        line (str): String containing message.
+
+    Returns:
+        match.group(1): First capturing group which is the JSON message.
+    """
+    regex = r'.*active-response\/bin\/firewall-drop: (.+)'
+    match = re.match(regex, line)
+
+    return None if not match else match.group(1)

--- a/tests/integration/test_active_response/test_execd/conftest.py
+++ b/tests/integration/test_active_response/test_execd/conftest.py
@@ -2,6 +2,7 @@ import os
 import platform
 import pytest
 
+import wazuh_testing.execd as execd
 from wazuh_testing.tools import WAZUH_PATH, get_version
 
 
@@ -41,3 +42,13 @@ def test_version():
     """Validate Wazuh version."""
     if get_version() < "v4.2.0":
         raise AssertionError("The version of the agent is < 4.2.0")
+
+
+@pytest.fixture
+def truncate_ar_log():
+    """Truncate the logs related with Active Response."""
+    execd.clean_logs()
+
+    yield
+
+    execd.clean_logs()

--- a/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
+++ b/tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py
@@ -140,6 +140,7 @@ def start_agent(request, get_configuration):
     remoted_simulator.stop()
     authd_simulator.shutdown()
 
+
 @pytest.fixture(scope="function")
 def remove_ip_from_iptables(request, get_configuration):
     """Remove the testing IP address from `iptables` if it exists.


### PR DESCRIPTION
|Related issue|
|-------------|
| #4336 |

## Description

There was a block of code checking IP tables but the problem was that it failed to get the IP on time. So, it was a ""race condition"" between AR and the test trying to get the output of a command just in time.

### Updated

- `tests/integration/test_active_response/test_execd/test_execd_firewall_drop.py`
- `tests/integration/test_active_response/test_execd/conftest.py`


---

## Testing performed


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  | test_active_response/ | [🟢](https://ci.wazuh.info/job/Test_integration/41916/) [🟢](https://ci.wazuh.info/job/Test_integration/41917/) [🟢](https://ci.wazuh.info/job/Test_integration/41918/) | [🟢](https://github.com/wazuh/wazuh-qa/files/12240669/Archive.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/12240671/Archive.2.zip) [🟢](https://github.com/wazuh/wazuh-qa/files/12240672/Archive.3.zip) | CentOS | cecd5f6 | Nothing to highlight |

