### PR TITLE
Updating tests after removing references to the legacy vulnerability detector module

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
@@ -1,326 +1,92 @@
----
 -
-  name: "Agents' CVEs table: vuln_cves"
-  description: "Checks the commands insert and clear"
+  name: Not existing agent
+  description: Check messages from not registered agents.
   test_case:
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_name",
-                                        "version":"1.0",
-                                        "architecture":"x64",
-                                        "cve":"CVE-2021-0001",
-                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
-                                        "type":"PACKAGE",
-                                        "status":"VALID",
-                                        "check_pkg_existence":true,
-                                        "severity":null,
-                                        "cvss2_score":0,
-                                        "cvss3_score":0}'
-    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert package when it does not exist in sys_programs"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_package",
-                                        "version":"1.0",
-                                        "architecture":"x86",
-                                        "cve":"CVE-2021-1001",
-                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
-                                        "type":"PACKAGE",
-                                        "status":"VALID",
-                                        "check_pkg_existence":false,
-                                        "severity":"Medium",
-                                        "cvss2_score":5.0,
-                                        "cvss3_score":6.1}'
-    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert test_package without checking if the package is present in sys_programs"
-  -
-    input: 'agent 000 sql SELECT * FROM vuln_cves where cve="CVE-2021-1001"'
-    output: 'ok [{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"Medium","cvss2_score":5,"cvss3_score":6.1,"reference":"03c06c4f118618400772367b1cf7e73ce0178e02","type":"PACKAGE","status":"VALID"}]'
-    stage: "agent vuln_cves checking test_package"
-    use_regex: "yes"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_package",
-                                        "version":"1.0",
-                                        "architecture":"x86",
-                                        "cve":"CVE-2021-1001",
-                                        "reference":"03c06c4f118618400772367b1cf7e73ce0178e02",
-                                        "type":"PACKAGE",
-                                        "status":"VALID",
-                                        "check_pkg_existence":false,
-                                        "severity":"Medium",
-                                        "cvss2_score":5.0,
-                                        "cvss3_score":6.1}'
-    output: 'ok {"action":"UPDATE","status":"SUCCESS"}'
-    stage: "agent vuln_cves update already inserted entry"
-  -
-    input: 'agent 000 sql INSERT INTO sys_programs (scan_id,scan_time,format,name,priority,section,size,vendor,install_time,version,architecture,multiarch,source,description,location,triaged,cpe,msu_name,checksum,item_id)
-                                             VALUES(0,"2021/04/07 22:00:00","deb","test package","optional","utils","7490","Wazuh wazuh@wazuh.com",NULL,"1.0.0","amd64",NULL,NULL,"Test package",NULL,0,NULL,NULL,"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","777fef8cc434b597769d102361af718d29ef72c1")'
-    output: 'ok []'
-    stage: "agent vuln_cves adding dummy test package to sys_programs"
-  -
-    input: 'agent 000 sql SELECT * FROM sys_programs WHERE name = "test package"'
-    output: 'ok [{"scan_id":0,"scan_time":"2021/04/07 22:00:00","format":"deb","name":"test package","priority":"optional","section":"utils","size":7490,"vendor":"Wazuh wazuh@wazuh.com","version":"1.0.0","architecture":"amd64","description":"Test package","triaged":0,"checksum":"e7dbc9bba5a0ee252866536225b952d3de7ea5cb","item_id":"777fef8cc434b597769d102361af718d29ef72c1"}]'
-    stage: "agent vuln_cves checking test package in sys_programs"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test package",
-                                        "version":"1.0",
-                                        "architecture":"x86",
-                                        "cve":"CVE-2021-1002",
-                                        "reference":"777fef8cc434b597769d102361af718d29ef72c1",
-                                        "type":"OS",
-                                        "status":"PENDING",
-                                        "check_pkg_existence":true,
-                                        "severity":null,
-                                        "cvss2_score":0,
-                                        "cvss3_score":0}'
-    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs"
-  -
-    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test package"'
-    output: 'ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","cvss2_score":0,"cvss3_score":0,"reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]'
-    stage: "agent vuln_cves checking test package"
-    use_regex: "yes"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_package","cve":"CVE-2021-1001"}'
-    output: "err Invalid JSON data, missing required fields"
-    stage: "agent vuln_cves insert incomplete package"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_package",'
-    output: "err Invalid JSON syntax, near '{\"name\":\"test_package\",'"
-    stage: "agent vuln_cves insert invalid JSON"
-  -
-    input: 'agent 000 vuln_cves'
-    output: "err Invalid vuln_cves query syntax, near 'vuln_cves'"
-    stage: "agent vuln_cves missing command"
-  -
-    input: 'agent 000 vuln_cves insert'
-    output: "err Invalid JSON syntax, near ''"
-    stage: "agent vuln_cves missing payload"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_package2",
-                                        "version":"3.0",
-                                        "architecture":"x86",
-                                        "cve":"CVE-2021-1001",
-                                        "reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa",
-                                        "type":"PACKAGE",
-                                        "status":"VALID",
-                                        "check_pkg_existence":false,
-                                        "severity":"Untriaged",
-                                        "cvss2_score":0,
-                                        "cvss3_score":0}'
-    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert package with same CVE without checking if the package is present in sys_programs"
-  -
-    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2"'
-    output: 'ok []'
-    stage: "agent vuln_cves checking package insertion with same CVE"
-    use_regex: "yes"
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test_package2",
-                                        "version":"3.0",
-                                        "architecture":"x86",
-                                        "cve":"CVE-2021-1002",
-                                        "reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa",
-                                        "type":"PACKAGE",
-                                        "status":"VALID",
-                                        "check_pkg_existence":false,
-                                        "severity":"High",
-                                        "cvss2_score":8.2,
-                                        "cvss3_score":9.35}'
-    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert same package with different CVE without checking if the package is present in sys_programs"
-  -
-    input: 'agent 000 sql SELECT * FROM vuln_cves WHERE name = "test_package2" AND cve = "CVE-2021-1002"'
-    output: 'ok [{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","severity":"High","cvss2_score":8.2,"cvss3_score":9.35,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"VALID"}]'
-    stage: "agent vuln_cves checking package with different CVE"
-    use_regex: "yes"
-  -
-    input: 'agent 000 vuln_cves update_status {"old_status":"PENDING",
-                                               "new_status":"OBSOLETE"}'
-    output: 'ok'
-    stage: "agent vuln_cves update specific status to another one"
-  -
-    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
-    output: 'ok [{"status":"OBSOLETE"},{"status":"VALID"}]'
-    stage: 'agent vuln_cves checking change specific status by another one'
-  -
-    input: 'agent 000 vuln_cves update_status {"new_status":"PENDING",
-                                               "type":"OS"}'
-    output: 'ok'
-    stage: 'agent vuln_cves update status by type "OS"'
-  -
-    input: 'agent 000 sql SELECT count(status) FROM vuln_cves WHERE type = "OS"'
-    output: 'ok [{"count(status)":1}]'
-    stage: 'agent vuln_cves checking update status by type "OS"'
-  -
-    input: 'agent 000 vuln_cves update_status {"new_status":"PENDING",
-                                               "type":"PACKAGE"}'
-    output: 'ok'
-    stage: 'agent vuln_cves update status by type "PACKAGE"'
-  -
-    input: 'agent 000 sql SELECT count(status) FROM vuln_cves WHERE type = "PACKAGE"'
-    output: 'ok [{"count(status)":4}]'
-    stage: 'agent vuln_cves checking update status by type "PACKAGE"'
-  -
-    input: 'agent 000 vuln_cves update_status {"new_status":"VALID",
-                                               "type":"PACKAGE"}'
-    output: 'ok'
-    stage: 'agent vuln_cves update status by type "PACKAGE" again'
-  -
-    input: 'agent 000 sql SELECT count(status) FROM vuln_cves WHERE type = "PACKAGE"'
-    output: 'ok [{"count(status)":4}]'
-    stage: 'agent vuln_cves checking update status by type "PACKAGE" again'
-  -
-    input: 'agent 000 vuln_cves remove {"status":"PENDING"}'
-    output: 'ok [{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","cvss2_score":0,"cvss3_score":0,"reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"PENDING"}]'
-    stage: 'agent vuln_cves remove by status'
-    use_regex: "yes"
-  -
-    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
-    output: 'ok [{"status":"VALID"}]'
-    stage: 'agent vuln_cves checking remove by status'
-  -
-    input: 'agent 000 vuln_cves insert {"name":"test package",
-                                        "version":"1.0",
-                                        "architecture":"x86",
-                                        "cve":"CVE-2021-1002",
-                                        "reference":"777fef8cc434b597769d102361af718d29ef72c1",
-                                        "type":"OS",
-                                        "status":"PENDING",
-                                        "check_pkg_existence":true,
-                                        "severity":"Low",
-                                        "cvss2_score":3.2,
-                                        "cvss3_score":2.1}'
-    output: 'ok {"action":"INSERT","status":"SUCCESS"}'
-    stage: "agent vuln_cves insert with spaces in json payload and the test package exist in sys_programs again"
-  -
-    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
-    output: 'ok [{"status":"PENDING"},{"status":"VALID"}]'
-    stage: "agent vuln_cves checking status"
-  -
-    input: 'agent 000 vuln_cves update_status {"old_status":"*",
-                                               "new_status":"OBSOLETE"}'
-    output: 'ok'
-    stage: "agent vuln_cves update all status"
-  -
-    input: 'agent 000 sql SELECT distinct status FROM vuln_cves'
-    output: 'ok [{"status":"OBSOLETE"}]'
-    stage: 'agent vuln_cves checking update all status'
-  -
-    input: 'agent 000 vuln_cves remove {"status":"OBSOLETE"}'
-    output: 'ok [{"name":"test_name","version":"1.0","architecture":"x64","cve":"CVE-2021-0001","detection_time":"*","cvss2_score":0,"cvss3_score":0,"reference":"03c06c4f118618400772367b1cf7e73ce0178e02","type":"PACKAGE","status":"OBSOLETE"},{"name":"test_package","version":"1.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"Medium","cvss2_score":5,"cvss3_score":6.1,"reference":"03c06c4f118618400772367b1cf7e73ce0178e02","type":"PACKAGE","status":"OBSOLETE"},{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1001","detection_time":"*","severity":"Untriaged","cvss2_score":0,"cvss3_score":0,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"OBSOLETE"},{"name":"test_package2","version":"3.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","severity":"High","cvss2_score":8.2,"cvss3_score":9.35,"reference":"99efe684b5ff4646b3c754de46cb6a9cbee9fbaa","type":"PACKAGE","status":"OBSOLETE"},{"name":"test package","version":"1.0","architecture":"x86","cve":"CVE-2021-1002","detection_time":"*","severity":"Low","cvss2_score":3.2,"cvss3_score":2.1,"reference":"777fef8cc434b597769d102361af718d29ef72c1","type":"OS","status":"OBSOLETE"}]'
-    stage: 'agent vuln_cves remove by status to clear vuln_cve table'
-    use_regex: "yes"
-  -
-    input: 'agent 000 sql SELECT * FROM vuln_cves'
-    output: 'ok []'
-    stage: "agent vuln_cve checking empty table again"
+    -
+      input: 'agent 004 syscheck delete '
+      output: err Agent not found
+      stage: Syscheck query to a non-existing agent
 -
