### PR TITLE
Fix misspelling regex and error in test_cluster_connection

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/cluster.py
+++ b/deps/wazuh_testing/wazuh_testing/cluster.py
@@ -26,7 +26,7 @@ def callback_detect_master_serving(line):
 
 
 def callback_detect_worker_connected(line):
-    match = re.match(r'.*Sucessfully connected to master', line)
+    match = re.match(r'.*Successfully connected to master', line)
     if match:
         return line
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/docker_wrapper.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/docker_wrapper.py
@@ -98,7 +98,7 @@ class DockerWrapper(Instance):
         try:
             DockerWrapper.LOGGER.debug(f"Restarting {self.name} cointainer")
             self.get_container().restart()
-            DockerWrapper.LOGGER.debug(f"The {self.name} cointainer has been restarted sucessfully")
+            DockerWrapper.LOGGER.debug(f"The {self.name} cointainer has been restarted successfully")
         except docker.errors.NotFound:
             pass
 
@@ -111,7 +111,7 @@ class DockerWrapper(Instance):
         try:
             DockerWrapper.LOGGER.debug(f"Stopping {self.name} cointainer")
             self.get_container().stop()
-            DockerWrapper.LOGGER.debug(f"The {self.name} cointainer has been stopped sucessfully")
+            DockerWrapper.LOGGER.debug(f"The {self.name} cointainer has been stopped successfully")
         except docker.errors.NotFound:
             pass
 
@@ -132,14 +132,14 @@ class DockerWrapper(Instance):
         try:
             DockerWrapper.LOGGER.debug(f"Removing {self.name} cointainer")
             self.get_container().remove()
-            DockerWrapper.LOGGER.debug(f"The {self.name} cointainer has been removed sucessfully")
+            DockerWrapper.LOGGER.debug(f"The {self.name} cointainer has been removed successfully")
         except docker.errors.NotFound:
             pass
 
         if remove_image:
             DockerWrapper.LOGGER.debug(f"Removing {self.image.id} docker image")
             self.docker_client.images.remove(image=self.image.id, force=True)
