### PR TITLE
Add XFAIL mark to Cluster reliability logs test

### DIFF
--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/test_cluster_worker_logs_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/test_cluster_worker_logs_order.py
@@ -42,6 +42,8 @@ logs_order = {
 }
 
 
+@pytest.mark.xfail(reason="known cluster log issue due to cluster logging refactor "
+                          "to be worked in https://github.com/wazuh/wazuh/issues/20162")
 def test_check_logs_order_workers(artifacts_path):
     """Check that cluster logs appear in the expected order.
 


### PR DESCRIPTION
|Related issue|
|-------------|
|      #4701       |

## Description

Closes #4701. Adds the XFAIL mark to those tests that require it in `reliability/test_cluster/test_cluster_logs` due to the latest changes in the cluster logging in Wazuh `4.7.1`.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- `test_cluster_worker_logs_order.py`



## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @fdalmaup  (Developer)  |   `/test_cluster_worker_logs_order/test_cluster_worker_logs_order.py`      | ⚫⚫⚫ | :green_circle::green_circle: :green_circle:   |    Ubuntu 22.04     |  `2b8270f7425f176c23e8dad0aa58e7d1f3f0d86b`       | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
