### PR TITLE
Update login API calls request method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release report: TBD
 
 ### Fixed
 
+- Update the request method used to call the login API endpoint. ([#4492](https://github.com/wazuh/wazuh-qa/pull/4492)) \- (Tests)
 - Enhancing the handling of authd and remoted simulators in case of restart failures ([#Wazuh-jenkins#3487](https://github.com/wazuh/wazuh-qa/pull/4205)) \- (Tests)
 
 ## [4.5.2] - TBD

--- a/tests/integration/test_api/test_config/test_logs/test_api_logs_formats.py
+++ b/tests/integration/test_api/test_config/test_logs/test_api_logs_formats.py
@@ -96,8 +96,8 @@ def send_request(remaining_attempts=3):
     # Make 3 attempts to wait for the API to start correctly
     while remaining_attempts > 0:
         try:
-            response = requests.get(login_url, headers=api.get_login_headers(api.API_USER, api.API_PASS), verify=False,
-                                    timeout=fw.T_5)
+            response = requests.post(login_url, headers=api.get_login_headers(api.API_USER, api.API_PASS), verify=False,
+                                     timeout=fw.T_5)
         except requests.exceptions.ConnectionError:
             # Capture the exception and wait
             time.sleep(fw.T_10)

--- a/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
+++ b/tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py
@@ -123,8 +123,8 @@ def test_request_timeout(tags_to_apply, get_configuration, configure_api_environ
         - r'3021' ('timeout error' in the response body)
     '''
     check_apply_test(tags_to_apply, get_configuration['tags'])
-    get_response = requests.get(f'{api.API_PROTOCOL}://{api.API_HOST}:{api.API_PORT}{api.API_LOGIN_ENDPOINT}',
-                                headers=api.get_login_headers(api.API_USER, api.API_PASS), verify=False)
+    get_response = requests.post(f'{api.API_PROTOCOL}://{api.API_HOST}:{api.API_PORT}{api.API_LOGIN_ENDPOINT}',
+                                 headers=api.get_login_headers(api.API_USER, api.API_PASS), verify=False)
 
     assert get_response.status_code == 500, f'Expected status code was 500, ' \
                                             f'but {get_response.status_code} was returned. \n' \


### PR DESCRIPTION
|Related issue|
|-------------|
|     Closes https://github.com/wazuh/wazuh-qa/issues/4412        |

## Description

Changes the request method used to call the `/security/user/authenticate` endpoint to **POST**. The **GET** method not longer works since it has been deleted in the related issue.

### Updated

- tests/integration/test_api/test_config/test_logs/test_api_logs_formats.py
- tests/integration/test_api/test_config/test_request_timeout/test_request_timeout.py

### Tests

<details><summary>API IT tier 0,1</summary>

```console
============================= test session starts ==============================
platform linux -- Python 3.9.16, pytest-7.1.2, pluggy-1.0.0 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-3.10.0-1160.81.1.el7.x86_64-x86_64-with-glibc2.17', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.0.0'}, 'Plugins': {'testinfra': '5.0.0', 'metadata': 
'2.0.4', 'html': '3.1.1'}}
rootdir: /tmp/Test_integration_B42284_20230811142329/tests/integration, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-2.0.4, html-3.1.1
collecting ... collected 93 items / 4 deselected / 89 selected

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py::test_DOS_blocking_system[get_configuration0-tags_to_apply0] PASSED [  1%]
test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py::test_DOS_blocking_system[get_configuration0-tags_to_apply1] SKIPPED [  2%]
test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py::test_DOS_blocking_system[get_configuration1-tags_to_apply0] SKIPPED [  3%]
test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py::test_DOS_blocking_system[get_configuration1-tags_to_apply1] PASSED [  4%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py::test_bruteforce_blocking_system[get_configuration0-tags_to_apply0] PASSED [  5%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py::test_bruteforce_blocking_system[get_configuration0-tags_to_apply1] SKIPPED [  6%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py::test_bruteforce_blocking_system[get_configuration1-tags_to_apply0] SKIPPED [  7%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py::test_bruteforce_blocking_system[get_configuration1-tags_to_apply1] PASSED [  8%]
test_api/test_config/test_cache/test_cache.py::test_cache[get_configuration0-tags_to_apply0] PASSED [ 10%]
test_api/test_config/test_cache/test_cache.py::test_cache[get_configuration0-tags_to_apply1] SKIPPED [ 11%]
test_api/test_config/test_cache/test_cache.py::test_cache[get_configuration1-tags_to_apply0] SKIPPED [ 12%]
test_api/test_config/test_cache/test_cache.py::test_cache[get_configuration1-tags_to_apply1] PASSED [ 13%]
test_api/test_config/test_cors/test_cors.py::test_cors[get_configuration0-https://test_url.com-tags_to_apply0] XFAIL [ 14%]
test_api/test_config/test_cors/test_cors.py::test_cors[get_configuration0-http://other_url.com-tags_to_apply1] PASSED [ 15%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py::test_drop_privileges[get_configuration0-tags_to_apply0] PASSED [ 16%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py::test_drop_privileges[get_configuration0-tags_to_apply1] SKIPPED [ 17%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py::test_drop_privileges[get_configuration1-tags_to_apply0] SKIPPED [ 19%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py::test_drop_privileges[get_configuration1-tags_to_apply1] PASSED [ 20%]
test_api/test_config/test_experimental_features/test_experimental_features.py::test_experimental_features[get_configuration0-tags_to_apply0] PASSED [ 21%]
test_api/test_config/test_experimental_features/test_experimental_features.py::test_experimental_features[get_configuration0-tags_to_apply1] SKIPPED [ 22%]
test_api/test_config/test_experimental_features/test_experimental_features.py::test_experimental_features[get_configuration1-tags_to_apply0] SKIPPED [ 23%]
test_api/test_config/test_experimental_features/test_experimental_features.py::test_experimental_features[get_configuration1-tags_to_apply1] PASSED [ 24%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration0-False-tags_to_apply0] PASSED [ 25%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration0-True-tags_to_apply1] SKIPPED [ 26%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration1-False-tags_to_apply0] PASSED [ 28%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration1-True-tags_to_apply1] SKIPPED [ 29%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration2-False-tags_to_apply0] SKIPPED [ 30%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration2-True-tags_to_apply1] PASSED [ 31%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration3-False-tags_to_apply0] SKIPPED [ 32%]
test_api/test_config/test_host_port/test_host_port.py::test_host_port[get_configuration3-True-tags_to_apply1] PASSED [ 33%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration0-tags_to_apply0] PASSED [ 34%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration0-tags_to_apply1] SKIPPED [ 35%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration1-tags_to_apply0] SKIPPED [ 37%]
test_api/test_config/test_https/test_https.py::test_https[get_configuration1-tags_to_apply1] PASSED [ 38%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration0-tags_to_apply0] PASSED [ 39%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration0-tags_to_apply1] SKIPPED [ 40%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration1-tags_to_apply0] SKIPPED [ 41%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py::test_jwt_token_exp_timeout[get_configuration1-tags_to_apply1] PASSED [ 42%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON] PASSED [ 43%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON] PASSED [ 44%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN] PASSED [ 46%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN] PASSED [ 47%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON-PLAIN] PASSED [ 48%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON-PLAIN] PASSED [ 49%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN-JSON] PASSED [ 50%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN-JSON] PASSED [ 51%]
test_api/test_config/test_logs/test_logs.py::test_logs[info] PASSED      [ 52%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_request_headers[info] PASSED [ 53%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_json_body[info-GET-None] PASSED [ 55%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_json_body[info-POST-json_body1] PASSED [ 56%]
test_api/test_config/test_logs/test_logs.py::test_logs[debug] PASSED     [ 57%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_request_headers[debug] PASSED [ 58%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_json_body[debug-GET-None] PASSED [ 59%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_json_body[debug-POST-json_body1] PASSED [ 60%]
test_api/test_config/test_logs/test_logs.py::test_logs[debug2] SKIPPED   [ 61%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_request_headers[debug2] PASSED [ 62%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_json_body[debug2-GET-None] PASSED [ 64%]
test_api/test_config/test_logs/test_logs.py::test_request_logging_json_body[debug2-POST-json_body1] PASSED [ 65%]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration0-tags_to_apply0] PASSED [ 66%]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration0-tags_to_apply1] SKIPPED [ 67%]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration1-tags_to_apply0] SKIPPED [ 68%]
test_api/test_config/test_rbac/test_rbac_mode.py::test_rbac_mode[get_configuration1-tags_to_apply1] PASSED [ 69%]
test_api/test_config/test_request_timeout/test_request_timeout.py::test_request_timeout[get_configuration0-tags_to_apply0] PASSED [ 70%]
test_api/test_middlewares/test_response_postprocessing.py::test_response_postprocessing[POST-/agents-json_body0-True-400-expected_response_text0] PASSED [ 71%]
test_api/test_middlewares/test_response_postprocessing.py::test_response_postprocessing[GET-/not_found_endpoint-None-True-404-expected_response_text1] PASSED [ 73%]
test_api/test_middlewares/test_response_postprocessing.py::test_response_postprocessing[GET-/agents-None-False-401-expected_response_text2] PASSED [ 74%]
test_api/test_middlewares/test_response_postprocessing.py::test_response_postprocessing[POST-/security/user/authenticate-None-False-401-expected_response_text3] PASSED [ 75%]
test_api/test_middlewares/test_set_secure_headers.py::test_secure_headers PASSED [ 76%]
test_api/test_rbac/test_add_old_resource.py::test_add_old_user PASSED    [ 77%]
test_api/test_rbac/test_add_old_resource.py::test_add_old_role PASSED    [ 78%]
test_api/test_rbac/test_add_old_resource.py::test_add_old_policy PASSED  [ 79%]
test_api/test_rbac/test_add_old_resource.py::test_add_old_rule PASSED    [ 80%]
test_api/test_rbac/test_admin_resources.py::test_admin_users PASSED      [ 82%]
test_api/test_rbac/test_admin_resources.py::test_admin_roles PASSED      [ 83%]
test_api/test_rbac/test_admin_resources.py::test_admin_policies PASSED   [ 84%]
test_api/test_rbac/test_admin_resources.py::test_admin_rules PASSED      [ 85%]
test_api/test_rbac/test_policy_position.py::test_policy_position PASSED  [ 86%]
test_api/test_rbac/test_remove_relationship.py::test_remove_user_role_relationship PASSED [ 87%]
test_api/test_rbac/test_remove_relationship.py::test_remove_role_policy_relationship PASSED [ 88%]
test_api/test_rbac/test_remove_relationship.py::test_remove_role_rule_relationship PASSED [ 89%]
test_api/test_rbac/test_remove_resource.py::test_remove_rule PASSED      [ 91%]
test_api/test_rbac/test_remove_resource.py::test_remove_policy PASSED    [ 92%]
test_api/test_rbac/test_remove_resource.py::test_remove_user PASSED      [ 93%]
test_api/test_rbac/test_remove_resource.py::test_remove_role PASSED      [ 94%]
test_api/test_statistics/test_statistics_format.py::test_manager_statistics_format[remoted_endpoint] PASSED [ 95%]
test_api/test_statistics/test_statistics_format.py::test_manager_statistics_format[analysisd_endpoint] PASSED [ 96%]
test_api/test_statistics/test_statistics_format.py::test_manager_statistics_format[wazuh-db_endpoint] PASSED [ 97%]
test_api/test_statistics/test_statistics_format.py::test_agent_statistics_format[remoted_endpoint] PASSED [ 98%]
test_api/test_statistics/test_statistics_format.py::test_agent_statistics_format[analysisd_endpoint] PASSED [100%]

=============================== warnings summary ===============================
test_api/test_config/test_request_timeout/test_request_timeout.py::test_request_timeout[get_configuration0-tags_to_apply0]
  /usr/local/python-3.10/lib/python3.10/site-packages/urllib3/connectionpool.py:1056: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verificatio
n is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated html file: file:///tmp/Test_integration_B42284_20230811142329/report.html -
= 67 passed, 21 skipped, 4 deselected, 1 xfailed, 1 warning in 1253.03s (0:20:53) =

```

</details>

<details><summary>test_request_timeout</summary>

```console
(venv) gasti@pop-os:~/work/wazuh-qa/tests/integration$ date --utc; python3 -m pytest -vv --disable-warnings test_api/test_config/test_request_timeout/test_request_timeout.py
Mon Sep 18 01:58:15 PM UTC 2023
=============================================================== test session starts ================================================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 1 item                                                                                                                                   

test_api/test_config/test_request_timeout/test_request_timeout.py::test_request_timeout[get_configuration0-tags_to_apply0] PASSED [100%]

==================================================================== 1 passed in 4.11s ====================================================================
(venv) gasti@pop-os:~/work/wazuh-qa/tests/integration$ date --utc; python3 -m pytest -vv --disable-warnings test_api/test_config/test_request_timeout/test_request_timeout.py
Mon Sep 18 01:58:25 PM UTC 2023
=============================================================== test session starts ================================================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 1 item                                                                                                                                   

test_api/test_config/test_request_timeout/test_request_timeout.py::test_request_timeout[get_configuration0-tags_to_apply0] PASSED [100%]

==================================================================== 1 passed in 4.32s ====================================================================
(venv) gasti@pop-os:~/work/wazuh-qa/tests/integration$ date --utc; python3 -m pytest -vv --disable-warnings test_api/test_config/test_request_timeout/test_request_timeout.py
Mon Sep 18 01:58:38 PM UTC 2023
=============================================================== test session starts ================================================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 1 item                                                                                                                                   

test_api/test_config/test_request_timeout/test_request_timeout.py::test_request_timeout[get_configuration0-tags_to_apply0] PASSED [100%]

==================================================================== 1 passed in 4.50s ====================================================================
```

</details>

<details><summary>test_api_logs_formats</summary>

```console
(venv) gasti@pop-os:~/work/wazuh-qa/tests/integration$ date --utc; python3 -m pytest -vv --disable-warnings test_api/test_config/test_logs/test_api_logs_formats.py
Mon Sep 18 02:03:34 PM UTC 2023
=============================================================== test session starts ================================================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 8 items

test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON] PASSED [12%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON] PASSED [25%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN] PASSED [37%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN] PASSED [50%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON-PLAIN] PASSED [62%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON-PLAIN] PASSED [75%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN-JSON] PASSED [87%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN-JSON] PASSED [100%]

========================================================= 8 passed in 28.08s ==========================================================
(venv) gasti@pop-os:~/work/wazuh-qa/tests/integration$ date --utc; python3 -m pytest -vv --disable-warnings test_api/test_config/test_logs/test_api_logs_formats.py
Mon Sep 18 02:05:12 PM UTC 2023
=============================================================== test session starts ================================================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 8 items

test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON] PASSED [12%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON] PASSED [25%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN] PASSED [37%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN] PASSED [50%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON-PLAIN] PASSED [62%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON-PLAIN] PASSED [75%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN-JSON] PASSED [87%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN-JSON] PASSED [100%]

========================================================= 8 passed in 29.19s ==========================================================
(venv) gasti@pop-os:~/work/wazuh-qa/tests/integration$ date --utc; python3 -m pytest -vv --disable-warnings test_api/test_config/test_logs/test_api_logs_formats.py
Mon Sep 18 02:06:52 PM UTC 2023
=============================================================== test session starts ================================================================
platform linux -- Python 3.9.16, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/gasti/work/wazuh-qa/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.9.16', 'Platform': 'Linux-6.2.0-76060200-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.2', 'pluggy': '0.13.1'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '2.0.4'}}
rootdir: /home/gasti/work/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 8 items

test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON] PASSED [12%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON] PASSED [25%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN] PASSED [37%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN] PASSED [50%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-JSON-PLAIN] PASSED [62%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-JSON-PLAIN] PASSED [75%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[INFO-PLAIN-JSON] PASSED [87%]
test_api/test_config/test_logs/test_api_logs_formats.py::test_api_logs_formats[ERROR-PLAIN-JSON] PASSED [100%]

========================================================= 8 passed in 28.47s ==========================================================
```


</details>