### PR TITLE
Adding changes in test - dependency input from string to dictionary

### DIFF
--- a/deployability/launchers/test.py
+++ b/deployability/launchers/test.py
@@ -1,25 +1,25 @@
 import argparse
 import sys
 import os
+import json
+
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(project_root)
 
 from modules.testing import Tester, InputPayload
 
-
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Wazuh testing tool")
     parser.add_argument("--inventory", required=True)
     parser.add_argument("--tests", required=True)
     parser.add_argument("--component", choices=['manager', 'agent'], required=True)
-    parser.add_argument("--dependency", required=False)
+    parser.add_argument("--dependencies", required=False)
     parser.add_argument("--cleanup", required=False, default=True)
     parser.add_argument("--wazuh-version", required=True)
     parser.add_argument("--wazuh-revision", required=True)
     parser.add_argument("--wazuh-branch", required=False)
     return parser.parse_args()
-
 
 if __name__ == "__main__":
     Tester.run(InputPayload(**vars(parse_arguments())))

--- a/deployability/launchers/test.py
+++ b/deployability/launchers/test.py
@@ -1,8 +1,6 @@
 import argparse
 import sys
 import os
-import json
-
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(project_root)

--- a/deployability/modules/testing/models.py
+++ b/deployability/modules/testing/models.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel, field_validator, model_validator
-from typing import Literal, Dict
+from typing import Literal
 
 class ExtraVars(BaseModel):
     """Extra vars for testing module."""

--- a/deployability/modules/testing/models.py
+++ b/deployability/modules/testing/models.py
@@ -5,7 +5,7 @@ from typing import Literal
 class ExtraVars(BaseModel):
     """Extra vars for testing module."""
     component: Literal['manager', 'agent']
-    dependencies: list[str]
+    dependencies: list[str] | None = None
     wazuh_version: str
     wazuh_revision: str
     wazuh_branch: str | None = None
@@ -15,7 +15,7 @@ class InputPayload(ExtraVars):
     """Input payload for testing module."""
     tests: list[str]
     inventory: Path
-    dependencies: list[str]
+    dependencies: list[str] = []
     cleanup: bool = True
 
     @field_validator('tests', mode='before')
@@ -25,6 +25,7 @@ class InputPayload(ExtraVars):
             value = value.split(',')
         return value
 
+    @field_validator('inventory', mode='before')
     def validate_inventory(cls, value) -> Path:
         """Validate inventory path."""
         if not Path(value).exists():

--- a/deployability/modules/testing/models.py
+++ b/deployability/modules/testing/models.py
@@ -1,23 +1,21 @@
 from pathlib import Path
 from pydantic import BaseModel, field_validator, model_validator
-from typing import Literal
-
+from typing import Literal, Dict
 
 class ExtraVars(BaseModel):
     """Extra vars for testing module."""
     component: Literal['manager', 'agent']
-    dependency: str | None = None
+    dependencies: list[str]
     wazuh_version: str
     wazuh_revision: str
     wazuh_branch: str | None = None
     working_dir: str = '/tmp/tests'
 
-
 class InputPayload(ExtraVars):
     """Input payload for testing module."""
     tests: list[str]
     inventory: Path
-    dependency: Path = None
+    dependencies: list[str]
     cleanup: bool = True
 
     @field_validator('tests', mode='before')
@@ -27,7 +25,6 @@ class InputPayload(ExtraVars):
             value = value.split(',')
         return value
 
-    @field_validator('inventory', mode='before')
     def validate_inventory(cls, value) -> Path:
         """Validate inventory path."""
         if not Path(value).exists():
@@ -35,8 +32,10 @@ class InputPayload(ExtraVars):
         return Path(value)
 
     @model_validator(mode='before')
-    def validate_dependency(cls, values) -> dict:
+    def validate_dependencies(cls, values) -> dict:
         """Validate required fields."""