-  name: 'Not existing agent'
-  description: 'Check messages from not registered agents.'
+  name: Agents OS table sys_osinfo
+  description: It checks the commands get and set
   test_case:
-  -
-    input: 'agent 004 syscheck delete '
-    output: 'err Agent not found'
-    stage: 'Syscheck query to a non-existing agent'
+    -
+      input: agent 000 sql DELETE FROM sys_osinfo
+      output: ok []
+      stage: agent sys_osinfo cleaning sys_osinfo table
+    -
+      input: agent 000 osinfo get
+      output: ok []
+      stage: agent sys_osinfo checking table is empty
+    -
+      input: agent 000 osinfo set 0|2021/04/08 10:00:00|focal|x86_64|Ubuntu|20.04.2 LTS (Focal Fossa)|focal|20|04|1|ubuntu|Linux|5.4.0-70-generic|#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021|1|2|NULL
+      output: ok
+      stage: agent sys_osinfo set information
+    -
+      input: agent 000 osinfo get
+      output: ok [{"scan_id":0,"scan_time":"2021/04/08 10:00:00","hostname":"focal","architecture":"x86_64","os_name":"Ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","os_codename":"focal","os_major":"20","os_minor":"04","os_patch":"2","os_build":"1","os_platform":"ubuntu","sysname":"Linux","release":"5.4.0-70-generic","version":"#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021","os_release":"1","checksum":"legacy","reference":"54d5344c8f49eae38d81651495227c5080755b45"}]
+      stage: agent sys_osinfo getting information
+    -
+      input: agent 000 sql DELETE FROM sys_osinfo
+      output: ok []
+      stage: agent sys_osinfo cleaning sys_osinfo table
+    -
+      input: agent 000 osinfo get
+      output: ok []
+      stage: agent sys_osinfo checking table is empty
 -
