### PR TITLE
Fix test validate feed content - Canonical

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -62,7 +62,7 @@
     path: /tmp/com.ubuntu.focal.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/focal.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Canonical Bionic
   description: Canonical provider
@@ -73,7 +73,7 @@
     path: /tmp/com.ubuntu.bionic.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/bionic.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Canonical Xenial
   description: Canonical provider
@@ -84,7 +84,7 @@
     path: /tmp/com.ubuntu.xenial.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/xenial.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Canonical Trusty
   description: Canonical provider
@@ -95,7 +95,7 @@
     path: /tmp/com.ubuntu.trusty.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/trusty.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Debian
   description: Debian provider


### PR DESCRIPTION
|Related issue|
|-------------|
|       https://github.com/wazuh/wazuh-qa/issues/4231      |

## Description

It has been detected that the vulnerability detector integration test test_validate_feed_content are failing for all the Canonical cases. This is error is motivated for the use of outdated URLs in the test (https://people.canonical.com/ instead of the updated https://security-metadata.canonical.com/)

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Update  URLs in the test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml 


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @BelenValdivia  (Developer)  |    test_vulnerability_detector/test_feeds/test_validate_feed_content.py       | [🟢](https://ci.wazuh.info/job/Test_integration/41859/) [🟢](https://ci.wazuh.info/job/Test_integration/41905/)  | [🟢](https://github.com/wazuh/wazuh-qa/files/12240657/R1-VD-.Canonical-fix.zip)  |   Ubuntu      |   1ac864084c13ef683af5d509f0f98ea952d12e0f      | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