-        if values.get('component') == 'agent' and not values.get('dependency'):
-            raise ValueError('dependency is required when component is agent')
+        if isinstance(values['dependencies'], str):
+            values['dependencies'] = values['dependencies'].split(',')
+        if values.get('component') == 'agent' and not values.get('dependencies'):
+            raise ValueError('dependencies are required when component is agent')
         return values

--- a/deployability/modules/testing/testing.py
+++ b/deployability/modules/testing/testing.py
@@ -3,9 +3,6 @@ import ast
 from modules.generic import Ansible, Inventory
 from modules.generic.utils import Utils
 from .models import InputPayload, ExtraVars
-import json
-
-
 
 class Tester:
     _playbooks_dir = Path('tests')

--- a/deployability/modules/testing/testing.py
+++ b/deployability/modules/testing/testing.py
@@ -1,8 +1,10 @@
 from pathlib import Path
-
+import ast
 from modules.generic import Ansible, Inventory
 from modules.generic.utils import Utils
 from .models import InputPayload, ExtraVars
+import json
+
 
 
 class Tester:
@@ -15,29 +17,39 @@ class Tester:
     def run(cls, payload: InputPayload) -> None:
         payload = InputPayload(**dict(payload))
         inventory = Inventory(**Utils.load_from_yaml(payload.inventory))
-        extra_vars = cls._get_extra_vars(payload)
+        extra_vars = cls._get_extra_vars(payload).model_dump()
+        dependencies_dict = {}
+        for dependency in extra_vars['dependencies']:
+            dependency = ast.literal_eval(dependency)
+            dependencies_dict.update(dependency)
+        extra_vars['dependencies'] = dependencies_dict
         ansible = Ansible(ansible_data=inventory.model_dump())
-        cls._setup(ansible, extra_vars.working_dir)
+        cls._setup(ansible, extra_vars['working_dir'])
         cls._run_tests(payload.tests, ansible, extra_vars)
         if payload.cleanup:
-            cls._cleanup(ansible, extra_vars.working_dir)
+            cls._cleanup(ansible, extra_vars['working_dir'])
 
     @classmethod
     def _get_extra_vars(cls, payload: InputPayload) -> ExtraVars:
-        if not payload.dependency:
+        if not payload.dependencies:
             return ExtraVars(**payload.model_dump())
+        
+        dependencies_ip = []
+        for dependency in range(len(payload.dependencies)):
+            dicts = eval(payload.dependencies[dependency])
+            for key, value in dicts.items():
+                dep_inventory = Inventory(**Utils.load_from_yaml(value))
+                dicts[key] = dep_inventory.ansible_host         
+                dependencies_ip.append(str(dicts))
 
-        dep_inventory = Inventory(**Utils.load_from_yaml(payload.dependency))
-        dep_ip = dep_inventory.ansible_host
-        return ExtraVars(**payload.model_dump(exclude={'dependency'}), dependency=dep_ip)
+        return ExtraVars(**payload.model_dump(exclude={'dependencies'}), dependencies=dependencies_ip)
 
     @classmethod
     def _run_tests(cls, test_list: list[str], ansible: Ansible, extra_vars: ExtraVars) -> None:
-        extra_vars = extra_vars.model_dump()
         for test in test_list:
-            rendering_vars = {**extra_vars, 'test': test}
+            rendering_var = {**extra_vars, 'test': test}
             template = str(ansible.playbooks_path / cls._test_template)
-            playbook = ansible.render_playbook(template, rendering_vars)
+            playbook = ansible.render_playbook(template, rendering_var)
             if not playbook:
                 print(f'ERROR: Playbook for test "{test}" not found')
                 continue

--- a/deployability/modules/testing/tests/conftest.py
+++ b/deployability/modules/testing/tests/conftest.py
@@ -8,6 +8,7 @@ def pytest_addoption(parser):
     parser.addoption('--wazuh_revision', required=False, help='Wazuh revision to test.')
     parser.addoption('--system', required=False, help='OS version where wazuh was installed.')
     parser.addoption('--component', required=False, help='Component to be tested.')
+    parser.addoption('--dependencies', required=False, help='Dependency to be tested.')
 
 
 @pytest.fixture(scope='session')

