### PR TITLE
Fix the IPs on the inventories returned by the Allocator

### DIFF
--- a/deployability/modules/__init__.py
+++ b/deployability/modules/__init__.py
@@ -1,5 +1,4 @@
 from .provision import Provision
 from .generic import Ansible
-from .allocation.vagrant import VagrantProvider
-from .allocation.aws import AWSProvider
+from .allocation import Allocator
 from .generic import SchemaValidator

--- a/deployability/modules/allocation/static/templates/vagrant.j2
+++ b/deployability/modules/allocation/static/templates/vagrant.j2
@@ -18,12 +18,13 @@ Vagrant.configure("2") do |config|
     # Create a file to indicate that the VM has been initialized
     # This is required to correctly get the ssh-config of the VM
     # TODO: find a better solution
-    if not ::File.exists? "./init"
-      File.write("./init", "initialized")
+    init_indicator = "./init"
+    if not ::File.exists?(init_indicator)
+        File.write(init_indicator, "initialized")
     else
-      # Use the IP address of the VM to connect via SSH
-      config.ssh.host = "{{ config.ip }}"
-      config.ssh.port = 22
-      config.ssh.private_key_path = "{{ config.private_key }}"
+        # Use the IP address of the VM to connect via SSH
+        config.ssh.host = "{{ config.ip }}"
+        config.ssh.port = 22
+        config.ssh.private_key_path = "{{ config.private_key }}"
     end
 end

--- a/deployability/modules/allocation/static/templates/vagrant.j2
+++ b/deployability/modules/allocation/static/templates/vagrant.j2
@@ -1,10 +1,27 @@
 Vagrant.configure("2") do |config|
     config.vm.box = "{{ config.box }}"
     config.vm.box_version = "{{ config.box_version }}"
+
+    # Copy the public key to the VM
     config.vm.provision "file", source: "{{ config.public_key }}", destination: ".ssh/authorized_keys"
-    config.vm.network "private_network", ip:"{{ config.ip }}"
+
+    # VirtualBox specific settings
     config.vm.provider "virtualbox" do |v|
         v.memory = {{ config.memory }}
         v.cpus = {{ config.cpu }}
+    end
+
+    # Network settings
+    config.vm.network "private_network", ip:"192.168.57.2"
+    config.ssh.forward_agent = true
+    # Create a file to indicate that the VM has been initialized
+    # This is required to correctly get the ssh-config of the VM
+    # TODO: find a better solution
+    if not ::File.exists? "./init"
+      File.write("./init", "initialized")
+    else
+      # Use the IP address of the VM to connect via SSH
+      config.ssh.host = "192.168.57.2"
+      config.ssh.port = 22
     end
 end

--- a/deployability/modules/allocation/static/templates/vagrant.j2
+++ b/deployability/modules/allocation/static/templates/vagrant.j2
@@ -1,4 +1,5 @@
 Vagrant.configure("2") do |config|
+    # Box image settings
     config.vm.box = "{{ config.box }}"
     config.vm.box_version = "{{ config.box_version }}"
 
@@ -12,7 +13,7 @@ Vagrant.configure("2") do |config|
     end
 
     # Network settings
-    config.vm.network "private_network", ip:"192.168.57.2"
+    config.vm.network "private_network", ip:"{{ config.ip }}"
     config.ssh.forward_agent = true
     # Create a file to indicate that the VM has been initialized
     # This is required to correctly get the ssh-config of the VM
@@ -21,7 +22,8 @@ Vagrant.configure("2") do |config|
       File.write("./init", "initialized")
     else
       # Use the IP address of the VM to connect via SSH
-      config.ssh.host = "192.168.57.2"
+      config.ssh.host = "{{ config.ip }}"
       config.ssh.port = 22
+      config.ssh.private_key_path = "{{ config.private_key }}"
     end
 end

--- a/deployability/modules/allocation/vagrant/models.py
+++ b/deployability/modules/allocation/vagrant/models.py
@@ -10,6 +10,7 @@ class VagrantConfig(ProviderConfig):
     memory: int
     box: str
     box_version: str
+    private_key: str
     public_key: str
 
     @field_validator('public_key', mode='before')

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -149,7 +149,6 @@ class VagrantProvider(Provider):
         def check_ip(ip):
             response = os.system("ping -c 1 -w3 " + ip + " > /dev/null 2>&1")
             if response != 0:
-                print(ip, 'is available')
                 return ip
 
         for i in range(1, 255):


### PR DESCRIPTION
### Description

This PR fixes the obtaining and retrieving of the IPs in the Allocator module. 
A part of the fix is done in the Vagrantfile's template, the rest are some minor modifications on the `Vagrant` provider.

#### Validations required
- [x] Execute a complete workflow with at least one Provision
- [x] Execute the Allocator locally at least two times to check the IPs are not repeated