-  name: "Agents' OS table: sys_osinfo"
-  description: "It checks the commands get, set and set_triaged"
+  name: "Agents Packages/Hotfixes tables: sys_programs and sys_hotfixes"
+  description: It checks the commands get packages and get hotfixes
   test_case:
-  -
-    input: 'agent 000 sql DELETE FROM sys_osinfo'
-    output: "ok []"
-    stage: "agent sys_osinfo cleaning sys_osinfo table"
-  -
-    input: 'agent 000 osinfo get'
-    output: "ok []"
-    stage: "agent sys_osinfo checking table is empty"
-  -
-    input: 'agent 000 osinfo set 0|2021/04/08 10:00:00|focal|x86_64|Ubuntu|20.04.2 LTS (Focal Fossa)|focal|20|04|1|ubuntu|Linux|5.4.0-70-generic|#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021|1|2|NULL'
-    output: 'ok'
-    stage: "agent sys_osinfo set information"
-  -
-    input: 'agent 000 osinfo get'
-    output: 'ok [{"scan_id":0,"scan_time":"2021/04/08 10:00:00","hostname":"focal","architecture":"x86_64","os_name":"Ubuntu","os_version":"20.04.2 LTS (Focal Fossa)","os_codename":"focal","os_major":"20","os_minor":"04","os_patch":"2","os_build":"1","os_platform":"ubuntu","sysname":"Linux","release":"5.4.0-70-generic","version":"#78-Ubuntu SMP Thu Apr 08 10:00:00 UTC 2021","os_release":"1","checksum":"legacy","triaged":0,"reference":"54d5344c8f49eae38d81651495227c5080755b45"}]'
-    stage: "agent sys_osinfo getting information"
-  -
-    input: 'agent 000 osinfo set_triaged'
-    output: 'ok'
-    stage: "agent sys_osinfo set triaged"
-  -
-    input: 'agent 000 sql SELECT triaged FROM sys_osinfo WHERE triaged = 1'
-    output: 'ok [{"triaged":1}]'
-    stage: "agent sys_osinfo checking triaged"
-  -
-    input: 'agent 000 sql DELETE FROM sys_osinfo'
-    output: "ok []"
-    stage: "agent sys_osinfo cleaning sys_osinfo table"
-  -
-    input: 'agent 000 osinfo get'
-    output: "ok []"
-    stage: "agent sys_osinfo checking table is empty"
--
-  name: "Agents' Packages/Hotfixes tables: sys_programs and sys_hotfixes"
-  description: "It checks the commands get packages and get hotfixes"
-  test_case:
-  -
-    input: 'agent 003 package save 0|2021/04/07 22:00:00|deb|test_deb_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1'
-    output: 'ok'
-    stage: "agent sys_programs adding dummy package"
-  -
-    input: 'agent 003 package save 0|2021/04/07 22:00:00|rpm|test_rpm_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1'
-    output: 'ok'
-    stage: "agent sys_programs adding dummy package"
-  -
-    input: 'agent 003 sql select count(*) from sys_programs'
-    output: 'ok [{"count(*)":2}]'
-    stage: "agent sys_programs count packages added"
-  -
-    input: 'agent 003 package get'
-    output: 'ok {"status":"NOT_SYNCED"}'
-    stage: "agent sys_programs getting not synced packages attempt"
-  -
-    input: 'agent 003 hotfix save 0|0|KB2980293|legacy'
-    output: 'ok'
-    stage: "agent sys_hotfixes adding dummy hotfix"
-  -
-    input: 'agent 003 hotfix save 0|0|KB2980294|legacy'
-    output: 'ok'
-    stage: "agent sys_hotfixes adding dummy hotfix"
-  -
-    input: 'agent 003 hotfix save 0|0|KB2980295|legacy'
-    output: 'ok'
-    stage: "agent sys_hotfixes adding dummy hotfix"
-  -
-    input: 'agent 003 sql SELECT count(*) FROM sys_hotfixes'
-    output: 'ok [{"count(*)":3}]'
-    stage: "agent sys_hotfixes count hotfixes added"
-  -
-    input: 'agent 003 hotfix get'
-    output: 'ok {"status":"NOT_SYNCED"}'
-    stage: "agent sys_programs getting not synced packages attempt"
-  -
-    input: 'agent 003 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-hotfixes"'
-    output: 'ok []'
-    stage: "agent sync_info set synced"
-  -
-    input: 'agent 003 hotfix get'
-    output: ['due {"hotfix":"KB2980293"}','due {"hotfix":"KB2980294"}','due {"hotfix":"KB2980295"}','ok {"status":"SUCCESS"}']
-    stage: "agent sys_hotfixes getting hotfixes"
-  -
-    input: 'agent 003 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-packages"'
-    output: 'ok []'
-    stage: "agent sync_info set synced"
-  -
-    input: 'agent 003 sql UPDATE sys_programs SET triaged = 1  WHERE name = "test_rpm_pkg"'
-    output: 'ok []'
-    stage: "agent sys_programs set package as triaged"
-  -
-    input: 'agent 003 package get not_triaged'
-    output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
-             'ok {"status":"SUCCESS"}']
-    stage: "agent sys_programs getting not triaged packages"
-  -
-    input: 'agent 003 package get'
-    output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
-             'due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
-             'ok {"status":"SUCCESS"}']
-    stage: "agent sys_programs getting not all packages"
+    -
+      input: agent 003 package save 0|2021/04/07 22:00:00|deb|test_deb_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1
+      output: ok
+      stage: agent sys_programs adding dummy package
+    -
+      input: agent 003 package save 0|2021/04/07 22:00:00|rpm|test_rpm_pkg|optional|utils|7490|Wazuh wazuh@wazuh.com|NULL|1.0.0|amd64|NULL|NULL|Test package|NULL|1
+      output: ok
+      stage: agent sys_programs adding dummy package
+    -
+      input: agent 003 sql select count(*) from sys_programs
+      output: ok [{"count(*)":2}]
+      stage: agent sys_programs count packages added
+    -
+      input: agent 003 package get
+      output: ok {"status":"NOT_SYNCED"}
+      stage: agent sys_programs getting not synced packages attempt
+    -
+      input: agent 003 hotfix save 0|0|KB2980293|legacy
+      output: ok
+      stage: agent sys_hotfixes adding dummy hotfix
+    -
+      input: agent 003 hotfix save 0|0|KB2980294|legacy
+      output: ok
+      stage: agent sys_hotfixes adding dummy hotfix
+    -
+      input: agent 003 hotfix save 0|0|KB2980295|legacy
+      output: ok
+      stage: agent sys_hotfixes adding dummy hotfix
+    -
+      input: agent 003 sql SELECT count(*) FROM sys_hotfixes
+      output: ok [{"count(*)":3}]
+      stage: agent sys_hotfixes count hotfixes added
+    -
+      input: agent 003 hotfix get
+      output: ok {"status":"NOT_SYNCED"}
+      stage: agent sys_programs getting not synced packages attempt
+    -
+      input: agent 003 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-hotfixes"
+      output: ok []
+      stage: agent sync_info set synced
+    -
+      input: agent 003 hotfix get
+      output: ['due {"hotfix":"KB2980293"}','due {"hotfix":"KB2980294"}','due {"hotfix":"KB2980295"}','ok {"status":"SUCCESS"}']
+      stage: agent sys_hotfixes getting hotfixes
+    -
+      input: agent 003 sql UPDATE sync_info SET last_attempt = 1, last_completion = 1 where component = "syscollector-packages"
+      output: ok []
+      stage: agent sync_info set synced
+    -
+      input: agent 003 package get
+      output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}','due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}','ok {"status":"SUCCESS"}']
+      stage: agent sys_programs getting not all packages