--- a/deployability/modules/workflow_engine/examples/dtt1-agents-poc.yaml
+++ b/deployability/modules/workflow_engine/examples/dtt1-agents-poc.yaml
@@ -22,7 +22,9 @@ tasks:
         args:
           - test.py
           - inventory: "{working-dir}/agent-{agent}/inventory.yaml"
-          - dependency: "{working-dir}/manager-{manager-os}/inventory.yaml"
+          - dependencies: 
+            - manager: "{working-dir}/manager-{manager-os}/inventory.yaml"
+            - agent: "{working-dir}/agent-{agent}/inventory.yaml"
           - tests: "install,register,stop"
           - component: "agent"
           - wazuh-version: "4.7.1"

--- a/deployability/playbooks/tests/test.yml
+++ b/deployability/playbooks/tests/test.yml
@@ -2,6 +2,6 @@
   become: true
   tasks:
     - name: Test {{ test }} for {{ component }}
-      command: "pytest test_{{component}}/test_{{ test }}.py  -v --wazuh_version={{ wazuh_version }} --component={{ component }}"
+      command: "pytest test_{{component}}/test_{{ test }}.py  -v --wazuh_version={{ wazuh_version }} --component={{ component }} --dependencies={{ dependencies }}"
       args:
         chdir: "{{ working_dir }}"


### PR DESCRIPTION
|Related issue|
|-------------|
|  #4848           |

## Description

Adding changes in test - dependency input from string to dictionary

### Updated

- Consumption of dependency parameter in test module

---

## Testing performed


Executing the test with some additional prints (for testing purposes)

-  print(extra_vars)
```
    @classmethod
    def run(cls, payload: InputPayload) -> None:
        payload = InputPayload(**dict(payload))
        inventory = Inventory(**Utils.load_from_yaml(payload.inventory))
        extra_vars = cls._get_extra_vars(payload).model_dump()
        dependencies_dict = {}
        for dependency in extra_vars['dependencies']:
            dependency = ast.literal_eval(dependency)
            dependencies_dict.update(dependency)
        extra_vars['dependencies'] = dependencies_dict
        print(extra_vars)
        ansible = Ansible(ansible_data=inventory.model_dump())
        cls._setup(ansible, extra_vars['working_dir'])
        cls._run_tests(payload.tests, ansible, extra_vars)
        if payload.cleanup:
            cls._cleanup(ansible, extra_vars['working_dir'])
```

Using the following command:

```
(deployability) akim@akim-PC:~/Desktop/wazuh-qa/deployability$ python3 launchers/test.py --inventory '/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml' --dependencies '{"manager": "/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/inventory.yaml"}','{"agent": "/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml"}' --tests install --wazuh-version 4.7.1 --wazuh-revision 1 --component agent
```

It is possible to see:

- Result of print(extra_vars)
```
{'component': 'agent', 'dependencies': {'manager': '127.0.0.1', 'agent': '127.0.0.1'}, 'wazuh_version': '4.7.1', 'wazuh_revision': '1', 'wazuh_branch': None, 'working_dir': '/tmp/tests'}
```

<details><summary>Complete result</summary>

```
{'component': 'agent', 'dependencies': {'manager': '127.0.0.1', 'agent': '127.0.0.1'}, 'wazuh_version': '4.7.1', 'wazuh_revision': '1', 'wazuh_branch': None, 'working_dir': '/tmp/tests'}
No config file found; using defaults

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
fatal: [127.0.0.1]: UNREACHABLE! => changed=false 
  msg: 'Failed to connect to the host via ssh: ssh: connect to host 127.0.0.1 port 2200: Connection refused'
  unreachable: true

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0   
No config file found; using defaults

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
fatal: [127.0.0.1]: UNREACHABLE! => changed=false 
  msg: 'Failed to connect to the host via ssh: ssh: connect to host 127.0.0.1 port 2200: Connection refused'
  unreachable: true

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0   
No config file found; using defaults

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
fatal: [127.0.0.1]: UNREACHABLE! => changed=false 
  msg: 'Failed to connect to the host via ssh: ssh: connect to host 127.0.0.1 port 2200: Connection refused'
  unreachable: true

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0   
```

