### PR TITLE
Fix handling of one_manager_agent_env pytest marker in System tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Fix one_manager_agent_env pytest marker for System Tests ([#4763](https://github.com/wazuh/wazuh-qa/pull/4763)) \- (Tests)
 - Enhance macOS deployment ansible taks ([#4685](https://github.com/wazuh/wazuh-qa/pull/4685)) \- (Framework)
 - Updated Filebeat module to 0.3 ([#4700](https://github.com/wazuh/wazuh-qa/pull/4700)) \- (Framework)
 - Change database v13 to v12. ([#4677](https://github.com/wazuh/wazuh-qa/pull/4677)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Fix one_manager_agent_env pytest marker for System Tests ([#4763](https://github.com/wazuh/wazuh-qa/pull/4763)) \- (Tests)
+- Fix one_manager_agent_env pytest marker for System Tests ([#4782](https://github.com/wazuh/wazuh-qa/pull/4782)) \- (Tests)
 - Enhance macOS deployment ansible taks ([#4685](https://github.com/wazuh/wazuh-qa/pull/4685)) \- (Framework)
 - Updated Filebeat module to 0.3 ([#4700](https://github.com/wazuh/wazuh-qa/pull/4700)) \- (Framework)
 - Change database v13 to v12. ([#4677](https://github.com/wazuh/wazuh-qa/pull/4677)) \- (Tests)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -126,7 +126,7 @@ def pytest_runtest_makereport(item, call):
                 arguments[key] = str(value)
         extra.append(pytest_html.extras.json(arguments, name="Test arguments"))
 
-        if "cluster" in report.markers and "one_manager_agent_env" not in report.markers:
+        if "cluster" in report.markers:
             host_manager = getattr(item.module, "host_manager")
 
             for host in host_manager.get_inventory()['managers']['hosts']:

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -126,7 +126,7 @@ def pytest_runtest_makereport(item, call):
                 arguments[key] = str(value)
         extra.append(pytest_html.extras.json(arguments, name="Test arguments"))
 
-        if "cluster" in report.markers:
+        if "cluster" in report.markers and "one_manager_agent_env" not in report.markers:
             host_manager = getattr(item.module, "host_manager")
 
             for host in host_manager.get_inventory()['managers']['hosts']:

--- a/tests/system/test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py
+++ b/tests/system/test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py
@@ -35,7 +35,7 @@ from wazuh_testing.tools.file import replace_regex_in_file
 from system import (assign_agent_to_new_group, clean_cluster_logs, create_new_agent_group, delete_agent_group,
                     restart_cluster)
 
-pytestmark = [pytest.mark.cluster, pytest.mark.one_manager_agent_env]
+pytestmark = [pytest.mark.one_manager_agent_env]
 
 agent_conf_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                '..', 'provisioning', 'one_manager_agent', 'roles', 'agent-role', 'files', 'ossec.conf')


### PR DESCRIPTION
|Related issue|
|-------------|
| closes #4763             |

## Description

This PR fixes the system tests so that it generates reports correctly when the test has the `cluster` and `one_manager_agent_env` markers.

<!-- Changes made to existing functionality or files. Remove if not applicable -->
### Updated

- tests/system/conftest.py


## Testing performed

- executed tests with marker command `# python3 -m pytest -m one_manager_agent_env -vvv --html=/home/qa/one_manager_agent.html`


```
# python3 -m pytest -m one_manager_agent_env -vvv --html=/home/qa/one_manager_agent.html
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.3.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.6-76060606-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.3.0'}, 'Plugins': {'html': '3.1.1', 'testinfra': '5.0.0', 'metadata': '3.0.0'}}
rootdir: /home/qa/Descargas/wazuh-qa/tests/system, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-3.0.0
collected 192 items / 165 deselected / 27 selected                                                                                                                                                         

test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[merged_created_on_start] PASSED                                         [  3%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[merged_updated_10_sec] PASSED                                           [  7%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_non_zero_file_default_folder_check_merged_created_starts] PASSED    [ 11%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_zero_file_default_folder_check_merged_created_starts] PASSED        [ 14%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_non_zero_size_file_default_folder_check_merged_updated_10_sec0] PASSED [ 18%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_non_zero_size_file_TestGroup1_folder_check_merged_updated_manager_starts] PASSED [ 22%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_non_zero_size_file_TestGroup1_folder_check_merged_updated_10_sec] PASSED [ 25%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_non_zero_size_file_default_folder_check_merged_updated_10_sec1] PASSED [ 29%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_zero_size_file_TestGroup1_folder_check_merged_updated_manager_starts] PASSED [ 33%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_zero_size_file_TestGroup1_folder_check_merged_updated_10_sec] PASSED [ 37%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_serveral_zero_size_file_default_folder_check_merged_updated_manager_starts] PASSED [ 40%]
test_cluster/test_correct_merged_file_generation/test_correct_merged_file_generation.py::test_correct_merged_file_generation[add_serveral_zero_size_file_TestGroup1_folder_check_merged_updated_manager_start] PASSED [ 44%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir1-add] PASSED                                                                                                                            [ 48%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir1-modify] PASSED                                                                                                                         [ 51%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir1-delete] PASSED                                                                                                                         [ 55%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir2-add] PASSED                                                                                                                            [ 59%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir2-modify] PASSED                                                                                                                         [ 62%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir2-delete] PASSED                                                                                                                         [ 66%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir3-add] PASSED                                                                                                                            [ 70%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir3-modify] PASSED                                                                                                                         [ 74%]
test_fim/test_files/test_files_cud.py::test_file_cud[testdir3-delete] PASSED                                                                                                                         [ 77%]
test_fim/test_synchronization/test_synchronization.py::test_synchronization[testdir1-add-wazuh-agent1] PASSED                                                                                        [ 81%]
test_fim/test_synchronization/test_synchronization.py::test_synchronization[testdir1-add-wazuh-manager] PASSED                                                                                       [ 85%]
test_fim/test_synchronization/test_synchronization.py::test_synchronization[testdir1-modify-wazuh-agent1] PASSED                                                                                     [ 88%]
test_fim/test_synchronization/test_synchronization.py::test_synchronization[testdir1-modify-wazuh-manager] PASSED                                                                                    [ 92%]
test_fim/test_synchronization/test_synchronization.py::test_synchronization[testdir1-delete-wazuh-agent1] PASSED                                                                                     [ 96%]
test_fim/test_synchronization/test_synchronization.py::test_synchronization[testdir1-delete-wazuh-manager] PASSED                                                                                    [100%]
----------------------------------------------------------------------- generated html file: file:///home/qa/one_manager_agent.html ------------------------------------------------------------------------
======================================================================= 27 passed, 165 deselected, 5 warnings in 1750.91s (0:29:10) ========================================================================
```

| Tester             | Test path |  Local  | OS | Commit | Notes                |
|--------------------|-----------|--------|-----|--------|----------------------|
| @Deblintrake09  (Developer)  |   tests/system/        | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/13717053/one_manager_agent1.zip) | Ubuntu     | a8b0ed9d281001a31ef827afbafe206a5745ccb0        | Nothing to highlight |
| @pro-akim (Reviewer)   |           | [:green_circle:](https://github.com/wazuh/wazuh-qa/files/13726489/report_one_manager_agent.zip) ⚫⚫ |        |         | Nothing to highlight |



