### PR TITLE
Include Syscollector delta delete package operation support for the agent simulator

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -30,6 +30,7 @@ package_data_list = [
     'qa_ctl/provisioning/wazuh_deployment/templates/preloaded_vars.conf.j2',
     'data/qactl_conf_validator_schema.json',
     'data/all_disabled_ossec.conf',
+    'data/syscollector_parsed_packages.json',
     'tools/migration_tool/delta_schema.json',
     'tools/migration_tool/CVE_JSON_5.0_bundled.json'
 ]

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector.py
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector.py
@@ -59,7 +59,7 @@ SYSCOLLECTOR_PACKAGE_DELTA_DATA_TEMPLATE = {
         "format": "<package_format>",
         "groups": "editors",
         "install_time": "<timestamp>",
-        "item_id": "<random_string>",
+        "item_id": "<package_item_id>",
         "location": " ",
         "multiarch":  "null",
         "name": "<package_name>",

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector_parsed_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector_parsed_packages.json
@@ -3,7 +3,5 @@
         "vendor": "bsdi",
         "product": "bsd_os",
         "version": "3.1",
-        "checksum": "66e8140425c4e12c2d35e8267d31deb2853f1f5e",
-        "item_id": "6bbdd1d1b4337b9cb73b2e6520528b013a9aab0c"
     }
 ]

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector_parsed_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector_parsed_packages.json
@@ -2,6 +2,116 @@
     {
         "vendor": "bsdi",
         "product": "bsd_os",
-        "version": "3.1",
+        "version": "3.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.0"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.1.5.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.2"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.0"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.0.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.0.5"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.5"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.6"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.6.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.7"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.7.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.2"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.3"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.4"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.5"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.6"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.8"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "3.0"
+    },
+    {
+        "vendor": "openbsd",
+        "product": "openbsd",
+        "version": "2.3"
+    },
+    {
+        "vendor": "openbsd",
+        "product": "openbsd",
+        "version": "2.4"
     }
 ]

--- a/deps/wazuh_testing/wazuh_testing/data/syscollector_parsed_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/data/syscollector_parsed_packages.json
@@ -1,0 +1,9 @@
+[
+    {
+        "vendor": "bsdi",
+        "product": "bsd_os",
+        "version": "3.1",
+        "checksum": "66e8140425c4e12c2d35e8267d31deb2853f1f5e",
+        "item_id": "6bbdd1d1b4337b9cb73b2e6520528b013a9aab0c"
+    }
+]

--- a/deps/wazuh_testing/wazuh_testing/scripts/parse_packages_content.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/parse_packages_content.py
@@ -6,11 +6,10 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("parse_packages_content.py")
 
-config = None
-
 
 def parse_packages_content(output_file, packages_file, n_packages):
     list_packages = []
+    config = None
 
     with open(packages_file) as f:
         for line in f:
@@ -55,10 +54,11 @@ def main():
     arg_parser.add_argument('-n', '--n_packages', metavar='<n_packages>', type=int, required=True,
                             help='Number of packages to parse', dest='n_packages')
 
-    arg_parser.add_argument('-d', '--debug', action='store_true', help='Enable debug mode', dest='debug')
-
     arg_parser.add_argument('-o', '--output', metavar='<output_file>', type=str, required=True,
                             help='Output file', dest='output_file')
+
+    arg_parser.add_argument('-d', '--debug', action='store_true', help='Enable debug mode', dest='debug')
+
 
     args = arg_parser.parse_args()
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/parse_packages_content.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/parse_packages_content.py
@@ -1,0 +1,76 @@
+import argparse
+import json
+import logging
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("parse_packages_content.py")
+
+config = None
+
+
+def parse_packages_content(output_file, packages_file, n_packages):
+    list_packages = []
+
+    with open(packages_file) as f:
+        for line in f:
+            if len(list_packages) >= n_packages:
+                break
+
+            if line.strip():
+                config = json.loads(line)
+
+                if 'payload' in config and 'containers' in config['payload'] \
+                        and 'cna' in config['payload']['containers']:
+                    if 'affected' in config['payload']['containers']['cna']:
+                        for affected in config['payload']['containers']['cna']['affected']:
+                            vendor = affected['vendor']
+                            product = affected['product']
+
+                            for affected_version in affected['versions']:
+                                status, version = affected_version['status'], affected_version['version']
+
+                                if status == 'affected':
+                                    list_packages.append({
+                                        'vendor': vendor,
+                                        'product': product,
+                                        'version': version
+                                    })
+                    else:
+                        logger.debug("No affected found in package: %s", config)
+                else:
+                    logger.warning("No payload found for package: %s", config['id'])
+                    logger.debug("Package: %s", config)
+
+    with open(output_file, 'w') as f:
+        json.dump(list_packages, f, indent=4)
+
+
+def main():
+    arg_parser = argparse.ArgumentParser()
+
+    arg_parser.add_argument('-p', '--packages', metavar='<packages_file>', type=str, required=True,
+                            help='Packages file', dest='packages_file')
+
+    arg_parser.add_argument('-n', '--n_packages', metavar='<n_packages>', type=int, required=True,
+                            help='Number of packages to parse', dest='n_packages')
+
+    arg_parser.add_argument('-d', '--debug', action='store_true', help='Enable debug mode', dest='debug')
+
+    arg_parser.add_argument('-o', '--output', metavar='<output_file>', type=str, required=True,
+                            help='Output file', dest='output_file')
+
+    args = arg_parser.parse_args()
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    logging.info("Parsing packages content...")
+    parse_packages_content(args.output_file, args.packages_file, args.n_packages)
+    logging.info("Packages parsed successfully")
+
+
+if __name__ == '__main__':
+    main()

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -910,7 +910,6 @@ class GeneratorSyscollector:
             message_data = syscollector.SYSCOLLECTOR_HOTFIX_DELTA_DATA_TEMPLATE
 
         if message_type == 'packages':
-            print("PACKAGEEEEEEEEEEEES")
             package_data, operation = self.get_package_data()
             message_operation = operation
 

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -910,8 +910,7 @@ class GeneratorSyscollector:
             message_data = syscollector.SYSCOLLECTOR_HOTFIX_DELTA_DATA_TEMPLATE
 
         if message_type == 'packages':