</details>

----

Executing:


```
(deployability) akim@akim-PC:~/Desktop/wazuh-qa/deployability$  python3 launchers/workflow_engine.py modules/workflow_engine/examples/dtt1-agents-poc.yaml modules/workflow_engine/schema.json
```

The result is:

```
Validation error: {'action': 'create'} is not of type 'string'

Failed validating 'type' in schema[0]:
    {'type': 'string'}

On instance:
    {'action': 'create'}
[2024-01-26 13:53:23] [INFO] Executing tasks in parallel.
[2024-01-26 13:53:23] [INFO] [allocate-manager] Starting task.
task_args ['/home/akim/Desktop/wazuh-qa/deployability/launchers/allocation.py', '--action=create', '--provider=vagrant', '--size=large', '--composite-name=linux-ubuntu-22.04-amd64', '--inventory-output=/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/inventory.yaml', '--track-output=/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/track.yaml']
[2024-01-26 13:56:11] [INFO] [allocate-manager] Finished task in 168.30 seconds.
[2024-01-26 13:56:11] [INFO] [allocate-linux-ubuntu-22.04-amd64] Starting task.
task_args ['/home/akim/Desktop/wazuh-qa/deployability/launchers/allocation.py', '--action=create', '--provider=vagrant', '--size=small', '--composite-name=linux-ubuntu-22.04-amd64', '--inventory-output=/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml', '--track-output=/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/track.yaml']
[2024-01-26 13:59:00] [INFO] [allocate-linux-ubuntu-22.04-amd64] Finished task in 169.26 seconds.
[2024-01-26 13:59:00] [INFO] [provision-manager] Starting task.
task_args ['/home/akim/Desktop/wazuh-qa/deployability/launchers/provision.py', '--inventory-manager=/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/inventory.yaml', '--install=component:wazuh-manager,install-type:package', '--install=component:curl']
[2024-01-26 14:02:18] [INFO] [provision-manager] Finished task in 197.65 seconds.
[2024-01-26 14:02:18] [INFO] [provision-linux-ubuntu-22.04-amd64] Starting task.
task_args ['/home/akim/Desktop/wazuh-qa/deployability/launchers/provision.py', '--inventory-agent=/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml', '--inventory-manager=/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/inventory.yaml', '--install=component:wazuh-agent,install-type:package', '--install=component:curl', '--install=component:nano']
[2024-01-26 14:04:06] [INFO] [provision-linux-ubuntu-22.04-amd64] Finished task in 107.78 seconds.
[2024-01-26 14:04:06] [INFO] [run-agent-tests-linux-ubuntu-22.04-amd64] Starting task.
task_args ['/home/akim/Desktop/wazuh-qa/deployability/launchers/test.py', '--inventory=/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml', "--dependencies={'manager': '/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/inventory.yaml'}", "--dependencies={'agent': '/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml'}", '--tests=install,register,stop', '--component=agent', '--wazuh-version=4.7.1', '--wazuh-revision=40709']
[2024-01-26 14:04:27] [INFO] [run-agent-tests-linux-ubuntu-22.04-amd64] Finished task in 21.12 seconds.
[2024-01-26 14:04:27] [INFO] Executing cleanup tasks.
``` 

Where is possible to see:

```
task_args ['/home/akim/Desktop/wazuh-qa/deployability/launchers/test.py', '--inventory=/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml', "--dependencies={'manager': '/tmp/dtt1-poc/manager-linux-ubuntu-22.04-amd64/inventory.yaml'}", "--dependencies={'agent': '/tmp/dtt1-poc/agent-linux-ubuntu-22.04-amd64/inventory.yaml'}", '--tests=install,register,stop', '--component=agent', '--wazuh-version=4.7.1', '--wazuh-revision=40709']
```