### PR TITLE
Updated AWS amis

### DIFF
--- a/deployability/modules/allocation/allocation.py
+++ b/deployability/modules/allocation/allocation.py
@@ -42,7 +42,7 @@ class Allocator:
 
         Args:
             payload (CreationPayload): The payload containing the parameters
-                                       for instance creation.
+                                        for instance creation.
         """
         instance_params = models.CreationPayload(**dict(payload))
         provider: Provider = PROVIDERS[payload.provider]()
@@ -50,7 +50,7 @@ class Allocator:
         instance = provider.create_instance(
             payload.working_dir, instance_params, config)
         logger.info(f"Instance {instance.identifier} created.")
-        # Start the instance    
+        # Start the instance
         instance.start()
         logger.info(f"Instance {instance.identifier} started.")
         # Generate the inventory and track files.
@@ -64,7 +64,7 @@ class Allocator:
 
         Args:
             payload (DeletionPayload): The payload containing the parameters
-                                              for instance deletion.
+                                                for instance deletion.
         """
         payload = models.DeletionPayload(**dict(payload))
         # Read the data from the track file.
@@ -81,7 +81,7 @@ class Allocator:
 
         Args:
             payload (CreationPayload): The payload containing the parameters
-                                       for instance creation.
+                                        for instance creation.
 
         Returns:
             ProviderConfig: The configuration object.
@@ -110,9 +110,9 @@ class Allocator:
             inventory_path.parent.mkdir(parents=True, exist_ok=True)
         ssh_config = instance.ssh_connection_info()
         inventory = models.InventoryOutput(ansible_host=ssh_config.hostname,
-                                           ansible_user=ssh_config.user,
-                                           ansible_port=ssh_config.port,
-                                           ansible_ssh_private_key_file=str(ssh_config.private_key))
+                                            ansible_user=ssh_config.user,
+                                            ansible_port=ssh_config.port,
+                                            ansible_ssh_private_key_file=str(ssh_config.private_key))
         with open(inventory_path, 'w') as f:
             yaml.dump(inventory.model_dump(), f)
         logger.info(f"Inventory file generated at {inventory_path}")
@@ -131,9 +131,9 @@ class Allocator:
         if not track_path.parent.exists():
             track_path.parent.mkdir(parents=True, exist_ok=True)
         track = models.TrackOutput(identifier=instance.identifier,
-                                   provider=provider_name,
-                                   instance_dir=str(instance.path),
-                                   key_path=str(instance.credentials.key_path))
+                                    provider=provider_name,
+                                    instance_dir=str(instance.path),
+                                    key_path=str(instance.credentials.key_path))
         with open(track_path, 'w') as f:
             yaml.dump(track.model_dump(), f)
         logger.info(f"Track file generated at {track_path}")

--- a/deployability/modules/allocation/aws/instance.py
+++ b/deployability/modules/allocation/aws/instance.py
@@ -68,9 +68,9 @@ class AWSInstance(Instance):
             ConnectionInfo: SSH connection information.
         """
         return ConnectionInfo(hostname=self._instance.public_dns_name,
-                              user=self._user,
-                              port=22,
-                              private_key=str(self.credentials.key_path))
+                                user=self._user,
+                                port=22,
+                                private_key=str(self.credentials.key_path))
 
     def __get_credentials(self) -> AWSCredentials:
         """

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -131,9 +131,10 @@ class AWSProvider(Provider):
         size_specs = cls._get_size_specs()[params.size]
         os_specs = cls._get_os_specs()[params.composite_name]
         mics_specs = cls._get_misc_specs()
+        arch = params.composite_name.split('-')[-1]
         # Parse the configuration.
         for spec in size_specs:
-            if fnmatch.fnmatch(params.composite_name, spec):
+            if fnmatch.fnmatch(arch, spec):
                 config['type'] = size_specs[spec]['type']
                 break
 

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -48,7 +48,7 @@ class AWSProvider(Provider):
             logger.debug(f"Using provided config")
             # Load the existing credentials.
             credentials.load(config.key_name)
-            # Create the temp directory. 
+            # Create the temp directory.
             # TODO: Review this on the credentials refactor.
             if not temp_dir.exists():
                 logger.debug(f"Creating temp directory: {temp_dir}")
