### PR TITLE
Update RHEL5 XML feed provider URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release report: TBD
 
 - Add an integration test to check the wazuh-analysisd's decoder parser ([#4286](https://github.com/wazuh/wazuh-qa/pull/4286)) \- (Tests)
 
+### Changed
+
+- Update RHEL5 URL provider for VD test_validate_xml_feed_content ([#4428](https://github.com/wazuh/wazuh-qa/pull/4428)) \- (Tests)
+
 ## [4.5.0] - TBD
 
 Wazuh commit: TBD \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Release report: TBD
 
 ### Changed
 
-- Update RHEL5 URL provider for VD test_validate_xml_feed_content ([#4428](https://github.com/wazuh/wazuh-qa/pull/4428)) \- (Tests)
+- Update vulnerability detector IT outdated URLs ([#4428](https://github.com/wazuh/wazuh-qa/pull/4428)) \- (Tests)
 
 ## [4.5.0] - TBD
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -7,7 +7,7 @@
     path: /tmp/com.redhat.rhsa-RHEL5.xml.bz2
     extension: bz2
     decompressed_file: /tmp/rhel5.xml
-    url: https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2
+    url: https://feed.wazuh.com/vulnerability-detector/RHEL/5/com.redhat.rhsa-RHEL5_v1.xml.bz2
 
 - name: Red Hat Enterprise Linux
   description: Red Hat Enterprise Linux provider

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -62,7 +62,7 @@
     path: /tmp/com.ubuntu.focal.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/focal.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Canonical Bionic
   description: Canonical provider
@@ -73,7 +73,7 @@
     path: /tmp/com.ubuntu.bionic.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/bionic.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Canonical Xenial
   description: Canonical provider
@@ -84,7 +84,7 @@
     path: /tmp/com.ubuntu.xenial.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/xenial.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Canonical Trusty
   description: Canonical provider
@@ -95,7 +95,7 @@
     path: /tmp/com.ubuntu.trusty.cve.oval.xml.bz2
     extension: bz2
     decompressed_file: /tmp/trusty.xml
-    url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2
+    url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
 
 - name: Debian
   description: Debian provider


### PR DESCRIPTION
|Related issue|
|-------------|
|     #4424         |

## Description


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Provider URL for RHEL5 for VD test XML validation


## Testing performed

**Build**: https://ci.wazuh.info/job/Test_integration/42463/

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | [:green_circle:](https://ci.wazuh.info/job/Test_integration/42463/) | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | [:large_blue_circle:](https://ci.wazuh.info/job/Test_integration/42462/)  | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


> **Note**
> Build fails SUSE download feeds tests. These failures are expected. Check [this](https://github.com/wazuh/wazuh-qa/issues/4370) issue
