### PR TITLE
Update APT repository update before installing E2E ubuntu agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Include ATP repository update before the installation of Ubuntu E2E agent installation ([#4761](https://github.com/wazuh/wazuh-qa/pull/4761)) \- (Framework)
 - Enhance macOS deployment ansible taks ([#4685](https://github.com/wazuh/wazuh-qa/pull/4685)) \- (Framework)
 - Updated Filebeat module to 0.3 ([#4700](https://github.com/wazuh/wazuh-qa/pull/4700)) \- (Framework)
 - Change database v13 to v12. ([#4677](https://github.com/wazuh/wazuh-qa/pull/4677)) \- (Tests)

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/Debian.yml
@@ -8,6 +8,12 @@
   register: wazuh_agent_ca_package_install
   until: wazuh_agent_ca_package_install is succeeded
 
+- name: Update apt-get repo and cache
+  apt:
+    update_cache: yes
+    force_apt_get: yes
+    cache_valid_time: 3600
+
 - name: Debian/Ubuntu | Install apt-transport-https and acl
   apt:
     name:


### PR DESCRIPTION
|Related issue|
|-------------|
|      #4760       |

## Description

This PR includes a APT update task in the Ubuntu/Debian installation playbook in order to troubleshoot reported error during the installation of dependencies

### Updated

- Include ATP repository update before the installation of Ubuntu E2E agent installation


### Testing

**Build**:  https://ci.wazuh.info/job/Test_e2e_system/210/

> [!NOTE]
> Failure of the tests is not related with the development