### PR TITLE
Update syscollector module prefix

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/modules/syscollector/event_monitor.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/syscollector/event_monitor.py
@@ -11,7 +11,7 @@ from wazuh_testing.event_monitor import check_event
 
 # Define the log messages prefix
 SYSCOLLECTOR_PREFIX = '.+wazuh-modulesd:syscollector.+'
-WMODULES_SYSCOLLECTOR_PREFIX = '.+wmodules_syscollector.+'
+WMODULES_SYSCOLLECTOR_PREFIX = '.+wmodules-syscollector.+'
 
 # Callback messages
 CB_MODULE_STARTING = 'DEBUG: Starting Syscollector.'


### PR DESCRIPTION
|Related issue|
|-------------|
|      #4382       |

## Description

This PR update the syscollector module prefix, changed in `4.6.0`


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Syscollector wmodule prefix

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | ⚫⚫⚫ | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
