### PR TITLE
Integration tests for Vulnerability Detector: Red Hat 9 support (#3040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Release report: TBD
 - Add IT tests FIM registry monitoring using wildcards. ([#4270](https://github.com/wazuh/wazuh-qa/pull/4270)) \- (Framework + Tests)
 - Update schema database version ([#4128](https://github.com/wazuh/wazuh-qa/pull/4128)) \- (Tests)
 - Update framework known flaws files ([#4380](https://github.com/wazuh/wazuh-qa/pull/4380)) \- (Tests)
+- Add tests for Vulnerability Detector: Red Hat 9 support (https://github.com/wazuh/wazuh-qa/pull/4497) \- (Tests)
 
 ### Changed
 
@@ -75,10 +76,6 @@ Release report: TBD
 
 Wazuh commit: https://github.com/wazuh/wazuh/commit/9087982b0c4ae0180bcdcd214a2b243e75cd8416 \
 Release report: https://github.com/wazuh/wazuh/issues/19111
-
-### Added
-
-- Add tests for Vulnerability Detector: Red Hat 9 support (https://github.com/wazuh/wazuh-qa/pull/4497) \- (Tests)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ Release report: TBD
 Wazuh commit: https://github.com/wazuh/wazuh/commit/9087982b0c4ae0180bcdcd214a2b243e75cd8416 \
 Release report: https://github.com/wazuh/wazuh/issues/19111
 
+### Added
+
+- Add tests for Vulnerability Detector: Red Hat 9 support (https://github.com/wazuh/wazuh-qa/pull/4497) \- (Tests)
+
 ### Changed
 
 - Update setuptools dependency ([#3788](https://github.com/wazuh/wazuh-qa/pull/3788))

--- a/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/mocking/__init__.py
@@ -76,6 +76,8 @@ SYSTEM_DATA = {
                   'config_sum': '', 'merged_sum': '', 'manager_host': 'alas2022',  'node_name': 'node01',
                   'date_add': '1645538646', 'last_keepalive': '253402300799',  'sync_status': 'synced',
                   'connection_status': 'active'},
+    'RHEL9': {'os_name': 'CentOS Linux', 'os_major': '9', 'os_minor': '1', 'os_platform': 'centos',
+              'name': 'centos9', 'connection_status': 'active'},
     'RHEL8': {'os_name': 'CentOS Linux', 'os_major': '8', 'os_minor': '1', 'os_platform': 'centos',
               'name': 'centos8', 'connection_status': 'active'},
     'RHEL7': {'os_name': 'CentOS Linux', 'os_major': '7', 'os_minor': '1', 'os_platform': 'centos', 'os_version': '7.0',

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_import_invalid_feed_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/configuration_template/configuration_import_invalid_feed_type.yaml
@@ -15,7 +15,7 @@
               - os:
                   attributes:
                     - url: CUSTOM_FEED_URL
-                  value: '8'
+                  value: '9'
               - url:
                   value: CUSTOM_FEED_URL
         - provider:

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_download_feeds.yaml
@@ -46,6 +46,18 @@
     download_timeout: 150
     update_treshold_weeks: 2
 
+- name: RHEL9
+  description: Red Hat Enterprise Linux provider
+  configuration_parameters:
+    PROVIDER: redhat
+    OS: '9'
+  metadata:
+    provider_name: Red Hat Enterprise Linux 9
+    provider_json_name: JSON Red Hat Enterprise Linux
+    provider_os: RHEL9
+    download_timeout: 150
+    update_treshold_weeks: 2
+
 - name: TRUSTY
   description: Canonical provider
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_duplicate_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_duplicate_feeds.yaml
@@ -1,4 +1,15 @@
 - name: RedHat
+  description: Insert RHEL 9 OVAL and JSON feed from local path
+  configuration_parameters:
+    PROVIDER: redhat
+    OS: '9'
+    OS_PATH: CUSTOM_REDHAT_OVAL_FEED_PATH
+    PATH: CUSTOM_REDHAT_JSON_FEED_PATH
+  metadata:
+    provider_name: Red Hat Enterprise Linux 9
+    provider_json_name: JSON Red Hat Enterprise Linux
+
+- name: RedHat
   description: Insert RHEL 8 OVAL and JSON feed from local path
   configuration_parameters:
     PROVIDER: redhat

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_import_invalid_feed_type.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_import_invalid_feed_type.yaml
@@ -5,7 +5,7 @@
     target: redhat
     custom_feed_url: https://s3.amazonaws.com/ci.wazuh.com/qa/testing_files/dummy_files/dummy.pdf
     provider_feed_names:
-      - redhat 8
+      - redhat 9
       - jredhat provider
 
 - name: Debian - JPG

--- a/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
+++ b/tests/integration/test_vulnerability_detector/test_feeds/data/test_cases/cases_validate_xml_feed_content.yaml
@@ -42,6 +42,17 @@
     decompressed_file: /tmp/rhel8.xml
     url: https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8-including-unpatched.oval.xml.bz2
 
+- name: Red Hat Enterprise Linux
+  description: Red Hat Enterprise Linux provider
+  configuration_parameters:
+  metadata:
+    provider_name: Red Hat Enterprise Linux 9
+    expected_format: application/x-bzip2
+    path: /tmp/rhel-9-including-unpatched.oval.xml.bz2
+    extension: bz2
+    decompressed_file: /tmp/rhel9.xml
+    url: https://www.redhat.com/security/data/oval/v2/RHEL9/rhel-9-including-unpatched.oval.xml.bz2
+
 - name: Canonical Jammy
   description: Canonical provider
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_disabled.yaml
@@ -70,6 +70,15 @@
   metadata:
     provider_name: Ubuntu Jammy
 
+- name: RHEL 9
+  description: Test disabled Red Hat Enterprise Linux 9
+  configuration_parameters:
+    ENABLED: 'no'
+    PROVIDER: redhat
+    OS: '9'
+  metadata:
+    provider_name: Red Hat Enterprise Linux 9
+
 - name: RHEL 8
   description: Test disabled Red Hat Enterprise Linux 8
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_enabled.yaml
@@ -70,6 +70,15 @@
   metadata:
     provider_name: Ubuntu Jammy
 
+- name: RHEL 9
+  description: Test enabled Red Hat Enterprise Linux 8
+  configuration_parameters:
+    ENABLED: 'yes'
+    PROVIDER: redhat
+    OS: '9'
+  metadata:
+    provider_name: Red Hat Enterprise Linux 9
+
 - name: RHEL 8
   description: Test enabled Red Hat Enterprise Linux 8
   configuration_parameters:

--- a/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_multiple_provider_feeds.yaml
+++ b/tests/integration/test_vulnerability_detector/test_providers/data/test_cases/cases_multiple_provider_feeds.yaml
@@ -1,12 +1,12 @@
-- name: RedHat 8
-  description: Insert RHEL 8 OVAL and JSON feed from local path
+- name: RedHat 9
+  description: Insert RHEL 9 OVAL and JSON feed from local path
   configuration_parameters:
     PROVIDER: redhat
-    OS: '8'
+    OS: '9'
     OS_PATH: CUSTOM_REDHAT_OVAL_FEED_PATH
     PATH: CUSTOM_REDHAT_JSON_FEED_PATH
   metadata:
-    provider_name: Red Hat Enterprise Linux 8
+    provider_name: Red Hat Enterprise Linux 9
     provider_json_name: JSON Red Hat Enterprise Linux
     oval_feed_path: CUSTOM_REDHAT_OVAL_FEED_PATH
     json_feed_path: CUSTOM_REDHAT_JSON_FEED_PATH

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_provider_and_nvd_vulnerabilities.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_provider_and_nvd_vulnerabilities.yaml
@@ -15,7 +15,7 @@
               - os:
                   attributes:
                     - path: CUSTOM_REDHAT_OVAL_FEED
-                  value: '8'
+                  value: '9'
               - path:
                   value: CUSTOM_REDHAT_JSON_FEED
         - provider:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_provider_vulnerabilities.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_provider_vulnerabilities.yaml
@@ -15,7 +15,7 @@
               - os:
                   attributes:
                     - path: CUSTOM_REDHAT_OVAL_FEED
-                  value: '8'
+                  value: '9'
               - path:
                   value: CUSTOM_REDHAT_JSON_FEED
         - provider:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_vulnerability_removal.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/configuration_template/configuration_scan_vulnerability_removal.yaml
@@ -19,7 +19,7 @@
               - os:
                   attributes:
                     - path: CUSTOM_REDHAT_OVAL_FEED
-                  value: '8'
+                  value: '9'
               - path:
                   value: CUSTOM_REDHAT_JSON_FEED
         - provider:

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_no_agent_data.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_no_agent_data.yaml
@@ -3,7 +3,7 @@
   configuration_parameters:
     NVD_JSON_PATH: CUSTOM_NVD_JSON_PATH
   metadata:
-    system: RHEL8
+    system: RHEL9
 
 - name: UBUNTU
   description: Scan UBUNTU vulnerabilities using only the NVD feed

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_provider_and_nvd_vulnerabilities.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_provider_and_nvd_vulnerabilities.yaml
@@ -3,7 +3,7 @@
   configuration_parameters: null
   metadata:
     provider_name: redhat
-    system: RHEL8
+    system: RHEL9
     json_feed: custom_redhat_json_feed.json
     oval_feed: custom_redhat_oval_feed.xml
     nvd_feed: custom_nvd_feed.json

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_provider_vulnerabilities.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_provider_vulnerabilities.yaml
@@ -3,7 +3,7 @@
   configuration_parameters: null
   metadata:
     provider_name: redhat
-    system: RHEL8
+    system: RHEL9
     json_feed: custom_redhat_json_feed.json
     oval_feed: custom_redhat_oval_feed.xml
     nvd_feed: custom_nvd_alternative_feed.json

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_vulnerabilities_triaged_null.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_vulnerabilities_triaged_null.yaml
@@ -1,8 +1,8 @@
 - name: RHEL
   description: Check that after partial scan is launched triaged status changes from NULL to 1
   configuration_parameters:
-    OS: '8'
+    OS: '9'
     SCAN_INTERVAL: '5'
   metadata:
-    system: RHEL8
+    system: RHEL9
     triaged: ''

--- a/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_vulnerability_removal.yaml
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/data/test_cases/cases_scan_vulnerability_removal.yaml
@@ -3,7 +3,7 @@
   configuration_parameters: null
   metadata:
     provider_name: redhat
-    system: RHEL8
+    system: RHEL9
     json_feed: custom_redhat_json_feed.json
     oval_feed: custom_redhat_oval_feed.xml
     nvd_feed: custom_nvd_feed.json


### PR DESCRIPTION
|Related issue|
|-------------|
| #3040 |

## Description
this development intends to add support for testing RHEL9 linux OS, added to the previous existing references

The following tests should cover the new supported OS version:

* [Feed tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_feeds): These tests have to cover the addition of the new feed for RHEL 9
* [Provider tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_providers): Here we will test the settings for Red Hat with OS version 9
* [Scan results tests](https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_vulnerability_detector/test_scan_results): Here we have to add the tests that ensure RHEL 9 agents are scanned properly

## Tests were affected
wazuh-qa/tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py
<details><summary>Details</summary>
<p>

```shell

root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py                                                                                       
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                    
cachedir: .pytest_cache                                                                                                                                                                                            
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}
}                                                                                                                                                                                                                  
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                  
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                               
collected 26 items                                                                                                                                                                                                 
                                                                                                                                                                                                                   
tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py::test_download_feeds[RHEL5] XFAIL  [  3%]
tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py::test_download_feeds[RHEL6] PASSED [  7%]
tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py::test_download_feeds[RHEL7] PASSED [ 11%]
tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py::test_download_feeds[RHEL8] PASSED [ 15%]
tests/integration/test_vulnerability_detector/test_feeds/test_download_feeds.py::test_download_feeds[RHEL9] PASSED [ 19%]

``` 
</p>
</details>
 
wazuh-qa/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py

<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py                                                                                      
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                    
cachedir: .pytest_cache                                                                                                                                                                                            
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                                                                                                                                  
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                  
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                               
collected 13 items                                                                                                                                                                                                 
                                                                                                                                                                                                                   
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[RedHat0] PASSED                                                                                      [  7%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[RedHat1] PASSED                                                                                      [ 15%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Debian] PASSED                                                                                       [ 23%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Ubuntu Trusty] PASSED                                                                                [ 30%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Ubuntu Xenial] PASSED                                                                                [ 38%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Ubuntu Bionic] PASSED                                                                                [ 46%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Ubuntu Focal] PASSED                                                                                 [ 53%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Ubuntu Jammy] PASSED                                                                                 [ 61%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[ALAS] PASSED                                                                                         [ 69%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[Arch] PASSED                                                                                         [ 76%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[MSU] PASSED                                                                                          [ 84%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[SUSE] PASSED                                                                                         [ 92%] 
tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py::test_duplicate_feeds[AlmaLinux] PASSED                                                                                    [100%] 

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py
<details><summary>Details</summary>
<p>

```shell
roott@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py                                                                               
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                    
cachedir: .pytest_cache                                                                                                                                                                                            
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}
}                                                                                                                                                                                                                  
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                  
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                               
collected 26 items                                                                                                                                                                                                 
                                                                                                                                                                                                                   
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_json_feed_content[Red Hat Enterprise Linux] PASSED                                                    [  3%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_json_feed_content[Debian] PASSED                                                                      [  7%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_json_feed_content[Arch Linux] PASSED                                                                  [ 11%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_json_feed_content[Amazon Linux] PASSED                                                                [ 15%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_json_feed_content[MSU] PASSED                                                                         [ 19%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_json_feed_content[NVD] PASSED                                                                         [ 23%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Red Hat Enterprise Linux0] PASSED                                                    [ 26%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Red Hat Enterprise Linux1] PASSED                                                    [ 30%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Red Hat Enterprise Linux2] PASSED                                                    [ 34%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Red Hat Enterprise Linux3] PASSED                                                    [ 38%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Red Hat Enterprise Linux4] PASSED                                                    [ 42%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Canonical Jammy] PASSED                                                              [ 46%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Canonical Focal] PASSED                                                              [ 50%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Canonical Bionic] PASSED                                                             [ 53%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Canonical Xenial] PASSED                                                             [ 57%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Canonical Trusty] PASSED                                                             [ 61%] 
tests/integration/test_vulnerability_detector/test_feeds/test_validate_feed_content.py::test_validate_xml_feed_content[Debian0] FAILED                                                                      [ 65%] 

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -v tests/integration/test_vulnerability_detector/test_providers/test_enabled.py                                                                                                                                                                                                     
=============================================================================================== test session starts ===============================================================================================                                                                                                          platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 52 items                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Amazon Linux 1] PASSED                                                                                           [  1%]                                                                                                           tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Amazon Linux 2] PASSED                                                                                           [  3%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Amazon Linux 2022] FAILED                                                                                        [  5%]                                                                                                           tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Ubuntu Focal] PASSED                                                                                             [  7%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Ubuntu Bionic] PASSED                                                                                            [  9%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Ubuntu Xenial] PASSED                                                                                            [ 11%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Ubuntu Trusty] PASSED                                                                                            [ 13%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Ubuntu Jammy] PASSED                                                                                             [ 15%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[RHEL 9] PASSED                                                                                                   [ 17%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[RHEL 8] PASSED                                                                                                   [ 19%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[RHEL 7] PASSED                                                                                                   [ 21%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[RHEL 6] PASSED                                                                                                   [ 23%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[RHEL 5] PASSED                                                                                                   [ 25%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Debian Bullseye] PASSED                                                                                          [ 26%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Debian Buster] PASSED                                                                                            [ 28%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[Arch Linux] PASSED                                                                                               [ 30%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[NVD] PASSED                                                                                                      [ 32%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[MSU] PASSED                                                                                                      [ 34%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[SUSE Linux Enterprise Server 11] PASSED                                                                          [ 36%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[SUSE Linux Enterprise Server 12] PASSED                                                                          [ 38%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[SUSE Linux Enterprise Server 15] PASSED                                                                          [ 40%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[SUSE Linux Enterprise Desktop 11] PASSED                                                                         [ 42%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[SUSE Linux Enterprise Desktop 12] PASSED                                                                         [ 44%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[SUSE Linux Enterprise Desktop 15] PASSED                                                                         [ 46%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[ALMALINUX 8] PASSED                                                                                              [ 48%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_enabled[ALMALINUX 9] PASSED                                                                                              [ 50%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Amazon Linux 1] PASSED                                                                                          [ 51%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Amazon Linux 2] PASSED                                                                                          [ 53%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Amazon Linux 2022] PASSED                                                                                       [ 55%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Ubuntu Focal] PASSED                                                                                            [ 57%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Ubuntu Bionic] PASSED                                                                                           [ 59%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Ubuntu Xenial] PASSED                                                                                           [ 61%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Ubuntu Trusty] PASSED                                                                                           [ 63%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Ubuntu Jammy] PASSED                                                                                            [ 65%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[RHEL 9] PASSED                                                                                                  [ 67%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[RHEL 8] PASSED                                                                                                  [ 69%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[RHEL 7] PASSED                                                                                                  [ 71%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[RHEL 6] PASSED                                                                                                  [ 73%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[RHEL 5] PASSED                                                                                                  [ 75%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Debian Bullseye] PASSED                                                                                         [ 76%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Debian Buster] PASSED                                                                                           [ 78%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[Arch Linux] PASSED                                                                                              [ 80%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[NVD] PASSED                                                                                                     [ 82%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[MSU] PASSED                                                                                                     [ 84%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[SUSE Linux Enterprise Server 11] PASSED                                                                         [ 86%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[SUSE Linux Enterprise Server 12] PASSED                                                                         [ 88%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[SUSE Linux Enterprise Server 15] PASSED                                                                         [ 90%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[SUSE Linux Enterprise Desktop 11] PASSED                                                                        [ 92%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[SUSE Linux Enterprise Desktop 12] PASSED                                                                        [ 94%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[SUSE Linux Enterprise Desktop 15] PASSED                                                                        [ 96%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[ALMALINUX 8] PASSED                                                                                             [ 98%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_enabled.py::test_disabled[ALMALINUX 9] PASSED                                                                                             [100%]                                                                                                           

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py                                                                                                                                                                                    
=============================================================================================== test session starts ===============================================================================================                                                                                                          
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 3 items                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                             
tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py::test_check_log_multiple_provider_feeds[RedHat 9] PASSED                                                       [ 33%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py::test_check_log_multiple_provider_feeds[Debian Buster] PASSED                                                  [ 66%]                                                                                                           
tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py::test_check_log_multiple_provider_feeds[ALMALINUX] PASSED                                                      [100%]                                                                                                           

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py                                                                                                                                                                                
=============================================================================================== test session starts ===============================================================================================                                                                                                          
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 14 items                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                             
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_scan_nvd_vulnerabilities[WINDOWS] PASSED                                                             [  7%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_scan_nvd_vulnerabilities[MACOS] PASSED                                                               [ 14%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[RHEL] PASSED                                                                           [ 21%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[UBUNTU] PASSED                                                                         [ 28%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[DEBIAN] PASSED                                                                         [ 35%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[ARCH] PASSED                                                                           [ 42%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[ALAS] PASSED                                                                           [ 50%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[SLED11] PASSED                                                                         [ 57%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[SLED12] PASSED                                                                         [ 64%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[SLED15] PASSED                                                                         [ 71%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[SLES11] PASSED                                                                         [ 78%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[SLES12] PASSED                                                                         [ 85%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[SLES15] PASSED                                                                         [ 92%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py::test_no_agent_data[ALMALINUX] PASSED                                                                      [100%]                                                                                                           

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py                                                                                                                                                                   
=============================================================================================== test session starts ===============================================================================================                                                                                                          
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 7 items                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                             
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[RHEL] PASSED                                      [ 14%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[Debian] PASSED                                    [ 28%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[Canonical] SKIPPED (OVAL does not have any vu...) [ 42%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[ALAS] PASSED                                      [ 57%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[Arch] PASSED                                      [ 71%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[SUSE] PASSED                                      [ 85%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py::test_scan_provider_and_nvd_vulnerabilities[ALMALINUX] PASSED                                 [100%]                                                                                                           

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py                                                                                                                                                                           
=============================================================================================== test session starts ===============================================================================================                                                                                                          
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 7 items                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                             
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[RHEL] PASSED                                                      [ 14%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[Debian] PASSED                                                    [ 28%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[Canonical] SKIPPED (OVAL does not have any vulnerability yet,...) [ 42%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[ALAS] PASSED                                                      [ 57%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[Arch] PASSED                                                      [ 71%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[SUSE] PASSED                                                      [ 85%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py::test_scan_provider_vulnerabilities[ALMALINUX] PASSED                                                 [100%]                                                                                                           

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py                                                                                                                                                                       
=============================================================================================== test session starts ===============================================================================================                                                                                                          
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 1 item                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                             
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py::test_scan_triaged_null_vulnerabilities[RHEL] PASSED                                              [100%]                                                                                                           

``` 

</p>
</details> 

wazuh-qa/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa# python3 -m pytest -vx tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py                                                                                                                                                                              
=============================================================================================== test session starts ===============================================================================================                                                                                                          
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3                                                                                                                                                                                                                                              
cachedir: .pytest_cache                                                                                                                                                                                                                                                                                                      
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.0'}}                                                                                                         
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                                                                                                                                            
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                                                                                                                                         
collected 8 items                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                             
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_update_package[Alert vulnerability removal] PASSED                           [ 12%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_update_package[Alert vulnerability removal - ALAS 2022] PASSED               [ 25%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_update_package[Alert vulnerability removal - SUSE] PASSED                    [ 37%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_update_package[Alert vulnerability removal - ALMALINUX] PASSED               [ 50%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_delete_package[Alert vulnerability removal] PASSED                           [ 62%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_delete_package[Alert vulnerability removal - ALAS 2022] PASSED               [ 75%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_delete_package[Alert vulnerability removal - SUSE] PASSED                    [ 87%]                                                                                                           
tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py::test_vulnerability_removal_delete_package[Alert vulnerability removal - ALMALINUX] PASSED               [100%]                                                                                                           

``` 

</p>
</details> 

wazuh_qa/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
<details><summary>Details</summary>
<p>

```shell
root@wazuh:~/wazuh-qa/deps/wazuh_testing# python3.9 -m pytest -v ../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py                                                
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.9.18, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3.9                                                                                                                               
cachedir: .pytest_cache                                                                                                                                                                                         
metadata: {'Python': '3.9.18', 'Platform': 'Linux-5.15.74-1-pve-x86_64-with-glibc2.31', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '3.0.
0'}}                                                                                                                                                                                                            
rootdir: /root/wazuh-qa/tests/integration, configfile: pytest.ini                                                                                                                                               
plugins: testinfra-5.0.0, html-3.1.1, metadata-3.0.0                                                                                                                                                            
collected 9 items                                                                                                                                                                                               
                                                                                                                                                                                                                
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[RHEL - PDF] PASSED                                                        [ 11%] 
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[Debian - JPG] PASSED                                                      [ 22%] 
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[Canonical - MP3] PASSED                                                   [ 33%] 
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[ALAS - DOC] ERROR                                                         [ 44%] 
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[Arch - AVI] PASSED                                                        [ 55%] 
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[MSU - JPG] PASSED                                                         [ 66%] 
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[NVD - MP3] PASSED                                                         [ 77%]
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[SUSE - JPG] PASSED                                                        [ 88%]
../../tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py::test_import_invalid_feed_type[AlmaLinux - JPG] PASSED                                                   [100%]

``` 

</p>
</details> 

- https://ci.wazuh.info/view/Tests/job/Test_integration/43184/ (RHEL and RHEL 9 - `PASSED`)
- `4.5.3` - https://ci.wazuh.info/view/Tests/job/Test_integration/43296/ (RHEL and RHEL 9 - `PASSED`)
--------
- `4.6.0` - https://ci.wazuh.info/view/Tests/job/Test_integration/43425/ - :green_circle:  