### PR TITLE
Create instances using custom configurations

### DIFF
--- a/deployability/launchers/allocation.py
+++ b/deployability/launchers/allocation.py
@@ -15,6 +15,7 @@ def parse_arguments():
     parser.add_argument("--composite-name", required=False, default=None)
     parser.add_argument("--action", choices=['create', 'delete'], required=False, default='create')
     parser.add_argument("--custom-credentials", required=False, default=None)
+    parser.add_argument("--custom-provider-config", required=False, default=None)
     parser.add_argument("--track-output", required=False, default='/tmp/wazuh-qa/track.yml')
     parser.add_argument("--inventory-output", required=False, default='/tmp/wazuh-qa/inventory.yml')
     parser.add_argument("--working-dir", required=False, default='/tmp/wazuh-qa')

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -20,7 +20,6 @@ class AWSProvider(Provider):
     """
 
     provider_name = 'aws'
-    _client = boto3.resource('ec2')
 
     @classmethod
     def _create_instance(cls, base_dir: Path, params: CreationPayload) -> AWSInstance:
@@ -41,11 +40,12 @@ class AWSProvider(Provider):
         credentials.generate(temp_dir, temp_id.split('-')[-1] + '_key')
         # Parse the config and create the AWS EC2 instance.
         config = cls._parse_config(params, credentials)
-        _instance = cls._client.create_instances(ImageId=config.ami,
-                                                 InstanceType=config.type,
-                                                 KeyName=config.key_name,
-                                                 SecurityGroupIds=config.security_groups,
-                                                 MinCount=1, MaxCount=1)[0]
+        client = boto3.resource('ec2')
+        _instance = client.create_instances(ImageId=config.ami,
+                                            InstanceType=config.type,
+                                            KeyName=config.key_name,
+                                            SecurityGroupIds=config.security_groups,
+                                            MinCount=1, MaxCount=1)[0]
         # Wait until the instance is running.
         _instance.wait_until_running()  
         # Rename the temp directory to its real name.

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -22,13 +22,14 @@ class AWSProvider(Provider):
     provider_name = 'aws'
 
     @classmethod
-    def _create_instance(cls, base_dir: Path, params: CreationPayload) -> AWSInstance:
+    def _create_instance(cls, base_dir: Path, params: CreationPayload, config: AWSConfig = None) -> AWSInstance:
         """
         Create an AWS EC2 instance.
 
         Args:
             base_dir (Path): Base directory for storing instance data.
             params (CreationPayload): Payload containing creation parameters.
+            config (AWSConfig, optional): Configuration for the instance. Defaults to None.
 
         Returns:
             AWSInstance: Created AWSInstance object.
@@ -38,22 +39,17 @@ class AWSProvider(Provider):
         # Generate the credentials.
         credentials = AWSCredentials()
         credentials.generate(temp_dir, temp_id.split('-')[-1] + '_key')
-        # Parse the config and create the AWS EC2 instance.
-        config = cls._parse_config(params, credentials)
-        client = boto3.resource('ec2')
-        _instance = client.create_instances(ImageId=config.ami,
-                                            InstanceType=config.type,
-                                            KeyName=config.key_name,
-                                            SecurityGroupIds=config.security_groups,
-                                            MinCount=1, MaxCount=1)[0]
-        # Wait until the instance is running.
-        _instance.wait_until_running()  
+        if not config:
+            # Parse the config if it is not provided.
+            config = cls.__parse_config(params, credentials)
+        # Generate the instance.
+        instance_id = cls.__create_ec2_instance(config)
         # Rename the temp directory to its real name.
-        instance_dir = Path(base_dir, _instance.instance_id)
+        instance_dir = Path(base_dir, instance_id)
         os.rename(temp_dir, instance_dir)
         credentials.key_path = (instance_dir / credentials.name).with_suffix('.pem')
 
-        return AWSInstance(instance_dir, _instance.instance_id, credentials, config.user)
+        return AWSInstance(instance_dir, instance_id, credentials, config.user)
 
     @staticmethod
     def _load_instance(instance_dir: Path, instance_id: str) -> AWSInstance:
@@ -83,8 +79,29 @@ class AWSProvider(Provider):
             instance.credentials.delete()
         instance.delete()
 