--- a/tests/integration/test_wazuh_db/data/global/wazuh_db_backup_command.yaml
+++ b/tests/integration/test_wazuh_db/data/global/wazuh_db_backup_command.yaml
@@ -1,89 +1,88 @@
----
 -
-  name: "Create One Backup File"
+  name: Create One Backup File
   test_case:
-  -
-    backups_amount: 1
-    command: 'global backup create'
+    -
+      backups_amount: 1
+      command: global backup create
 -
-  name: "Create Three Backups Files"
+  name: Create Three Backups Files
   test_case:
-  -
-    backups_amount: 3
-    command: 'global backup create'
+    -
+      backups_amount: 3
+      command: global backup create
 -
-  name: "Restore backup file saving previous state - save_pre_restore_state == false"
+  name: Restore backup file saving previous state - save_pre_restore_state == false
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    save_pre_restore: 'false'
-    restore_response: ok
+    -
+      backups_amount: 1
+      restore: true
+      save_pre_restore: 'false'
+      restore_response: ok
 -
-  name: "Restore backup file saving previous state - save_pre_restore_state == true"
+  name: Restore backup file saving previous state - save_pre_restore_state == true
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    save_pre_restore: 'true'
-    restore_response: ok
+    -
+      backups_amount: 1
+      restore: true
+      save_pre_restore: 'true'
+      restore_response: ok
 -
