### PR TITLE
Update ITs URL for Debian OVAL

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -102,20 +102,22 @@
   configuration_parameters:
   metadata:
     provider_name: Debian Buster
-    expected_format: xml
-    path: /tmp/oval-definitions-buster.xml
-    extension: xml
-    url: https://www.debian.org/security/oval/oval-definitions-buster.xml
+    expected_format: application/x-bzip2
+    path: /tmp/oval-definitions-buster.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/buster.xml
+    url: https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2
 
 - name: Debian
   description: Debian provider
   configuration_parameters:
   metadata:
     provider_name: Debian Bullseye
-    expected_format: xml
-    path: /tmp/oval-definitions-bullseye.xml
-    extension: xml
-    url: https://www.debian.org/security/oval/oval-definitions-bullseye.xml
+    expected_format: application/x-bzip2
+    path: /tmp/oval-definitions-bullseye.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/bullseye.xml
+    url: https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2
 
 - name: SUSE Linux Enterprise Desktop 11
   description: SUSE Linux Enterprise Desktop 11 provider


### PR DESCRIPTION
|Related issue|
|-------------|
|wazuh/wazuh#18765|

## Description

This PR updates the Debian OVALs URL for Vulnerability Detector ITs, due to the change applied in the following PR:
- https://github.com/wazuh/wazuh/pull/18770

### Updated

-  [Feed tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_feeds): These tests have been updated to download the `Debian` compressed feed.

Modules involved: 
- test_vulnerability_detector/test_feeds/test_validate_feed_content.py

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  | [test_feeds](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_feeds) | ⚫⚫⚫ | :green_circle: :green_circle: :green_circle: | Debian |  | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

- Local:
```py
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Debian0] 
------------------------------------------ live log setup -------------------------------------------
DEBUG    urllib3.connectionpool:connectionpool.py:1014 Starting new HTTPS connection (1): www.debian.org:443
DEBUG    urllib3.connectionpool:connectionpool.py:473 https://www.debian.org:443 "GET /security/oval/oval-definitions-buster.xml.bz2 HTTP/1.1" 200 2874176
PASSED
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Debian1] 
------------------------------------------ live log setup -------------------------------------------
DEBUG    urllib3.connectionpool:connectionpool.py:1014 Starting new HTTPS connection (1): www.debian.org:443
DEBUG    urllib3.connectionpool:connectionpool.py:473 https://www.debian.org:443 "GET /security/oval/oval-definitions-bullseye.xml.bz2 HTTP/1.1" 200 2967126
PASSED
```