+    @staticmethod
+    def __create_ec2_instance(config: AWSConfig) -> str:
+        """
+        Create an AWS EC2 instance.
+
+        Args:
+            config (AWSConfig): Configuration for the instance.
+
+        Returns:
+            str: Identifier of the created instance.
+        """
+        client = boto3.resource('ec2')
+        instance = client.create_instances(ImageId=config.ami,
+                                           InstanceType=config.type,
+                                           KeyName=config.key_name,
+                                           SecurityGroupIds=config.security_groups,
+                                           MinCount=1, MaxCount=1)[0]
+        # Wait until the instance is running.
+        instance.wait_until_running()
+        return instance.instance_id
+
     @classmethod
-    def _parse_config(cls, params: CreationPayload, credentials: AWSCredentials) -> AWSConfig:
+    def __parse_config(cls, params: CreationPayload, credentials: AWSCredentials) -> AWSConfig:
         """
         Parse configuration parameters for creating an AWS EC2 instance.
 

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -36,12 +36,19 @@ class AWSProvider(Provider):
         """
         temp_id = cls._generate_instance_id(cls.provider_name)
         temp_dir = base_dir / temp_id
-        # Generate the credentials.
         credentials = AWSCredentials()
-        credentials.generate(temp_dir, temp_id.split('-')[-1] + '_key')
         if not config:
+            # Generate the credentials.
+            credentials.generate(temp_dir, temp_id.split('-')[-1] + '_key')
             # Parse the config if it is not provided.
             config = cls.__parse_config(params, credentials)
+        else:
+            # Load the existing credentials.
+            credentials.load(config.key_name)
+            # Create the temp directory. 
+            # TODO: Review this on the credentials refactor.
+            if not temp_dir.exists():
+                temp_dir.mkdir(parents=True, exist_ok=True)
         # Generate the instance.
         instance_id = cls.__create_ec2_instance(config)
         # Rename the temp directory to its real name.

--- a/deployability/modules/allocation/generic/models.py
+++ b/deployability/modules/allocation/generic/models.py
@@ -35,13 +35,14 @@ class TrackOutput(BaseModel):
 
 class InputPayload(BaseModel):
     action: Literal['create', 'delete', 'status'] = 'create'
-    provider: str | None
-    size: Literal['micro', 'small', 'medium', 'large', None]
-    composite_name: str | None
-    track_output: Path | None
-    inventory_output: Path | None
-    working_dir: Path | None
-    custom_credentials: str | None
+    provider: str | None = None
+    size: Literal['micro', 'small', 'medium', 'large', None] = None
+    composite_name: str | None = None
+    working_dir: Path | None = Path('/tmp/wazuh-qa')
+    track_output: Path | None = working_dir / 'track.yml'
+    inventory_output: Path | None = working_dir / 'inventory.yml'
+    custom_credentials: str | None = None
+    custom_provider_config: Path | None = None
 
 
 class CreationPayload(InputPayload):

--- a/deployability/modules/allocation/generic/models.py
+++ b/deployability/modules/allocation/generic/models.py
@@ -53,15 +53,19 @@ class CreationPayload(InputPayload):
     inventory_output: Path
     working_dir: Path
     custom_credentials: str | None = None
+    custom_provider_config: Path | None = None
 
-    @field_validator('custom_credentials')
+    @field_validator('custom_provider_config')
     @classmethod
-    def check_credentials(cls, v: str) -> str | None:
+    def check_config(cls, v: Path | None) -> Path | None:
         if not v:
             return None
-        path = Path(v)
-        if not path.exists() or not path.is_file():
-            raise ValueError(f"Invalid credentials path: {path}")
+        if not v.exists():
+            raise ValueError(f"Custom provider config file does not exist: {v}")
+        elif not v.is_file():
+            raise ValueError(f"Custom provider config file is not a file: {v}")
+        elif not v.suffix in ['.yml', '.yaml']:
+            raise ValueError(f"Custom provider config file must be yaml: {v}")
         return v
 
     @field_validator('working_dir', mode='before')

--- a/deployability/modules/allocation/generic/provider.py
+++ b/deployability/modules/allocation/generic/provider.py
@@ -61,7 +61,7 @@ class Provider(ABC):
         """
         params = CreationPayload(**dict(params))
         base_dir = Path(base_dir)
-        return cls._create_instance(base_dir, params)
+        return cls._create_instance(base_dir, params, config)
 
     @classmethod
     def load_instance(cls, instance_dir: str | Path, instance_id: str) -> Instance:
@@ -98,13 +98,14 @@ class Provider(ABC):
 
     @classmethod
     @abstractmethod
-    def _create_instance(cls, base_dir: Path, params: CreationPayload) -> Instance:
+    def _create_instance(cls, base_dir: Path, params: CreationPayload, config: ProviderConfig = None) -> Instance:
         """
         Abstract method that creates a new instance.
 
         Args:
             base_dir (Path): The base directory for the instance.
             params (CreationPayload): The parameters for creating the instance.
