### PR TITLE
Update Agent Simulator Syscollector format messages

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/data/syscollector.py
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector.py
@@ -1,3 +1,5 @@
+# Legacy Syscollector Templates
+
 LEGACY_SYSCOLLECTOR_HEADER = '{"type":"<syscollector_type>",' \
                       '"ID":<random_int>,"timestamp":"<timestamp>"'
 
@@ -40,142 +42,141 @@ LEGACY_SYSCOLLECTOR_NETWORK_EVENT_TEMPLATE = ',"iface":{"name":"<random_string>"
                                       '"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],' \
                                       '"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}'
 
-LEGACY_SYSCOLLECTOR_PORT_EVENT_TEMPLATE = ',"port":{"protocol":"tcp","local_ip":"0.0.0.0",' \
+LEGACY_SYSCOLLECTOR_PORTS_EVENT_TEMPLATE = ',"port":{"protocol":"tcp","local_ip":"0.0.0.0",' \
                                    '"local_port":<random_int>,"remote_ip":"0.0.0.0",' \
                                    '"remote_port":0,"tx_queue":0,' \
                                    '"rx_queue":0,"inode":22273,"state":"listening"}}'
-1
+
 LEGACY_SYSCOLLECTOR_HOTFIX_EVENT_TEMPLATE = ',"hotfix":"<random_string>"}'
 
 
-
-
+# Delta Templates
 
 SYSCOLLECTOR_PACKAGE_DELTA_DATA_TEMPLATE = {
-        "architecture": "<package_architecture>",
-        "checksum":"<random_string>",
-        "description":"<package_description>",
-        "format":"<package_format>",
-        "groups":"editors",
-        "install_time":"<timestamp>",
-        "item_id":"<random_string>",
-        "location":" ",
-        "multiarch": "null",
-        "name":"<package_name>",
-        "priority":"optional",
-        "scan_time":"2023/12/19 15:32:25",
-        "size":"<random_int>",
-        "source":"<package_source>",
-        "vendor":"<package_vendor>",
-        "version":"<package_version>"
+        "architecture":  "<package_architecture>",
+        "checksum": "<random_string>",
+        "description": "<package_description>",
+        "format": "<package_format>",
+        "groups": "editors",
+        "install_time": "<timestamp>",
+        "item_id": "<random_string>",
+        "location": " ",
+        "multiarch":  "null",
+        "name": "<package_name>",
+        "priority": "optional",
+        "scan_time": "2023/12/19 15:32:25",
+        "size": "<random_int>",
+        "source": "<package_source>",
+        "vendor": "<package_vendor>",
+        "version": "<package_version>"
 }
 
 
 SYSCOLLECTOR_HOTFIX_DELTA_DATA_TEMPLATE = {
-        "checksum":"<random_string>",
-        "hotfix":"<random_string>",
-        "scan_time":"<timestamp>"
+        "checksum": "<random_string>",
+        "hotfix": "<random_string>",
+        "scan_time": "<timestamp>"
 }
 
 SYSCOLLECTOR_OSINFO_DELTA_EVENT_TEMPLATE = {
-        "checksum":"1634140017886803554",
-        "architecture":"x86_64",
-        "hostname":"<agent_name>",
-        "os_codename":"focal",
-        "os_major":"20",
-        "os_minor":"04",
-        "os_name":"Ubuntu",
-        "os_platform":"ubuntu",
-        "os_patch": "6",
-        "os_release":"sp1",
-        "os_version":"20.04.6 LTS (Focal Fossa)",
-        "os_build":"4.18.0-305.12.1.el8_4.x86_64",
-        "release":"6.2.6-76060206-generic",
-        "scan_time":"2023/12/20 11:24:58",
-        "sysname":"Linux",
-        "version":"#202303130630~1689015125~22.04~ab2190e SMP PREEMPT_DYNAMIC"
+        "checksum": "1634140017886803554",
+        "architecture": "x86_64",
+        "hostname": "<agent_name>",
+        "os_codename": "focal",
+        "os_major": "20",
+        "os_minor": "04",
+        "os_name": "Ubuntu",
+        "os_platform": "ubuntu",
+        "os_patch":  "6",
+        "os_release": "sp1",
+        "os_version": "20.04.6 LTS (Focal Fossa)",
+        "os_build": "4.18.0-305.12.1.el8_4.x86_64",
+        "release": "6.2.6-76060206-generic",
+        "scan_time": "2023/12/20 11:24:58",
+        "sysname": "Linux",
+        "version": "#202303130630~1689015125~22.04~ab2190e SMP PREEMPT_DYNAMIC"
 }
 
 SYSCOLLECTOR_PROCESSSES_DELTA_EVENT_TEMPLATE = {
-        "argvs":"<random_int",
-        "checksum":"<random_string>",
-        "euser":"<random_string>",
-        "fgroup":"<random_string>",
-        "name":"<random_string>",
-        "nice":"<random_int>",
-        "nlwp":"<random_int>",
-        "pgrp":"<random_int>",
-        "ppid":"<random_int>",
-        "priority":"<random_int>",
-        "processor":"<random_int>",
-        "resident":"<random_int>",
-        "rgroup":"<random_string>",
-        "scan_time":"<timestamp>",
-        "session":"<random_int>",
-        "sgroup":"<random_string>",
-        "share":"<random_int>",
-        "size":"<random_int>",
-        "start_time":"<random_int>",
-        "state":"S",
-        "stime":"<random_int>",
-        "suser":"<random_string>",
-        "tgid":"<random_int>",
-        "tty":"<random_int>",
-        "utime":"<random_int>",
-        "vm_size":"<random_int>",
-        "cmd":"",
-        "egroup":"<random_string>",
-        "ruser":"<random_string>"
+        "argvs": "<random_int",
+        "checksum": "<random_string>",
+        "euser": "<random_string>",
+        "fgroup": "<random_string>",
+        "name": "<random_string>",
+        "nice": "<random_int>",
+        "nlwp": "<random_int>",
+        "pgrp": "<random_int>",
+        "ppid": "<random_int>",
+        "priority": "<random_int>",
+        "processor": "<random_int>",
+        "resident": "<random_int>",
+        "rgroup": "<random_string>",
+        "scan_time": "<timestamp>",
+        "session": "<random_int>",
+        "sgroup": "<random_string>",
+        "share": "<random_int>",
+        "size": "<random_int>",
+        "start_time": "<random_int>",
+        "state": "S",
+        "stime": "<random_int>",
+        "suser": "<random_string>",
+        "tgid": "<random_int>",
+        "tty": "<random_int>",
+        "utime": "<random_int>",
+        "vm_size": "<random_int>",
+        "cmd": "",
+        "egroup": "<random_string>",
+        "ruser": "<random_string>"
 }
 
 SYSCOLLECTOR_PORTS_DELTA_EVENT_TEMPLATE = {
-        "checksum":"<random_string>",
-        "item_id":"<random_string>",
-        "local_ip":"0.0.0.0",
-        "local_port":"<random_int>",
-        "pid":"<random_int>",
-        "process":"NULL",
-        "protocol":"tcp",
-        "remote_ip":"0.0.0.0",
-        "remote_port":"<random_int>",
-        "rx_queue":"<random_int>",
-        "scan_time":"<timestamp>",
-        "state":"listening",
-        "tx_queue":"<random_int>"
+        "checksum": "<random_string>",
+        "item_id": "<random_string>",
+        "local_ip": "0.0.0.0",
+        "local_port": "<random_int>",
+        "pid": "<random_int>",
+        "process": "NULL",
+        "protocol": "tcp",
+        "remote_ip": "0.0.0.0",
+        "remote_port": "<random_int>",
+        "rx_queue": "<random_int>",
+        "scan_time": "<timestamp>",
+        "state": "listening",
+        "tx_queue": "<random_int>"
 }
 
 
 SYSCOLLECTOR_HWINFO_DELTA_EVENT_TEMPLATE = {
-        "scan_time":"<timestamp>",
-        "board_serial":"<random_string>",
-        "checksum":"<random_string>",
-        "cpu_mhz":"<random_int>",
-        "cpu_cores":"<random_int>",
-        "cpu_name":"<random_string>",
-        "ram_free":"<random_int>",
-        "ram_total":"<random_int>",
-        "ram_usage":"<random_int>"
+        "scan_time": "<timestamp>",
+        "board_serial": "<random_string>",
+        "checksum": "<random_string>",
+        "cpu_mhz": "<random_int>",
+        "cpu_cores": "<random_int>",
+        "cpu_name": "<random_string>",
+        "ram_free": "<random_int>",
+        "ram_total": "<random_int>",
+        "ram_usage": "<random_int>"
 }
 
 
 SYSCOLLECTOR_NETWORK_IFACE_DELTA_EVENT_TEMPLATE = {
         "adapter": None,
-        "checksum":"<random_int>",
-        "item_id":"<random_int>",
-        "mac":"<random_int>",
-        "mtu":"<random_int>",
-        "name":"<random_int>",
-        "rx_bytes":"<random_int>",
-        "rx_dropped":"<random_int>",
-        "rx_errors":"<random_int>",
-        "rx_packets":"<random_int>",
-        "scan_time":"<timestamp>",
-        "state":"<random_int>",
-        "tx_bytes":"<random_int>",
-        "tx_dropped":"<random_int>",
-        "tx_errors":"<random_int>",
-        "tx_packets":"<random_int>",
-        "type":"<random_int>"
+        "checksum": "<random_int>",
+        "item_id": "<random_int>",
+        "mac": "<random_int>",
+        "mtu": "<random_int>",
+        "name": "<random_int>",
+        "rx_bytes": "<random_int>",
+        "rx_dropped": "<random_int>",
+        "rx_errors": "<random_int>",
+        "rx_packets": "<random_int>",
+        "scan_time": "<timestamp>",
+        "state": "<random_int>",
+        "tx_bytes": "<random_int>",
+        "tx_dropped": "<random_int>",
+        "tx_errors": "<random_int>",
+        "tx_packets": "<random_int>",
+        "type": "<random_int>"
 }
 
 

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector.py
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector.py
@@ -71,7 +71,6 @@ SYSCOLLECTOR_PACKAGE_DELTA_DATA_TEMPLATE = {
         "version": "<package_version>"
 }
 
