### PR TITLE
fix: remove deprecated message

### DIFF
--- a/tests/system/test_cluster/test_agent_files_deletion/data/messages.yml
+++ b/tests/system/test_cluster/test_agent_files_deletion/data/messages.yml
@@ -1,8 +1,5 @@
 ---
 wazuh-worker2:
-  - regex: '.*Received.*shared files to update from .*'
-    path: "/var/ossec/logs/cluster.log"
-    timeout: 60
   - regex: '.*Worker wazuh-worker2.*Integrity sync.*Finished in.*'
     path: "/var/ossec/logs/cluster.log"
     timeout: 60


### PR DESCRIPTION
|Related issue|
|-------------|
| #4735    |

## Description

After 4.7.0 an expected message was deprecated, causing `test_cluster/test_agent_files_deletion/test_agent_files_deletion.py` test to fail. This issue removes the deprecated message.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Updated `test_cluster/test_agent_files_deletion/test_agent_files_deletion.py` expected messages

---

## Testing performed

```
# python3 -m pytest test_agent_files_deletion/test_agent_files_deletion.py --html=/home/deblintrake/Documents/Vagrant/test.html
====================================== test session starts ======================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.3.0
rootdir: /home/deblintrake/Documents/Vagrant/wazuh-qa/tests/system, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-3.0.0, html-3.1.1
collected 1 item                                                                                

test_agent_files_deletion/test_agent_files_deletion.py .                                  [100%]

----------- generated html file: file:///home/deblintrake/Documents/Vagrant/test.html -----------
================================= 1 passed in 272.26s (0:04:32) =================================


# python3 -m pytest test_agent_files_deletion/test_agent_files_deletion.py --html=/home/deblintrake/Documents/Vagrant/test2.html
====================================== test session starts ======================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.3.0
rootdir: /home/deblintrake/Documents/Vagrant/wazuh-qa/tests/system, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-3.0.0, html-3.1.1
collected 1 item                                                                                

test_agent_files_deletion/test_agent_files_deletion.py .                                  [100%]

---------- generated html file: file:///home/deblintrake/Documents/Vagrant/test2.html -----------
================================= 1 passed in 279.19s (0:04:39) =================================


# python3 -m pytest test_agent_files_deletion/test_agent_files_deletion.py --html=/home/deblintrake/Documents/Vagrant/test3.html
====================================== test session starts ======================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.3.0
rootdir: /home/deblintrake/Documents/Vagrant/wazuh-qa/tests/system, configfile: pytest.ini
plugins: testinfra-5.0.0, metadata-3.0.0, html-3.1.1
collected 1 item                                                                                

test_agent_files_deletion/test_agent_files_deletion.py .                                  [100%]

---------- generated html file: file:///home/deblintrake/Documents/Vagrant/test3.html -----------
================================= 1 passed in 218.19s (0:03:38) =================================
```