### PR TITLE
Delete `update_from_year` from system and E2E tests

### DIFF
--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/configuration.yaml
@@ -53,7 +53,6 @@
           <!-- Aggregate vulnerabilities -->
           <provider name="nvd">
           <enabled>yes</enabled>
-          <update_from_year>2021</update_from_year>
           <update_interval>1h</update_interval>
           </provider>
           </vulnerability-detector>

--- a/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/data/playbooks/configuration.yaml
+++ b/tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/data/playbooks/configuration.yaml
@@ -66,7 +66,6 @@
           <!-- Aggregate vulnerabilities -->
           <provider name="nvd">
           <enabled>yes</enabled>
-          <update_from_year>2021</update_from_year>
           <update_interval>1h</update_interval>
           </provider>
           </vulnerability-detector>

--- a/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/big_cluster_40_agents/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/big_cluster_40_agents/roles/master-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/big_cluster_40_agents/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/big_cluster_40_agents/roles/worker-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/master-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/files/ossec.conf
+++ b/tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/tests/system/provisioning/manager_agent/roles/manager-role/files/ossec.conf
+++ b/tests/system/provisioning/manager_agent/roles/manager-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 
@@ -169,7 +168,7 @@
     <rules_id>5710</rules_id>
     <timeout>30</timeout>
   </active-response>
-  
+
   <active-response>
     <disabled>no</disabled>
     <command>firewall-drop-sh</command>

--- a/tests/system/provisioning/manager_agent/roles/master-role/files/ossec.conf
+++ b/tests/system/provisioning/manager_agent/roles/master-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 
@@ -169,7 +168,7 @@
     <rules_id>5710</rules_id>
     <timeout>30</timeout>
   </active-response>
-  
+
   <active-response>
     <disabled>no</disabled>
     <command>firewall-drop-sh</command>

--- a/tests/system/provisioning/one_manager_agent/roles/manager-role/files/ossec.conf
+++ b/tests/system/provisioning/one_manager_agent/roles/manager-role/files/ossec.conf
@@ -111,7 +111,6 @@
 
     <provider name="nvd">
       <enabled>no</enabled>
-      <update_from_year>2010</update_from_year>
       <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
|Related issue|
|-------------|
|     #4302         |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->
Since `update_from_year` is deprecated, we have deleted it from our templates

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_linux/data/playbooks/configuration.yaml
- tests/end_to_end/test_basic_cases/test_vulnerability_detector/test_vulnerability_detector_windows/data/playbooks/configuration.yaml
- tests/system/provisioning/agentless_cluster/roles/master-role/files/ossec.conf
- tests/system/provisioning/agentless_cluster/roles/worker-role/files/ossec.conf
- tests/system/provisioning/basic_cluster/roles/master-role/files/ossec.conf
- tests/system/provisioning/basic_cluster/roles/worker-role/files/ossec.conf
- tests/system/provisioning/big_cluster_40_agents/roles/master-role/files/ossec.conf
- tests/system/provisioning/big_cluster_40_agents/roles/worker-role/files/ossec.conf
- tests/system/provisioning/enrollment_cluster/roles/master-role/files/ossec.conf
- tests/system/provisioning/enrollment_cluster/roles/worker-role/files/ossec.conf
- tests/system/provisioning/four_manager_disconnected_node/roles/master-role/files/ossec.conf
- tests/system/provisioning/four_manager_disconnected_node/roles/worker-role/files/ossec.conf
- tests/system/provisioning/manager_agent/roles/manager-role/files/ossec.conf
- tests/system/provisioning/manager_agent/roles/master-role/files/ossec.conf
- tests/system/provisioning/one_manager_agent/roles/manager-role/files/ossec.conf



---

## Testing performed

We are going to test only the E2E tests, which are the ones that really use this configuration, the rest are simply in a template, in which the vulnerability detector is disabled.

In addition, the https://github.com/wazuh/wazuh-qa/pull/4251 and https://github.com/wazuh/wazuh-qa/pull/4252 changes have been brought in for testing, as the tests were as `xfail`.

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local   | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|----------------------|
| @juliamagan (Developer)  |      end_to_end/test_basic_cases/test_vulnerability_detector     | 🚫🚫🚫  | ⚫⚫⚫ |      358b15cc67ea095e5172be839940a79e959532c7   |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
