### PR TITLE
Fix macOS Vulnerability Detection handler provision in E2E tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix macOS Vulnerability Detection handler provision in E2E tests ([#4948](https://github.com/wazuh/wazuh-qa/pull/4948)) \- (Framework)
 - Migrate HostMonitor to system_monitoring to avoid Windows import of ansible module ([#4917](https://github.com/wazuh/wazuh-qa/pull/4917/)) \- (Framework)
 - Fixed ansible_runner import conditional to avoid errors on Windows and python 3.6 ([#4916](https://github.com/wazuh/wazuh-qa/pull/4916)) \- (Framework)
 - Fixed IT control_service Windows loop ([#4765](https://github.com/wazuh/wazuh-qa/pull/4765)) \- (Framework)

--- a/provisioning/environments/e2e_vulnerability_detector.yaml
+++ b/provisioning/environments/e2e_vulnerability_detector.yaml
@@ -34,3 +34,9 @@ agent5:
     os: ubuntu_22
     manager: manager2
     architecture: arm64v8
+
+agent6:
+    roles: [agent]
+    os: macos_1400
+    manager: manager1
+    architecture: arm64v8

--- a/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/macos.yml
+++ b/provisioning/roles/wazuh/ansible-wazuh-agent/tasks/macos.yml
@@ -14,7 +14,7 @@
     owner: root
     group: wazuh
     mode: 0644
-  notify: MacOS | restart wazuh-agent
+  notify: MacOS | Restart Wazuh Agent
   tags:
     - init
     - config
@@ -33,7 +33,7 @@
     owner: root
     group: wazuh
     mode: 0640
-  notify: MacOS | restart wazuh-agent
+  notify: MacOS | Restart Wazuh Agent
   tags:
     - init
     - config


### PR DESCRIPTION
## Description

Enhances macOS restart agent handler in the Vulnerability Detector provision, ensuring seamless functionality. Additionally, integrates macOS agent into the default VD environment for comprehensive coverage


**Build**:  https://ci.wazuh.info/job/Wazuh_QA_environment/919/

> [!NOTE]
> Testing performed with `fix/6234-sqlite-error-mitigation` branch, which include a fix for tests collection error: https://github.com/wazuh/wazuh-jenkins/issues/6234