-  name: "Restore backup from pre_restore backup - database should not have the test_values"
+  name: Restore backup from pre_restore backup - database should not have the test_values
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    save_pre_restore: 'true'
-    restore_response: ok
-    restore_pre_restore: true
+    -
+      backups_amount: 1
+      restore: true
+      save_pre_restore: 'true'
+      restore_response: ok
+      restore_pre_restore: true
 -
-  name: "Restore backup with no save_pre_restore_state - pre_restore backup is generated normally"
+  name: Restore backup with no save_pre_restore_state - pre_restore backup is generated normally
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    save_pre_restore: 'none'
-    restore_response: ok
+    -
+      backups_amount: 1
+      restore: true
+      save_pre_restore: none
+      restore_response: ok
 -
-  name: "ERROR - Restore backup with empty pre_restore value - save_pre_restore_state ==''  "
+  name: ERROR - Restore backup with empty pre_restore value - save_pre_restore_state ==''
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    save_pre_restore: ''
-    restore_response: err Invalid JSON syntax
+    -
+      backups_amount: 1
+      restore: true
+      save_pre_restore: ''
+      restore_response: err Invalid JSON syntax
 -
-  name: "ERROR - Restore backup with invalid pre_restore value - save_pre_restore_state == value  "
+  name: ERROR - Restore backup with invalid pre_restore value - save_pre_restore_state == value
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    save_pre_restore: value
-    restore_response: err Invalid JSON syntax
+    -
+      backups_amount: 1
+      restore: true
+      save_pre_restore: value
+      restore_response: err Invalid JSON syntax
 -