-            DockerWrapper.LOGGER.debug(f"The {self.image.id} image has been removed sucessfully")
+            DockerWrapper.LOGGER.debug(f"The {self.image.id} image has been removed successfully")
 
     def get_instance_info(self):
         """Get the parameters information.

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/qa_infraestructure.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/qa_infraestructure.py
@@ -122,13 +122,13 @@ class QAInfraestructure:
         """Run the instances deployment when the local host is UNIX."""
         QAInfraestructure.LOGGER.info(f"Starting {len(self.instances)} instances deployment")
         self.__threads_runner([ThreadExecutor(instance.run) for instance in self.instances])
-        QAInfraestructure.LOGGER.info('The instances deployment has finished sucessfully')
+        QAInfraestructure.LOGGER.info('The instances deployment has finished successfully')
 
     def halt(self):
         """Execute the 'halt' method on every configured instance."""
         QAInfraestructure.LOGGER.info(f"Stopping {len(self.instances)} instances")
         self.__threads_runner([ThreadExecutor(instance.halt) for instance in self.instances])
-        QAInfraestructure.LOGGER.info('The instances have been stopped sucessfully')
+        QAInfraestructure.LOGGER.info('The instances have been stopped successfully')
 
     def restart(self):
         """Execute the 'restart' method on every configured instance."""
@@ -139,13 +139,13 @@ class QAInfraestructure:
         """Execute the 'destroy' method on every configured instance."""
         QAInfraestructure.LOGGER.info(f"Destroying {len(self.instances)} instances")
         self.__threads_runner([ThreadExecutor(instance.destroy) for instance in self.instances])
-        QAInfraestructure.LOGGER.info(f"The instances have been destroyed sucessfully")
+        QAInfraestructure.LOGGER.info(f"The instances have been destroyed successfully")
 
         if self.docker_network:
             QAInfraestructure.LOGGER.info('Removing docker network')
             try:
                 self.docker_network.remove()
-                QAInfraestructure.LOGGER.info('Docker network has been removed sucessfully')
+                QAInfraestructure.LOGGER.info('Docker network has been removed successfully')
             except docker.errors.NotFound:
                 QAInfraestructure.LOGGER.error('Could not remove docker network')
                 pass
@@ -160,7 +160,7 @@ class QAInfraestructure:
         QAInfraestructure.LOGGER.debug('Getting instances status')
         for instance in self.instances:
             status[instance.get_name()] = instance.status()
-        QAInfraestructure.LOGGER.debug('Instances status info was obtained sucessfully')
+        QAInfraestructure.LOGGER.debug('Instances status info was obtained successfully')
 
         return status
 
@@ -174,6 +174,6 @@ class QAInfraestructure:
         QAInfraestructure.LOGGER.debug('Getting instances info')
         for instance in self.instances:
             info[instance.get_name()] = instance.get_instance_info()
-        QAInfraestructure.LOGGER.debug('Instances info was obtained sucessfully')
+        QAInfraestructure.LOGGER.debug('Instances info was obtained successfully')
 
         return info

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/deployment/vagrant_wrapper.py
@@ -60,25 +60,25 @@ class VagrantWrapper(Instance):
             VagrantWrapper.LOGGER.info(f"{self.vm_box} vagrant box not found in local repository. Downloading and "
                                        'running')
         self.vagrant.up()
-        VagrantWrapper.LOGGER.debug(f"Instance {self.vm_name} has been created sucessfully")
+        VagrantWrapper.LOGGER.debug(f"Instance {self.vm_name} has been created successfully")
 
     def halt(self):
         """Stop the VM specified in the vagrantfile."""
         VagrantWrapper.LOGGER.debug(f"Running {self.vm_name} vagrant halt")
         self.vagrant.halt()
-        VagrantWrapper.LOGGER.debug(f"Instance {self.vm_name} has been off sucessfully")
+        VagrantWrapper.LOGGER.debug(f"Instance {self.vm_name} has been off successfully")
 
     def restart(self):
         """Restart the VM specified in the vagrantfile."""
         VagrantWrapper.LOGGER.debug(f"Running {self.vm_name} vagrant restart")
         self.vagrant.restart()
-        VagrantWrapper.LOGGER.debug(f"Instance {self.vm_name} has been restarted sucessfully")
+        VagrantWrapper.LOGGER.debug(f"Instance {self.vm_name} has been restarted successfully")
 
     def destroy(self):
         """Destroy the VM specified in the vagrantfile and remove the vagrantfile."""
         VagrantWrapper.LOGGER.debug(f"Running {self.vm_name} vagrant destroy")
         self.vagrant.destroy()
-        VagrantWrapper.LOGGER.debug(f"{self.vm_name} instance has been destroyed sucessfully")
+        VagrantWrapper.LOGGER.debug(f"{self.vm_name} instance has been destroyed successfully")
         self.vagrantfile.remove_vagrantfile()
         rmtree(self.box_folder)
 

--- a/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
+++ b/deps/wazuh_testing/wazuh_testing/qa_ctl/provisioning/qa_provisioning.py
@@ -230,7 +230,7 @@ class QAProvisioning():
             for runner_thread in provision_threads:
                 runner_thread.join()
 
-            QAProvisioning.LOGGER.info('The instances have been provisioned sucessfully')
+            QAProvisioning.LOGGER.info('The instances have been provisioned successfully')
 
     def destroy(self):
         """Destroy all the temporary files created by an instance of this object"""

--- a/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/qa_ctl.py
@@ -437,7 +437,7 @@ def main():
         config_generator.run()
         launched['config_generator'] = True
         configuration_file = config_generator.config_file_path
-        qactl_logger.debug(f"Configuration file has been created sucessfully in {configuration_file}")
+        qactl_logger.debug(f"Configuration file has been created successfully in {configuration_file}")
 
         # If dry-run mode, then exit after generating the configuration file
         if arguments.dry_run:

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/README.md
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/README.md
@@ -67,12 +67,13 @@ artifacts_path = '/tmp/artifacts/cluster_performance/57'
             with open(log_file) as f:
                 s = mmap(f.fileno(), 0, access=ACCESS_READ)
                 # Search first successful connection message.
-                if not (conn := re.search(rb'^.*Sucessfully connected to master.*$', s, flags=re.MULTILINE)):
-                    pytest.fail(f'Could not find "Sucessfully connected to master" message in the '
+                if not (conn := re.search(rb'^.*Successfully connected to master.*$', s, flags=re.MULTILINE)):
+                    pytest.fail(f'Could not find "Successfully connected to master" message in the '
                                 f'{node_name.search(log_file)[1]}')
     
                 # Search if there are any connection attempts after the message found above.
-                if re.search(rb'^.*Could not connect to master. Trying.*$', s[conn.end():], flags=re.MULTILINE):
+                if re.search(rb'^.*Could not connect to master. Trying.*$|^.*Successfully connected to master.*$',
+                             s[conn.end():], flags=re.MULTILINE):
                     disconnected_nodes.append(node_name.search(log_file)[1])
     
         if disconnected_nodes:

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -35,11 +35,11 @@ def test_cluster_connection(artifacts_path):
             # Search first successful connection message.
             conn = re.search(rb'^.*Successfully connected to master.*$', s, flags=re.MULTILINE)
             if not conn:
-                pytest.fail(f'Could not find "Sucessfully connected to master" message in the '
+                pytest.fail(f'Could not find "Successfully connected to master" message in the '
                             f'{node_name.search(log_file)[1]}')
 
             # Search if there are any connection attempts after the message found above.
-            if re.search(rb'^.*Could not connect to master. Trying.*$|^.*Sucessfully connected to master.*$',
+            if re.search(rb'^.*Could not connect to master. Trying.*$|^.*Successfully connected to master.*$',
                          s[conn.end():], flags=re.MULTILINE):
                 disconnected_nodes.append(node_name.search(log_file)[1])
 


### PR DESCRIPTION
|Related issue|
|-------------|
|     #4391        |

## Description
The test case where the connection pattern is searched, it is not well formatted.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `test_cluster_connection` `Successfully connected to master` pattern fixed
- `test_cluster_connection` `Successfully connected to master` error message fixed
- Update README
- Fix some loggers info and debug level messages

These changes were tested with the artifacts within this issue https://github.com/wazuh/wazuh-qa/issues/4386, so it fails as expected because the artifact generated had some errors.

```
        if disconnected_nodes:
>           pytest.fail(f'The following nodes disconnected from master at any point:\n- ' + '\n- '.join(disconnected_nodes))
E           Failed: The following nodes disconnected from master at any point:
E           - worker_3
E           - worker_1
E           - worker_2
E           - worker_24
E           - worker_21
E           - worker_22
E           - worker_23
E           - worker_11
E           - worker_20
E           - worker_9
E           - worker_15
E           - worker_17
E           - worker_18
E           - worker_14
E           - worker_12
E           - worker_4
E           - worker_10
E           - worker_7
E           - worker_25
E           - worker_6
E           - worker_13
E           - worker_8
E           - worker_5
E           - worker_19
E           - worker_16
```

## Evidences
[report_test_cluster.zip](https://github.com/wazuh/wazuh-qa/files/12429365/report_test_cluster.zip)