-
 SYSCOLLECTOR_HOTFIX_DELTA_DATA_TEMPLATE = {
         "checksum": "<random_string>",
         "hotfix": "<random_string>",
@@ -145,7 +144,6 @@ SYSCOLLECTOR_PORTS_DELTA_EVENT_TEMPLATE = {
         "tx_queue": "<random_int>"
 }
 
-
 SYSCOLLECTOR_HWINFO_DELTA_EVENT_TEMPLATE = {
         "scan_time": "<timestamp>",
         "board_serial": "<random_string>",
@@ -157,7 +155,6 @@ SYSCOLLECTOR_HWINFO_DELTA_EVENT_TEMPLATE = {
         "ram_total": "<random_int>",
         "ram_usage": "<random_int>"
 }
-
 
 SYSCOLLECTOR_NETWORK_IFACE_DELTA_EVENT_TEMPLATE = {
         "adapter": None,
@@ -179,7 +176,6 @@ SYSCOLLECTOR_NETWORK_IFACE_DELTA_EVENT_TEMPLATE = {
         "type": "<random_int>"
 }
 
-
 SYSCOLLECTOR_NETWORK_NETADDR_DELTA_EVENT_TEMPLATE = {
     "id": "<random_int>",
     "scan_id": "<random_int>",
@@ -190,7 +186,6 @@ SYSCOLLECTOR_NETWORK_NETADDR_DELTA_EVENT_TEMPLATE = {
     "checksum": "<random_string",
     "item_id": "<random_string>"
 }
-
 
 SYSCOLLECTOR_NETWORK_NETPRO_DELTA_EVENT_TEMPLATE = {
     "id": "<random_int>",

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector.py
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector.py
@@ -159,7 +159,7 @@ SYSCOLLECTOR_HWINFO_DELTA_EVENT_TEMPLATE = {
 
 
 SYSCOLLECTOR_NETWORK_IFACE_DELTA_EVENT_TEMPLATE = {
-        "adapter":"null",
+        "adapter": None,
         "checksum":"<random_int>",
         "item_id":"<random_int>",
         "mac":"<random_int>",

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector.py
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector.py
@@ -1,25 +1,25 @@
-SYSCOLLECTOR_HEADER = '{"type":"<syscollector_type>",' \
+LEGACY_SYSCOLLECTOR_HEADER = '{"type":"<syscollector_type>",' \
                       '"ID":<random_int>,"timestamp":"<timestamp>"'
 
-SYSCOLLECTOR_OS_EVENT_TEMPLATE = ',"inventory":{"os_name":"<random_string>",' \
+LEGACY_SYSCOLLECTOR_OS_EVENT_TEMPLATE = ',"inventory":{"os_name":"<random_string>",' \
                                  '"os_major":"8","os_minor":"3","os_version":"8.3",' \
                                  '"os_platform":"centos","sysname":"Linux",' \
                                  '"hostname":"centos3","release":"4.18.0-240.1.1.el8_3.x86_64",' \
                                  '"version":"#1 SMP Thu Nov 19 17:20:08 UTC 2020","architecture":"x86_64"}}'
 
-SYSCOLLECTOR_HARDWARE_EVENT_TEMPLATE = ',"inventory":{"board_serial":"0",' \
+LEGACY_SYSCOLLECTOR_HARDWARE_EVENT_TEMPLATE = ',"inventory":{"board_serial":"0",' \
                                        '"cpu_name":"AMD Ryzen 7 3750H with Radeon Vega Mobile Gfx",' \
                                        '"cpu_cores":<random_int>,"cpu_MHz":2295.686,"ram_total":828084,' \
                                        '"ram_free":60488,"ram_usage":93}}'
 
-SYSCOLLECTOR_PACKAGES_EVENT_TEMPLATE = ',"program":{"format":"rpm","name":"<random_string>",' \
+LEGACY_SYSCOLLECTOR_PACKAGES_EVENT_TEMPLATE = ',"program":{"format":"rpm","name":"<random_string>",' \
                                        '"description":"JSON::XS compatible pure-Perl module",' \
                                        '"size":126,"vendor":"CentOS","group":"Unspecified",' \
                                        '"architecture":"noarch","source":"perl-JSON-PP-2.97.001-3.el8.src.rpm",' \
                                        '"install_time":"2021/03/12 12:23:17"' \
                                        ',"version":"1:2.97.001-3.el8"}}'
 
-SYSCOLLECTOR_PROCESS_EVENT_TEMPLATE = ',"process":{"pid":3150,"name":"<random_string>","state":"R",' \
+LEGACY_SYSCOLLECTOR_PROCESS_EVENT_TEMPLATE = ',"process":{"pid":3150,"name":"<random_string>","state":"R",' \
                                       '"ppid":2965,"utime":58,' \
                                       '"stime":2,"cmd":"rpm","argvs":["-qa","xorg-x11*"],' \
                                       '"euser":"root","ruser":"root","suser":"root","egroup":"ossec",' \
@@ -31,7 +31,7 @@ SYSCOLLECTOR_PROCESS_EVENT_TEMPLATE = ',"process":{"pid":3150,"name":"<random_st
                                       '"session":3150,"nlwp":1,' \
                                       '"tgid":3150,"tty":0,"processor":0}}'
 
-SYSCOLLECTOR_NETWORK_EVENT_TEMPLATE = ',"iface":{"name":"<random_string>","type":"ethernet","state":"up",' \
+LEGACY_SYSCOLLECTOR_NETWORK_EVENT_TEMPLATE = ',"iface":{"name":"<random_string>","type":"ethernet","state":"up",' \
                                       '"MAC":"08:00:27:be:ce:3a","tx_packets":2135,' \
                                       '"rx_packets":9091,"tx_bytes":210748,' \
                                       '"rx_bytes":10134272,"tx_errors":0,' \
@@ -40,9 +40,164 @@ SYSCOLLECTOR_NETWORK_EVENT_TEMPLATE = ',"iface":{"name":"<random_string>","type"
                                       '"netmask":["255.255.255.0"],"broadcast":["10.0.2.255"],' \
                                       '"metric":100,"gateway":"10.0.2.2","DHCP":"enabled"}}}'
 
-SYSCOLLECTOR_PORT_EVENT_TEMPLATE = ',"port":{"protocol":"tcp","local_ip":"0.0.0.0",' \
+LEGACY_SYSCOLLECTOR_PORT_EVENT_TEMPLATE = ',"port":{"protocol":"tcp","local_ip":"0.0.0.0",' \
                                    '"local_port":<random_int>,"remote_ip":"0.0.0.0",' \
                                    '"remote_port":0,"tx_queue":0,' \
                                    '"rx_queue":0,"inode":22273,"state":"listening"}}'
+1
+LEGACY_SYSCOLLECTOR_HOTFIX_EVENT_TEMPLATE = ',"hotfix":"<random_string>"}'
 
-SYSCOLLECTOR_HOTFIX_EVENT_TEMPLATE = ',"hotfix":"<random_string>"}'
+
+
+
+
+SYSCOLLECTOR_PACKAGE_DELTA_DATA_TEMPLATE = {
+        "architecture": "<package_architecture>",
+        "checksum":"<random_string>",
+        "description":"<package_description>",
+        "format":"<package_format>",
+        "groups":"editors",
+        "install_time":"<timestamp>",
+        "item_id":"<random_string>",
+        "location":" ",
+        "multiarch": "null",
+        "name":"<package_name>",
+        "priority":"optional",
+        "scan_time":"2023/12/19 15:32:25",
+        "size":"<random_int>",
+        "source":"<package_source>",
+        "vendor":"<package_vendor>",
+        "version":"<package_version>"
+}
+
+
+SYSCOLLECTOR_HOTFIX_DELTA_DATA_TEMPLATE = {
+        "checksum":"<random_string>",
+        "hotfix":"<random_string>",
+        "scan_time":"<timestamp>"
+}
+
+SYSCOLLECTOR_OSINFO_DELTA_EVENT_TEMPLATE = {
+        "checksum":"1634140017886803554",
+        "architecture":"x86_64",
+        "hostname":"<agent_name>",
+        "os_codename":"focal",
+        "os_major":"20",
+        "os_minor":"04",
+        "os_name":"Ubuntu",
+        "os_platform":"ubuntu",
+        "os_patch": "6",
+        "os_release":"sp1",
+        "os_version":"20.04.6 LTS (Focal Fossa)",
+        "os_build":"4.18.0-305.12.1.el8_4.x86_64",
+        "release":"6.2.6-76060206-generic",
+        "scan_time":"2023/12/20 11:24:58",
+        "sysname":"Linux",
+        "version":"#202303130630~1689015125~22.04~ab2190e SMP PREEMPT_DYNAMIC"
+}
+
+SYSCOLLECTOR_PROCESSSES_DELTA_EVENT_TEMPLATE = {
+        "argvs":"<random_int",
+        "checksum":"<random_string>",
+        "euser":"<random_string>",
+        "fgroup":"<random_string>",
+        "name":"<random_string>",
+        "nice":"<random_int>",
+        "nlwp":"<random_int>",
+        "pgrp":"<random_int>",
+        "ppid":"<random_int>",
+        "priority":"<random_int>",
+        "processor":"<random_int>",
+        "resident":"<random_int>",
+        "rgroup":"<random_string>",
+        "scan_time":"<timestamp>",
+        "session":"<random_int>",
+        "sgroup":"<random_string>",
+        "share":"<random_int>",
+        "size":"<random_int>",
+        "start_time":"<random_int>",
+        "state":"S",
+        "stime":"<random_int>",
+        "suser":"<random_string>",
+        "tgid":"<random_int>",
+        "tty":"<random_int>",
+        "utime":"<random_int>",
+        "vm_size":"<random_int>",
+        "cmd":"",
+        "egroup":"<random_string>",
+        "ruser":"<random_string>"
+}
+
+SYSCOLLECTOR_PORTS_DELTA_EVENT_TEMPLATE = {
+        "checksum":"<random_string>",
+        "item_id":"<random_string>",
+        "local_ip":"0.0.0.0",
+        "local_port":"<random_int>",
+        "pid":"<random_int>",
+        "process":"NULL",
+        "protocol":"tcp",
+        "remote_ip":"0.0.0.0",
+        "remote_port":"<random_int>",
+        "rx_queue":"<random_int>",
+        "scan_time":"<timestamp>",
+        "state":"listening",
+        "tx_queue":"<random_int>"
+}
+
+
+SYSCOLLECTOR_HWINFO_DELTA_EVENT_TEMPLATE = {
+        "scan_time":"<timestamp>",
+        "board_serial":"<random_string>",
+        "checksum":"<random_string>",
+        "cpu_mhz":"<random_int>",
+        "cpu_cores":"<random_int>",
+        "cpu_name":"<random_string>",
+        "ram_free":"<random_int>",
+        "ram_total":"<random_int>",
+        "ram_usage":"<random_int>"
+}
+
+
+SYSCOLLECTOR_NETWORK_IFACE_DELTA_EVENT_TEMPLATE = {
+        "adapter":"null",
+        "checksum":"<random_int>",
+        "item_id":"<random_int>",
+        "mac":"<random_int>",
+        "mtu":"<random_int>",
+        "name":"<random_int>",
+        "rx_bytes":"<random_int>",
+        "rx_dropped":"<random_int>",
+        "rx_errors":"<random_int>",
+        "rx_packets":"<random_int>",
+        "scan_time":"<timestamp>",
+        "state":"<random_int>",
+        "tx_bytes":"<random_int>",
+        "tx_dropped":"<random_int>",
+        "tx_errors":"<random_int>",
+        "tx_packets":"<random_int>",
+        "type":"<random_int>"
+}
+
+
+SYSCOLLECTOR_NETWORK_NETADDR_DELTA_EVENT_TEMPLATE = {
+    "id": "<random_int>",
+    "scan_id": "<random_int>",
+    "proto": "<random_string>",
+    "address": "192.168.1.87",
+    "netmask": "255.255.255.0",
+    "broadcast": "192.168.1.255",
+    "checksum": "<random_string",
+    "item_id": "<random_string>"
+}
+
+
+SYSCOLLECTOR_NETWORK_NETPRO_DELTA_EVENT_TEMPLATE = {
+    "id": "<random_int>",
+    "scan_id": "<random_int>",
+    "iface": "eth0",
+    "type": "ipv4",
+    "gateway": "192.168.1.1",
+    "dhcp": "enabled",
+    "checksum": "<random_int>",
+    "item_id": "<random_int>"
+}

--- a/deps/wazuh_testing/wazuh_testing/modules/syscollector/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/syscollector/__init__.py
@@ -1,0 +1,1 @@
+SYSCOLLECTOR_DELTA_EVENT_TYPES = ['packages', 'hotfix', 'hwinfo', 'ports', 'osinfo', 'network', 'process']

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -57,6 +57,9 @@ def process_script_parameters(args):
         if any(event_type not in SYSCOLLECTOR_DELTA_EVENT_TYPES for event_type in args.syscollector_event_types):
             raise ValueError(f'Invalid syscollector event type. Valid values are: {SYSCOLLECTOR_DELTA_EVENT_TYPES}')
 
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
 
 def set_agent_modules_and_eps(agent, active_modules, modules_eps):
     """Set active modules and EPS to an agent.
@@ -340,6 +343,13 @@ def main():
     arg_parser.add_argument('-k', '--disable-keepalive', metavar='<disable_keepalive>', type=bool,
                             help='Disable keepalive module',
                             required=False, default=False, dest='disable_keepalive')
+
+    arg_parser.add_argument('--debug',
+                            help='Enable debug mode',
+                            required=False,
+                            action='store_true',
+                            default=False,
+                            dest='debug')
 
     arg_parser.add_argument('-d', '--disable-receive', metavar='<disable_receive>', type=bool,
                             help='Disable receive message module',

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -55,7 +55,6 @@ def process_script_parameters(args):
     if args.syscollector_event_types:
         args.syscollector_event_types = args.syscollector_event_types.split(' ')
         if any(event_type not in SYSCOLLECTOR_DELTA_EVENT_TYPES for event_type in args.syscollector_event_types):
-            print(args.syscollector_event_types)
             raise ValueError(f'Invalid syscollector event type. Valid values are: {SYSCOLLECTOR_DELTA_EVENT_TYPES}')
 
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -377,7 +377,8 @@ def main():
                             metavar='<syscollector_event_types>',
                             type=str,
                             help='''Space-separated list of event types for syscollector messages.
-                            Default is "packages".''',
+                            Default is "packages". Available types are "packages", "processes", "ports",
+                            "network", "hotfix", "hwinfo", "osinfo"''',
                             required=False,
                             default='packages',
                             dest='syscollector_event_types')

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -2,11 +2,11 @@ import argparse
 import logging
 import os
 import wazuh_testing.tools.agent_simulator as ag
-from wazuh_testing.modules.syscollector import SYSCOLLECTOR_DELTA_EVENT_TYPES
 
-from wazuh_testing import TCP
 from multiprocessing import Process
 from time import sleep
+from wazuh_testing.modules.syscollector import SYSCOLLECTOR_DELTA_EVENT_TYPES
+from wazuh_testing import TCP
 
 
 logging.basicConfig(level=logging.INFO)

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -1,14 +1,15 @@
 import argparse
 import logging
 import os
+import wazuh_testing.tools.agent_simulator as ag
+from wazuh_testing.modules.syscollector import SYSCOLLECTOR_DELTA_EVENT_TYPES
+
+from wazuh_testing import TCP
 from multiprocessing import Process
 from time import sleep
 
-import wazuh_testing.tools.agent_simulator as ag
-from wazuh_testing import TCP
 
 logging.basicConfig(level=logging.INFO)
-
 logger = logging.getLogger(f"P{os.getpid()}")
 
 
@@ -51,6 +52,12 @@ def process_script_parameters(args):
     if not args.version.startswith('v'):
         args.version = 'v' + args.version
 
+    if args.syscollector_event_types:
+        args.syscollector_event_types = args.syscollector_event_types.split(' ')
+        if any(event_type not in SYSCOLLECTOR_DELTA_EVENT_TYPES for event_type in args.syscollector_event_types):
+            print(args.syscollector_event_types)
+            raise ValueError(f'Invalid syscollector event type. Valid values are: {SYSCOLLECTOR_DELTA_EVENT_TYPES}')
+
 
 def set_agent_modules_and_eps(agent, active_modules, modules_eps):
     """Set active modules and EPS to an agent.
@@ -86,6 +93,18 @@ def set_agent_modules_and_eps(agent, active_modules, modules_eps):
     logger.info(agent.modules)
 
 
+def create_agent(args, custom_labels):
+    agent = ag.Agent(manager_address=args.manager_address, os=args.os,
+                     registration_address=args.manager_registration_address,
+                     version=args.version, fixed_message_size=args.fixed_message_size, labels=custom_labels,
+                     logcollector_msg_number=args.enable_logcollector_message_number,
+                     custom_logcollector_message=args.custom_logcollector_message,
+                     syscollector_frequency=args.syscollector_frequency,
+                     syscollector_event_types=args.syscollector_event_types,
+                     syscollector_legacy_messages=args.syscollector_legacy_messages)
+    return agent
+
+
 def create_agents(args):
     """Create a list of agents according to script parameters like the mode, EPS...
     Args:
@@ -110,21 +129,14 @@ def create_agents(args):
         logger.info(f"Agents-EPS distributon = {distribution_list}")
 
         for item in distribution_list:  # item[0] = modules - item[1] = eps
-            agent = ag.Agent(manager_address=args.manager_address, os=args.os,
-                             registration_address=args.manager_registration_address,
-                             version=args.version, fixed_message_size=args.fixed_message_size, labels=custom_labels,
-                             logcollector_msg_number=args.enable_logcollector_message_number,
-                             custom_logcollector_message=args.custom_logcollector_message)
+            agent = create_agent(args, custom_labels)
             set_agent_modules_and_eps(agent, item[0].split(' ') + ['keepalive', 'receive_messages'],
                                       item[1].split(' ') + ['0', '0'])
             agents.append(agent)
     else:
         for _ in range(args.agents_number):
-            agent = ag.Agent(manager_address=args.manager_address, os=args.os,
-                             registration_address=args.manager_registration_address,
-                             version=args.version, fixed_message_size=args.fixed_message_size, labels=custom_labels,
-                             logcollector_msg_number=args.enable_logcollector_message_number,
-                             custom_logcollector_message=args.custom_logcollector_message)
+            agent = create_agent(args, custom_labels)
+
             set_agent_modules_and_eps(agent, args.modules, args.modules_eps)
             agents.append(agent)
 
@@ -343,6 +355,30 @@ def main():
                             metavar='<custom_logcollector_message>', type=str,
                             help='Custom logcollector message',
                             required=False, default='', dest='custom_logcollector_message')
+
+    arg_parser.add_argument('--syscollector-frequency',
+                            metavar='<syscollector_frequency>',
+                            type=int,
+                            help='Frequency of Syscollector scans. Set to 1 for constant message sending.',
+                            required=False,
+                            default=60,
+                            dest='syscollector_frequency')
+
+    arg_parser.add_argument('--syscollector-event-types',
+                            metavar='<syscollector_event_types>',
+                            type=str,
+                            help='''Space-separated list of event types for syscollector messages.
+                            Default is "packages".''',
+                            required=False,
+                            default='packages',
+                            dest='syscollector_event_types')
+
+    arg_parser.add_argument('--syscollector-legacy-messages',
+                            help='Enable prior 4.2 agents syscollector format. Default is False.',
+                            required=False,
+                            action='store_true',
+                            default=False,
+                            dest='syscollector_legacy_messages')
 
     args = arg_parser.parse_args()
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -96,14 +96,22 @@ def set_agent_modules_and_eps(agent, active_modules, modules_eps):
 
 
 def create_agent(args, custom_labels):
-    agent = ag.Agent(manager_address=args.manager_address, os=args.os,
-                     registration_address=args.manager_registration_address,
-                     version=args.version, fixed_message_size=args.fixed_message_size, labels=custom_labels,
-                     logcollector_msg_number=args.enable_logcollector_message_number,
-                     custom_logcollector_message=args.custom_logcollector_message,
-                     syscollector_frequency=args.syscollector_frequency,
-                     syscollector_event_types=args.syscollector_event_types,
-                     syscollector_legacy_messages=args.syscollector_legacy_messages)
+    agent_args = {
+        'manager_address': args.manager_address,
+        'os': args.os,
+        'registration_address': args.manager_registration_address,
+        'version': args.version,
+        'fixed_message_size': args.fixed_message_size,
+        'labels': custom_labels,
+        'logcollector_msg_number': args.enable_logcollector_message_number,
+        'custom_logcollector_message': args.custom_logcollector_message,
+        'syscollector_frequency': args.syscollector_frequency,
+        'syscollector_event_types': args.syscollector_event_types,
+        'syscollector_legacy_messages': args.syscollector_legacy_messages
+    }
+
+    agent = ag.Agent(**agent_args)
+
     return agent
 
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -903,7 +903,6 @@ class GeneratorSyscollector:
             event_template = self.get_event_template(self.list_events[self.current_batch_events])
 
         event_final = self.format_event_template(event_template, event)
-        print(event_final)
 
         self.current_id += 1
 
@@ -1677,8 +1676,6 @@ class InjectorThread(threading.Thread):
         module_info = self.agent.modules[module]
         eps = module_info['eps'] if 'eps' in module_info else 1
         frequency = module_info["frequency"] if 'frequency' in module_info else 1
-        print(f"Defining frequency as {frequency}")
-
 
         sleep(10)
         start_time = time()
@@ -1718,7 +1715,6 @@ class InjectorThread(threading.Thread):
         while self.stop_thread == 0:
             sent_messages = 0
             while sent_messages < batch_messages:
-                print("Send event")
                 event_msg = module_event_generator()
                 if self.agent.fixed_message_size is not None:
                     event_msg_size = getsizeof(event_msg)
@@ -1737,14 +1733,8 @@ class InjectorThread(threading.Thread):
                 self.totalMessages += 1
                 sent_messages += 1
                 if self.totalMessages % eps == 0:
-                    print("Sleeping")
-                    print(self.totalMessages)
-                    print(1.0 - ((time() - start_time) % 1.0))
                     sleep(1.0 - ((time() - start_time) % 1.0))
             if frequency > 1:
-                print("Sleeping freq")
-                print(frequency)
-                print(frequency - ((time() - start_time) % frequency))
                 sleep(frequency - ((time() - start_time) % frequency))
 
     def run(self):

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -19,6 +19,7 @@ import socket
 import ssl
 import threading
 import zlib
+import re
 from datetime import date
 from itertools import cycle
 from random import randint, sample, choice, getrandbits
@@ -27,7 +28,6 @@ from string import ascii_letters, digits
 from struct import pack
 from sys import getsizeof
 from time import mktime, localtime, sleep, time
-import re
 
 import wazuh_testing.data.syscollector as syscollector
 import wazuh_testing.data.winevt as winevt

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -903,6 +903,7 @@ class GeneratorSyscollector:
             event_template = self.get_event_template(self.list_events[self.current_batch_events])
 
         event_final = self.format_event_template(event_template, event)
+        logging.debug(f"Syscollector Event  - {event_final}")
 
         self.current_id += 1
 
@@ -1734,6 +1735,7 @@ class InjectorThread(threading.Thread):
                 sent_messages += 1
                 if self.totalMessages % eps == 0:
                     sleep(1.0 - ((time() - start_time) % 1.0))
+
             if frequency > 1:
                 sleep(frequency - ((time() - start_time) % frequency))
 


### PR DESCRIPTION
|Related issue|
|-------------|
|       https://github.com/wazuh/wazuh-qa/issues/4783      |

### Description

This pull request enhances the Syscollector generator module within the agent simulator.

### Summary of Changes

- Included debug option in the simulate agents script
- Continued support for legacy messages is maintained until the resolution of https://github.com/wazuh/wazuh/issues/21319 is determined.
- New syscollector message formats have been introduced, specifically addressing the Delta syscollector message as an integral component of the agent. The development phase excluded DbSync messages.
- A new customization option has been incorporated, allowing for the scripting of simulation options for syscollector logs, providing enhanced flexibility for emulation.
- The templates for Network Address (network addr) and Network Protocol (netpro) SysCollector events have been added to the template lists. However, it's important to note that the simulator currently lacks the necessary logic to incorporate these specific events. The implementation of this logic will be addressed in upcoming issues


### Testing


<details>

<summary>Basic Syscollector Package events</summary>

```
> simulate-agents -a MANAGER_IP  -n 1 -t 10 -s 1 -m syscollector --debug
DEBUG:root:Registration - 1-bqzjVhAF9Xe5IiEP-debian8(076) in 172.31.0.65
DEBUG:root:Keep alive message = #!-Linux |agent-debian8 |3.16.0-9-amd64 |#1 SMP Debian 3.16.68-1 (2019-05-22) |x86_64 [Debian GNU/Linux|debian: 8 (jessie)] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00
d6e3ac3e75ca0319af3e7c262776f331 merged.mg
#"_agent_ip":10.0.2.15

INFO:P115137:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'enabled', 'frequency': 60, 'eps': 1}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'disabled', 'eps': 0}, 'receive_messages': {'status': 'enabled'}}
INFO:P115137:Waiting 0 seconds before sending EPS and keep-alive events
INFO:P115137:Starting 1 agents.
DEBUG:root:Starting - 1-bqzjVhAF9Xe5IiEP-debian8(076)(debian8) - keepalive
DEBUG:root:Starting - 1-bqzjVhAF9Xe5IiEP-debian8(076)(debian8) - syscollector
DEBUG:root:Starting - 1-bqzjVhAF9Xe5IiEP-debian8(076)(debian8) - receive_messages
DEBUG:root:Startup - 1-bqzjVhAF9Xe5IiEP-debian8(076)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"BRS64WHQHZ","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"BRS64WHQHZ","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"1","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architectu
```

**Alerts**:

```
{"timestamp":"2024-01-10T17:09:18.042+0000","rule":{"level":10,"description":"CVE-2015-8805 affects nettle","id":"23505","firedtimes":186,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"076","name":"1-bqzjVhAF9Xe5IiEP-debian8"},"manager":{"name":"ip-172-31-0-65"},"id":"1704906558.3989024951","cluster":{"name":"wazuh","node":"master"},"decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2015-8805","cvss":{"cvss2":{"base_score":"7.500000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"PARTIAL","integrity_impact":"PARTIAL"}}},"cwe_reference":"CWE-310","enumeration":"CVE","package":{"architecture":"x86_64","condition":"Package less than 3.1.1-4ubuntu0.1","name":"nettle","source":"vim","version":"2.7.1-9.el7_9"},"published":"2016-02-23T19:59:03Z","rationale":"The ecc_256_modq function in ecc-256.c in Nettle before 3.2 does not properly handle carry propagation and produces incorrect output in its implementation of the P-256 NIST elliptic curve, which allows attackers to have unspecified impact via unknown vectors, a different vulnerability than CVE-2015-8803.","reference":"https://git.lysator.liu.se/nettle/nettle/commit/c71d2c9d20eeebb985e3872e4550137209e3ce4d, http://lists.opensuse.org/opensuse-updates/2016-02/msg00091.html, http://lists.opensuse.org/opensuse-updates/2016-02/msg00093.html, http://lists.opensuse.org/opensuse-updates/2016-02/msg00100.html, http://rhn.redhat.com/errata/RHSA-2016-2582.html, http://www.openwall.com/lists/oss-security/2016/02/02/2, http://www.openwall.com/lists/oss-security/2016/02/03/1, http://www.securityfocus.com/bid/84272, http://www.ubuntu.com/usn/USN-2897-1, https://blog.fuzzing-project.org/38-Miscomputations-of-elliptic-curve-scalar-multiplications-in-Nettle.html","severity":"High","status":"Active","title":"CVE-2015-8805 affects nettle","type":"Packages","updated":"2018-10-30T16:27:35Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-10T17:09:18.052+0000","rule":{"level":7,"description":"CVE-2016-6489 affects nettle","id":"23504","firedtimes":186,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"076","name":"1-bqzjVhAF9Xe5IiEP-debian8"},"manager":{"name":"ip-172-31-0-65"},"id":"1704906558.3989028685","cluster":{"name":"wazuh","node":"master"},"decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"debian","cve":"CVE-2016-6489","cvss":{"cvss2":{"base_score":"5","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"NONE","confidentiality_impact":"PARTIAL","integrity_impact":"NONE"}}},"cwe_reference":"CWE-203","enumeration":"CVE","package":{"architecture":"x86_64","condition":"Package less than 3.2-1ubuntu0.16.04.1","name":"nettle","source":"vim","version":"2.7.1-9.el7_9"},"published":"2017-04-14T18:59:00Z","rationale":"The RSA and DSA decryption code in Nettle makes it easier for attackers to discover private keys via a cache side channel attack.","reference":"https://bugzilla.redhat.com/show_bug.cgi?id=1362016, http://www.openwall.com/lists/oss-security/2016/07/29/7, https://git.lysator.liu.se/nettle/nettle/commit/3fe1d6549765ecfb24f0b80b2ed086fdc818bff3, https://eprint.iacr.org/2016/596.pdf, http://www.ubuntu.com/usn/USN-3193-1, https://security.gentoo.org/glsa/201706-21, https://www.oracle.com/security-alerts/cpuapr2020.html, http://rhn.redhat.com/errata/RHSA-2016-2582.html","severity":"Medium","status":"Active","title":"CVE-2016-6489 affects nettle","type":"Packages","updated":"2020-11-16T20:20:41Z"}},"location":"vulnerability-detector"}
```



</details>


<details>

<summary> Legacy Syscollector format </summary>


```
> simulate-agents -a MANAGER_IP  -n 1 -t 30 -s 1 -m syscollector --debug --syscollector-legacy-messages
DEBUG:root:Registration - 1-1rTIP9V0wN5bmkOJ-debian8(079) in 172.31.0.65
DEBUG:root:Keep alive message = #!-Linux |agent-debian8 |3.16.0-9-amd64 |#1 SMP Debian 3.16.68-1 (2019-05-22) |x86_64 [Debian GNU/Linux|debian: 8 (jessie)] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00
d6e3ac3e75ca0319af3e7c262776f331 merged.mg
#"_agent_ip":10.0.2.15

INFO:P116405:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'enabled', 'frequency': 60, 'eps': 1}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'disabled', 'eps': 0}, 'receive_messages': {'status': 'enabled'}}
INFO:P116405:Waiting 0 seconds before sending EPS and keep-alive events
INFO:P116405:Starting 1 agents.
DEBUG:root:Starting - 1-1rTIP9V0wN5bmkOJ-debian8(079)(debian8) - keepalive
DEBUG:root:Starting - 1-1rTIP9V0wN5bmkOJ-debian8(079)(debian8) - syscollector
DEBUG:root:Starting - 1-1rTIP9V0wN5bmkOJ-debian8(079)(debian8) - receive_messages
DEBUG:root:Startup - 1-1rTIP9V0wN5bmkOJ-debian8(079)
DEBUG:root:KeepAlive - 1-1rTIP9V0wN5bmkOJ-debian8(079)
DEBUG:root:Syscollector Event  - d:syscollector:{"type":"packages","ID":1,"timestamp":"2024/01/10 00:00:00","program":{"format":"rpm","name":"V20QQSTO02","description":"JSON::XS compatible pure-Perl module","size":126,"vendor":"CentOS","group":"Unspecified","architecture":"noarch","source":"perl-JSON-PP-2.97.001-3.el8.src.rpm","install_time":"2021/03/12 12:23:17","version":"1:2.97.001-3.el8"}}
DEBUG:root:Syscollector Event  - d:syscollector:{"type":"packages","ID":2,"timestamp":"2024/01/10 00:00:00","program":{"format":"rpm","name":"KCI3
```

**Manager Log**

```
2024/01/10 17:14:03 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:04 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:05 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:06 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:07 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:08 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:09 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:10 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:11 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:12 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:13 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
2024/01/10 17:14:14 :router: ERROR: Error sending message to provider: Error parsing message, 1: 135: error: unknown enum value: packages
```

- Reported here https://github.com/wazuh/wazuh/issues/21319

</details>



<details>

<summary> Syscollector messages with custom frequency </summary>


simulate-agents -a 172.31.0.65  -n 1 -t 120 -s 1 -m syscollector --debug --syscollector-frequency 1
DEBUG:root:Registration - 1-wGhgYVvCcX2ZSWkR-debian8(080) in 172.31.0.65
DEBUG:root:Keep alive message = #!-Linux |agent-debian8 |3.16.0-9-amd64 |#1 SMP Debian 3.16.68-1 (2019-05-22) |x86_64 [Debian GNU/Linux|debian: 8 (jessie)] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00
d6e3ac3e75ca0319af3e7c262776f331 merged.mg
#"_agent_ip":10.0.2.15

INFO:P116973:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'enabled', 'frequency': 1, 'eps': 1}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'disabled', 'eps': 0}, 'receive_messages': {'status': 'enabled'}}
INFO:P116973:Waiting 0 seconds before sending EPS and keep-alive events
INFO:P116973:Starting 1 agents.
DEBUG:root:Starting - 1-wGhgYVvCcX2ZSWkR-debian8(080)(debian8) - keepalive
DEBUG:root:Starting - 1-wGhgYVvCcX2ZSWkR-debian8(080)(debian8) - syscollector
DEBUG:root:Starting - 1-wGhgYVvCcX2ZSWkR-debian8(080)(debian8) - receive_messages
DEBUG:root:Startup - 1-wGhgYVvCcX2ZSWkR-debian8(080)
DEBUG:root:KeepAlive - 1-wGhgYVvCcX2ZSWkR-debian8(080)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"HEKIXBOS6T","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"HEKIXBOS6T","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"1","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"4Z6ECR3GOG","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"4Z6ECR3GOG","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"2","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}


</details>



<details>

<summary> Custom Syscollector Types events </summary>

```
> simulate-agents -a MANAGER_IP  -n 1 -t 500 -s 1 -m syscollector --syscollector-event-types 'packages ports network' --debug
DEBUG:root:Registration - 1-ySTO8LtVpBioIrJh-debian8(083) in 172.31.0.65
DEBUG:root:Keep alive message = #!-Linux |agent-debian8 |3.16.0-9-amd64 |#1 SMP Debian 3.16.68-1 (2019-05-22) |x86_64 [Debian GNU/Linux|debian: 8 (jessie)] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00
d6e3ac3e75ca0319af3e7c262776f331 merged.mg
#"_agent_ip":10.0.2.15

INFO:P118261:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'enabled', 'frequency': 60, 'eps': 1}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'disabled', 'eps': 0}, 'receive_messages': {'status': 'enabled'}}
INFO:P118261:Waiting 0 seconds before sending EPS and keep-alive events
INFO:P118261:Starting 1 agents.
DEBUG:root:Starting - 1-ySTO8LtVpBioIrJh-debian8(083)(debian8) - keepalive
DEBUG:root:Starting - 1-ySTO8LtVpBioIrJh-debian8(083)(debian8) - syscollector
DEBUG:root:Starting - 1-ySTO8LtVpBioIrJh-debian8(083)(debian8) - receive_messages
DEBUG:root:Startup - 1-ySTO8LtVpBioIrJh-debian8(083)
DEBUG:root:KeepAlive - 1-ySTO8LtVpBioIrJh-debian8(083)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"LK8VO2TVRU","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"LK8VO2TVRU","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"1","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"HIURVR7M2O","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"HIURVR7M2O","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"2","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"5SWP41O9LJ","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"5SWP41O9LJ","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"3","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"CAERI1ZXH8","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"CAERI1ZXH8","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"4","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"07SYGDD1OV","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"07SYGDD1OV","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"5","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"ZNRILVJV2O","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"ZNRILVJV2O","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"6","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"7KYGH75A73","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"7KYGH75A73","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"7","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"9R2R2R4MEF","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"9R2R2R4MEF","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"8","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"W0YOCG43Q1","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"W0YOCG43Q1","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"9","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"x86_64","checksum":"L4N4B7WCT3","description":"A low-level cryptographic library","format":"rpm","groups":"editors","install_time":"2024/01/10 00:00:00","item_id":"L4N4B7WCT3","location":"","multiarch":"null","name":"nettle","priority":"optional","scan_time":"2023/12/1915:32:25","size":"10","source":"vim","vendor":"Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>","version":"2.7.1-9.el7_9"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"S42984ZCKE","item_id":"S42984ZCKE","local_ip":"0.0.0.0","local_port":"11","pid":"11","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"11","rx_queue":"11","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"11"}, "operation": "MODIFIED"}
DEBUG:root:KeepAlive - 1-ySTO8LtVpBioIrJh-debian8(083)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"ANYBWMIZ1Q","item_id":"ANYBWMIZ1Q","local_ip":"0.0.0.0","local_port":"12","pid":"12","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"12","rx_queue":"12","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"12"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"T0IXYZOCA0","item_id":"T0IXYZOCA0","local_ip":"0.0.0.0","local_port":"13","pid":"13","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"13","rx_queue":"13","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"13"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"03B4FHYFCT","item_id":"03B4FHYFCT","local_ip":"0.0.0.0","local_port":"14","pid":"14","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"14","rx_queue":"14","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"14"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"J2TNQ8RBWK","item_id":"J2TNQ8RBWK","local_ip":"0.0.0.0","local_port":"15","pid":"15","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"15","rx_queue":"15","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"15"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"B44MXO3OCR","item_id":"B44MXO3OCR","local_ip":"0.0.0.0","local_port":"16","pid":"16","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"16","rx_queue":"16","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"16"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"OY2YOSQ133","item_id":"OY2YOSQ133","local_ip":"0.0.0.0","local_port":"17","pid":"17","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"17","rx_queue":"17","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"17"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"3DMMZDAWBO","item_id":"3DMMZDAWBO","local_ip":"0.0.0.0","local_port":"18","pid":"18","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"18","rx_queue":"18","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"18"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"E2DZWE0XOD","item_id":"E2DZWE0XOD","local_ip":"0.0.0.0","local_port":"19","pid":"19","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"19","rx_queue":"19","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"19"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_ports", "data": {"checksum":"C3QWBLW2TZ","item_id":"C3QWBLW2TZ","local_ip":"0.0.0.0","local_port":"20","pid":"20","process":"NULL","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":"20","rx_queue":"20","scan_time":"2024/01/10 00:00:00","state":"listening","tx_queue":"20"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"21","item_id":"21","mac":"21","mtu":"21","name":"21","rx_bytes":"21","rx_dropped":"21","rx_errors":"21","rx_packets":"21","scan_time":"2024/01/10 00:00:00","state":"21","tx_bytes":"21","tx_dropped":"21","tx_errors":"21","tx_packets":"21","type":"21"}, "operation": "MODIFIED"}
DEBUG:root:KeepAlive - 1-ySTO8LtVpBioIrJh-debian8(083)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"22","item_id":"22","mac":"22","mtu":"22","name":"22","rx_bytes":"22","rx_dropped":"22","rx_errors":"22","rx_packets":"22","scan_time":"2024/01/10 00:00:00","state":"22","tx_bytes":"22","tx_dropped":"22","tx_errors":"22","tx_packets":"22","type":"22"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"23","item_id":"23","mac":"23","mtu":"23","name":"23","rx_bytes":"23","rx_dropped":"23","rx_errors":"23","rx_packets":"23","scan_time":"2024/01/10 00:00:00","state":"23","tx_bytes":"23","tx_dropped":"23","tx_errors":"23","tx_packets":"23","type":"23"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"24","item_id":"24","mac":"24","mtu":"24","name":"24","rx_bytes":"24","rx_dropped":"24","rx_errors":"24","rx_packets":"24","scan_time":"2024/01/10 00:00:00","state":"24","tx_bytes":"24","tx_dropped":"24","tx_errors":"24","tx_packets":"24","type":"24"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"25","item_id":"25","mac":"25","mtu":"25","name":"25","rx_bytes":"25","rx_dropped":"25","rx_errors":"25","rx_packets":"25","scan_time":"2024/01/10 00:00:00","state":"25","tx_bytes":"25","tx_dropped":"25","tx_errors":"25","tx_packets":"25","type":"25"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"26","item_id":"26","mac":"26","mtu":"26","name":"26","rx_bytes":"26","rx_dropped":"26","rx_errors":"26","rx_packets":"26","scan_time":"2024/01/10 00:00:00","state":"26","tx_bytes":"26","tx_dropped":"26","tx_errors":"26","tx_packets":"26","type":"26"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"27","item_id":"27","mac":"27","mtu":"27","name":"27","rx_bytes":"27","rx_dropped":"27","rx_errors":"27","rx_packets":"27","scan_time":"2024/01/10 00:00:00","state":"27","tx_bytes":"27","tx_dropped":"27","tx_errors":"27","tx_packets":"27","type":"27"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"28","item_id":"28","mac":"28","mtu":"28","name":"28","rx_bytes":"28","rx_dropped":"28","rx_errors":"28","rx_packets":"28","scan_time":"2024/01/10 00:00:00","state":"28","tx_bytes":"28","tx_dropped":"28","tx_errors":"28","tx_packets":"28","type":"28"}, "operation": "MODIFIED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_network_iface", "data": {"adapter":null,"checksum":"29","item_id":"29","mac":"29","mtu":"29","name":"29","rx_bytes":"29","rx_dropped":"29","rx_errors":"29","rx_packets":"29","scan_time":"2024/01/10 00:00:00","state":"29","tx_bytes":"29","tx_dropped":"29","tx_errors":"29","tx_packets":"29","type":"29"}, "operation": "MODIFIED"}
```


</details>


