### PR TITLE
Add an IT to check that the agent erases its wazuh-agent.state file

### DIFF
--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -183,6 +183,25 @@ def test_agentd_state(configure_environment, test_case):
         check_fields(expected_output)
 
 
+def test_state_delete(restart_wazuh_daemon_after_finishing):
+    '''
+    description: Check that the statistics file 'wazuh-agentd.state' is deleted automatically
+                 when the agent stops.
+
+    wazuh_min_version: 4.2.0
+
+    tier: 0
+
+    assertions:
+        - Verify that the 'wazuh-agentd.state' statistics file has been deleted.
+    '''
+
+    # Stop service
+    control_service('stop')
+
+    assert not os.path.exists(state_file_path)
+
+
 def parse_state_file():
     """Parse state file
 

--- a/tests/integration/test_agentd/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state.py
@@ -194,6 +194,10 @@ def test_state_delete(restart_wazuh_daemon_after_finishing):
 
     assertions:
         - Verify that the 'wazuh-agentd.state' statistics file has been deleted.
+    parameters:
+        - restart_wazuh_daemon_after_finishing:
+            type: fixture
+            brief: Restart wazuh modules after finishing the test module.
     '''
 
     # Stop service


### PR DESCRIPTION
|Related issue|Related PR|
|-------------|--|
| https://github.com/wazuh/wazuh/issues/16253 |https://github.com/wazuh/wazuh/pull/20425|

## Description

The agent holds a file called wazuh-agent.state containing data related to the connection. We expect this file to disappear at the agent's stop.

This PR aims to fix this behavior in the Windows agent, that was not deleting the file properly.

<!-- Added functionalities or files. Remove if not applicable -->
### Added

- `test_state_delete` at `test_agent_delete`.

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|:-------:|:------:|-----|--------|----------------------|
| @vikman90 (Developer)  |  `test_agent_delete/test_state_delete`       |   | 🟢 |   Windows 11      |   84a6353503      | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |


<details><summary>Test output</summary>

```
================================================= test session starts =================================================
platform win32 -- Python 3.11.6, pytest-7.1.2, pluggy-1.2.0
rootdir: D:\Vikman\Desktop\wazuh-qa-4.7.1\tests\integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0, testinfra-8.1.0
collected 4 items / 3 deselected / 1 selected

test_agentd_state.py .                                                                                           [100%]

================================================== warnings summary ===================================================
C:\Users\Vikman\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\certifi\core.py:36
  C:\Users\Vikman\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\certifi\core.py:36: DeprecationWarning: path is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    _CACERT_CTX = get_path("certifi", "cacert.pem")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================== 1 passed, 3 deselected, 1 warning in 0.81s ======================================
```

</details>