+            config (ProviderConfig, optional): The configuration for the instance. Defaults to None.
 
         Returns:
             Instance: The created instance.

--- a/deployability/modules/allocation/generic/provider.py
+++ b/deployability/modules/allocation/generic/provider.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 from .instance import Instance
-from .models import CreationPayload
+from .models import CreationPayload, ProviderConfig
 
 
 class Provider(ABC):
@@ -47,13 +47,14 @@ class Provider(ABC):
         pass
 
     @classmethod
-    def create_instance(cls, base_dir: str | Path, params: CreationPayload) -> Instance:
+    def create_instance(cls, base_dir: str | Path, params: CreationPayload, config: ProviderConfig = None) -> Instance:
         """
         Creates a new instance.
 
         Args:
             base_dir (str | Path): The base directory for the instance.
             params (CreationPayload): The parameters for creating the instance.
+            config (ProviderConfig, optional): The configuration for the instance. Defaults to None.
 
         Returns:
             Instance: The created instance.

--- a/deployability/modules/allocation/vagrant/credentials.py
+++ b/deployability/modules/allocation/vagrant/credentials.py
@@ -71,30 +71,22 @@ class VagrantCredentials(Credentials):
         self.key_path = private_key_path
         return self.key_path
 
-    def load(self, base_dir: str | Path, name: str) -> None:
+    def load(self, path: str | Path) -> None:
         """
         Loads an existing key pair from the specified directory.
 
         Args:
-            base_dir (str | Path): The directory where the key pair is stored.
-            name (str): The filename of the key pair.
+            path (str | Path): The path to the key pair.
 
         Raises:
             CredentialsError: This exception is raised if the key pair doesn't exist or the specified directory is invalid.
         """
-        base_dir = Path(base_dir)
-        if not base_dir.exists() or not base_dir.is_dir():
-            raise self.CredentialsError(f"Invalid path {base_dir}.")
-        key_path = Path(base_dir, name)
-        pub_key_path = key_path.with_suffix(".pub")
+        key_path = Path(path)
         if not key_path.exists() or not key_path.is_file():
-            raise self.CredentialsError(f"Invalid key name {name}.")
-        if not pub_key_path.exists() or not pub_key_path.is_file():
-            raise self.CredentialsError(f"Non-existen public key for {name}.")
-        # Save instance attributes.
+            raise self.CredentialsError(f"Invalid path {key_path}.")
         self.key_path = key_path
-        self.name = name
-        self.key_id = name
+        self.name = key_path.name
+        self.key_id = key_path.name
 
     def delete(self) -> None:
         """

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -22,13 +22,14 @@ class VagrantProvider(Provider):
     provider_name = 'vagrant'
 
     @classmethod
