### PR TITLE
Delete commit and release references in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [4.7.0] - TBD
 
-Wazuh commit: TBD \
-Release report: TBD
-
 ### Added
 
 - Add callbacks and IT tests for Integratord options tag. ([#4166](https://github.com/wazuh/wazuh-qa/pull/4166)) \- (Framework + tests)


### PR DESCRIPTION
|Related issue|
|-------------|
|  #4619            |

## Description

It has been decided to remove the reference to the wazuh/wazuh commit and the release report because it is easier to maintain. Also, the date will not be changed until post-release.