### PR TITLE
Fix service tests to handle Python version-dependent issues by optimizing Ansible runner import strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed ansible_runner import conditional to avoid errors on Windows and python 3.6 ([#4916](https://github.com/wazuh/wazuh-qa/pull/4916)) \- (Framework)
 - Fixed IT control_service Windows loop ([#4765](https://github.com/wazuh/wazuh-qa/pull/4765)) \- (Framework)
 - Fix macOS agents provision to enable registration and connection with managers. ([#4770](https://github.com/wazuh/wazuh-qa/pull/4770/)) \- (Framework)
 - Fix hardcoded python interpreter in qa_framework role. ([#4658](https://github.com/wazuh/wazuh-qa/pull/4658)) \- (Framework)

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -608,7 +608,7 @@ class HostManager:
         result = None
 
         if sys.version_info < (3, 7) or sys.platform.startswith("win"):
-            raise ValueError("Python 3.7 or higher is required to run Ansible playbooks.")
+            raise ValueError("Python 3.7 or higher and a Unix-like system are required to run Ansible playbooks.")
         else:
             import ansible_runner
 

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -4,13 +4,13 @@
 
 import json
 import tempfile
+import sys
 import os
 import logging
 import xml.dom.minidom as minidom
 from typing import Union, List
 import testinfra
 import yaml
-import ansible_runner
 
 from wazuh_testing.tools import WAZUH_CONF, WAZUH_API_CONF, API_LOG_FILE_PATH, WAZUH_LOCAL_INTERNAL_OPTIONS
 from wazuh_testing.tools.configuration import set_section_wazuh_conf
@@ -590,38 +590,58 @@ class HostManager:
         return remove_operation_result
 
     def run_playbook(self, host, playbook_name, params=None):
-        file_dir = os.path.dirname(os.path.realpath(__file__))
-        playbook_path = f"{file_dir}/playbooks/{playbook_name}.yaml"
-        new_playbook = None
-        new_playbook_path = None
+        """
+        Executes an Ansible playbook on the specified host.
 
-        with open(playbook_path, 'r') as playbook_file:
-            playbook = playbook_file.read()
-            new_playbook = playbook.replace('HOSTS', host)
+        Args:
+            host (str): The target host on which to execute the playbook.
+            playbook_name (str): The name of the playbook to be executed.
+            params (dict, optional): The parameters to be passed to the playbook. Defaults to None.
 
-        temp_dir = tempfile.mkdtemp()
-        new_playbook_path = f"{temp_dir}/playbook.yaml"
+        Returns:
+            Runner: The result of the playbook execution.
 
-        with open(f"{temp_dir}/playbook.yaml", 'w') as playbook_file:
-            playbook_file.write(new_playbook)
+        Raises:
+            ValueError: If the Python version is less than 3.7.
+        """
 
-        r = None
+        result = None
 
-        logger.setLevel(logging.DEBUG)
-        try:
-            r = ansible_runner.run(
-                inventory=self.inventory_path,
-                playbook=new_playbook_path,
-                host_pattern=host,
-                extravars=params,
-            )
-            print("Ansible playbook executed successfully.")
-        except Exception as e:
-            print(f"Error executing Ansible playbook: {e}")
+        if sys.version_info < (3, 7):
+            raise ValueError("Python 3.7 or higher is required to run Ansible playbooks.")
+        else:
+            import ansible_runner
 
-        logger.setLevel(logging.CRITICAL)
+            file_dir = os.path.dirname(os.path.realpath(__file__))
+            playbook_path = f"{file_dir}/playbooks/{playbook_name}.yaml"
+            new_playbook = None
+            new_playbook_path = None
 
-        return r
+            with open(playbook_path, 'r') as playbook_file:
+                playbook = playbook_file.read()
+                new_playbook = playbook.replace('HOSTS', host)
+
+            temp_dir = tempfile.mkdtemp()
+            new_playbook_path = f"{temp_dir}/playbook.yaml"
+
+            with open(f"{temp_dir}/playbook.yaml", 'w') as playbook_file:
+                playbook_file.write(new_playbook)
+
+            logger.setLevel(logging.DEBUG)
+            try:
+                result = ansible_runner.run(
+                    inventory=self.inventory_path,
+                    playbook=new_playbook_path,
+                    host_pattern=host,
+                    extravars=params,
+                )
+                print("Ansible playbook executed successfully.")
+            except Exception as e:
+                print(f"Error executing Ansible playbook: {e}")
+
+            logger.setLevel(logging.CRITICAL)
+
+        return result
 
     def handle_wazuh_services(self, host, operation):
         """

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -627,7 +627,6 @@ class HostManager:
             with open(f"{temp_dir}/playbook.yaml", 'w') as playbook_file:
                 playbook_file.write(new_playbook)
 
-            logger.setLevel(logging.DEBUG)
             try:
                 result = ansible_runner.run(
                     inventory=self.inventory_path,
@@ -635,11 +634,9 @@ class HostManager:
                     host_pattern=host,
                     extravars=params,
                 )
-                print("Ansible playbook executed successfully.")
+                logging.info("Ansible playbook executed successfully.")
             except Exception as e:
-                print(f"Error executing Ansible playbook: {e}")
-
-            logger.setLevel(logging.CRITICAL)
+                logging.critical(f"Error executing Ansible playbook: {e}")
 
         return result
 

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -607,7 +607,7 @@ class HostManager:
 
         result = None
 
-        if sys.version_info < (3, 7):
+        if sys.version_info < (3, 7) or sys.platform.startswith("win"):
             raise ValueError("Python 3.7 or higher is required to run Ansible playbooks.")
         else:
             import ansible_runner


### PR DESCRIPTION
# Description

This PR includes a minor logic to avoid to `ansible_runner` module in the system module in case python version is less than 3.7

More information about the motivation of this change can be found in https://github.com/wazuh/wazuh-jenkins/issues/6238#issuecomment-1927362809

**Build**: https://ci.wazuh.info/job/Test_service/7281/

> [!WARNING]
> This is only a temporal fix. We should troubleshoot this issue in the future creating a more flexible framework