### PR TITLE
Adapt reliability test to run with python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 Wazuh commit: TBD \
 Release report: TBD
 
+### Changed
+
+- Updated the cluster master logs reliability test to run with python 3.7 [#4445](https://github.com/wazuh/wazuh-qa/pull/4478) \- (Tests)
+
 ### Fixed
 
 - Enhancing the handling of authd and remoted simulators in case of restart failures ([#Wazuh-jenkins#3487](https://github.com/wazuh/wazuh-qa/pull/4205)) \- (Tests)

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/README.md
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/README.md
@@ -63,7 +63,8 @@ artifacts_path = '/docs/agent_groups'
     
         with open(cluster_log_files) as file:
             for line in file.readlines():
-                if result := logs_format.search(line):
+                result = logs_format.search(line)
+                if result:
                     if 'Worker' in result.group(1):
                         name = re.search('.*Worker (.*?)]', result.group(1)).group(1)
                         if name not in all_managers:

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py
@@ -68,7 +68,8 @@ def test_check_logs_order_master(artifacts_path):
 
     with open(cluster_log_files) as file:
         for line in file.readlines():
-            if result := logs_format.search(line):
+            result = logs_format.search(line)
+            if result:
                 node_name = result.group(1)
                 if 'Worker' in node_name:
                     name = re.search('.*Worker (.*?)]', node_name).group(1)


### PR DESCRIPTION
|Related issue|
|-------------|
|    Closes https://github.com/wazuh/wazuh-qa/issues/4299         |

## Description

Removed the walrus operator from the `tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py` test to support running it in Python 3.7.

> Re-created PR to merge it in **4.5.3**

### Logs

```console
(venv3.7) gasti@pop-os:~/work/wazuh-qa$ python --version
Python 3.7.17
(venv3.7) gasti@pop-os:~/work/wazuh-qa$ python3 -m pytest -vv --disable-warnings tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/ --artifacts_path=/home/gasti/work/wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order --html=report.html --self-contained-html
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.17, pytest-7.1.2, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv3.7/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.7.17', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-Pop-22.04-jammy', 'Packages': {'pytest': '7.1.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh-qa/tests, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-3.0.0
collected 1 item                                                                                                                                          

tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py::test_check_logs_order_master PASSED [100%]

-------------------------------------------- generated html file: file:///home/gasti/work/wazuh-qa/report.html --------------------------------------------
==================================================================== 1 passed in 0.01s ====================================================================
```

### Report

![cluster_logs_Test](https://github.com/wazuh/wazuh-qa/assets/51374959/17455f59-5139-4c5b-9266-f94cc023235e)
