### PR TITLE
Update known flaws files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release report: TBD
 
 - Update _wazuh_db_ schema database version ([#4353](https://github.com/wazuh/wazuh-qa/pull/4353)) \- (Tests)
 - Update the JSON schema with the required fields for the output content of the migration tool ([#4375](https://github.com/wazuh/wazuh-qa/pull/4375)) \- (Tests)
+- Update framework known flaws file ([#4443](https://github.com/wazuh/wazuh-qa/pull/4443)) \- (Tests)
 
 ## [4.7.0] - TBD
 

--- a/tests/scans/code_analysis/known_flaws/known_flaws_framework.json
+++ b/tests/scans/code_analysis/known_flaws/known_flaws_framework.json
@@ -136,9 +136,9 @@
             "issue_confidence": "HIGH",
             "issue_severity": "MEDIUM",
             "issue_text": "Use of possibly insecure function - consider using safer ast.literal_eval.",
-            "line_number": 1793,
+            "line_number": 1796,
             "line_range": [
-                1793
+                1796
             ],
             "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b307-eval",
             "test_id": "B307",


### PR DESCRIPTION
|Related issue|
|-------------|
|     #4448     |

## Description

This PR updates the framework file of known flaws with the recent scan results.

<!-- Add a description of the context and content of all changes made in the pull request -->

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Known flaws in the framework file

---


## Tests

```
(wqa310) ➜  wazuh-qa git:(4282-update-framework-known-flaws-4-8-0) pytest tests/scans/code_analysis/test_python_flaws.py --disable-warnings --exclude_directories tests,test --reference master; git status
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.2.0
rootdir: /home/nstefani/git/wazuh-qa/tests, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0, testinfra-5.0.0
collected 1 item

tests/scans/code_analysis/test_python_flaws.py .                                                                                                                                                              [100%]

========================================================================================== 1 passed, 3 warnings in 44.90s ===========================================================================================
On branch 4282-update-framework-known-flaws-4-8-0
nothing to commit, working tree clean
```