-  name: "ERROR - Restore backup with invalid snapshot value - snapshot == invalid_snapshot_value"
+  name: ERROR - Restore backup with invalid snapshot value - snapshot == invalid_snapshot_value
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    snapshot: '"snapshot":"invalid_snapshot_value"'
-    save_pre_restore: false
-    restore_response: err Invalid JSON syntax
+    -
+      backups_amount: 1
+      restore: true
+      snapshot: '"snapshot":"invalid_snapshot_value"'
+      save_pre_restore: false
+      restore_response: err Invalid JSON syntax
 -
-  name: "ERROR - Restore backup with empty snapshot value - snapshot ==''"
+  name: ERROR - Restore backup with empty snapshot value - snapshot ==''
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    snapshot: '"snapshot":""'
-    save_pre_restore: false
-    restore_response: err Invalid JSON syntax
+    -
+      backups_amount: 1
+      restore: true
+      snapshot: '"snapshot":""'
+      save_pre_restore: false
+      restore_response: err Invalid JSON syntax
 -
-  name: "ERROR - Restore backup with no snapshot parameter"
+  name: ERROR - Restore backup with no snapshot parameter
   test_case:
-  -
-    backups_amount: 1
-    restore: true
-    snapshot: 
-    save_pre_restore: false
-    restore_response: err Invalid JSON syntax
+    -
+      backups_amount: 1
+      restore: true
+      snapshot: None
+      save_pre_restore: false
+      restore_response: err Invalid JSON syntax

--- a/tests/integration/test_wazuh_db/data/wazuh_db_backups_conf.yaml
+++ b/tests/integration/test_wazuh_db/data/wazuh_db_backups_conf.yaml
@@ -1,31 +1,33 @@
 - tags:
