### PR TITLE
Eliminate Redundant Tasks in Wazuh Agent Provisioning Role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix macOS agents provision to enable registration and connection with managers. ([#4770](https://github.com/wazuh/wazuh-qa/pull/4770/)) \- (Framework)
 - Fix hardcoded python interpreter in qa_framework role. ([#4658](https://github.com/wazuh/wazuh-qa/pull/4658)) \- (Framework)
 - Fix duplicated jq dependency ([#4678](https://github.com/wazuh/wazuh-qa/pull/4678)) \- (Framework)
 

--- a/provisioning/playbooks/wazuh_environment.yaml
+++ b/provisioning/playbooks/wazuh_environment.yaml
@@ -59,8 +59,5 @@
     - name: Agents
       block:
         - name: Install UNIX based agents
-          become: true
-          become_user: root
           import_role:
             name: "../roles/wazuh/ansible-wazuh-agent"
-          when: ansible_os_family != "Windows"

--- a/provisioning/playbooks/wazuh_environment.yaml
+++ b/provisioning/playbooks/wazuh_environment.yaml
@@ -64,8 +64,3 @@
           import_role:
             name: "../roles/wazuh/ansible-wazuh-agent"
           when: ansible_os_family != "Windows"
-
-        - name: Install Windows based agents
-          import_role:
-            name: "../roles/wazuh/ansible-wazuh-agent"
-          when: ansible_os_family == "Windows"

--- a/provisioning/playbooks/wazuh_environment.yaml
+++ b/provisioning/playbooks/wazuh_environment.yaml
@@ -53,11 +53,8 @@
         username: wazuh
         password: wazuh
 
-# Agent
 - hosts: agent
-  tasks:
-    - name: Agents
-      block:
-        - name: Install UNIX based agents
-          import_role:
-            name: "../roles/wazuh/ansible-wazuh-agent"
+  roles:
+    - role: "../roles/wazuh/ansible-wazuh-agent"
+      become: "{{ ansible_os_family != 'Windows' }}"
+      become_user: root

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/handlers/main.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/handlers/main.yml
@@ -4,3 +4,6 @@
 
 - name: Windows | Restart Wazuh Agent
   win_service: name=WazuhSvc start_mode=auto state=restarted
+
+- name: macOS | Restart Wazuh Agent
+  command: /Library/Ossec/bin/wazuh-control restart

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/MacOS.yml
@@ -14,7 +14,7 @@
     owner: root
     group: wazuh
     mode: 0644
-  notify: restart wazuh-agent
+  notify: macOS | Restart Wazuh Agent
   tags:
     - init
     - config
@@ -33,7 +33,7 @@
     owner: root
     group: wazuh
     mode: 0640
-  notify: restart wazuh-agent
+  notify: macOS | Restart Wazuh Agent
   tags:
     - init
     - config

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -22,10 +22,13 @@
   when: ansible_os_family == "Windows"
 
 - include_tasks: "Linux.yml"
+  become: true
   when: ansible_system == "Linux"
 
 - include_tasks: "MacOS.yml"
+  become: true
   when: ansible_system == "Darwin"
 
 - include_tasks: "Solaris.yml"
+  become: true
   when: ansible_os_family == "Solaris"

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/main.yml
@@ -22,13 +22,10 @@
   when: ansible_os_family == "Windows"
 
 - include_tasks: "Linux.yml"
-  become: true
   when: ansible_system == "Linux"
 
 - include_tasks: "MacOS.yml"
-  become: true
   when: ansible_system == "Darwin"
 
 - include_tasks: "Solaris.yml"
-  become: true
   when: ansible_os_family == "Solaris"


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-jenkins/issues/6067        |

## Description

The current state of the Wazuh-agents provisioning is afflicted by a bug where tasks related to the agent role are executed twice. This redundancy is specifically impacting macOS agents, rendering them unconnected.


### Updated

- Removed duplication in Wazuh agents provisioning role



## Testing performed

**Build**:  https://ci.wazuh.info/job/Wazuh_QA_environment/829/
**Agent Control**:
```
root@ip-172-31-8-14:/home/qa# /var/ossec/bin/agent_control -l

Wazuh agent_control. List of available agents:

   ID: 000, Name: ip-172-31-8-14 (server), IP: 127.0.0.1, Active/Local
   ID: 001, Name: ip-172-31-10-99, IP: any, Active
   ID: 002, Name: ip-172-31-6-36, IP: any, Active
   ID: 003, Name: ip-172-31-7-119.ec2.internal, IP: any, Active
   ID: 004, Name: ip-172-31-12-118.ec2.internal, IP: any, Active
   ID: 005, Name: DESKTOP-AQ2R8SM, IP: any, Active
   ID: 006, Name: macos-1200, IP: any, Active
```