### PR TITLE
Fix duplicated jq requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Release report: TBD
 - Update framework known flaws file ([#4443](https://github.com/wazuh/wazuh-qa/pull/4443)) \- (Tests)
 - Align migration tool system tests to the tool's new output directory structure ([#4561](https://github.com/wazuh/wazuh-qa/pull/4561)) \- (Tests)
 
+### Fixed
+
+- Fix duplicated jq dependency ([#4678](https://github.com/wazuh/wazuh-qa/pull/4678)) \- (Framework)
+
 ## [4.7.1] - TBD
 
 Wazuh commit: TBD \

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or pl
 setuptools~=56.0.0
 testinfra==5.0.0
 jq==1.1.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version <= "3.9"
-jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version < "3.11" and python_version > "3.9"
+jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version == "3.10"
 jq==1.6.0 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version >= "3.11"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 urllib3>=1.26.5,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ seaborn>=0.11.1; platform_system == "Linux" or platform_system == "Darwin" or pl
 setuptools~=56.0.0
 testinfra==5.0.0
 jq==1.1.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version <= "3.9"
-jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version < "3.11"
+jq==1.2.2 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version < "3.11" and python_version > "3.9"
 jq==1.6.0 ; (platform_system == "Linux" or platform_system == "Darwin") and python_version >= "3.11"
 cryptography==3.3.2; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 urllib3>=1.26.5,<2


### PR DESCRIPTION
|Related issue|
|-------------|
|    https://github.com/wazuh/wazuh-qa/issues/4679         |

## Description


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Fix duplicated `jq` requirement

---

## Testing performed


**Test Integration**: https://ci.wazuh.info/job/Test_integration/44467/consoleFull
> **Note**
> Error not related with the development. Instances were correctly provisioned

**Tests E2E System**: https://ci.wazuh.info/job/Test_e2e_system/142/console
> **Note**
> E2E pipeline fails for different issue. It provision qa framework correctly
