### PR TITLE
Remove Playbook class and update test module removing its usage

### DIFF
--- a/deployability/modules/generic/__init__.py
+++ b/deployability/modules/generic/__init__.py
@@ -1,3 +1,2 @@
 from .ansible import Ansible, Inventory
-from .playbook import Playbook
 from .schemaValidator import SchemaValidator

--- a/deployability/modules/generic/playbook.py
+++ b/deployability/modules/generic/playbook.py
@@ -1,5 +1,0 @@
-from pathlib import Path
-
-
-class Playbook:
-    PLAYBOOKS_PATH = Path(__file__).parent.parent.parent / "playbooks"

--- a/deployability/modules/testing/testing.py
+++ b/deployability/modules/testing/testing.py
@@ -1,16 +1,15 @@
 from pathlib import Path
 
-from modules.generic import Playbook, Ansible, Inventory
+from modules.generic import Ansible, Inventory
 from modules.generic.utils import Utils
-
 from .models import InputPayload, ExtraVars
 
 
 class Tester:
-    _playbooks_dir = Playbook.PLAYBOOKS_PATH / 'tests'
-    _test_playbook = str(_playbooks_dir / 'test.yml')
-    _setup_playbook = str(_playbooks_dir / 'setup.yml')
-    _cleanup_playbook = str(_playbooks_dir / 'cleanup.yml')
+    _playbooks_dir = Path('tests')
+    _setup_playbook = _playbooks_dir / 'setup.yml'
+    _cleanup_playbook = _playbooks_dir / 'cleanup.yml'
+    _test_template = _playbooks_dir / 'test.yml'
 
     @classmethod
     def run(cls, payload: InputPayload) -> None:
@@ -34,22 +33,25 @@ class Tester:
 
     @classmethod
     def _run_tests(cls, test_list: list[str], ansible: Ansible, extra_vars: ExtraVars) -> None:
-        # Run tests playbooks
+        extra_vars = extra_vars.model_dump()
         for test in test_list:
-            rendering_vars = {**dict(extra_vars), 'test': test}
-            playbook = ansible.render_playbook(cls._test_playbook, rendering_vars)
+            rendering_vars = {**extra_vars, 'test': test}
+            template = str(ansible.playbooks_path / cls._test_template)
+            playbook = ansible.render_playbook(template, rendering_vars)
             if not playbook:
                 print(f'ERROR: Playbook for test "{test}" not found')
                 continue
-            ansible.run_playbook(playbook)
+            ansible.run_playbook(playbook, extra_vars)
 
     @classmethod
     def _setup(cls, ansible: Ansible, remote_working_dir: str = '/tmp') -> None:
         extra_vars = {'local_path': str(Path(__file__).parent / 'tests'),
                       'working_dir': remote_working_dir}
-        ansible.run_playbook(cls._setup_playbook, extra_vars)
+        playbook = str(ansible.playbooks_path / cls._setup_playbook)
+        ansible.run_playbook(playbook, extra_vars)
 
     @classmethod
     def _cleanup(cls, ansible: Ansible, remote_working_dir: str = '/tmp') -> None:
         extra_vars = {'working_dir': remote_working_dir}
-        ansible.run_playbook(cls._cleanup_playbook, extra_vars)
+        playbook = str(ansible.playbooks_path / cls._cleanup_playbook)
+        ansible.run_playbook(playbook, extra_vars)


### PR DESCRIPTION
## Description

Removes the **`Playbook`** class and its usage inside the Test Module, replaced the `playbook_path` to use the one defined inside the Ansible class.

> Related issue: #4846 