### PR TITLE
Update ITs URL for SUSE OVAL

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -122,57 +122,63 @@
   configuration_parameters:
   metadata:
     provider_name: SUSE Linux Enterprise Desktop 11
-    expected_format: xml
-    path: /tmp/suse.linux.enterprise.desktop.11.xml
-    extension: xml
-    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.11.xml
+    expected_format: application/gzip
+    path: /tmp/suse.linux.enterprise.desktop.11.xml.gz
+    extension: gz
+    decompressed_file: /tmp/suse.desktop.11.xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.11.xml.gz
 
 - name: SUSE Linux Enterprise Desktop 12
   description: SUSE Linux Enterprise Desktop 12 provider
   configuration_parameters:
   metadata:
     provider_name: SUSE Linux Enterprise Desktop 12
-    expected_format: xml
-    path: /tmp/suse.linux.enterprise.desktop.12.xml
-    extension: xml
-    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml
+    expected_format: application/gzip
+    path: /tmp/suse.linux.enterprise.desktop.12.xml.gz
+    extension: gz
+    decompressed_file: /tmp/suse.desktop.12.xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml.gz
 
 - name: SUSE Linux Enterprise Desktop 15
   description: SUSE Linux Enterprise Desktop 15 provider
   configuration_parameters:
   metadata:
     provider_name: SUSE Linux Enterprise Desktop 15
-    expected_format: xml
-    path: /tmp/suse.linux.enterprise.desktop.15.xml
-    extension: xml
-    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.15.xml
+    expected_format: application/gzip
+    path: /tmp/suse.linux.enterprise.desktop.15.xml.gz
+    extension: gz
+    decompressed_file: /tmp/suse.desktop.15.xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.15.xml.gz
 
 - name: SUSE Linux Enterprise Server 11
   description: SUSE Linux Enterprise Server 11 provider
   configuration_parameters:
   metadata:
     provider_name: SUSE Linux Enterprise Server 11
-    expected_format: xml
-    path: /tmp/suse.linux.enterprise.server.11.xml
-    extension: xml
-    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.11.xml
+    expected_format: application/gzip
+    path: /tmp/suse.linux.enterprise.server.11.xml.gz
+    extension: gz
+    decompressed_file: /tmp/suse.server.11.xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.11.xml.gz
 
 - name: SUSE Linux Enterprise Server 12
   description: SUSE Linux Enterprise Server 12 provider
   configuration_parameters:
   metadata:
     provider_name: SUSE Linux Enterprise Server 12
-    expected_format: xml
-    path: /tmp/suse.linux.enterprise.server.12.xml
-    extension: xml
-    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml
+    expected_format: application/gzip
+    path: /tmp/suse.linux.enterprise.server.12.xml.gz
+    extension: gz
+    decompressed_file: /tmp/suse.server.12.xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml.gz
 
 - name: SUSE Linux Enterprise Server 15
   description: SUSE Linux Enterprise Server 15 provider
   configuration_parameters:
   metadata:
     provider_name: SUSE Linux Enterprise Server 15
-    expected_format: xml
-    path: /tmp/suse.linux.enterprise.server.15.xml
-    extension: xml
-    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml
+    expected_format: application/gzip
+    path: /tmp/suse.linux.enterprise.server.15.xml.gz
+    extension: gz
+    decompressed_file: /tmp/suse.server.15.xml
+    url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml.gz


### PR DESCRIPTION
|Related issue|
|-------------|
|wazuh/wazuh#18593|

## Description

This PR updates the SUSE OVALs URL for Vulnerability Detector ITs, due to the change applied in the following PR:
- https://github.com/wazuh/wazuh/pull/18783

### Updated

-  [Feed tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_feeds): These tests have been updated to download the `SUSE` compressed feed.

Modules involved: 
- test_vulnerability_detector/test_feeds/test_validate_feed_content.py

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  | [test_feeds](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_feeds) | ⚫⚫⚫ | :green_circle: :green_circle: :green_circle: | SUSE |  | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

- Local:
```py
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[SUSE Linux Enterprise Desktop 11] PASSED                                                               [ 16%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[SUSE Linux Enterprise Desktop 12] PASSED                                                               [ 33%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[SUSE Linux Enterprise Desktop 15] PASSED                                                               [ 50%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[SUSE Linux Enterprise Server 11] PASSED                                                                [ 66%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[SUSE Linux Enterprise Server 12] PASSED                                                                [ 83%]
test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[SUSE Linux Enterprise Server 15] PASSED                                                                [100%]

```