+    - wazuh_db
+    - wdb_socket
   apply_to_modules:
-  - test_db_backup
-  - test_wdb_backup_configs
+    - test_db_backup
+    - test_wdb_backup_configs
   sections:
-  - section: wdb
-    elements:
-    - backup:
-        attributes:
-          - database: 'global'
-        elements:
+    - section: wdb
+      elements:
+        - backup:
+            attributes:
+              - database: global
+            elements:
+              - enabled:
+                  value: ENABLED
+              - interval:
+                  value: INTERVAL
+              - max_files:
+                  value: MAX_FILES
+    - section: sca
+      elements:
         - enabled:
-            value: ENABLED
-        - interval:
-            value: INTERVAL
-        - max_files:
-            value: MAX_FILES
-  - section: sca
-    elements:
-    - enabled:
-        value: 'no'
-  - section: rootcheck
-    elements:
-    - disabled:
-        value: 'yes'
-  - section: wodle
-    attributes:
-      - name: 'syscollector'
-    elements:
-      - disabled:
-          value: 'yes'
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_wazuh_db/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_agent_database_version.py
@@ -9,7 +9,7 @@ from wazuh_testing.tools.wazuh_manager import remove_all_agents
 pytestmark = [TIER0, LINUX, SERVER]
 
 # Variables
-expected_database_version = '12'
+expected_database_version = '13'
 
 
 # Fixtures
@@ -45,7 +45,7 @@ def test_agent_database_version(restart_wazuh_daemon, remove_agents):
         - Verify that database version is the expected one.
 
     expected_output:
-        - Database version: 12
+        - Database version: 13
 
     tags:
         - wazuh_db

--- a/tests/integration/test_wazuh_db/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_wazuh_db.py
@@ -300,10 +300,10 @@ def pre_insert_packages():
     for pkg_n in range(PACKAGES_NUMBER):
         command = f"agent 000 sql INSERT OR REPLACE INTO sys_programs \
         (scan_id,scan_time,format,name,priority,section,size,vendor,install_time,version,\
-        architecture,multiarch,source,description,location,triaged,cpe,msu_name,checksum,item_id)\
+        architecture,multiarch,source,description,location,cpe,msu_name,checksum,item_id)\
         VALUES(0,'2021/04/07 22:00:00','deb','test_package_{pkg_n}','optional','utils',{random.randint(200,1000)},\
         'Wazuh wazuh@wazuh.com',NULL,'{random.randint(1,10)}.0.0','all',NULL,NULL,'Test package {pkg_n}',\
-        NULL,0,NULL,NULL,'{random.getrandbits(128)}','{random.getrandbits(128)}')"
+        NULL,NULL,NULL,'{random.getrandbits(128)}','{random.getrandbits(128)}')"
         receiver_sockets[0].send(command, size=True)
         response = receiver_sockets[0].receive(size=True).decode()
         data = response.split()
@@ -379,7 +379,7 @@ def test_wazuh_db_messages_agent(restart_wazuh, clean_registered_agents, configu
             match = True if regex_match(expected_output, response) else False
         else:
             match = validate_wazuh_db_response(expected_output, response)
-        assert match, 'Failed test case stage {}: {}. Expected: {}. Response: {}' \
+        assert match, 'Failed test case stage {}: {}. Expected: "{}". Response: "{}".' \
             .format(index + 1, stage['stage'], expected_output, response)
 
 


### PR DESCRIPTION
|Related issue|
|-------------|
|    https://github.com/wazuh/wazuh/issues/21303         |

## Description

<!-- Add a description of the context and content of all changes made in the pull request -->

This PR removes all the tests related to the `vuln_cves` table because now it's deprecated.
Also, the column `triaged` in both `sys_programs` and `sys_osinfo` tables was removed; and the agent's DB schema was updated.


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- The developer only has to update his row. The same for the reviewer -->
<!-- Reviewer has only to test in Jenkins -->
| Tester             | Test path | Jenkins | Local  | OS | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|----------------------|
| @pereyra-m  (Matias Pereyra)  |      `tests/integration/test_wazuh_db/`     | Not run yet | :green_circle:  |  Ubuntu 22.04        |      11a5a33dd5   | The linting check fails because of some long lines and it isn't related to these changes. |

