### PR TITLE
Fix integrity sync test and config to avoid flaky behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Release report: TBD
 - Fix a regex error in the FIM integration tests ([#3061](https://github.com/wazuh/wazuh-qa/issues/3061)) \- (Framework + Tests)
 - Fix an error in the cluster performance tests related to CSV parser ([#2999](https://github.com/wazuh/wazuh-qa/pull/2999)) \- (Framework + Tests)
 - Fix bug in the framework on migration tool ([#4027](https://github.com/wazuh/wazuh-qa/pull/4027)) \- (Framework)
+- Fix test cluster / integrity sync system test and configuration to avoid flaky behavior ([#4406](https://github.com/wazuh/wazuh-qa/pull/4406)) \- (Tests)
 
 ## [4.5.1] - TBD
 

--- a/tests/system/test_cluster/test_integrity_sync/data/cluster_json.yaml
+++ b/tests/system/test_cluster/test_integrity_sync/data/cluster_json.yaml
@@ -1,5 +1,5 @@
 ---
 timeout_receiving_file: 1
-max_zip_size: 52428800    # 50 MB
+max_zip_size: 104857600    # 100 MB
 min_zip_size: 15728640    # 15 MB
 compress_level: 0

--- a/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
+++ b/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.cluster, pytest.mark.agentless_cluster_env]
 test_hosts = ['wazuh-master', 'wazuh-worker1', 'wazuh-worker2']
 worker_hosts = test_hosts[1:]
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-configuration = yaml.safe_load(open(os.path.join(test_data_path, 'cluster_json.yml')))
+configuration = yaml.safe_load(open(os.path.join(test_data_path, 'cluster_json.yaml')))
 messages_path = os.path.join(test_data_path, 'messages.yml')
 tmp_path = os.path.join(test_data_path, 'tmp')
 inventory_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
@@ -262,7 +262,7 @@ def test_zip_size_limit(clean_files, update_cluster_json):
     """
     too_big_size = configuration['max_zip_size'] + 1024
     big_size = configuration['min_zip_size'] - 1024
-    big_filenames = {file_prefix + str(i) for i in range(5)}
+    big_filenames = {file_prefix + str(i) for i in range(10)}
 
     # Create a tmp folder and all files inside in the master node.
     host_manager.run_command(test_hosts[0], f"mkdir {tmp_size_test_path}")


### PR DESCRIPTION
|Related issue|
|-------------|
| Closes #4368             |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Added functionalities or files. Remove if not applicable -->
### Added

As explained in #4368 to fix the integrity sync test a change in the test had to be made to ensure the timeout occurs and expected and the `cancel_task` signals were properly received.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py` : changed number of files created from 5 to 10
- `tests/system/test_cluster/test_integrity_sync/data/cluster_json.yml`: changed max zip size config from 50 MB to 100 MB. 



---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->

Failing System test were ran multiple times to confirm behavior.

```
(system-test-env) eduardoleon@pop-os:~/git/wazuh-qa/tests/system/test_cluster$ pytest test_integrity_sync/
==================================== test session starts =====================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh-qa/tests/system, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-2.0.4, html-3.1.1
collected 1 item

test_integrity_sync/test_integrity_sync.py .                                           [100%]

=============================== 1 passed in 244.11s (0:04:04) ================================
(system-test-env) eduardoleon@pop-os:~/git/wazuh-qa/tests/system/test_cluster$ pytest test_integrity_sync/
==================================== test session starts =====================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh-qa/tests/system, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-2.0.4, html-3.1.1
collected 1 item

test_integrity_sync/test_integrity_sync.py .                                           [100%]

=============================== 1 passed in 260.82s (0:04:20) ================================
(system-test-env) eduardoleon@pop-os:~/git/wazuh-qa/tests/system/test_cluster$ pytest test_integrity_sync/
==================================== test session starts =====================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/eduardoleon/git/wazuh-qa/tests/system, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-2.0.4, html-3.1.1
collected 1 item

test_integrity_sync/test_integrity_sync.py .                                           [100%]

=============================== 1 passed in 250.99s (0:04:10) ================================
```