-    def _create_instance(cls, base_dir: Path, params: CreationPayload) -> VagrantInstance:
+    def _create_instance(cls, base_dir: Path, params: CreationPayload, config: VagrantConfig = None) -> VagrantInstance:
         """
         Creates a Vagrant instance.
 
         Args:
             base_dir (Path): The base directory for the instance.
             params (CreationPayload): The parameters for instance creation.
+            config (VagrantConfig, optional): The configuration for the instance. Defaults to None.
 
         Returns:
             VagrantInstance: The created Vagrant instance.
@@ -40,8 +41,10 @@ class VagrantProvider(Provider):
         # Generate the credentials.
         credentials = VagrantCredentials()
         credentials.generate(instance_dir, 'instance_key')
-        # Parse the config and create Vagrantfile.
-        config = cls.__parse_config(params, credentials)
+        if not config:
+            # Parse the config if it is not provided.
+            config = cls.__parse_config(params, credentials)
+        # Create the Vagrantfile.
         cls.__create_vagrantfile(instance_dir, config)
         return VagrantInstance(instance_dir, instance_id, credentials)
 

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -38,12 +38,14 @@ class VagrantProvider(Provider):
         # Create the instance directory.
         instance_dir = base_dir / instance_id
         instance_dir.mkdir(parents=True, exist_ok=True)
-        # Generate the credentials.
         credentials = VagrantCredentials()
-        credentials.generate(instance_dir, 'instance_key')
         if not config:
+            # Generate the credentials.
+            credentials.generate(instance_dir, 'instance_key')
             # Parse the config if it is not provided.
             config = cls.__parse_config(params, credentials)
+        else:
+            credentials.load(config.public_key)
         # Create the Vagrantfile.
         cls.__create_vagrantfile(instance_dir, config)
         return VagrantInstance(instance_dir, instance_id, credentials)


### PR DESCRIPTION
|Related issue|
|-------------|
| #4864 |

## Description

This PR enables the usage of a custom configuration file to generate instances, this configuration file must be a `.yaml` that matches the specific `ProviderConfig`. E.g a custom vagrant config:
```yaml
ip: '192.168.57.3'
cpu: 1
memory: 2048
box: 'generic/ubuntu2004'
box_version: '4.3.8'
public_key: '/tmp/wazuh-qa/VAGRANT-1179DAFB-EFDD-47BA-B97F-5ECC8B3428B7/instance_key.pub'
``` 
We can observe it matches the `VagrantConfig` model
```python
class VagrantConfig(ProviderConfig):
    ip: str
    cpu: int
    memory: int
    box: str
    box_version: str
    public_key: str
```

---

### Testing performed

**Vagrant instance creation**
1. Create a .yaml file with the `VagrantConfig` values
    `test.yaml`
    ```yaml
    ip: '192.168.57.3'
    cpu: 1
    memory: 2048
    box: 'generic/ubuntu2004'
    box_version: '4.3.8'
    public_key: '/tmp/wazuh-qa/VAGRANT-1179DAFB-EFDD-47BA-B97F-5ECC8B3428B7/instance_key.pub'
    ```
2. Execute the allocator with the new parameter
    ```shellsession
    python launchers/allocation.py --provider vagrant --size small --composite-name linux-ubuntu-20.04-amd64  --custom-provider-config test.yaml
    ```
3. Check `track-output` and the created `Vagrantfile`
    ```shellsession
    cat /tmp/wazuh-qa/track.yml
    identifier: VAGRANT-6B268EB6-3E12-454A-85EF-1B52548F4882
    instance_dir: /tmp/wazuh-qa/VAGRANT-6B268EB6-3E12-454A-85EF-1B52548F4882
    key_path: /tmp/wazuh-qa/VAGRANT-1179DAFB-EFDD-47BA-B97F-5ECC8B3428B7/instance_key.pub
    provider: vagrant
    ```
    `/tmp/wazuh-qa/VAGRANT-6B268EB6-3E12-454A-85EF-1B52548F4882/Vagrantfile `
    ```Ruby
    Vagrant.configure("2") do |config|
        config.vm.box = "generic/ubuntu2004"
        config.vm.box_version = "4.3.8"
        config.vm.provision "file", source: "/tmp/wazuh-qa/VAGRANT-1179DAFB-EFDD-47BA-B97F-5ECC8B3428B7/instance_key.pub", destination: ".ssh/authorized_keys"
        config.vm.network "private_network", ip:"192.168.57.3"
        config.vm.provider "virtualbox" do |v|
            v.memory = 2048
            v.cpus = 1
        end
    ```

**AWS instance creation**

**Usage validation**
1. Create a .yaml file with the `AWSConfig` values
    `test.yaml`
    ```yaml
    ami: 'ami-0fc5d935ebf8bc3bc'
    zone: 'us-east-1'
    user: 'ubuntu'
    key_name: 'AA86C4DBBF5A_key'
    type: 't2.small'
    security_groups: ['sg-023fd37c4e5b679de']
    ```
2. Execute the allocator with the new parameter
    ```shellsession
    python launchers/allocation.py --provider aws --size small --composite-name linux-ubuntu-20.04-amd64  --custom-provider-config test.yaml
    ```
3. Check `track-output` and the created instance on AWS
    ```shellsession
    cat /tmp/wazuh-qa/track.yml
    identifier: i-07cfa6cca8bda9628
    instance_dir: /tmp/wazuh-qa/i-07cfa6cca8bda9628
    key_path: /tmp/wazuh-qa/i-07cfa6cca8bda9628/AA86C4DBBF5A_key.pem
    provider: aws
    ```
    ![image](https://github.com/wazuh/wazuh-qa/assets/44633633/b5524ac3-2748-4a6d-a2f8-99e4a6b05fc9)

