### PR TITLE
fix control_service error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Enhance control_service error handling on windows agents. ([#4733](https://github.com/wazuh/wazuh-qa/pull/4733)) \- (Framework)
 - Add XFAIL mark to Cluster reliability logs test. ([#4706](https://github.com/wazuh/wazuh-qa/pull/4706)) \- (Tests)
 
 ## [4.7.0] - TBD

--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -89,14 +89,18 @@ def control_service(action, daemon=None, debug_mode=False):
                 command = subprocess.run(["net", action, "WazuhSvc"], stderr=subprocess.PIPE)
                 result = command.returncode
                 if result != 0:
-                    if action == 'stop' and 'The Wazuh service is not started.' in command.stderr.decode():
+                    error = command.stderr.decode()
+                    if 'The service is starting or stopping' in error:
+                        time.sleep(1)
+                        continue
+                    if action == 'stop' and 'The Wazuh service is not started.' in error:
                         result = 0
                         break
-                    if action == 'start' and 'The requested service has already been started.' \
-                       in command.stderr.decode():
+                    if action == 'start' and 'The requested service has already been started.' in error:
                         result = 0
                         break
-                    elif "System error 109 has occurred" not in command.stderr.decode():
+                    elif "System error 109 has occurred" not in error:
+                        print(f"Unexpected error when control_service failed with the following error: {error}")
                         break
     else:  # Default Unix
         if daemon is None:


### PR DESCRIPTION
|Related issue|
|-------------|
| closes #4733              |

## Description
This PR enhances `control_service` function error handling on windows agents and prints the error in case an unexpected error is presented and the agent cannot be stopped or started.

### Updated

- `wazuh_testing.tools.services.py`


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  |           | [:green_circle:](https://ci.wazuh.info/job/Test_integration/45170/)  | ⚫⚫⚫ |         |         | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |
