### PR TITLE
Enhance macOS deployment ansible taks

### DIFF
--- a/provisioning/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/defaults/main.yml
@@ -60,6 +60,7 @@ wazuh_winagent_config_url: https://packages.wazuh.com/4.x/windows/wazuh-agent-4.
 wazuh_winagent_package_name: wazuh-agent-4.8.0-1.msi
 wazuh_winagent_package_name_generic: wazuh-agent.msi
 wazuh_dir: "/var/ossec"
+macos_wazuh_dir: "/Library/Ossec"
 
 # This is deprecated, see: wazuh_agent_address
 wazuh_agent_nat: false

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
@@ -51,10 +51,3 @@
     - authd_pass | length > 0
   tags:
     - config
-
-- name: macOS | Ensure Wazuh Agent service is started and enabled
-  service:
-    name: wazuh-agent
-    enabled: true
-    state: started
-  tags: config

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
@@ -6,3 +6,55 @@
 
 - include_tasks: "installation_from_custom_packages.yml"
   when: wazuh_custom_packages_installation_agent_enabled
+
+- name: macOS | Installing agent configuration (ossec.conf)
+  template:
+    src: var-ossec-etc-ossec-agent.conf.j2
+    dest: "{{ wazuh_dir }}/etc/ossec.conf"
+    owner: root
+    group: wazuh
+    mode: 0644
+  notify: restart wazuh-agent
+  tags:
+    - init
+    - config
+
+- name: macOS | Check if client.keys exists
+  stat:
+    path: "{{ wazuh_dir }}/etc/client.keys"
+  register: client_keys_file
+  tags:
+    - config
+
+- name: macOS | Installing local_internal_options.conf
+  template:
+    src: var-ossec-etc-local-internal-options.conf.j2
+    dest: "{{ wazuh_dir }}/etc/local_internal_options.conf"
+    owner: root
+    group: wazuh
+    mode: 0640
+  notify: restart wazuh-agent
+  tags:
+    - init
+    - config
+
+- name: Create auto-enrollment password file
+  template:
+    src: authd_pass.j2
+    dest: "{{ wazuh_dir }}/etc/authd.pass"
+    owner: wazuh
+    group: wazuh
+    mode: 0640
+  when:
+    - wazuh_agent_config.enrollment.enabled == 'yes'
+    - wazuh_agent_config.enrollment.authorization_pass_path | length > 0
+    - authd_pass | length > 0
+  tags:
+    - config
+
+- name: macOS | Ensure Wazuh Agent service is started and enabled
+  service:
+    name: wazuh-agent
+    enabled: true
+    state: started
+  tags: config

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
@@ -10,7 +10,7 @@
 - name: macOS | Installing agent configuration (ossec.conf)
   template:
     src: var-ossec-etc-ossec-agent.conf.j2
-    dest: "{{ wazuh_dir }}/etc/ossec.conf"
+    dest: "{{ macos_wazuh_dir }}/etc/ossec.conf"
     owner: root
     group: wazuh
     mode: 0644
@@ -21,7 +21,7 @@
 
 - name: macOS | Check if client.keys exists
   stat:
-    path: "{{ wazuh_dir }}/etc/client.keys"
+    path: "{{ macos_wazuh_dir }}/etc/client.keys"
   register: client_keys_file
   tags:
     - config
@@ -29,7 +29,7 @@
 - name: macOS | Installing local_internal_options.conf
   template:
     src: var-ossec-etc-local-internal-options.conf.j2
-    dest: "{{ wazuh_dir }}/etc/local_internal_options.conf"
+    dest: "{{ macos_wazuh_dir }}/etc/local_internal_options.conf"
     owner: root
     group: wazuh
     mode: 0640
@@ -41,7 +41,7 @@
 - name: Create auto-enrollment password file
   template:
     src: authd_pass.j2
-    dest: "{{ wazuh_dir }}/etc/authd.pass"
+    dest: "{{ macos_wazuh_dir }}/etc/authd.pass"
     owner: wazuh
     group: wazuh
     mode: 0640

--- a/provisioning/roles/wazuh/wazuh_environment/schema.j2
+++ b/provisioning/roles/wazuh/wazuh_environment/schema.j2
@@ -220,7 +220,6 @@ manager:
       master:
         {{ expand_ansible_connection_attributes(manager['master']) | indent(8) }}
         private_ip:  {{ manager['master']['ip'] }}
-        public_ip: {{ manager['master']['public_ip'] }}
         {{ expand_custom_package('manager', manager['master']) | indent(8)  }}
         wazuh_manager_config:
           cluster:
@@ -276,12 +275,8 @@ agent:
       {{ expand_custom_package('agent', agent_value) | indent(6)  }}
       {{ expand_ansible_connection_attributes(agent_value) | indent(6) }}
       wazuh_managers:
-      {% if agent["architecture"] == "amd64" %}
-        - address: {{ agent_value['manager_ip'] }}
-      {% else %}
-        - address: {{ agent_value['manager_public_ip'] }}
-      {% endif %}
-      - port: 1514
+      - address: {{ agent_value['manager_ip'] }}
+        port: 1514
         protocol: tcp
         api_port: 55000
         api_proto: 'http'

--- a/provisioning/roles/wazuh/wazuh_environment/schema.j2
+++ b/provisioning/roles/wazuh/wazuh_environment/schema.j2
@@ -220,6 +220,7 @@ manager:
       master:
         {{ expand_ansible_connection_attributes(manager['master']) | indent(8) }}
         private_ip:  {{ manager['master']['ip'] }}
+        public_ip: {{ manager['master']['public_ip'] }}
         {{ expand_custom_package('manager', manager['master']) | indent(8)  }}
         wazuh_manager_config:
           cluster:
@@ -275,8 +276,12 @@ agent:
       {{ expand_custom_package('agent', agent_value) | indent(6)  }}
       {{ expand_ansible_connection_attributes(agent_value) | indent(6) }}
       wazuh_managers:
-      - address: {{ agent_value['manager_ip'] }}
-        port: 1514
+      {% if agent["architecture"] == "amd64" %}
+        - address: {{ agent_value['manager_ip'] }}
+      {% else %}
+        - address: {{ agent_value['manager_public_ip'] }}
+      {% endif %}
+      - port: 1514
         protocol: tcp
         api_port: 55000
         api_proto: 'http'


### PR DESCRIPTION
|Related issue|
|-------------|
|   https://github.com/wazuh/wazuh-jenkins/issues/5774        |

## Description

This PR aims to enhance the macOS ansible tasks for provisioning the enviroment with the Wazuh_QA_Enviroment pipeline.


<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Added new tasks to set up manager IP in agent, add local_internal_options, and start the agent.

---

## Testing performed

Tested using pipeline https://ci.wazuh.info/job/Wazuh_QA_environment/664/
