### PR TITLE
EC2 Information for system tests added 

### DIFF
--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -4,22 +4,22 @@ Wazuh - System quality assurance automation templates
 
 ## Setting up a test environment
 
-To run these tests we need to use a **Linux** machine.
+To run these tests it will be required to use a **Linux** machine.
 
 In the event that the tests are to be executed using AWS EC2 instances:
 
-### EC2 requirements for system testing.
+### EC2 requirements for system testing
 
 | Environment                  | EC2                                       |
 |------------------------------|-------------------------------------------|
-|Basic_cluster                 |Ubuntu 22.04.2 LTS `C5`.`XLarge` `15GB` HD |
-|Big_cluster_40_agents         |Ubuntu 22.04.2 LTS T3.Large `60GB` HD      |
-|Agentless_cluster             |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
-|Four_manager_disconnected_node|Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
-|One_manager_agent             |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
-|Manager_agent                 |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
-|Enrollment_cluster            |Ubuntu 22.04.2 LTS T3.Large 30GB HD        | 
-| Basic_environment            |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
+|Basic_cluster                 |Ubuntu 22.04.2 LTS C5.XLarge 15GB SSD      |
+|Big_cluster_40_agents         |Ubuntu 22.04.2 LTS T3.Large 60GB SSD       |
+|Agentless_cluster             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
+|Four_manager_disconnected_node|Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
+|One_manager_agent             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
+|Manager_agent                 |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
+|Enrollment_cluster            |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       | 
+|Basic_environment             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
 
 
 Now it will be needed to install the following tools:

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -4,7 +4,7 @@ Wazuh - System quality assurance automation templates
 
 ## Setting up a test environment
 
-To run these tests it will be required to use a **Linux** machine.
+To run these tests a **Linux** machine will be required.
 
 In the event that the tests are to be executed using AWS EC2 instances:
 

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -22,7 +22,7 @@ In the event that the tests are to be executed using AWS EC2 instances:
 |Basic_environment             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
 
 
-Now it will be needed to install the following tools:
+Now, the following tools will need to be installed:
 
 - [Docker](https://docs.docker.com/install/)
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -4,7 +4,25 @@ Wazuh - System quality assurance automation templates
 
 ## Setting up a test environment
 
-To run these tests we need to use a **Linux** machine and install the following tools:
+To run these tests we need to use a **Linux** machine.
+
+In the event that the tests are to be executed using AWS EC2 instances:
+
+### EC2 requirements for system testing.
+
+| Environment                  | EC2                                       |
+|------------------------------|-------------------------------------------|
+|Basic_cluster                 |Ubuntu 22.04.2 LTS `C5`.`XLarge` `15GB` HD |
+|Big_cluster_40_agents         |Ubuntu 22.04.2 LTS T3.Large `60GB` HD      |
+|Agentless_cluster             |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
+|Four_manager_disconnected_node|Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
+|One_manager_agent             |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
+|Manager_agent                 |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
+|Enrollment_cluster            |Ubuntu 22.04.2 LTS T3.Large 30GB HD        | 
+| Basic_environment            |Ubuntu 22.04.2 LTS T3.Large 30GB HD        |
+
+
+Now it will be needed to install the following tools:
 
 - [Docker](https://docs.docker.com/install/)
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)


### PR DESCRIPTION
|Related issue|
|-------------|
|   #4527   |

## Description

Adding information to `wazuh-qa/tests/system/README.md` about EC2 requirements for running system tests in EC2
