### PR TITLE
Agentless_cluster_env system tests timeout changed in order to reduce EC2 requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release report: TBD
 
 ### Changed
 
+- `Agentless_cluster` system tests timeout changed in order to reduce EC2 requirements ([#4534](https://github.com/wazuh/wazuh-qa/pull/4534)) \- (Tests)
 - Skip `test_authd_ssl_options` cases that use TLS 1.1 causing errors on several OpenSSL versions. ([#4229](https://github.com/wazuh/wazuh-qa/pull/4229)) \- (Tests)
 - Update database version ([#4467](https://github.com/wazuh/wazuh-qa/pull/4467)) \- (Tests)
 - Remove versionStartIncluding from NVD custom feed ([#4441](https://github.com/wazuh/wazuh-qa/pull/4441)) \- (Tests)

--- a/tests/system/test_cluster/test_integrity_sync/data/messages.yml
+++ b/tests/system/test_cluster/test_integrity_sync/data/messages.yml
@@ -2,30 +2,30 @@
 wazuh-master:
   - regex: '.*File too large to be synced: /var/ossec/etc/rules/test_file_too_big'
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 120
   - regex: '.*Maximum zip size exceeded. Not all files will be compressed during this sync.*'
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 120
   - regex: ".*Command received: b'cancel_task'.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 120
   - regex: ".*Decreasing sync size limit to .* MB.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 120
   - regex: ".*wazuh-worker1.*Files to create in worker: 1 \\| Files to update in worker: 0 \\| Files to delete in worker: 0.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 100
+    timeout: 180
   - regex: ".*wazuh-worker2.*Files to create in worker: 1 \\| Files to update in worker: 0 \\| Files to delete in worker: 0.*"
     path: "/var/ossec/logs/cluster.log"
     timeout: 100
   - regex: ".*Increasing sync size limit to .* MB.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 60
+    timeout: 120
 wazuh-worker1:
   - regex: ".*Files to create: 0 \\| Files to update: 0 \\| Files to delete: 0.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 120
+    timeout: 180
 wazuh-worker2:
   - regex: ".*Files to create: 0 \\| Files to update: 0 \\| Files to delete: 0.*"
     path: "/var/ossec/logs/cluster.log"
-    timeout: 120
+    timeout: 180


### PR DESCRIPTION
|Related issue|
|-------------|
|   #4526          |

## Description

Agentless_cluster_env system tests required extended timeout in its message.yml logs in to be stable in EC2 Ubuntu 22.04.3 LTS t3.large 15GB HD
<!-- Add a description of the context and content of all changes made in the pull request -->


### Updated

Changed test_integrity_sync/data/messages.yml timeout out figures:

|From|To|
|--|--|
|120 | 180|
|60 | 120|
|100 | 180|


## Testing performed

Test results are focused in test_integrity_sync where one of the tests had a stable Failure without the timeout changes.

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @pro-akim (Developer)  |           | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/12674601/report_agentless_cluster.html.zip)[:green_circle:](https://github.com/wazuh/wazuh-qa/files/12674658/timeout_180.zip)⚫ | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


