### PR TITLE
Upgrade py dependency version for wazuh-qa when Python is in version 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ All notable changes to this project will be documented in this file.
 Wazuh commit: TBD \
 Release report: TBD
 
-## Fixed
-
-- Fix py dependency version to install for Windows after the change to Python 3.11([#4523](https://github.com/wazuh/wazuh-qa/pull/4523/files)) \- (Framework)
-
 ### Changed
 
 - Updated the cluster master logs reliability test to run with python 3.7 [#4445](https://github.com/wazuh/wazuh-qa/pull/4478) \- (Tests)
@@ -18,6 +14,7 @@ Release report: TBD
 ### Fixed
 
 - Enhancing the handling of authd and remoted simulators in case of restart failures ([#Wazuh-jenkins#3487](https://github.com/wazuh/wazuh-qa/pull/4205)) \- (Tests)
+- Fix py dependency version to install for Windows after the change to Python 3.11([#4523](https://github.com/wazuh/wazuh-qa/pull/4523/files)) \- (Framework)
 
 ## [4.5.2] - TBD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 Wazuh commit: TBD \
 Release report: TBD
 
+## Fixed
+- Fix py dependency version to install for Windows after the change to Python 3.11([#4523](https://github.com/wazuh/wazuh-qa/pull/4523/files)) \- (Framework)
+
 ### Fixed
 
 - Enhancing the handling of authd and remoted simulators in case of restart failures ([#Wazuh-jenkins#3487](https://github.com/wazuh/wazuh-qa/pull/4205)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Release report: TBD
 ### Fixed
 
 - Enhancing the handling of authd and remoted simulators in case of restart failures ([#Wazuh-jenkins#3487](https://github.com/wazuh/wazuh-qa/pull/4205)) \- (Tests)
-- Fix py dependency version to install for Windows after the change to Python 3.11([#4523](https://github.com/wazuh/wazuh-qa/pull/4523/files)) \- (Framework)
+- Fix py dependency version to install for Windows after the change to Python 3.11([#4523](https://github.com/wazuh/wazuh-qa/pull/4523)) \- (Framework)
 
 ## [4.5.2] - TBD
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pandas>=1.1.5
 pillow>=6.2.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 psutil>=5.6.6
 py~=1.10.0
+py==1.11.0; platform_system == "Windows" and python_version >= "3.11"
 pycryptodome>=3.9.8
 pyOpenSSL==19.1.0
 pytest-html==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numpy>=1.18.1
 pandas>=1.1.5
 pillow>=6.2.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 psutil>=5.6.6
-py~=1.10.0
+py~=1.10.0; platform_system != "Windows" or python_version <= "3.10"
 py==1.11.0; platform_system == "Windows" and python_version >= "3.11"
 pycryptodome>=3.9.8
 pyOpenSSL==19.1.0


### PR DESCRIPTION
|Related issue|
|-------------|
|https://github.com/wazuh/wazuh-jenkins/issues/5407|

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

When testing the changes in PR https://github.com/wazuh/wazuh-jenkins/pull/5342, it has been seen the tests fail with an error shown later if the dependency `py` is in version `1.10` instead of `1.11`, as seen in https://github.com/pytest-dev/apipkg/issues/30.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- requirements.txt
---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
The test fails on some fim tests, but it is expected, as running it using branch 4.5.3 also fails with it. 


| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @user (Developer)  |           | [:green_circle: ](https://ci.wazuh.info/job/Test_integration/43006/) | ⚫⚫⚫  |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
