### PR TITLE
Update default vacuum settings in IT

### DIFF
--- a/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
+++ b/tests/integration/test_wazuh_db/data/global/wazuhdb_getconfig.yaml
@@ -31,7 +31,7 @@
     -
       input: '{"version": 1, "origin": {"module": "api"}, "command": "getconfig", "module": "api", "parameters": {
               "section": "internal"}}'
-      output: '"data":{"wazuh_db":{"commit_time_max":60,"commit_time_min":10,"open_db_limit":64,"worker_pool_size":8,"fragmentation_threshold":80,"fragmentation_delta":5,"free_pages_percentage":5,"max_fragmentation":95,"check_fragmentation_interval":43200}}'
+      output: '"data":{"wazuh_db":{"commit_time_max":60,"commit_time_min":10,"open_db_limit":64,"worker_pool_size":8,"fragmentation_threshold":75,"fragmentation_delta":5,"free_pages_percentage":0,"max_fragmentation":90,"check_fragmentation_interval":7200}}'
 -
   name: Get wdb config
   test_case:


### PR DESCRIPTION
|Related issue|
|-------------|
|https://github.com/wazuh/wazuh/issues/19954|

## Description

This PR fixes the wazuh DB test that validates the internal options after the changes in the default values of the automatic vacuum configuration.
