### PR TITLE
Security flaws check improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Release report: TBD
 ### Fixed
 - Update `get_test_cases_data` function so it handles fim_mode parameter ([#4185](https://github.com/wazuh/wazuh-qa/pull/4185)) \- (Framework)
 - Fix warnings in the rids tests([#4151](https://github.com/wazuh/wazuh-qa/pull/4151)) \- (Framework + Tests)
+- Minor fixes in the `tests_python_flaws.py` scan([#439`](https://github.com/wazuh/wazuh-qa/pull/4393)) \- (Tests)
 
 ## [4.6.0] - TBD
 

--- a/tests/scans/code_analysis/README.md
+++ b/tests/scans/code_analysis/README.md
@@ -38,7 +38,7 @@ The workaround for this test will be the following:
   - If the new vulnerability is considered a false positive, we add it to the `false_positives` list of the dictionary in its respective `known_flaws` JSON file.
   - If the new vulnerability is a real vulnerability, we solve the problem reported and remove the flaw from the known flaws file.
 
-The test also updates the known_flaws files automatically. If we have a look to a known_flaws file, we will see that each flaw dictionary contains information like the line number or range. This information si the one updated by the test. The test also removes flaws from the known_flaws file if they don't appear in the Bandit output.
+The test also updates the known_flaws files automatically. If we have a look at a known_flaws file, we will see that each flaw dictionary contains information like the line number or range. This information is the one updated by the test. The test also removes flaws from the known_flaws file if they don't appear in the Bandit output.
 
 #### Parameters
 

--- a/tests/scans/code_analysis/README.md
+++ b/tests/scans/code_analysis/README.md
@@ -16,12 +16,12 @@ In order to find new vulnerabilities, the test compares the Bandit output with v
 This test is located at `wazuh-qa/tests/scans/code_analysis`.
 In this directory, we can find the test itself, called `test_python_flaws.py`, this `README.md`, a pytest configuration file (`conftest.py`); and a folder called `known_flaws`.
 
-- `known_flaws`: contains three JSON files. Each file contains a dictionary with two keys: false_positives and to_fix. The values are a list of vulnerabilities considered false positives and a list of vulnerabilities we must fix (with issues), respectively. 
+- `known_flaws`: contains three JSON files. Each file contains a dictionary with two keys: false_positives and to_fix. The values are a list of vulnerabilities considered false positives and a list of vulnerabilities we must fix (with issues), respectively.
 These files must be edited after analyzing new vulnerabilities when passing the test.
 
 - `conftest.py`: pytest configuration file. It adds the possibility to use specific parameters when passing the test.
 
-- `test_python_flaws.py`: the test itself. This test will be passed using the same Python virtual environment used in the Wazuh framework and API unittests. 
+- `test_python_flaws.py`: the test itself. This test will be passed using the same Python virtual environment used in the Wazuh framework and API unittests.
 If the test fails, a new JSON file will be created in `wazuh-qa/tests/scans/code_analysis` showing information about the possible new vulnerabilities found.
 
 ### Usage
@@ -32,29 +32,29 @@ The workaround for this test will be the following:
 
 - If the test passes, no actions are needed, everything is correct.
 
-- If the test fails, new code vulnerabilities will be found in `wazuh-qa/tests/scans/code_analysis/new_flaws_{module}.json`. 
+- If the test fails, new code vulnerabilities will be found in `wazuh-qa/tests/scans/code_analysis/new_flaws_{module}.json`.
   - We analyze the new vulnerabilities found in the module and report them in GitHub issues.
   - We move the vulnerabilities to the `to_fix` key of the known flaws JSON file.
   - If the new vulnerability is considered a false positive, we add it to the `false_positives` list of the dictionary in its respective `known_flaws` JSON file.
   - If the new vulnerability is a real vulnerability, we solve the problem reported and remove the flaw from the known flaws file.
 
-The test also updates the known_flaws files automatically. If we have a look to a known_flaws file, we will see that each flaw dictionary contains information like the line number or range. This information si the one updated by the test. The test also removes flaws from the known_flaws file if they don't appear in the Bandit output. 
+The test also updates the known_flaws files automatically. If we have a look to a known_flaws file, we will see that each flaw dictionary contains information like the line number or range. This information si the one updated by the test. The test also removes flaws from the known_flaws file if they don't appear in the Bandit output.
 
 #### Parameters
 
-As said in the description, the test uses `Bandit` to look for possible Python flaws. By default, the tests checks the framework, wodles and api directories in the Wazuh repository, in its master branch. 
+As said in the description, the test uses `Bandit` to look for possible Python flaws. By default, the tests checks the framework, wodles and api directories in the Wazuh repository, in its master branch.
 
 These directories, repository and branch can be passed to the test as parameters so it is possible to run the test in any directory containing Python code inside the Wazuh organization.
 
 Apart from this parameters, there are more that can be used to customize the test functionality. Note that the test will fail if we check different directories and/or repository as we don't have known_flaws files for non-default directories.
 
 - **--repo**: set the repository used. Default: `wazuh`
-- **--branch**: set the repository branch. Default: `master`
-- **--check_directories**: set the directories to check, this must be a string with the directory name. 
+- **--reference**: set the repository branch or tag. Default: `master`
+- **--check_directories**: set the directories to check, this must be a string with the directory name.
 If more than one is indicated, they must be separated with comma. Default: `framework/,api/,wodles/`.
 - **--exclude_directories**: set the directories to exclude, this must be a string with the directory name.
 If more than one is indicated, they must be separated with comma. Default: `test/,tests/`.
-- **--confidence**: set the minimum value of confidence of the Bandit scan. 
+- **--confidence**: set the minimum value of confidence of the Bandit scan.
 This value must be 'UNDEFINED', 'LOW', 'MEDIUM' or 'HIGH'. Default: `MEDIUM`
 - **--severity**: set the minimum value of severity of the Bandit scan.
 This value must be 'UNDEFINED', 'LOW', 'MEDIUM' or 'HIGH'. Default: `LOW`
@@ -67,12 +67,12 @@ This value must be 'UNDEFINED', 'LOW', 'MEDIUM' or 'HIGH'. Default: `LOW`
 <summary>test_output</summary>
 
 ```
-pytest tests/scans/code_analysis/test_python_flaws.py 
+pytest tests/scans/code_analysis/test_python_flaws.py
 ============================= test session starts ==============================
 platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
 rootdir: /home/manuel/git/wazuh-qa
 plugins: html-3.1.1, metadata-1.11.0, cov-2.12.0, testinfra-5.0.0, asyncio-0.14.0
-collected 1 item                                                               
+collected 1 item
 
 tests/scans/code_analysis/test_python_flaws.py F                         [100%]
 
@@ -84,13 +84,13 @@ get_test_parameters = {'directories_to_check': ['framework/', 'api/', 'wodles/']
 
     def test_check_security_flaws(clone_wazuh_repository, get_test_parameters):
         """Test whether the directory to check has python files with possible vulnerabilities or not.
-    
+
         The test passes if there are no new vulnerabilities. The test fails in other case and generates a report.
-    
+
         In case there is at least one vulnerability, a json file will be generated with the report. If we consider this
         result or results are false positives, we will move the json object containing each specific result to the
         `known_flaws/known_flaws_{framework|api|wodles}.json` file.
-    
+
         Args:
             clone_wazuh_repository (fixture): Pytest fixture returning the path of the temporary directory path the
                 repository cloned. This directory is removed at the end of the pytest session.
@@ -103,39 +103,39 @@ get_test_parameters = {'directories_to_check': ['framework/', 'api/', 'wodles/']
                                        "please check the Wazuh branch set in the parameter."
         # Change to the cloned Wazuh repository directory
         os.chdir(clone_wazuh_repository)
-    
+
         directories_to_check = get_test_parameters['directories_to_check']
         bandit_output_list = \
             run_bandit_multiple_directories(directories_to_check,
                                             get_test_parameters['directories_to_exclude'],
                                             get_test_parameters['min_severity_level'],
                                             get_test_parameters['min_confidence_level'])
-    
+
         flaws_already_found = {}
         for bandit_output, directory in zip(bandit_output_list, directories_to_check):
             assert not bandit_output['errors'], \
                 f"\nBandit returned errors when trying to get possible vulnerabilities in the directory " \
                 f"{directory}:\n{bandit_output['errors']}"
-    
+
             bandit_result = bandit_output['results']
-    
+
             known_flaws = update_known_flaws_in_file(known_flaws_directory=KNOWN_FLAWS_DIRECTORY,
                                                      directory=directory,
                                                      is_default_check_dir=
                                                      directory.replace('/', '') in
                                                      DEFAULT_DIRECTORIES_TO_CHECK.replace('/', '').split(','),
                                                      bandit_results=bandit_result)
-    
+
             flaws_already_found = get_new_flaws(bandit_results=bandit_result,
                                                 known_flaws=known_flaws,
                                                 directory=directory,
                                                 flaws_already_found=flaws_already_found,
                                                 new_flaws_output_dir=TEST_PYTHON_CODE_PATH)
-    
+
 >       assert not any(
             flaws_already_found.get(directory, None) for directory in directories_to_check), \
             f"\nThe following possible vulnerabilities were found: {json.dumps(flaws_already_found, indent=4, sort_keys=True)}"
-E       AssertionError: 
+E       AssertionError:
 E         The following possible vulnerabilities were found: {
 E             "wodles/": "Vulnerabilities found in files: wodles/utils.py, check them in /home/manuel/git/wazuh-qa/tests/scans/code_analysis/new_flaws_wodles.json"
 E         }
@@ -232,7 +232,7 @@ pytest tests/security/test_python_code/test_python_flaws.py
 platform linux -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
 rootdir: /home/manuel/git/wazuh-qa
 plugins: html-3.1.1, metadata-1.11.0, cov-2.12.0, testinfra-5.0.0, asyncio-0.14.0
-collected 1 item                                                                                                                                       
+collected 1 item
 
 tests/security/test_python_code/test_python_flaws.py .                                                                                           [100%]
 

--- a/tests/scans/code_analysis/conftest.py
+++ b/tests/scans/code_analysis/conftest.py
@@ -1,7 +1,8 @@
 import shutil
 import tempfile
+
 import pytest
-from git import Git, Repo
+from git import Git, GitCommandError, Repo
 
 DEFAULT_DIRECTORIES_TO_CHECK = 'framework/,api/,wodles/'
 DEFAULT_DIRECTORIES_TO_EXCLUDE = 'tests,test'
@@ -54,7 +55,7 @@ def clone_wazuh_repository(pytestconfig):
                             repository_path,
                             depth=1,
                             branch=reference)
-        except:
+        except GitCommandError:
             repo = Repo.clone_from(f"https://github.com/wazuh/{repository_name}.git",
                                    repository_path, branch='master', no_single_branch=True)
 

--- a/tests/scans/code_analysis/conftest.py
+++ b/tests/scans/code_analysis/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from git import Git, Repo
 
 DEFAULT_DIRECTORIES_TO_CHECK = 'framework/,api/,wodles/'
-DEFAULT_DIRECTORIES_TO_EXCLUDE = 'tests/,test/'
+DEFAULT_DIRECTORIES_TO_EXCLUDE = 'tests,test'
 DEFAULT_CONFIDENCE_LEVEL = 'MEDIUM'
 DEFAULT_SEVERITY_LEVEL = 'LOW'
 

--- a/tests/scans/code_analysis/test_python_flaws.py
+++ b/tests/scans/code_analysis/test_python_flaws.py
@@ -1,8 +1,11 @@
 import json
 import os
 
-from wazuh_testing.tools.scans.code_analysis import \
-    run_bandit_multiple_directories, update_known_flaws_in_file, get_new_flaws
+from wazuh_testing.tools.scans.code_analysis import (
+    get_new_flaws,
+    run_bandit_multiple_directories,
+    update_known_flaws_in_file,
+)
 
 ACTUAL_PATH = os.getcwd()
 TEST_PYTHON_CODE_PATH = os.path.dirname(__file__)

--- a/tests/scans/code_analysis/test_python_flaws.py
+++ b/tests/scans/code_analysis/test_python_flaws.py
@@ -51,11 +51,10 @@ def test_check_security_flaws(clone_wazuh_repository, get_test_parameters):
 
         bandit_result = bandit_output['results']
 
+        directories = directory.replace('/', '') in DEFAULT_DIRECTORIES_TO_CHECK.replace('/', '').split(',')
         known_flaws = update_known_flaws_in_file(known_flaws_directory=KNOWN_FLAWS_DIRECTORY,
                                                  directory=directory,
-                                                 is_default_check_dir=
-                                                 directory.replace('/', '') in
-                                                 DEFAULT_DIRECTORIES_TO_CHECK.replace('/', '').split(','),
+                                                 is_default_check_dir=directories,
                                                  bandit_results=bandit_result)
 
         flaws_already_found = get_new_flaws(bandit_results=bandit_result,
@@ -64,9 +63,10 @@ def test_check_security_flaws(clone_wazuh_repository, get_test_parameters):
                                             flaws_already_found=flaws_already_found,
                                             new_flaws_output_dir=TEST_PYTHON_CODE_PATH)
 
+    vulnerabilities_found = json.dumps(flaws_already_found, indent=4, sort_keys=True)
     assert not any(
-        flaws_already_found.get(directory, None) for directory in directories_to_check), \
-        f"\nThe following possible vulnerabilities were found: {json.dumps(flaws_already_found, indent=4, sort_keys=True)}"
+        flaws_already_found.get(directory, None) for directory in directories_to_check
+    ), f"\nThe following possible vulnerabilities were found: {vulnerabilities_found}"
 
     # Change again to the path where we first executed the test
     os.chdir(ACTUAL_PATH)

--- a/tests/scans/conftest.py
+++ b/tests/scans/conftest.py
@@ -4,6 +4,6 @@ DEFAULT_REPOSITORY = 'wazuh'
 
 def pytest_addoption(parser):
     parser.addoption("--reference", action="store", default=DEFAULT_REFERENCE,
-                     help=f"Set the reference used. Default: {DEFAULT_REPOSITORY}")
+                     help=f"Set the reference used. Default: {DEFAULT_REFERENCE}")
     parser.addoption("--repo", action="store", default=DEFAULT_REPOSITORY,
                      help=f"Set the repository used. Default: {DEFAULT_REPOSITORY}")


### PR DESCRIPTION
|Related issue|
|-------------|
|   #4283  |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR closes #4283. Adds some fixes and improvements for the `test_python_flaws.py`.

I was not able to find the reason for the warnings because these are not present in the `tests_python_flaws.py` and neither is present the line number of the warning in the report. 
So I decided that we can continue using the `--disable-warnings` option since this is not a major issue.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Update readme replacing `branch` with `reference`.
- Fix the default value for the `reference` option.
- Fix the format value of directories to exclude default.

---

## Testing performed

```
(wqa310) ➜  wazuh-qa git:(4283-fix-security-flaws-check) ✗ pytest tests/scans/code_analysis/test_python_flaws.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.1.2, pluggy-1.2.0
rootdir: /home/nstefani/git/wazuh-qa/tests, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0, testinfra-5.0.0
collected 1 item

tests/scans/code_analysis/test_python_flaws.py .                                                                                                                                                              [100%]

================================================================================================= warnings summary ==================================================================================================
scans/code_analysis/test_python_flaws.py::test_check_security_flaws
  invalid escape sequence '\w'

scans/code_analysis/test_python_flaws.py::test_check_security_flaws
  invalid escape sequence '\g'

scans/code_analysis/test_python_flaws.py::test_check_security_flaws
  invalid escape sequence '\d'

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================== 1 passed, 3 warnings in 8.69s ===========================================================================================
```