@@ -105,10 +105,10 @@ class AWSProvider(Provider):
         """
         client = boto3.resource('ec2')
         instance = client.create_instances(ImageId=config.ami,
-                                           InstanceType=config.type,
-                                           KeyName=config.key_name,
-                                           SecurityGroupIds=config.security_groups,
-                                           MinCount=1, MaxCount=1)[0]
+                                            InstanceType=config.type,
+                                            KeyName=config.key_name,
+                                            SecurityGroupIds=config.security_groups,
+                                            MinCount=1, MaxCount=1)[0]
         # Wait until the instance is running.
         instance.wait_until_running()
         return instance.instance_id

--- a/deployability/modules/allocation/generic/models.py
+++ b/deployability/modules/allocation/generic/models.py
@@ -64,9 +64,8 @@ class CreationPayload(InputPayload):
         for attr in required_if_not_config:
             if not values.get(attr):
                 raise ValueError(f"{attr} is required if custom_provider_config is not provided.")
-            
         return values
-    
+
     @field_validator('custom_provider_config')
     @classmethod
     def check_config(cls, v: Path | None) -> Path | None:

--- a/deployability/modules/allocation/generic/provider.py
+++ b/deployability/modules/allocation/generic/provider.py
@@ -14,7 +14,7 @@ class Provider(ABC):
     """
     An abstract base class for providers.
 
-    This class provides an interface for creating, loading, and destroying instances. 
+    This class provides an interface for creating, loading, and destroying instances.
     It also provides methods to get OS, size, and miscellaneous specifications for the provider.
 
     Attributes:
@@ -28,8 +28,8 @@ class Provider(ABC):
     OS_PATH = SPECS_DIR / 'os.yml'
     SIZE_PATH = SPECS_DIR / 'size.yml'
     MISC_PATH = SPECS_DIR / 'misc.yml'
