### PR TITLE
Fixed IT control_service Windows loop

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/services.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/services.py
@@ -88,7 +88,9 @@ def control_service(action, daemon=None, debug_mode=False):
             for _ in range(error_109_windows_retry):
                 command = subprocess.run(["net", action, "WazuhSvc"], stderr=subprocess.PIPE)
                 result = command.returncode
-                if result != 0:
+                if result == 0:
+                    break
+                else:
                     if action == 'stop' and 'The Wazuh service is not started.' in command.stderr.decode():
                         result = 0
                         break


### PR DESCRIPTION
|Related issue|
|-------------|
|Closes #4758|

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This pull request corrects a condition that did not include the successful return code, causing multiple executions of the net command in Windows and causing the integration test to fail on certain occasions.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- Fixed conditional to avoid unnecessary loops and run the same command multiple times

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @raulpm (Developer)  | test_active_response/          | :green_circle:  | :green_circle: | Windows 2016  |  ba3e41e4495199cf4dd731fa501090ac4b10ef31       | Nothing to highlight |
| @user (Reviewer)   |           | ⚫⚫⚫ | :no_entry_sign: :no_entry_sign: :no_entry_sign:  |        |         | Nothing to highlight |

- Jenkins test: https://ci.wazuh.info/job/Test_integration/45412
- Local test: Added print command to check the iteractions

<details><summary>Local test</summary>

```
PS C:\tmp\Test_integration_B45414_20231212181558\tests\integration> pytest .\test_active_response\ -sv
====================================================== test session starts =======================================================
platform win32 -- Python 3.11.4, pytest-7.1.2, pluggy-1.3.0 -- C:\Python311\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.11.4', 'Platform': 'Windows-10-10.0.14393-SP0', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugi
s': {'html': '3.1.1', 'metadata': '3.0.0', 'testinfra': '5.0.0'}}
rootdir: C:\tmp\Test_integration_B45414_20231212181558\tests\integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0, testinfra-5.0.0
collected 14 items / 12 deselected / 2 selected

test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration0] stop

The Wazuh service was stopped successfully.


Result

0

Iteraction

0
2023/12/12 17:43:33 agent-auth: INFO: Started (pid: 6404).
2023/12/12 17:43:33 agent-auth: INFO: Requesting a key from server: 127.0.0.1
2023/12/12 17:43:33 agent-auth: INFO: No authentication password provided
2023/12/12 17:43:33 agent-auth: INFO: Using agent name as: EC2AMAZ-NRK2S46
2023/12/12 17:43:33 agent-auth: INFO: Waiting for server reply
2023/12/12 17:43:33 agent-auth: INFO: Valid key received
start
The Wazuh service is starting.
The Wazuh service was started successfully.


Result

0

Iteraction

0
PASSED
test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration1]
Tuesday, December 12, 2023 5:43:37 PM


stop

The Wazuh service was stopped successfully.


Result

0

Iteraction

0
start
The Wazuh service is starting.
The Wazuh service was started successfully.


Result

0

Iteraction

0
stop
The Wazuh service is stopping.
The Wazuh service was stopped successfully.


Result

0

Iteraction

0
2023/12/12 17:43:45 agent-auth: INFO: Started (pid: 5004).
2023/12/12 17:43:45 agent-auth: INFO: Requesting a key from server: 127.0.0.1
2023/12/12 17:43:45 agent-auth: INFO: No authentication password provided
2023/12/12 17:43:45 agent-auth: INFO: Using agent name as: EC2AMAZ-NRK2S46
2023/12/12 17:43:45 agent-auth: INFO: Waiting for server reply
2023/12/12 17:43:45 agent-auth: INFO: Valid key received
start
The Wazuh service is starting.
The Wazuh service was started successfully.


Result

0

Iteraction

0
PASSED
Tuesday, December 12, 2023 5:43:50 PM


stop

The Wazuh service was stopped successfully.


Result

0

Iteraction

0
start
The Wazuh service is starting.
The Wazuh service was started successfully.


Result

0

Iteraction

0


======================================================== warnings summary ========================================================
test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration0]
test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration1]
  C:\Python311\Lib\site-packages\wazuh_testing\tools\remoted_sim.py:108: DeprecationWarning: setName() is deprecated, set the name
attribute instead
    self.listener_thread.setName('listener_thread')

test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration0]
test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration1]
  C:\Python311\Lib\site-packages\wazuh_testing\tools\monitoring.py:594: DeprecationWarning: ssl.wrap_socket() is deprecated, use S
LContext.wrap_socket()
    connstream = ssl.wrap_socket(newsocket,

test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration0]
test_active_response/test_execd/test_execd_restart.py::test_execd_restart[get_configuration1]
  C:\Python311\Lib\ssl.py:1438: DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated
    context = SSLContext(ssl_version)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================= 2 passed, 12 deselected, 6 warnings in 21.12s ==========================================
```

</details>