### PR TITLE
Remove configobj library from requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Removed configobj library from requirements.txt ([#4803](https://github.com/wazuh/wazuh-qa/pull/4803)) \- (Framework)
 - Fix one_manager_agent_env pytest marker for System Tests ([#4782](https://github.com/wazuh/wazuh-qa/pull/4782)) \- (Tests)
 - Updated Filebeat module to 0.4 ([#4775](https://github.com/wazuh/wazuh-qa/pull/4775)) \- (Framework)
 - Include ATP repository update before the installation of Ubuntu E2E agent installation ([#4761](https://github.com/wazuh/wazuh-qa/pull/4761)) \- (Framework)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-configobj==5.0.6
 certifi>=2022.12.7
 cffi>=1.14.0; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'
 cycler>=0.10; platform_system == "Linux" or platform_system == "Darwin" or platform_system=='Windows'


### PR DESCRIPTION
|Related issue|
|-------------|
|  #4632        |

## Description

This PR removes the configob library from requirements.txt. This library contains a vulnerability but is not being used,  in this repository by any test module. It is not used by any wazuh-jenkins pipeline either, so it is is not a dependency for that repository.


<!-- Functionalities or files that have been deleted. Remove if not applicable -->
### Deleted

- Removed `configobj` library from requirements.txt