### PR TITLE
Add pre-release and staging Filebeat module template URL

### DIFF
--- a/provisioning/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
+++ b/provisioning/roles/wazuh/ansible-filebeat-oss/defaults/main.yml
@@ -9,6 +9,8 @@ filebeat_output_indexer_hosts:
   - "localhost:9200"
 
 filebeat_module_package_url: https://packages.wazuh.com/4.x/filebeat
+filebeat_module_pre_release_package_url: https://packages-dev.wazuh.com/pre-release/filebeat
+filebeat_module_staging_package_url: https://packages-dev.wazuh.com/staging/filebeat
 filebeat_module_package_name: wazuh-filebeat-0.4.tar.gz
 filebeat_module_package_path: /tmp/
 filebeat_module_destination: /usr/share/filebeat/module

--- a/provisioning/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
+++ b/provisioning/roles/wazuh/ansible-filebeat-oss/tasks/main.yml
@@ -30,6 +30,18 @@
     path: "{{ filebeat_module_folder }}"
   register: filebeat_module_folder
 
+- name: Download pre-release Filebeat module package
+  get_url:
+    url: "{{ filebeat_module_pre_release_package_url }}/{{ filebeat_module_package_name }}"
+    dest: "{{ filebeat_module_package_path }}"
+  when: not filebeat_module_folder.stat.exists and {{ repository }} == pre-release
+
+- name: Download staging Filebeat module package
+  get_url:
+    url: "{{ filebeat_module_staging_package_url }}/{{ filebeat_module_package_name }}"
+    dest: "{{ filebeat_module_package_path }}"
+  when: not filebeat_module_folder.stat.exists and {{ repository }} == staging
+
 - name: Download Filebeat module package
   get_url:
     url: "{{ filebeat_module_package_url }}/{{ filebeat_module_package_name }}"


### PR DESCRIPTION
# Description

This PR aims to add the corresponding URLs for the filebeat module template when staging or pre-release packages are being utilized since it was discovered that the filebeat module consistently retrieves the filebeat template from the production environment.

---

Related issue: https://github.com/wazuh/wazuh-qa/issues/4931

## Testing performed

