### PR TITLE
Fix body format for `get_api_token`

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -216,7 +216,8 @@ class HostManager:
         login_body = ''
         if auth_context is not None:
             login_endpoint = '/security/user/authenticate/run_as'
-            login_body = 'body="{}"'.format(json.dumps(auth_context).replace('"', '\\"').replace(' ', ''))
+            login_body = 'body="{}" body_format="json"'.format(
+                json.dumps(auth_context).replace('"', '\\"').replace(' ', ''))
 
         try:
             token_response = self.get_host(host).ansible('uri', f"url=https://localhost:{port}{login_endpoint} "


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh/issues/20947       |

## Description

Fixes the request format of the `POST /security/user/authenticate/run_as` body inside the `get_api_token` test function.