### PR TITLE
Fix enrollment system tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release report: https://github.com/wazuh/wazuh/issues/19111
 
 ### Fixed
 
+- Fix enrollment system tests ([#4562](https://github.com/wazuh/wazuh-qa/pull/4562/)) \- (Tests)
 - Update the request method used to call the login API endpoint. ([#4492](https://github.com/wazuh/wazuh-qa/pull/4492)) \- (Tests)
 - Enhancing the handling of authd and remoted simulators in case of restart failures ([#Wazuh-jenkins#3487](https://github.com/wazuh/wazuh-qa/pull/4205)) \- (Tests)
 - Fix py dependency version to install for Windows after the change to Python 3.11([#4523](https://github.com/wazuh/wazuh-qa/pull/4523)) \- (Framework)

--- a/tests/system/test_agent_auth/test_agent_auth.py
+++ b/tests/system/test_agent_auth/test_agent_auth.py
@@ -64,6 +64,7 @@ def clean_environment():
     host_manager.run_command('wazuh-manager', f"{WAZUH_PATH}/bin/manage_agents -r {agent_id}")
     host_manager.clear_file(host='wazuh-manager', file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
     host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
+    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
 
 
 # IPV6 fixtures
@@ -234,7 +235,6 @@ def test_agent_auth(test_case, get_ip_directions, configure_network, modify_ip_a
     '''
     # Clean ossec.log and cluster.log
     host_manager.clear_file(host='wazuh-manager', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
-    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
     host_manager.control_service(host='wazuh-manager', service='wazuh', state="restarted")
 
     # Start the agent enrollment process using agent-auth

--- a/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
+++ b/tests/system/test_cluster/test_agent_enrollment/test_agent_enrollment.py
@@ -32,6 +32,7 @@ def clean_environment():
                                                   check=False)
     host_manager.control_service(host='wazuh-agent1', service='wazuh', state="stopped")
     host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
+    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
 
 
 def test_agent_enrollment(clean_environment):
@@ -40,7 +41,6 @@ def test_agent_enrollment(clean_environment):
     # Clean ossec.log and cluster.log
     host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
     host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
-    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
     host_manager.clear_file(host='wazuh-master', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
     host_manager.clear_file(host='wazuh-worker1', file_path=os.path.join(WAZUH_LOGS_PATH, 'cluster.log'))
 

--- a/tests/system/test_enrollment/test_enrollment.py
+++ b/tests/system/test_enrollment/test_enrollment.py
@@ -72,6 +72,7 @@ def clean_environment():
 
     host_manager.clear_file(host='wazuh-manager', file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
     host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_PATH, 'etc', 'client.keys'))
+    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
 
 
 # IPV6 fixtures
@@ -220,7 +221,6 @@ def test_agent_enrollment(test_case, get_ip_directions, configure_network, modif
     '''
     # Clean ossec.log and cluster.log
     host_manager.clear_file(host='wazuh-manager', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
-    host_manager.clear_file(host='wazuh-agent1', file_path=os.path.join(WAZUH_LOGS_PATH, 'ossec.log'))
 
     # Start the agent enrollment process by restarting the wazuh-agent
     host_manager.control_service(host='wazuh-manager', service='wazuh', state="restarted")


### PR DESCRIPTION
|Related issue|
|-------------|
|       #4552       |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

We've found that the test's function `clear_file()` is creating a new file _etc/ossec.log_ with these permissions:

```
rw--r--r-- root root
```

This means that _wazuh-agentd_  is unable to write into _ossec.log_ after dropping its permissions.


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Clear `ossec.log` after yield, so the file exists and it isn't created with wrong permissions.

---

## Testing performed

- [🟢 ](https://github.com/wazuh/wazuh-qa/files/12747929/test_enrollment.zip) `test_cluster/test_agent_enrollment`
- [🟢 ](https://github.com/wazuh/wazuh-qa/files/12747931/basic_environment_env.zip) `test_enrollment`

