### PR TITLE
Migrate E2E timeouts to waiters module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Migrate Vulnerability Detection timeouts variables to the waiters module ([#4949](https://github.com/wazuh/wazuh-qa/pull/4949)) \- (Framework)
 - Migrate HostMonitor to system_monitoring to avoid Windows import of ansible module ([#4917](https://github.com/wazuh/wazuh-qa/pull/4917/)) \- (Framework)
 - Fixed ansible_runner import conditional to avoid errors on Windows and python 3.6 ([#4916](https://github.com/wazuh/wazuh-qa/pull/4916)) \- (Framework)
 - Fixed IT control_service Windows loop ([#4765](https://github.com/wazuh/wazuh-qa/pull/4765)) \- (Framework)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -29,7 +29,10 @@ from wazuh_testing.end_to_end.regex import get_event_regex
 from wazuh_testing.end_to_end.logs import truncate_remote_host_group_files
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.modules.syscollector import TIMEOUT_SYSCOLLECTOR_SHORT_SCAN
-from wazuh_testing.modules.vulnerability_detector import VD_FEED_UPDATE_TIMEOUT, VD_INITIAL_SCAN_PER_AGENT_TIMEOUT
+
+
+VD_FEED_UPDATE_TIMEOUT = 300
+VD_INITIAL_SCAN_PER_AGENT_TIMEOUT = 15
 
 
 def wait_until_vd_is_updated(host_manager: HostManager) -> None:

--- a/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/__init__.py
+++ b/deps/wazuh_testing/wazuh_testing/modules/vulnerability_detector/__init__.py
@@ -42,11 +42,6 @@ CUSTOM_ALMA_OVAL_FEED = 'custom_alsa8_oval_feed.xml'
 
 VULNERABILITY_DETECTOR_PREFIX = r'.*wazuh-modulesd:vulnerability-detector.*'
 
-
-# End to end tests variables
-VD_FEED_UPDATE_TIMEOUT = 300
-VD_INITIAL_SCAN_PER_AGENT_TIMEOUT = 15
-
 VULNERABLE_PACKAGES = [
     {
         "name": "custom-package-0",


### PR DESCRIPTION
### Description

This PR migrate Vulnerability Detection timeouts variables to the waiters module in order to avoid the sqlite3 provisioning error.


**Build**:  https://ci.wazuh.info/job/Wazuh_QA_environment/919/