### PR TITLE
Fix hardcoded python interpreter in qa_framework role

### DIFF
--- a/provisioning/roles/qa_framework/tasks/linux.yaml
+++ b/provisioning/roles/qa_framework/tasks/linux.yaml
@@ -25,12 +25,12 @@
   when: ansible_os_family == "Solaris"
 
 - name: Install python requirements | UNIX
-  command: "{{ python_executable }} -m pip install -r {{ qa_requirements_file }} --no-cache-dir \
+  command: "{{ ansible_python_interpreter }} -m pip install -r {{ qa_requirements_file }} --no-cache-dir \
             --only-binary=:cryptography,grpcio: --user"
   args:
     chdir: "{{ build_dir }}"
 
 - name: Install setup.py | UNIX
-  command: "{{ python_executable }} {{ setup_installer }} install --user"
+  command: "{{ ansible_python_interpreter }} {{ setup_installer }} install --user"
   args:
     chdir: "{{ build_dir }}/{{ test_setup_qa_path }}"

--- a/provisioning/roles/qa_framework/tasks/main.yaml
+++ b/provisioning/roles/qa_framework/tasks/main.yaml
@@ -1,24 +1,3 @@
-# Unix
-- name: Include Unix custom vars
-  include_vars: linux.yaml
-  when:
-    - customize == false
-    - ansible_os_family != "Windows"
-
-# Solaris
-- name: Include Solaris custom vars
-  include_vars: solaris.yaml
-  when:
-    - customize == false
-    - ansible_os_family == "Solaris"
-
-# macOS
-- name: Include macOS custom vars
-  include_vars: macos.yaml
-  when:
-    - customize == false
-    - ansible_os_family == "Darwin"
-
 # Windows
 - name: Include Windows custom vars
   include_vars: windows.yaml

--- a/provisioning/roles/qa_framework/tasks/solaris.yaml
+++ b/provisioning/roles/qa_framework/tasks/solaris.yaml
@@ -1,4 +1,4 @@
 - name: Install python requirements on Solaris
-  command: "{{ python_executable }} -m pip install -r {{ qa_requirements_file }}"
+  command: "{{ ansible_python_interpreter }} -m pip install -r {{ qa_requirements_file }}"
   args:
     chdir: "{{ build_dir }}"

--- a/provisioning/roles/qa_framework/tasks/windows.yaml
+++ b/provisioning/roles/qa_framework/tasks/windows.yaml
@@ -12,12 +12,12 @@
       {{ build_dir }}/tmp; move tmp/* ./
 
 - name: Install python requirements | Windows
-  win_command: "{{ python_executable }} -m pip install -r {{ qa_requirements_file }} \
+  win_command: "{{ ansible_python_interpreter }} -m pip install -r {{ qa_requirements_file }} \
                 --no-cache-dir --only-binary=:cryptography,grpcio:"
   args:
     chdir: "{{ build_dir }}"
 
 - name: Install setup.py | Windows
-  win_command: "{{ python_executable }} {{ setup_installer }} install"
+  win_command: "{{ ansible_python_interpreter }} {{ setup_installer }} install"
   args:
     chdir: "{{ build_dir }}\\{{ test_setup_qa_path }}"

--- a/provisioning/roles/qa_framework/tasks/windows.yaml
+++ b/provisioning/roles/qa_framework/tasks/windows.yaml
@@ -3,13 +3,12 @@
     path: "{{ build_dir }}"
     state: directory
 
-- name: Clone Wazuh-QA repo | Windows
-  win_command: powershell.exe -
-  args:
-    chdir: "{{ build_dir }}"
-    stdin: >
-      git clone {{ qa_repository_url }} -b {{ qa_repository_reference }} --depth=1"
-      {{ build_dir }}/tmp; move tmp/* ./
+- name: Clone a repo with separate git directory
+  ansible.builtin.git:
+    repo: "{{ qa_repository_url }}"
+    dest: "{{ build_dir }}"
+    single_branch: yes
+    version: "{{ qa_repository_reference }}"
 
 - name: Install python requirements | Windows
   win_command: "{{ ansible_python_interpreter }} -m pip install -r {{ qa_requirements_file }} \

--- a/provisioning/roles/qa_framework/tasks/windows.yaml
+++ b/provisioning/roles/qa_framework/tasks/windows.yaml
@@ -1,18 +1,16 @@
-- name: Create {{ build_dir }} if does not exist
+- name: Delete the file, if it doesnt exist already
   win_file:
     path: "{{ build_dir }}"
-    state: directory
+    state: absent
 
-- name: Clone a repo with separate git directory
-  ansible.builtin.git:
-    repo: "{{ qa_repository_url }}"
-    dest: "{{ build_dir }}"
-    single_branch: yes
-    version: "{{ qa_repository_reference }}"
+- name: Clone Wazuh-QA repo | Windows
+  win_command: powershell.exe -
+  args:
+    stdin: >
+      git clone {{ qa_repository_url }} -b {{ qa_repository_reference }} {{ build_dir }}
 
-- name: Install python requirements | Windows
-  win_command: "{{ ansible_python_interpreter }} -m pip install -r {{ qa_requirements_file }} \
-                --no-cache-dir --only-binary=:cryptography,grpcio:"
+- name: Install Python requirements
+  win_command: "{{ ansible_python_interpreter }} -m pip install -r {{ qa_requirements_file }} --no-cache-dir --only-binary=:cryptography,grpcio:"
   args:
     chdir: "{{ build_dir }}"
 

--- a/provisioning/roles/qa_framework/vars/linux.yaml
+++ b/provisioning/roles/qa_framework/vars/linux.yaml
@@ -1,1 +1,0 @@
-python_executable: /usr/local/bin/python3.10

--- a/provisioning/roles/qa_framework/vars/macos.yaml
+++ b/provisioning/roles/qa_framework/vars/macos.yaml
@@ -1,1 +1,0 @@
-python_executable: /Library/Developer/CommandLineTools/usr/bin/python3

--- a/provisioning/roles/qa_framework/vars/solaris.yaml
+++ b/provisioning/roles/qa_framework/vars/solaris.yaml
@@ -1,1 +1,0 @@
-python_executable: /opt/python3/bin/python3

--- a/provisioning/roles/qa_framework/vars/windows.yaml
+++ b/provisioning/roles/qa_framework/vars/windows.yaml
@@ -1,2 +1,1 @@
 build_dir: C:\Users\qa\AppData\Local\Temp\wazuh-qa
-python_executable: C:\Users\qa\AppData\Local\Programs\Python\Python310\python.exe

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@ seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or pl
 setuptools~=56.0.0
 testinfra==5.0.0
 jq==1.1.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version <= "3.9"
-jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version >= "3.10"
+jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version < "3.11"
+jq==1.6.0 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version >= "3.11"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 urllib3>=1.26.5,<2
 numpydoc>=1.1.0


### PR DESCRIPTION
|Related issue|
|-------------|
|      #wazuh-jenkins/5883       |

## Description

This pull request enhances the QA Framework role by eliminating the hardcoded Python interpreter specification. Furthermore, it introduces a minor addition to the requirements, enabling the framework's installation on CentOS hosts with Python 3.11.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Refactor qa_framework role to allow custom python interpreter
- Fix framework installation for python311


## Testing performed

**Build**: https://ci.wazuh.info/job/Wazuh_QA_environment/506/console