-    
-    
+
+
     class ProvisioningError(Exception):
         """
         Exception raised for errors in the provisioning process.

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -80,7 +80,7 @@ vagrant:
     box: generic/fedora37
     box_version: 4.3.8
   linux-fedora-38-amd64:
-    box: generic/fedora38
+    box: alvistack/fedora-38
     box_version: 4.3.8
   # Rocky Linux
   linux-rocky-9-amd64:
@@ -144,7 +144,7 @@ aws:
     zone: us-east-1
     user: admin
   linux-debian-12-amd64:
-    ami: ami-0d3eda47adff3e44b
+    ami: ami-058bd2d568351da34
     zone: us-east-1
     user: admin
   # Oracle Linux
@@ -253,7 +253,7 @@ aws:
     ami: ami-09d8cef159442d5b0
     zone: us-east-1
     user: Administrator
-  windows-server-2012R2-amd64:
+  windows-server-2012r2-amd64:
     ami: ami-0eb3cabd65ed56ee6
     zone: us-east-1
     user: Administrator

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -4,14 +4,14 @@ vagrant:
     box: generic/ubuntu1604
     box_version: 4.3.8
   linux-ubuntu-18.04-amd64:
-    box: generic/ubuntu1804
-    box_version: 4.3.8
+    box: ubuntu/bionic64
+    box_version: 20230607.0.0
   linux-ubuntu-20.04-amd64:
-    box: generic/ubuntu2004
-    box_version: 4.3.8
+    box: ubuntu/focal64
+    box_version: 20240130.0.0
   linux-ubuntu-22.04-amd64:
-    box: generic/ubuntu2204
-    box_version: 4.3.8
+    box: ubuntu/jammy64
+    box_version: 20240131.0.0
   # Debian
   linux-debian-9-amd64:
     box: generic/debian9
@@ -20,26 +20,35 @@ vagrant:
     box: generic/debian10
     box_version: 4.3.8
   linux-debian-11-amd64:
-    box: generic/debian11
-    box_version: 4.3.8
+    box: debian/bullseye64
+    box_version: 11.20231211.1
   linux-debian-12-amd64:
-    box: generic/debian12
-    box_version: 4.3.8
+    box: debian/bookworm64
+    box_version: 12.20231211.1
   # Oracle Linux
+  linux-oracle-7-amd64:
+    box: generic/oracle7
+    box_version: 4.3.12
+  linux-oracle-8-amd64:
+    box: generic/oracle8
+    box_version: 4.3.12
   linux-oracle-9-amd64:
     box: generic/oracle9
-    box_version: 4.3.8
+    box_version: 4.3.12
   # Suse Linux
   linux-suse-15-amd64:
     box: generic/opensuse15
     box_version: 4.3.8
   # Centos
   linux-centos-7-amd64:
-    box: generic/centos7
-    box_version: 4.3.8
+    box: centos/7
+    box_version: 2004.01
   linux-centos-8-amd64:
-    box: generic/centos8
-    box_version: 4.3.8
+    box: centos/stream8
+    box_version: 20230710.0
+  linux-centos-9-amd64:
+    box: centos/stream9
+    box_version: 20230807.1
   # Redhat
   linux-redhat-7-amd64:
     box: generic/rhel7
@@ -73,6 +82,10 @@ vagrant:
   linux-fedora-38-amd64:
     box: generic/fedora38
     box_version: 4.3.8
+  # Rocky Linux
+  linux-rocky-9-amd64:
+    box: rockylinux/9
+    box_version: 3.0.0
   # # Macos
   # macos-ventura-13.04-amd64:
   #   box: logantbond/ventura
@@ -104,11 +117,155 @@ vagrant:
   #   box_version: 2102.0.2312
 
 aws:
+  # Ubuntu
   linux-ubuntu-22.04-amd64:
-    ami: ami-0fc5d935ebf8bc3bc
+    ami: ami-053b0d53c279acc90
     zone: us-east-1
     user: ubuntu
   linux-ubuntu-22.04-arm64:
     ami: ami-016485166ec7fa705
     zone: us-east-1
     user: ubuntu
+  linux-ubuntu-18.04-amd64:
+    ami: ami-0d23ec1228995e83b
+    zone: us-east-1
+    user: ubuntu
+  linux-ubuntu-20.04-amd64:
+    ami: ami-0261755bbcb8c4a84
+    zone: us-east-1
+    user: ubuntu
+  # Debian
+  linux-debian-10-amd64:
+    ami: ami-0aef3e5090bf17640
+    zone: us-east-1
+    user: admin
+  linux-debian-11-amd64:
+    ami: ami-0f63aa666117f7cc1
+    zone: us-east-1
+    user: admin
+  linux-debian-12-amd64:
+    ami: ami-0d3eda47adff3e44b
+    zone: us-east-1
+    user: admin
+  # Oracle Linux
+  linux-oracle-7-amd64:
+    ami: ami-0fb08d5eb039a9ebd
+    zone: us-east-1
+    user: admin
+  linux-oracle-8-amd64:
+    ami: ami-04921b5223c6ab7f0
+    zone: us-east-1
+    user: admin
+  linux-oracle-9-amd64:
+    ami: ami-01453ca80e53609e3
+    zone: us-east-1
+    user: admin
+  # openSUSE Linux
+  linux-opensuse-15-amd64:
+    ami: ami-06b6eb8f8fb7f2916
+    zone: us-east-1
+    user: ec2-user
+  # SUSE Linux
+  linux-suse-15-amd64:
+    ami: ami-08f3662e2d5b3989a
+    zone: us-east-1
+    user: ec2-user
+  # Centos
+  linux-centos-7-amd64:
+    ami: ami-0aedf6b1cb669b4c7
+    zone: us-east-1
+    user: ec2-user
+  linux-centos-8-amd64:
+    ami: ami-0ee534f954d1b2c98
+    zone: us-east-1
+    user: ec2-user
+  linux-centos-9-amd64:
+    ami: ami-0259c451b16b72e24
+    zone: us-east-1
+    user: ec2-user
+  # Redhat
+  linux-redhat-7-amd64:
+    ami: ami-0bd83a2aad0515b35
+    zone: us-east-1
+    user: ec2-user
+  linux-redhat-7-arm64:
+    ami: ami-0e97b0e0c6dce1d4e
+    zone: us-east-1
+    user: ec2-user
+  linux-redhat-8-amd64:
+    ami: ami-054333d53aa32850c
+    zone: us-east-1
+    user: ec2-user
+  linux-redhat-9-amd64:
+    ami: ami-026ebd4cfe2c043b2
+    zone: us-east-1
+    user: ec2-user
+  # Amazon
+  linux-amazon-2-amd64:
+    ami: ami-0bb4c991fa89d4b9b
+    zone: us-east-1
+    user: ec2-user
+  linux-amazon-2023-amd64:
+    ami: ami-067d1e60475437da2
+    zone: us-east-1
+    user: ec2-user
+  # Fedora
+  linux-fedora-37-amd64:
+    ami: ami-0a3279828fb6dad65
+    zone: us-east-1
+    user: ec2-user
+  linux-fedora-38-amd64:
+    ami: ami-081f29ca9a2a16cec
+    zone: us-east-1
+    user: ec2-user
+  # Rocky Linux
+  linux-rocky-9-amd64:
+    ami: ami-09c77dc92e45bc3ea
+    zone: us-east-1
+    user: rocky
+  # Macos
+  macos-ventura-13.04-amd64:
+    ami: ami-05f4e10ccf8272fba
+    zone: us-east-1
+    user: ec2-user
+  macos-ventura-13.04-arm64:
+    ami: ami-05acb4959a4fc514d
+    zone: us-east-1
+    user: ec2-user
+  macos-sonoma-14.2.1-amd64:
+    ami: ami-0308cf13df41f942f
+    zone: us-east-1
+    user: ec2-user
+  macos-sonoma-14.2.1-arm64:
+    ami: ami-088797a8c678dfc1a
+    zone: us-east-1
+    user: ec2-user
+  macos-monterey-12.7.2-arm64:
+    ami: ami-040d932478899fea7
+    zone: us-east-1
+    user: ec2-user
+  # Windows
+  windows-desktop-10-amd64:
+    ami: ami-004ca0c10752e17ce
+    zone: us-east-1
+    user: Administrator
+  windows-desktop-11-amd64:
+    ami: ami-09d8cef159442d5b0
+    zone: us-east-1
+    user: Administrator
+  windows-server-2012R2-amd64:
+    ami: ami-0eb3cabd65ed56ee6
+    zone: us-east-1
+    user: Administrator
+  windows-server-2016-amd64:
+    ami: ami-0f8b5c22ce0a7cf3b
+    zone: us-east-1
+    user: Administrator
+  windows-server-2019-amd64:
+    ami: ami-0ffb936e0378c083f
+    zone: us-east-1
+    user: Administrator
+  windows-server-2022-amd64:
+    ami: ami-0ad422b1ff6909089
+    zone: us-east-1
+    user: Administrator

--- a/deployability/modules/allocation/static/specs/size.yml
+++ b/deployability/modules/allocation/static/specs/size.yml
@@ -24,11 +24,11 @@ aws:
       type: c7gn.small
   medium:
     linux-*-amd64:
-      type: t2.medium
+      type: t3a.medium
     linux-*-arm64:
       type: c7gn.medium
   large:
     linux-*-amd64:
-      type: c5a.xlarge
+      type: c5ad.xlarge
     linux-*-arm64:
       type: c6g.xlarge

--- a/deployability/modules/allocation/static/specs/size.yml
+++ b/deployability/modules/allocation/static/specs/size.yml
@@ -13,22 +13,22 @@ vagrant:
       memory: 8192
 aws:
   micro:
-    linux-*-amd64:
-      type: t2.micro
-    linux-*-arm64:
-      type: c7gn.micro
+    amd64:
+      type: t3.micro
+    arm64:
+      type: a1.medium
   small:
-    linux-*-amd64:
-      type: t2.small
-    linux-*-arm64:
-      type: c7gn.small
+    amd64:
+      type: t3.small
+    arm64:
+      type: a1.large
   medium:
-    linux-*-amd64:
+    amd64:
       type: t3a.medium
-    linux-*-arm64:
+    arm64:
       type: c7gn.medium
   large:
-    linux-*-amd64:
+    amd64:
       type: c5ad.xlarge
-    linux-*-arm64:
+    arm64:
       type: c6g.xlarge

--- a/deployability/modules/allocation/vagrant/credentials.py
+++ b/deployability/modules/allocation/vagrant/credentials.py
@@ -59,11 +59,11 @@ class VagrantCredentials(Credentials):
             public_key_path.unlink()
         # Generate the key pair.
         command = ["ssh-keygen",
-                   "-f", str(private_key_path),
-                   "-m", "PEM",
-                   "-t", "rsa",
-                   "-N", "",
-                   "-q"]
+                    "-f", str(private_key_path),
+                    "-m", "PEM",
+                    "-t", "rsa",
+                    "-N", "",
+                    "-q"]
         output = subprocess.run(command, check=True,
                                 capture_output=True, text=True)
         os.chmod(private_key_path, 0o600)


### PR DESCRIPTION
Close https://github.com/wazuh/wazuh-qa/issues/4854
Updated the AMIs for AWS deployment:



### Ubuntu 22.04 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932321882
### Ubuntu 22.04 arm64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932323292
### Ubuntu 18.04 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932332037
### Ubuntu 20.04 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932339803
### Debian 10 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932351637
### Debian 11 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932362079
### Debian 12 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932372858
### Oracle Linux 7 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932381275
### Oracle Linux 8 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932386419
### Oracle Linux 9 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932392149
### openSUSE 15 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932401702
### SUSE 15 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932410820
### Centos 7 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932417663
### Centos 8 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932422705
### Centos 9 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932427855
### Red Hat 7 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932430664
### Red Hat 8 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932443876
### Red Hat 9 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932449710
### Amazon Linux 2 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932460984
### Amazon Linux 2023 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932465454
### Fedora 37 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932471609
### Fedora 38 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932477423
### Rocky Linux 9 amd64: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932479320
### macOS: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932491214
### Windows desktop 10: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932639734
### Windows desktop 11: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932652843
### Windows server 2012 R2: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932673876
### Windows server 2016: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932679827
### Windows server 2019: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932683514
### Windows server 2022: https://github.com/wazuh/wazuh-qa/issues/4854#issuecomment-1932688109

---

we had to modify this code:

```console
        arch = params.composite_name.split('-')[-1]
        # Parse the configuration.
        for spec in size_specs:
            if fnmatch.fnmatch(arch, spec):
                config['type'] = size_specs[spec]['type']
                break

```
This is because it was limited only to Linux systems, and it was necessary to add it for macOS and Windows, this the AMI is now searched by architecture.

We also had to update the amd64 micro and small instances since they were not compatible with Windows 11 systems onwards.