### PR TITLE
Fix invalid AR conf in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Release report: TBD
 
 ### Fixed
 
+- Fix invalid AR conf in integration tests ([#4521](https://github.com/wazuh/wazuh-qa/pull/4521)) \- (Tests)
 - Fix FIM framework to validate path in event correctly ([#4390](https://github.com/wazuh/wazuh-qa/pull/4390)) \- (Framework)
 - Fix an error related to logs format in reliability test ([#4387](https://github.com/wazuh/wazuh-qa/pull/4387)) \- (Tests)
 - Fix boto3 version requirement for legacy OS ([#4150](https://github.com/wazuh/wazuh-qa/pull/4150)) \- (Framework)

--- a/tests/integration/test_active_response/test_execd/conftest.py
+++ b/tests/integration/test_active_response/test_execd/conftest.py
@@ -14,7 +14,7 @@ def set_ar_conf_mode():
     debug_line = "restart-wazuh0 - restart-wazuh - 0\nrestart-wazuh0 - restart-wazuh.exe - 0\n" \
                  "firewall-drop0 - firewall-drop - 0\nfirewall-drop5 - firewall-drop - 5\n"
     with open(local_int_conf_path, 'w') as local_file_write:
-        local_file_write.write('\n'+debug_line)
+        local_file_write.write(debug_line)
     with open(local_int_conf_path, 'r') as local_file_read:
         lines = local_file_read.readlines()
         for line in lines:


### PR DESCRIPTION
|Related issue|
|-------------|
| #4516            |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

The `ossec.log` was showing `2023/09/11 12:38:29 wazuh-agent[1584] exec.c:65 at ReadExecConfig(): ERROR: (1313): Invalid active response config: 'shared/ar.conf'.` because `shared/ar.conf` file started with an empty line due to:

https://github.com/wazuh/wazuh-qa/blob/3686d48250d1905b4ef38815e6b0d18b6a9b4d75/tests/integration/test_active_response/test_execd/conftest.py#L16-L17

We have deleted that extra line.


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Updated `tests/integration/test_active_response/test_execd/conftest.py`



---

## Testing performed
 The test execution failed due to https://github.com/wazuh/wazuh-qa/issues/4512, but we can see that the error log stopped appearing.

If we launch the test with the changes from https://github.com/wazuh/wazuh-qa/pull/4511, the test passes:
[passed-active-response.zip](https://github.com/wazuh/wazuh-qa/files/12608090/passed-active-response.zip)


<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @juliamagan (Developer)  |   `tests/integration/test_active_response`        | [🟢 ](https://ci.wazuh.info/job/Test_integration/42985/)[🟢 ](https://ci.wazuh.info/job/Test_integration/42991/)[🟢 ](https://ci.wazuh.info/job/Test_integration/42994/)  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/12608412/R1-4516-centos-manager.tar.gz)[🟢 ](https://github.com/wazuh/wazuh-qa/files/12608414/R2-4516-centos-manager.tar.gz)[🟢 ](https://github.com/wazuh/wazuh-qa/files/12608419/R3-4516-centos-manager.tar.gz) |    CentOS 8     |   8aedacb19d82f0ba1d4445554a4e141f66d31ce6      | Manager |
| @juliamagan (Developer)  |   `tests/integration/test_active_response`        | [🟢 ](https://ci.wazuh.info/job/Test_integration/42986/)[🟢 ](https://ci.wazuh.info/job/Test_integration/42990/)[🟢 ](https://ci.wazuh.info/job/Test_integration/42993/) | [🟢 ](https://github.com/wazuh/wazuh-qa/files/12608484/R1-4516-centos-agent.tar.gz)[🟢 ](https://github.com/wazuh/wazuh-qa/files/12608486/R2-4516-centos-agent.tar.gz)[🟢 ](https://github.com/wazuh/wazuh-qa/files/12608488/R3-4516-centos-agent.tar.gz) |     CentOS 8      |   8aedacb19d82f0ba1d4445554a4e141f66d31ce6      |Agent   |
| @juliamagan (Developer)  |   `tests/integration/test_active_response`        | [🔴 ](https://ci.wazuh.info/job/Test_integration/42986/)[🔴 ](https://ci.wazuh.info/job/Test_integration/42990/)[🔴 ](https://ci.wazuh.info/job/Test_integration/42993/) | [🔴 ](https://github.com/wazuh/wazuh-qa/files/12608080/failed-active-response.zip)[🔴 ](https://github.com/wazuh/wazuh-qa/files/12608084/failed-active-response-2.zip)[🔴 ](https://github.com/wazuh/wazuh-qa/files/12608088/failed-active-response-3.zip) |   Windows Server 2016      |         8aedacb19d82f0ba1d4445554a4e141f66d31ce6 |  Failed as expected due to https://github.com/wazuh/wazuh-qa/issues/4512 |