-            package_data, operation = self.get_package_data()
-            message_operation = operation
+            package_data, message_operation = self.get_package_data()
 
         message = '{"type": "%s", "data": %s, "operation": "%s"}' % (
             message_event_type,

--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -822,10 +822,11 @@ class GeneratorSyscollector:
             dict: Package data.
             str: Operation (INSERTED or DELETED).
         """
-
-        operation = 'INSERTED' if not self.packages[self.package_index]['installed'] else 'DELETED'
+        operation = 'DELETED' if self.packages[self.package_index]['installed'] else 'INSERTED'
 
         package_data = self.packages[self.package_index]
+
+        self.packages[self.package_index]['installed'] = not self.packages[self.package_index]['installed']
         self.package_index = (self.package_index + 1) % len(self.packages)
 
         return package_data, operation
@@ -920,7 +921,6 @@ class GeneratorSyscollector:
 
         if message_type == 'packages':
             message = self.parse_package_template(message, package_data)
-            self.packages[self.package_index]['installed'] = not self.packages[self.package_index]['installed']
 
         return message
 


### PR DESCRIPTION
|Related issue|
|-------------|
|     https://github.com/wazuh/wazuh-qa/issues/4794        |

### Description

This PR includes the support for deletion of packages operations ins syscollector generator for the Agent simulator


</details>

### Evidences




<details>

<summary> Simulate Agents Output </summary>

```
python3 simulate_agents.py  -a 192.168.56.8  -n 1 -t 100 -s 1 -m syscollector --syscollector-event-types 'packages'  --debug
DEBUG:root:Registration - 1-nl20Hjz8PcDNrxKp-debian8(033) in 192.168.56.8
DEBUG:root:Keep alive message = #!-Linux |agent-debian8 |3.16.0-9-amd64 |#1 SMP Debian 3.16.68-1 (2019-05-22) |x86_64 [Debian GNU/Linux|debian: 8 (jessie)] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00
d6e3ac3e75ca0319af3e7c262776f331 merged.mg
#"_agent_ip":10.0.2.15

INFO:P64085:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'enabled', 'frequency': 60, 'eps': 1}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'disabled', 'eps': 0}, 'receive_messages': {'status': 'enabled'}}
INFO:P64085:Waiting 0 seconds before sending EPS and keep-alive events
INFO:P64085:Starting 1 agents.
DEBUG:root:Starting - 1-nl20Hjz8PcDNrxKp-debian8(033)(debian8) - keepalive
DEBUG:root:Starting - 1-nl20Hjz8PcDNrxKp-debian8(033)(debian8) - syscollector
DEBUG:root:Starting - 1-nl20Hjz8PcDNrxKp-debian8(033)(debian8) - receive_messages
DEBUG:root:Startup - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"DIEJR7NNOH","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"35ROHX8S1M","location":"","multiarch":"null","name":"bsd_os","priority":"optional","scan_time":"2023/12/1915:32:25","size":"1","source":"","vendor":"bsdi","version":"3.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"C558O1L1QA","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"WIAV5D35Z5","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"2","source":"","vendor":"freebsd","version":"1.0"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"184CEBU3F6","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"5CEH3MWH88","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"3","source":"","vendor":"freebsd","version":"1.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"DD7VS5SHMR","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"X89KKZXOX6","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"4","source":"","vendor":"freebsd","version":"1.1.5.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"30VZN0YYPL","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"YYM759PL7I","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"5","source":"","vendor":"freebsd","version":"1.2"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"KLGDR5D88W","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"4IWO24G901","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"6","source":"","vendor":"freebsd","version":"2.0"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"G5GUSD45D1","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"GUU17WCJK8","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"7","source":"","vendor":"freebsd","version":"2.0.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"7UG5XDV89Q","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"39ZH46TVFW","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"8","source":"","vendor":"freebsd","version":"2.0.5"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"KM9QPF41L8","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"D13O67BSQ4","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"9","source":"","vendor":"freebsd","version":"2.1.5"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"BU66FSDIMD","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"945REOGUDT","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"10","source":"","vendor":"freebsd","version":"2.1.6"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"TA28D8QYLV","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"15C6EQIFQ4","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"11","source":"","vendor":"freebsd","version":"2.1.6.1"}, "operation": "INSERTED"}
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"QURYYZBY52","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"8HNA653HCC","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"12","source":"","vendor":"freebsd","version":"2.1.7"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"A4D3U0DCVA","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"1KGH6SP3MJ","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"13","source":"","vendor":"freebsd","version":"2.1.7.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"F8DHV8SFQ9","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"1QVWCPOGPR","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"14","source":"","vendor":"freebsd","version":"2.2"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"YI66VJMIVH","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"BQAIPUEXL3","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"15","source":"","vendor":"freebsd","version":"2.2.2"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"26C340F75H","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"9PF2KUYTW3","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"16","source":"","vendor":"freebsd","version":"2.2.3"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"CGBKW5ZSXS","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"9AXLWKZKN0","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"17","source":"","vendor":"freebsd","version":"2.2.4"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"VGYWGFEG28","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"4V1RVH6JL3","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"18","source":"","vendor":"freebsd","version":"2.2.5"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"M68RB3AHEB","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"39PDA1CJ87","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"19","source":"","vendor":"freebsd","version":"2.2.6"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"CB22TK4KZV","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"2NX7TTEFQA","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"20","source":"","vendor":"freebsd","version":"2.2.8"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"L0SEFN3A15","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"P8ZMDUU3KU","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"21","source":"","vendor":"freebsd","version":"3.0"}, "operation": "INSERTED"}
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"1SN2KTCWXA","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"W9SKOQ5PNW","location":"","multiarch":"null","name":"openbsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"22","source":"","vendor":"openbsd","version":"2.3"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"Q8LL15KHGP","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"IU55YBOY24","location":"","multiarch":"null","name":"openbsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"23","source":"","vendor":"openbsd","version":"2.4"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"73VGX48WMH","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"35ROHX8S1M","location":"","multiarch":"null","name":"bsd_os","priority":"optional","scan_time":"2023/12/1915:32:25","size":"24","source":"","vendor":"bsdi","version":"3.1"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"20F6RKR9OJ","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"WIAV5D35Z5","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"25","source":"","vendor":"freebsd","version":"1.0"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"CC9ZKUZLXZ","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"5CEH3MWH88","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"26","source":"","vendor":"freebsd","version":"1.1"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"9ALEJV8ZHQ","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"X89KKZXOX6","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"27","source":"","vendor":"freebsd","version":"1.1.5.1"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"8NEDCS3NRM","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"YYM759PL7I","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"28","source":"","vendor":"freebsd","version":"1.2"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"D4L3MY7BKP","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"4IWO24G901","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"29","source":"","vendor":"freebsd","version":"2.0"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"V1Y7P7Y0XD","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"GUU17WCJK8","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"30","source":"","vendor":"freebsd","version":"2.0.1"}, "operation": "DELETED"}
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"8MLUEEFXWQ","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"39ZH46TVFW","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"31","source":"","vendor":"freebsd","version":"2.0.5"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"G2HS3VXFAT","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"D13O67BSQ4","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"32","source":"","vendor":"freebsd","version":"2.1.5"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"NA4C2DWJN0","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"945REOGUDT","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"33","source":"","vendor":"freebsd","version":"2.1.6"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"7O4919LNEC","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"15C6EQIFQ4","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"34","source":"","vendor":"freebsd","version":"2.1.6.1"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"U27BTZSCSO","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"8HNA653HCC","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"35","source":"","vendor":"freebsd","version":"2.1.7"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"1V8Y3RP5S6","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"1KGH6SP3MJ","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"36","source":"","vendor":"freebsd","version":"2.1.7.1"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"7NR7Q9CQJ6","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"1QVWCPOGPR","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"37","source":"","vendor":"freebsd","version":"2.2"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"UOQAUR4ZOZ","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"BQAIPUEXL3","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"38","source":"","vendor":"freebsd","version":"2.2.2"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"JS49WKVXVO","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"9PF2KUYTW3","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"39","source":"","vendor":"freebsd","version":"2.2.3"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"XGICDR1CS6","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"9AXLWKZKN0","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"40","source":"","vendor":"freebsd","version":"2.2.4"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"VPXA135877","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"4V1RVH6JL3","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"41","source":"","vendor":"freebsd","version":"2.2.5"}, "operation": "DELETED"}
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"9OEL4UL22V","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"39PDA1CJ87","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"42","source":"","vendor":"freebsd","version":"2.2.6"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"SS2MTD6PL0","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"2NX7TTEFQA","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"43","source":"","vendor":"freebsd","version":"2.2.8"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"399WZGCNID","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"P8ZMDUU3KU","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"44","source":"","vendor":"freebsd","version":"3.0"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"K2CYHWSB80","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"W9SKOQ5PNW","location":"","multiarch":"null","name":"openbsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"45","source":"","vendor":"openbsd","version":"2.3"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"C3CJODT0XY","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"IU55YBOY24","location":"","multiarch":"null","name":"openbsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"46","source":"","vendor":"openbsd","version":"2.4"}, "operation": "DELETED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"YOKII0RP1M","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"35ROHX8S1M","location":"","multiarch":"null","name":"bsd_os","priority":"optional","scan_time":"2023/12/1915:32:25","size":"47","source":"","vendor":"bsdi","version":"3.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"NEIUATGVZ4","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"WIAV5D35Z5","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"48","source":"","vendor":"freebsd","version":"1.0"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"BSVOTHHM8L","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"5CEH3MWH88","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"49","source":"","vendor":"freebsd","version":"1.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"ZQ6S165TUR","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"X89KKZXOX6","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"50","source":"","vendor":"freebsd","version":"1.1.5.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"GR4G103KA5","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"YYM759PL7I","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"51","source":"","vendor":"freebsd","version":"1.2"}, "operation": "INSERTED"}
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"7NX6M37Q3N","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"4IWO24G901","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"52","source":"","vendor":"freebsd","version":"2.0"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"Q957ZS3YPI","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"GUU17WCJK8","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"53","source":"","vendor":"freebsd","version":"2.0.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"UUHX8JVSZX","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"39ZH46TVFW","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"54","source":"","vendor":"freebsd","version":"2.0.5"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"X3IM2R979K","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"D13O67BSQ4","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"55","source":"","vendor":"freebsd","version":"2.1.5"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"UG581HM5EH","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"945REOGUDT","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"56","source":"","vendor":"freebsd","version":"2.1.6"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"QR3MDXPMYC","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"15C6EQIFQ4","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"57","source":"","vendor":"freebsd","version":"2.1.6.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"CUQKGQNKPG","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"8HNA653HCC","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"58","source":"","vendor":"freebsd","version":"2.1.7"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"G3FPNYD295","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"1KGH6SP3MJ","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"59","source":"","vendor":"freebsd","version":"2.1.7.1"}, "operation": "INSERTED"}
DEBUG:root:Syscollector Event  - d:syscollector:{"type": "dbsync_packages", "data": {"architecture":"","checksum":"7MVMA7JLLZ","description":"","format":"","groups":"editors","install_time":"2024/01/17 00:00:00","item_id":"1QVWCPOGPR","location":"","multiarch":"null","name":"freebsd","priority":"optional","scan_time":"2023/12/1915:32:25","size":"60","source":"","vendor":"freebsd","version":"2.2"}, "operation": "INSERTED"}
DEBUG:root:KeepAlive - 1-nl20Hjz8PcDNrxKp-debian8(033)
```


</details>



<details>

<summary> Alerts </summary>

```
{"timestamp":"2024-01-17T11:39:05.788+0000","rule":{"level":10,"description":"CVE-2008-4609 affects bsd_os","id":"23505","firedtimes":2075,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491545.17738770","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2008-4609","cvss":{"cvss2":{"base_score":"7.100000","vector":{"access_complexity":"MEDIUM","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-16","enumeration":"CVE","package":{"condition":"Package equal to 3.1","name":"bsd_os","version":"3.1"},"published":"2008-10-20T17:59:26Z","rationale":"The TCP implementation in (1) Linux, (2) platforms based on BSD Unix, (3) Microsoft Windows, (4) Cisco products, and probably other operating systems allows remote attackers to cause a denial of service (connection queue exhaustion) via multiple vectors that manipulate information in the TCP state table, as demonstrated by sockstress.","reference":"http://blog.robertlee.name/2008/10/conjecture-speculation.html, http://insecure.org/stf/tcp-dos-attack-explained.html, http://lists.immunitysec.com/pipermail/dailydave/2008-October/005360.html, http://searchsecurity.techtarget.com.au/articles/27154-TCP-is-fundamentally-borked, http://www.cisco.com/en/US/products/products_security_advisory09186a0080af511d.shtml, http://www.cisco.com/en/US/products/products_security_response09186a0080a15120.html, http://www.cpni.gov.uk/Docs/tn-03-09-security-assessment-TCP.pdf, http://www.mandriva.com/security/advisories?name=MDVSA-2013:150, http://www.outpost24.com/news/news-2008-10-02.html, https://oval.cisecurity.org/repository/search/definition/oval%3Aorg.mitre.oval%3Adef%3A6340, https://www.cert.fi/haavoittuvuudet/2008/tcp-vulnerabilities.html, https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-048, http://marc.info/?l=bugtraq&m=125856010926699&w=2, http://www.oracle.com/technetwork/topics/security/cpujul2012-392727.html, http://www.us-cert.gov/cas/techalerts/TA09-251A.html","severity":"High","status":"Active","title":"CVE-2008-4609 affects bsd_os","type":"Packages","updated":"2022-12-14T16:40:36Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:05.800+0000","rule":{"level":7,"description":"CVE-1999-0001 affects bsd_os","id":"23504","firedtimes":2105,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491545.17743254","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-1999-0001","cvss":{"cvss2":{"base_score":"5","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-20","enumeration":"CVE","package":{"condition":"Package equal to 3.1","name":"bsd_os","version":"3.1"},"published":"1999-12-30T05:00:00Z","rationale":"ip_input.c in BSD-derived TCP/IP implementations allows remote attackers to cause a denial of service (crash or hang) via crafted packets.","reference":"http://www.openbsd.org/errata23.html#tcpfix, http://www.osvdb.org/5707","severity":"Medium","status":"Active","title":"CVE-1999-0001 affects bsd_os","type":"Packages","updated":"2010-12-16T05:00:00Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:05.811+0000","rule":{"level":10,"description":"CVE-2000-1103 affects bsd_os","id":"23505","firedtimes":2076,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491545.17745366","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2000-1103","cvss":{"cvss2":{"base_score":"7.200000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"COMPLETE","integrity_impact":"COMPLETE"}}},"enumeration":"CVE","package":{"condition":"Package equal to 3.1","name":"bsd_os","version":"3.1"},"published":"2001-01-09T05:00:00Z","rationale":"rcvtty in BSD 3.0 and 4.0 does not properly drop privileges before executing a script, which allows local attackers to gain privileges by specifying an alternate Trojan horse script on the command line.","reference":"http://www.securityfocus.com/archive/1/147120, http://www.securityfocus.com/bid/2009","severity":"High","status":"Active","title":"CVE-2000-1103 affects bsd_os","type":"Packages","updated":"2008-09-05T20:22:39Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:05.821+0000","rule":{"level":5,"description":"CVE-2001-1133 affects bsd_os","id":"23503","firedtimes":522,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491545.17747614","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-1133","cvss":{"cvss2":{"base_score":"2.100000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"enumeration":"CVE","package":{"condition":"Package equal to 3.1","name":"bsd_os","version":"3.1"},"published":"2001-08-21T04:00:00Z","rationale":"Vulnerability in a system call in BSDI 3.0 and 3.1 allows local users to cause a denial of service (reboot) in the kernel via a particular sequence of instructions.","reference":"http://www.securityfocus.com/bid/3220, http://www.iss.net/security_center/static/7023.php, http://www.securityfocus.com/archive/1/209192","severity":"Low","status":"Active","title":"CVE-2001-1133 affects bsd_os","type":"Packages","updated":"2008-09-05T20:25:46Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:05.833+0000","rule":{"level":10,"description":"CVE-1999-0704 affects bsd_os","id":"23505","firedtimes":2077,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491545.17749869","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-1999-0704","cvss":{"cvss2":{"base_score":"9.300000","vector":{"access_complexity":"MEDIUM","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"COMPLETE","integrity_impact":"COMPLETE"}}},"enumeration":"CVE","package":{"condition":"Package equal to 3.1","name":"bsd_os","version":"3.1"},"published":"1999-09-16T04:00:00Z","rationale":"Buffer overflow in Berkeley automounter daemon (amd) logging facility provided in the Linux am-utils package and others.","reference":"http://www.securityfocus.com/bid/614","severity":"High","status":"Active","title":"CVE-1999-0704 affects bsd_os","type":"Packages","updated":"2008-09-09T12:35:15Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:05.842+0000","rule":{"level":10,"description":"CVE-2001-1541 affects bsd_os","id":"23505","firedtimes":2078,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491545.17751863","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-1541","cvss":{"cvss2":{"base_score":"7.200000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"COMPLETE","integrity_impact":"COMPLETE"}}},"enumeration":"CVE","package":{"condition":"Package equal to 3.1","name":"bsd_os","version":"3.1"},"published":"2001-12-31T05:00:00Z","rationale":"Buffer overflow in Unix-to-Unix Copy Protocol (UUCP) in BSDI BSD/OS 3.0 through 4.2 allows local users to execute arbitrary code via a long command line argument.","reference":"http://www.securityfocus.com/bid/3603, http://www.iss.net/security_center/static/7633.php, http://www.securityfocus.com/archive/1/243096","severity":"High","status":"Active","title":"CVE-2001-1541 affects bsd_os","type":"Packages","updated":"2008-09-05T20:26:48Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:06.981+0000","rule":{"level":10,"description":"CVE-2022-32264 affects freebsd","id":"23505","firedtimes":2079,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491546.17754135","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2022-32264","cvss":{"cvss3":{"base_score":"7.500000","vector":{"availability":"HIGH","confidentiality_impact":"NONE","integrity_impact":"NONE","privileges_required":"NONE","scope":"UNCHANGED","user_interaction":"NONE"}}},"cwe_reference":"CWE-755","enumeration":"CVE","package":{"condition":"Package less than 7.0","name":"freebsd","version":"1.0"},"published":"2022-09-06T18:15:15Z","rationale":"** UNSUPPORTED WHEN ASSIGNED ** sys/netinet/tcp_timer.h in FreeBSD before 7.0 contains a denial-of-service (DoS) vulnerability due to improper handling of TSopt on TCP connections. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.","reference":"https://cgit.freebsd.org/src/commit/?id=4dc630cdd2f7a790604d2724ecb19c6aa95130a7, http://jvn.jp/en/jp/JVN20930118/","severity":"High","status":"Active","title":"CVE-2022-32264 affects freebsd","type":"Packages","updated":"2022-09-09T02:36:50Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:06.992+0000","rule":{"level":7,"description":"CVE-2020-24385 affects freebsd","id":"23504","firedtimes":2106,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491546.17756719","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2020-24385","cvss":{"cvss2":{"base_score":"4.900000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-476","enumeration":"CVE","package":{"condition":"Package less than or equal to 7.0","name":"freebsd","version":"1.0"},"published":"2020-09-03T15:15:11Z","rationale":"In MidnightBSD before 1.2.6 and 1.3 before August 2020, and FreeBSD before 7, a NULL pointer dereference was found in the Linux emulation layer that allows attackers to crash the running kernel. During binary interaction, td->td_emuldata in sys/compat/linux/linux_emul.h is not getting initialized and returns NULL from em_find().","reference":"https://www.midnightbsd.org/notes/, http://www.midnightbsd.org/security/adv/MIDNIGHTBSD-SA-20:02.txt","severity":"Medium","status":"Active","title":"CVE-2020-24385 affects freebsd","type":"Packages","updated":"2020-09-11T14:06:02Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.006+0000","rule":{"level":10,"description":"CVE-2017-1081 affects freebsd","id":"23505","firedtimes":2080,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17759322","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"freebsd","cve":"CVE-2017-1081","cvss":{"cvss2":{"base_score":"7.800000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-20","enumeration":"CVE","package":{"condition":"Package less than or equal to 11.0","name":"freebsd","version":"1.0"},"published":"2018-04-10T13:29:00Z","rationale":"In FreeBSD before 11.0-STABLE, 11.0-RELEASE-p10, 10.3-STABLE, and 10.3-RELEASE-p19, ipfilter using \"keep state\" or \"keep frags\" options can cause a kernel panic when fed specially crafted packet fragments due to incorrect memory handling.","reference":"http://www.securityfocus.com/bid/98089, http://www.securitytracker.com/id/1038369, https://www.freebsd.org/security/advisories/FreeBSD-SA-17:04.ipfilter.asc","severity":"High","status":"Active","title":"CVE-2017-1081 affects freebsd","type":"Packages","updated":"2019-10-09T23:26:01Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.016+0000","rule":{"level":5,"description":"CVE-2014-3956 affects freebsd","id":"23503","firedtimes":523,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17761853","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2014-3956","cvss":{"cvss2":{"base_score":"1.900000","vector":{"access_complexity":"MEDIUM","authentication":"NONE","availability":"NONE","confidentiality_impact":"PARTIAL","integrity_impact":"NONE"}}},"cwe_reference":"CWE-200","enumeration":"CVE","package":{"condition":"Package less than or equal to 9.2","name":"freebsd","version":"1.0"},"published":"2014-06-04T11:19:13Z","rationale":"The sm_close_on_exec function in conf.c in sendmail before 8.14.9 has arguments in the wrong order, and consequently skips setting expected FD_CLOEXEC flags, which allows local users to access unintended high-numbered file descriptors via a custom mail-delivery program.","reference":"http://www.sendmail.com/sm/open_source/download/8.14.9/, http://advisories.mageia.org/MGASA-2014-0270.html, http://lists.fedoraproject.org/pipermail/package-announce/2014-June/134349.html, https://h20566.www2.hpe.com/portal/site/hpsc/public/kb/docDisplay?docId=emr_na-c05216368, http://packetstormsecurity.com/files/126975/Slackware-Security-Advisory-sendmail-Updates.html, http://www.securityfocus.com/bid/67791, http://www.securitytracker.com/id/1030331, ftp://ftp.sendmail.org/pub/sendmail/RELEASE_NOTES, http://lists.opensuse.org/opensuse-updates/2014-06/msg00032.html, http://lists.opensuse.org/opensuse-updates/2014-06/msg00033.html, http://secunia.com/advisories/57455, http://secunia.com/advisories/58628, http://security.gentoo.org/glsa/glsa-201412-32.xml, http://www.freebsd.org/security/advisories/FreeBSD-SA-14%3A11.sendmail.asc, http://www.mandriva.com/security/advisories?name=MDVSA-2014:147, http://www.mandriva.com/security/advisories?name=MDVSA-2015:128, http://www.slackware.com/security/viewer.php?l=slackware-security&y=2014&m=slackware-security.728644","severity":"Low","status":"Active","title":"CVE-2014-3956 affects freebsd","type":"Packages","updated":"2017-12-29T02:29:22Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.027+0000","rule":{"level":10,"description":"CVE-2014-3879 affects freebsd","id":"23505","firedtimes":2081,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17766273","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2014-3879","cvss":{"cvss2":{"base_score":"7.500000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"PARTIAL","integrity_impact":"PARTIAL"}}},"cwe_reference":"CWE-287","enumeration":"CVE","package":{"condition":"Package less than or equal to 9.2","name":"freebsd","version":"1.0"},"published":"2020-02-18T17:15:12Z","rationale":"OpenPAM Nummularia 9.2 through 10.0 does not properly handle the error reported when an include directive refers to a policy that does not exist, which causes the loaded policy chain to no be discarded and allows context-dependent attackers to bypass authentication via a login (1) without a password or (2) with an incorrect password.","reference":"http://www.freebsd.org/security/advisories/FreeBSD-SA-14:13.pam.asc, http://www.securitytracker.com/id/1030330, http://www.openpam.org/browser/openpam/trunk/HISTORY, http://www.securityfocus.com/bid/67808","severity":"High","status":"Active","title":"CVE-2014-3879 affects freebsd","type":"Packages","updated":"2020-02-27T15:52:50Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.037+0000","rule":{"level":7,"description":"CVE-2013-6833 affects freebsd","id":"23504","firedtimes":2107,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17769096","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2013-6833","cvss":{"cvss2":{"base_score":"4.900000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"NONE","confidentiality_impact":"COMPLETE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-20","enumeration":"CVE","package":{"condition":"Package less than or equal to 10.0","name":"freebsd","version":"1.0"},"published":"2013-11-21T04:40:59Z","rationale":"The qls_eioctl function in sys/dev/qlxge/qls_ioctl.c in the kernel in FreeBSD 10 and earlier does not validate a certain size parameter, which allows local users to obtain sensitive information from kernel memory via a crafted ioctl call.","reference":"http://archives.neohapsis.com/archives/fulldisclosure/2013-11/0107.html","severity":"Medium","status":"Active","title":"CVE-2013-6833 affects freebsd","type":"Packages","updated":"2013-11-25T04:36:31Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.047+0000","rule":{"level":7,"description":"CVE-2013-6832 affects freebsd","id":"23504","firedtimes":2108,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17771452","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2013-6832","cvss":{"cvss2":{"base_score":"4.900000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"NONE","confidentiality_impact":"COMPLETE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-200","enumeration":"CVE","package":{"condition":"Package less than or equal to 10.0","name":"freebsd","version":"1.0"},"published":"2013-11-21T04:40:59Z","rationale":"The nand_ioctl function in sys/dev/nand/nand_geom.c in the nand driver in the kernel in FreeBSD 10 and earlier does not properly initialize a certain data structure, which allows local users to obtain sensitive information from kernel memory via a crafted ioctl call.","reference":"http://archives.neohapsis.com/archives/fulldisclosure/2013-11/0106.html","severity":"Medium","status":"Active","title":"CVE-2013-6832 affects freebsd","type":"Packages","updated":"2013-11-25T04:36:31Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.058+0000","rule":{"level":10,"description":"CVE-2012-5365 affects freebsd","id":"23505","firedtimes":2082,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17773868","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2012-5365","cvss":{"cvss2":{"base_score":"7.800000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-400","enumeration":"CVE","package":{"condition":"Package less than 9.2","name":"freebsd","version":"1.0"},"published":"2020-02-20T15:15:11Z","rationale":"The IPv6 implementation in FreeBSD and NetBSD (unknown versions, year 2012 and earlier) allows remote attackers to cause a denial of service via a flood of ICMPv6 Router Advertisement packets containing multiple Routing entries.","reference":"http://www.openwall.com/lists/oss-security/2012/10/10/12, https://www.securityfocus.com/bid/56170/info","severity":"High","status":"Active","title":"CVE-2012-5365 affects freebsd","type":"Packages","updated":"2020-02-25T19:30:04Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.068+0000","rule":{"level":10,"description":"CVE-2012-5363 affects freebsd","id":"23505","firedtimes":2083,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17776239","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2012-5363","cvss":{"cvss2":{"base_score":"7.800000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-400","enumeration":"CVE","package":{"condition":"Package less than 9.2","name":"freebsd","version":"1.0"},"published":"2020-02-20T15:15:11Z","rationale":"The IPv6 implementation in FreeBSD and NetBSD (unknown versions, year 2012 and earlier) allows remote attackers to cause a denial of service via a flood of ICMPv6 Neighbor Solicitation messages, a different vulnerability than CVE-2011-2393.","reference":"http://www.openwall.com/lists/oss-security/2012/10/10/12, https://www.securityfocus.com/bid/56170/info","severity":"High","status":"Active","title":"CVE-2012-5363 affects freebsd","type":"Packages","updated":"2020-02-28T16:34:33Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.079+0000","rule":{"level":7,"description":"CVE-2012-2143 affects freebsd","id":"23504","firedtimes":2109,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17778634","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"redhat","cve":"CVE-2012-2143","cvss":{"cvss2":{"base_score":"4.300000","vector":{"access_complexity":"MEDIUM","authentication":"NONE","availability":"NONE","confidentiality_impact":"NONE","integrity_impact":"PARTIAL"}}},"cwe_reference":"CWE-310","enumeration":"CVE","package":{"condition":"Package less than or equal to 9.0","name":"freebsd","version":"1.0"},"published":"2012-07-05T14:55:02Z","rationale":"The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password.","reference":"http://www.mandriva.com/security/advisories?name=MDVSA-2012:092, http://secunia.com/advisories/49304, http://secunia.com/advisories/50718, https://bugzilla.redhat.com/show_bug.cgi?id=816956, http://lists.apple.com/archives/security-announce/2012/Sep/msg00004.html, http://lists.fedoraproject.org/pipermail/package-announce/2012-June/082258.html, http://lists.fedoraproject.org/pipermail/package-announce/2012-June/082292.html, http://lists.fedoraproject.org/pipermail/package-announce/2012-June/082294.html, http://lists.opensuse.org/opensuse-security-announce/2012-07/msg00003.html, http://lists.opensuse.org/opensuse-updates/2012-09/msg00102.html, http://lists.opensuse.org/opensuse-updates/2012-10/msg00013.html, http://lists.opensuse.org/opensuse-updates/2012-10/msg00024.html, http://kb.juniper.net/InfoCenter/index?page=content&id=JSA10705, http://rhn.redhat.com/errata/RHSA-2012-1037.html, http://support.apple.com/kb/HT5501, http://www.debian.org/security/2012/dsa-2491, http://www.securitytracker.com/id?1026995, http://git.php.net/?p=php-src.git;a=commit;h=aab49e934de1fff046e659cbec46e3d053b41c34, http://git.postgresql.org/gitweb/?p=postgresql.git&a=commit&h=932ded2ed51e8333852e370c7a6dad75d9f236f9, http://security.freebsd.org/advisories/FreeBSD-SA-12:02.crypt.asc, http://www.postgresql.org/docs/8.3/static/release-8-3-19.html, http://www.postgresql.org/docs/8.4/static/release-8-4-12.html, http://www.postgresql.org/docs/9.0/static/release-9-0-8.html, http://www.postgresql.org/docs/9.1/static/release-9-1-4.html, http://www.postgresql.org/support/security/","severity":"Medium","status":"Active","title":"CVE-2012-2143 affects freebsd","type":"Packages","updated":"2023-01-20T17:52:34Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.089+0000","rule":{"level":10,"description":"CVE-2001-0402 affects freebsd","id":"23505","firedtimes":2084,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17784346","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-0402","cvss":{"cvss2":{"base_score":"7.500000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"PARTIAL","integrity_impact":"PARTIAL"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 4.1","name":"freebsd","version":"1.0"},"published":"2001-06-18T04:00:00Z","rationale":"IPFilter 3.4.16 and earlier does not include sufficient session information in its cache, which allows remote attackers to bypass access restrictions by sending fragmented packets to a restricted port after sending unfragmented packets to an unrestricted port.","reference":"http://archives.neohapsis.com/archives/freebsd/2001-04/0338.html, http://marc.info/?l=bugtraq&m=98679734015538&w=2, https://exchange.xforce.ibmcloud.com/vulnerabilities/6331","severity":"High","status":"Active","title":"CVE-2001-0402 affects freebsd","type":"Packages","updated":"2017-10-10T01:29:42Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.100+0000","rule":{"level":7,"description":"CVE-1999-0345 affects freebsd","id":"23504","firedtimes":2110,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17786913","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-1999-0345","cvss":{"cvss2":{"base_score":"5","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"enumeration":"CVE","package":{"condition":"Package equal to 1.0","name":"freebsd","version":"1.0"},"published":"1997-01-01T05:00:00Z","rationale":"Jolt ICMP attack causes a denial of service in Windows 95 and Windows NT systems.","reference":"http://www.securityfocus.com/archive/1/62170","severity":"Medium","status":"Active","title":"CVE-1999-0345 affects freebsd","type":"Packages","updated":"2022-08-17T06:15:13Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.110+0000","rule":{"level":7,"description":"CVE-2001-0469 affects freebsd","id":"23504","firedtimes":2111,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17788822","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-0469","cvss":{"cvss2":{"base_score":"5","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 4.2","name":"freebsd","version":"1.0"},"published":"2001-06-27T04:00:00Z","rationale":"rwho daemon rwhod in FreeBSD 4.2 and earlier, and possibly other operating systems, allows remote attackers to cause a denial of service via malformed packets with a short length.","reference":"http://archives.neohapsis.com/archives/freebsd/2001-03/0163.html, http://www.securityfocus.com/bid/2473, https://exchange.xforce.ibmcloud.com/vulnerabilities/6229","severity":"Medium","status":"Active","title":"CVE-2001-0469 affects freebsd","type":"Packages","updated":"2017-10-10T01:29:44Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.120+0000","rule":{"level":10,"description":"CVE-2001-0388 affects freebsd","id":"23505","firedtimes":2085,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17791189","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-0388","cvss":{"cvss2":{"base_score":"10","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"COMPLETE","integrity_impact":"COMPLETE"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 4.1","name":"freebsd","version":"1.0"},"published":"2001-06-27T04:00:00Z","rationale":"time server daemon timed allows remote attackers to cause a denial of service via malformed packets.","reference":"ftp://ftp.FreeBSD.org/pub/FreeBSD/CERT/advisories/FreeBSD-SA-01:28.timed.asc, http://www.linux-mandrake.com/en/security/2001/MDKSA-2001-034.php3, http://www.novell.com/linux/security/advisories/2001_007_nkitserv.html, https://exchange.xforce.ibmcloud.com/vulnerabilities/6228","severity":"High","status":"Active","title":"CVE-2001-0388 affects freebsd","type":"Packages","updated":"2017-10-10T01:29:42Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.131+0000","rule":{"level":7,"description":"CVE-2004-0114 affects freebsd","id":"23504","firedtimes":2112,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17793641","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2004-0114","cvss":{"cvss2":{"base_score":"4.600000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"PARTIAL","integrity_impact":"PARTIAL"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 5.2","name":"freebsd","version":"1.0"},"published":"2004-03-03T05:00:00Z","rationale":"The shmat system call in the System V Shared Memory interface for FreeBSD 5.2 and earlier, NetBSD 1.3 and earlier, and OpenBSD 2.6 and earlier, does not properly decrement a shared memory segment's reference count when the vm_map_find function fails, which could allow local users to gain read or write access to a portion of kernel memory and gain privileges.","reference":"ftp://ftp.freebsd.org/pub/FreeBSD/CERT/advisories/FreeBSD-SA-04:02.shmat.asc, http://www.securityfocus.com/bid/9586, ftp://ftp.netbsd.org/pub/NetBSD/security/advisories/NetBSD-SA2004-004.txt.asc, http://marc.info/?l=bugtraq&m=107608375207601&w=2, http://www.openbsd.org/errata33.html#sysvshm, http://www.osvdb.org/3836, http://www.pine.nl/press/pine-cert-20040201.txt, https://exchange.xforce.ibmcloud.com/vulnerabilities/15061","severity":"Medium","status":"Active","title":"CVE-2004-0114 affects freebsd","type":"Packages","updated":"2017-10-10T01:30:17Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.141+0000","rule":{"level":7,"description":"CVE-2013-6834 affects freebsd","id":"23504","firedtimes":2113,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17796919","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2013-6834","cvss":{"cvss2":{"base_score":"4.900000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"NONE","confidentiality_impact":"COMPLETE","integrity_impact":"NONE"}}},"cwe_reference":"CWE-20","enumeration":"CVE","package":{"condition":"Package less than or equal to 10.0","name":"freebsd","version":"1.0"},"published":"2013-11-21T04:40:59Z","rationale":"The ql_eioctl function in sys/dev/qlxgbe/ql_ioctl.c in the kernel in FreeBSD 10 and earlier does not validate a certain size parameter, which allows local users to obtain sensitive information from kernel memory via a crafted ioctl call.","reference":"http://archives.neohapsis.com/archives/fulldisclosure/2013-11/0107.html","severity":"Medium","status":"Active","title":"CVE-2013-6834 affects freebsd","type":"Packages","updated":"2014-03-04T18:52:21Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.151+0000","rule":{"level":7,"description":"CVE-1999-1313 affects freebsd","id":"23504","firedtimes":2114,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17799273","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-1999-1313","cvss":{"cvss2":{"base_score":"4.600000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"PARTIAL","integrity_impact":"PARTIAL"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 2.2","name":"freebsd","version":"1.0"},"published":"1996-05-23T04:00:00Z","rationale":"Manual page reader (man) in FreeBSD 2.2 and earlier allows local users to gain privileges via a sequence of commands.","reference":"ftp://ftp.FreeBSD.org/pub/FreeBSD/CERT/advisories/old/FreeBSD-SA-96:11.man.asc, http://ciac.llnl.gov/ciac/bulletins/g-24.shtml, https://exchange.xforce.ibmcloud.com/vulnerabilities/7348","severity":"Medium","status":"Active","title":"CVE-1999-1313 affects freebsd","type":"Packages","updated":"2017-12-19T02:29:07Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.162+0000","rule":{"level":10,"description":"CVE-1999-0017 affects freebsd","id":"23505","firedtimes":2086,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17801581","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-1999-0017","cvss":{"cvss2":{"base_score":"7.500000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"PARTIAL","integrity_impact":"PARTIAL"}}},"enumeration":"CVE","package":{"condition":"Package equal to 1.0","name":"freebsd","version":"1.0"},"published":"1997-12-10T05:00:00Z","rationale":"FTP servers can allow an attacker to connect to arbitrary ports on machines other than the FTP client, aka FTP bounce.","reference":"https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-1999-0017","severity":"High","status":"Active","title":"CVE-1999-0017 affects freebsd","type":"Packages","updated":"2022-08-17T07:15:08Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.172+0000","rule":{"level":7,"description":"CVE-2019-6111 affects freebsd","id":"23504","firedtimes":2115,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17803624","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2019-6111","cvss":{"cvss2":{"base_score":"5.800000","vector":{"access_complexity":"MEDIUM","authentication":"NONE","availability":"PARTIAL","confidentiality_impact":"NONE","integrity_impact":"PARTIAL"}}},"cwe_reference":"CWE-22","enumeration":"CVE","package":{"condition":"Package less than 12.0","name":"freebsd","version":"1.0"},"published":"2019-01-31T18:29:00Z","rationale":"An issue was discovered in OpenSSH 7.9. Due to the scp implementation being derived from 1983 rcp, the server chooses which files/directories are sent to the client. However, the scp client only performs cursory validation of the object name returned (only directory traversal attacks are prevented). A malicious scp server (or Man-in-The-Middle attacker) can overwrite arbitrary files in the scp client target directory. If recursive operation (-r) is performed, the server can manipulate subdirectories as well (for example, to overwrite the .ssh/authorized_keys file).","reference":"http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00058.html, http://www.securityfocus.com/bid/106741, https://bugzilla.redhat.com/show_bug.cgi?id=1677794, https://www.exploit-db.com/exploits/46193/, http://www.openwall.com/lists/oss-security/2019/04/18/1, http://www.openwall.com/lists/oss-security/2022/08/02/1, https://lists.apache.org/thread.html/c45d9bc90700354b58fb7455962873c44229841880dcb64842fa7d23@%3Cdev.mina.apache.org%3E, https://lists.apache.org/thread.html/c7301cab36a86825359e1b725fc40304d1df56dc6d107c1fe885148b@%3Cdev.mina.apache.org%3E, https://lists.apache.org/thread.html/d540139359de999b0f1c87d05b715be4d7d4bec771e1ae55153c5c7a@%3Cdev.mina.apache.org%3E, https://lists.apache.org/thread.html/e47597433b351d6e01a5d68d610b4ba195743def9730e49561e8cf3f@%3Cdev.mina.apache.org%3E, https://lists.debian.org/debian-lts-announce/2019/03/msg00030.html, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/W3YVQ2BPTOVDCFDVNC2GGF5P5ISFG37G/, https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html, https://cvsweb.openbsd.org/src/usr.bin/ssh/scp.c, https://access.redhat.com/errata/RHSA-2019:3702, https://cert-portal.siemens.com/productcert/pdf/ssa-412672.pdf, https://security.gentoo.org/glsa/201903-16, https://security.netapp.com/advisory/ntap-20190213-0001/, https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt, https://usn.ubuntu.com/3885-1/, https://usn.ubuntu.com/3885-2/, https://www.debian.org/security/2019/dsa-4387, https://www.freebsd.org/security/advisories/FreeBSD-EN-19:10.scp.asc","severity":"Medium","status":"Active","title":"CVE-2019-6111 affects freebsd","type":"Packages","updated":"2023-03-24T18:12:40Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.183+0000","rule":{"level":7,"description":"CVE-2001-0371 affects freebsd","id":"23504","firedtimes":2116,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17809698","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-0371","cvss":{"cvss2":{"base_score":"6.200000","vector":{"access_complexity":"HIGH","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"COMPLETE","integrity_impact":"COMPLETE"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 4.2","name":"freebsd","version":"1.0"},"published":"2001-06-18T04:00:00Z","rationale":"Race condition in the UFS and EXT2FS file systems in FreeBSD 4.2 and earlier, and possibly other operating systems, makes deleted data available to user processes before it is zeroed out, which allows a local user to access otherwise restricted information.","reference":"http://archives.neohapsis.com/archives/freebsd/2001-03/0403.html, http://www.osvdb.org/5682, https://exchange.xforce.ibmcloud.com/vulnerabilities/6268","severity":"Medium","status":"Active","title":"CVE-2001-0371 affects freebsd","type":"Packages","updated":"2017-10-10T01:29:42Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.193+0000","rule":{"level":10,"description":"CVE-1999-1385 affects freebsd","id":"23505","firedtimes":2087,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17812224","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-1999-1385","cvss":{"cvss2":{"base_score":"7.200000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"COMPLETE","integrity_impact":"COMPLETE"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 2.1.0","name":"freebsd","version":"1.0"},"published":"1996-12-19T05:00:00Z","rationale":"Buffer overflow in ppp program in FreeBSD 2.1 and earlier allows local users to gain privileges via a long HOME environment variable.","reference":"ftp://ftp.FreeBSD.org/pub/FreeBSD/CERT/advisories/old/FreeBSD-SA-96:20.stack-overflow.asc, http://marc.info/?l=bugtraq&m=87602167420332&w=2, http://www.iss.net/security_center/static/7465.php, http://www.osvdb.org/6085","severity":"High","status":"Active","title":"CVE-1999-1385 affects freebsd","type":"Packages","updated":"2016-10-18T02:03:54Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.203+0000","rule":{"level":7,"description":"CVE-2006-4178 affects freebsd","id":"23504","firedtimes":2117,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17814637","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2006-4178","cvss":{"cvss2":{"base_score":"4.900000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"COMPLETE","confidentiality_impact":"NONE","integrity_impact":"NONE"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 5.5","name":"freebsd","version":"1.0"},"published":"2006-09-26T02:07:00Z","rationale":"Integer signedness error in the i386_set_ldt call in FreeBSD 5.5, and possibly earlier versions down to 5.2, allows local users to cause a denial of service (crash) via unspecified arguments that use negative signed integers to cause the bzero function to be called with a large length parameter, a different vulnerability than CVE-2006-4172.","reference":"http://www.idefense.com/intelligence/vulnerabilities/display.php?id=415, http://secunia.com/advisories/22064, http://securitytracker.com/id?1016927, http://www.securityfocus.com/archive/1/446946/100/0/threaded, http://www.securityfocus.com/bid/20158","severity":"Medium","status":"Active","title":"CVE-2006-4178 affects freebsd","type":"Packages","updated":"2018-10-17T21:33:50Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:39:07.214+0000","rule":{"level":5,"description":"CVE-2001-1029 affects freebsd","id":"23503","firedtimes":524,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"033","name":"1-nl20Hjz8PcDNrxKp-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705491547.17817513","decoder":{"name":"json"},"data":{"vulnerability":{"assigner":"mitre","cve":"CVE-2001-1029","cvss":{"cvss2":{"base_score":"2.100000","vector":{"access_complexity":"LOW","authentication":"NONE","availability":"NONE","confidentiality_impact":"PARTIAL","integrity_impact":"NONE"}}},"enumeration":"CVE","package":{"condition":"Package less than or equal to 4.4","name":"freebsd","version":"1.0"},"published":"2001-09-20T04:00:00Z","rationale":"libutil in OpenSSH on FreeBSD 4.4 and earlier does not drop privileges before verifying the capabilities for reading the copyright and welcome files, which allows local users to bypass the capabilities checks and read arbitrary files by specifying alternate copyright or welcome files.","reference":"http://archives.neohapsis.com/archives/bugtraq/2001-09/0173.html, http://www.osvdb.org/6073, https://exchange.xforce.ibmcloud.com/vulnerabilities/8697","severity":"Low","status":"Active","title":"CVE-2001-1029 affects freebsd","type":"Packages","updated":"2017-10-10T01:29:58Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.608+0000","rule":{"level":3,"description":"The CVE-2014-3879 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3122,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27388318","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-2014-3879","cvss":{"cvss2":{"base_score":"7.500000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"2020-02-18T17:15:12Z","reference":"http://www.freebsd.org/security/advisories/FreeBSD-SA-14:13.pam.asc, http://www.securitytracker.com/id/1030330, http://www.openpam.org/browser/openpam/trunk/HISTORY, http://www.securityfocus.com/bid/67808","severity":"High","status":"Solved","title":"CVE-2014-3879 affecting freebsd was solved","type":"Packages","updated":"2020-02-27T15:52:50Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.626+0000","rule":{"level":3,"description":"The CVE-1999-0023 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3123,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27389855","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-1999-0023","cvss":{"cvss2":{"base_score":"7.200000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"1996-07-24T04:00:00Z","reference":"https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-1999-0023","severity":"High","status":"Solved","title":"CVE-1999-0023 affecting freebsd was solved","type":"Packages","updated":"2022-08-17T07:15:08Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.641+0000","rule":{"level":3,"description":"The CVE-2006-4178 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3124,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27391116","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-2006-4178","cvss":{"cvss2":{"base_score":"4.900000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"2006-09-26T02:07:00Z","reference":"http://www.idefense.com/intelligence/vulnerabilities/display.php?id=415, http://secunia.com/advisories/22064, http://securitytracker.com/id?1016927, http://www.securityfocus.com/archive/1/446946/100/0/threaded, http://www.securityfocus.com/bid/20158","severity":"Medium","status":"Solved","title":"CVE-2006-4178 affecting freebsd was solved","type":"Packages","updated":"2018-10-17T21:33:50Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.652+0000","rule":{"level":3,"description":"The CVE-1999-1385 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3125,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27392747","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-1999-1385","cvss":{"cvss2":{"base_score":"7.200000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"1996-12-19T05:00:00Z","reference":"ftp://ftp.FreeBSD.org/pub/FreeBSD/CERT/advisories/old/FreeBSD-SA-96:20.stack-overflow.asc, http://marc.info/?l=bugtraq&m=87602167420332&w=2, http://www.iss.net/security_center/static/7465.php, http://www.osvdb.org/6085","severity":"High","status":"Solved","title":"CVE-1999-1385 affecting freebsd was solved","type":"Packages","updated":"2016-10-18T02:03:54Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.663+0000","rule":{"level":3,"description":"The CVE-2002-2092 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3126,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27394312","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-2002-2092","cvss":{"cvss2":{"base_score":"3.700000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"2002-12-31T05:00:00Z","reference":"http://www.securityfocus.com/bid/3891, ftp://ftp.FreeBSD.org/pub/FreeBSD/CERT/advisories/FreeBSD-SA-02:08.exec.asc, ftp://ftp.netbsd.org/pub/NetBSD/security/advisories/NetBSD-SA2002-001.txt.asc, http://www.osvdb.org/19475, https://exchange.xforce.ibmcloud.com/vulnerabilities/7945","severity":"Low","status":"Solved","title":"CVE-2002-2092 affecting freebsd was solved","type":"Packages","updated":"2017-12-19T02:29:38Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.674+0000","rule":{"level":3,"description":"The CVE-2006-4172 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3127,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27395999","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-2006-4172","cvss":{"cvss2":{"base_score":"7.200000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"2006-09-26T02:07:00Z","reference":"http://archives.neohapsis.com/archives/bugtraq/2006-09/0376.html, http://secunia.com/advisories/22064, http://securitytracker.com/id?1016926, http://securitytracker.com/id?1016928, http://www.idefense.com/intelligence/vulnerabilities/display.php?id=414, http://www.securityfocus.com/archive/1/446945/100/0/threaded, http://www.securityfocus.com/bid/20158, https://exchange.xforce.ibmcloud.com/vulnerabilities/29132","severity":"High","status":"Solved","title":"CVE-2006-4172 affecting freebsd was solved","type":"Packages","updated":"2018-10-17T21:33:49Z"}},"location":"vulnerability-detector"}
{"timestamp":"2024-01-17T11:58:43.687+0000","rule":{"level":3,"description":"The CVE-2001-0402 that affected freebsd was solved due to a package removal/update or a system upgrade","id":"23502","firedtimes":3128,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"034","name":"1-87XVLwNkgcQ5KyRW-debian8","ip":"10.0.2.15"},"manager":{"name":"ubuntu22"},"id":"1705492723.27397956","decoder":{"name":"json"},"data":{"vulnerability":{"cve":"CVE-2001-0402","cvss":{"cvss2":{"base_score":"7.500000"}},"enumeration":"CVE","package":{"name":"freebsd","version":"2.0"},"published":"2001-06-18T04:00:00Z","reference":"http://archives.neohapsis.com/archives/freebsd/2001-04/0338.html, http://marc.info/?l=bugtraq&m=98679734015538&w=2, https://exchange.xforce.ibmcloud.com/vulnerabilities/6331","severity":"High","status":"Solved","title":"CVE-2001-0402 affecting freebsd was solved","type":"Packages","updated":"2017-10-10T01:29:42Z"}},"location":"vulnerability-detector"}

```
