### PR TITLE
Update python integration test dependencies of macOS

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -117,7 +117,7 @@ brew install python3
 brew install autoconf automake libtool
 
 # Install Python libraries
-pip3 install pytest freezegun jq jsonschema pyyaml==5.4 psutil paramiko distro pandas==0.25.3 pytest-html==2.0.1 numpydoc==0.9.2
+pip3 install filetype freezegun jq jsonschema lockfile numpydoc psutil pytest-html pytest-testinfra pyyaml
 ```
 
 - Add some internal options and restart


### PR DESCRIPTION
|Related issue|
|-------------|
|#4411|

## Description

After conducting an analysis and setting up a new environment for running integration tests, the dependencies of the Python modules were subsequently updated in the documentation.

### Updated

- wazuh-qa/tests/integration/README.md

## Testing performed

Development and Smoke test in MacOs Ventura. As #4411 states.

| Platform  | Result |
| --------- | ------ |
| MacOs ARM |      🟢   |
| MacOs x86 |      🟢   |
