### PR TITLE
Fix test_file_checker in check_mtime case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Fix macOS agents provision to enable registration and connection with managers. ([#4770](https://github.com/wazuh/wazuh-qa/pull/4770/)) \- (Framework)
 - Fix hardcoded python interpreter in qa_framework role. ([#4658](https://github.com/wazuh/wazuh-qa/pull/4658)) \- (Framework)
 - Fix duplicated jq dependency ([#4678](https://github.com/wazuh/wazuh-qa/pull/4678)) \- (Framework)
+- Fix test_file_checker in check_mtime case ([#4873](https://github.com/wazuh/wazuh-qa/pull/4873)) \- (Tests)
 
 ## [4.7.2] - TBD
 


### PR DESCRIPTION
|Related issue|
|-------------|
|https://github.com/wazuh/wazuh-qa/issues/4839|

## Description

This PR is to fix some false negative cases that were coming up in the `test_file_checkers`.

This test configures a Wazuh directory with `check_all=no` and `check_mtime=yes` so only the `timestamp` will be taken into account by FIM to see if there have been changes in the file. And if it coincides that the added and the modified happen in the same second (same timestamp), the modification event is not detected and that's why the test fails.

To solve it I have included a sleep of one second after the creation of the file for the case of the `check_mtime`. This way we make sure that the timestamp of the event is different and we get correctly the alert.

Jenkins build success:
https://ci.wazuh.info/job/Test_integration/45871/
