### PR TITLE
Change e2e vd configuration keystore

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/configuration.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/configuration.py
@@ -202,3 +202,22 @@ def configure_environment(host_manager: HostManager, configurations: Dict[str, L
                      [(host, config, host_manager) for host, config in configure_environment_parallel_map])
 
     logging.info("Environment configured")
+
+
+def save_indexer_credentials_into_keystore(host_manager):
+    """
+    Save indexer credentials into the keystore.
+
+    Args:
+        host_manager: An instance of the HostManager class containing information about hosts.
+    """
+    keystore_path = '/var/ossec/bin/wazuh-keystore'
+
+    indexer_server = host_manager.get_group_hosts('indexer')[0]
+    indexer_server_variables = host_manager.get_host_variables(indexer_server)
+    indexer_user = indexer_server_variables['indexer_user']
+    indexer_password = indexer_server_variables['indexer_password']
+
+    for manager in host_manager.get_group_hosts('manager'):
+        host_manager.run_command(manager, f"{keystore_path} -f indexer -k username -v {indexer_user}")
+        host_manager.run_command(manager, f"{keystore_path} -f indexer -k password -v {indexer_password}")

--- a/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
@@ -15,20 +15,16 @@
             elements:
               - host:
                   value: 'https://INDEXER_SERVER:9200'
-        - username:
-            value: INDEXER_USERNAME
-        - password:
-            value: INDEXER_PASSWORD
         - ssl:
             elements:
               - certificate_authorities:
                   elements:
                     - ca:
                         value: FILEBEAT_ROOT_CA
-                    - certificate:
-                        value: FILEBEAT_CERTIFICATE
-                    - key:
-                        value: FILEBEAT_KEY
+          certificate:
+            value: FILEBEAT_CERTIFICATE
+          key:
+            value: FILEBEAT_KEY
     - section: sca
       elements:
         - enabled:

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -47,9 +47,9 @@ import yaml
 import time
 import ast
 import datetime
-from typing import Generator, List
 
-from wazuh_testing.end_to_end.configuration import backup_configurations, restore_configuration, configure_environment
+from wazuh_testing.end_to_end.configuration import backup_configurations, restore_configuration, \
+        configure_environment, save_indexer_credentials_into_keystore
 from wazuh_testing.end_to_end.logs import truncate_remote_host_group_files
 from wazuh_testing.end_to_end.waiters import wait_until_vd_is_updated
 from wazuh_testing.end_to_end.monitoring import generate_monitoring_logs, monitoring_events_multihost
@@ -91,13 +91,10 @@ def load_vulnerability_detector_configurations(host_manager):
             configuration_template = load_configuration_template(configurations_paths['manager'], [{}], [{}])
 
             # Replace placeholders by real values
+            manager_index = host_manager.get_group_hosts('manager').index(host) + 2
             indexer_server = host_manager.get_group_hosts('indexer')[0]
             indexer_server_variables = host_manager.get_host_variables(indexer_server)
-            manager_index = host_manager.get_group_hosts('manager').index(host) + 2
-
             configuration_variables = {
-                'INDEXER_USERNAME': indexer_server_variables['indexer_user'],
-                'INDEXER_PASSWORD': indexer_server_variables['indexer_password'],
                 'INDEXER_SERVER': indexer_server_variables['ip'],
                 'FILEBEAT_ROOT_CA': '/etc/pki/filebeat/root-ca.pem',
                 'FILEBEAT_CERTIFICATE': f"/etc/pki/filebeat/node-{manager_index}.pem",
@@ -125,6 +122,10 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
     # Configure managers and agents
     logger.error("Getting backup of current configurations")
     hosts_configuration_backup = backup_configurations(host_manager)
+
+    logger.error("Save the Wazuh indexer username and password into the Wazuh manager keystore")
+    save_indexer_credentials_into_keystore(host_manager)
+
     logger.error("Configuring environment")
     configure_environment(host_manager, load_vulnerability_detector_configurations(host_manager))
 


### PR DESCRIPTION
## Description

This PR updates Vulnerability Detector E2E tests configuration in order to fit with new keystore system,

---

## Testing performed

<details>

<summary> Configure remote manager</summary>

```
In [21]: old_conf = hm.get_file_content('manager1', '/var/ossec/etc/ossec.conf')


In [22]: 

In [22]: print(old_conf)
<ossec_config>
		  	
	<global>
				    		
		<jsonout_output>yes</jsonout_output>
				    		
		<alerts_log>yes</alerts_log>
				    		
		<logall>no</logall>
				    		
		<logall_json>no</logall_json>
				    		
		<email_notification>no</email_notification>
				    		
		<email_to>admin@example.net</email_to>
				    		
		<smtp_server>smtp.example.wazuh.com</smtp_server>
				    		
		<email_from>wazuh@example.wazuh.com</email_from>
				    		
		<email_maxperhour>12</email_maxperhour>
				    		
		<email_log_source>alerts.log</email_log_source>
				    		
		<agents_disconnection_time>20s</agents_disconnection_time>
				    		
		<agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
				  	
	</global>
		  	
	<alerts>
				    		
		<log_alert_level>3</log_alert_level>
				    		
		<email_alert_level>12</email_alert_level>
				  	
	</alerts>
		    	
	<logging>
				    		
		<log_format>plain</log_format>
				  	
	</logging>
		  	
	<remote>
				    		
		<connection>secure</connection>
				    		
		<port>1514</port>
				    		
		<protocol>tcp</protocol>
				    		
		<queue_size>131072</queue_size>
				  	
	</remote>
		    	
	<rootcheck>
				    		
		<disabled>yes</disabled>
		
  
	</rootcheck>
		  	
	<wodle name="cis-cat">
				    		
		<disabled>yes</disabled>
				    		
		<timeout>1800</timeout>
				    		
		<interval>1d</interval>
				    		
		<scan-on-start>yes</scan-on-start>
				    		
		<java_path>wodles/java</java_path>
				    		
		<ciscat_path>wodles/ciscat</ciscat_path>
				  	
	</wodle>
		    	
	<wodle name="osquery">
				    		
		<disabled>yes</disabled>
				    		
		<run_daemon>yes</run_daemon>
				    		
		<log_path>/var/log/osquery/osqueryd.results.log</log_path>
				    		
		<config_path>/etc/osquery/osquery.conf</config_path>
				    		
		<add_labels>yes</add_labels>
				  	
	</wodle>
		    	
	<wodle name="syscollector">
				    		
		<disabled>no</disabled>
		
  
	</wodle>
		  	
	<sca>
				    		
		<enabled>no</enabled>
		
  
	</sca>
		  	
	<syscheck>
				    		
		<disabled>yes</disabled>
		
  
	</syscheck>
		  	
	<global>
				    		
		<white_list>127.0.0.1</white_list>
				    		
		<white_list>^localhost.localdomain$</white_list>
				    		
		<white_list>127.0.0.53</white_list>
				  	
	</global>
		  	
	<command>
				    		
		<name>disable-account</name>
				    		
		<executable>disable-account</executable>
				        		
		<timeout_allowed>yes</timeout_allowed>
				  	
	</command>
		  	
	<command>
				    		
		<name>restart-wazuh</name>
				    		
		<executable>restart-wazuh</executable>
				  	
	</command>
		  	
	<command>
				    		
		<name>firewall-drop</name>
				    		
		<executable>firewall-drop</executable>
				        		
		<timeout_allowed>yes</timeout_allowed>
				  	
	</command>
		  	
	<command>
				    		
		<name>host-deny</name>
				    		
		<executable>host-deny</executable>
				        		
		<timeout_allowed>yes</timeout_allowed>
				  	
	</command>
		  	
	<command>
				    		
		<name>route-null</name>
				    		
		<executable>route-null</executable>
				        		
		<timeout_allowed>yes</timeout_allowed>
				  	
	</command>
		  	
	<command>
				    		
		<name>win_route-null</name>
				    		
		<executable>route-null.exe</executable>
				        		
		<timeout_allowed>yes</timeout_allowed>
				  	
	</command>
		  	
	<command>
				    		
		<name>netsh</name>
				    		
		<executable>netsh.exe</executable>
				        		
		<timeout_allowed>yes</timeout_allowed>
				  	
	</command>
		  	
	<localfile>
				     		
		<log_format>command</log_format>
				     		
		<command>df -P</command>
				     		
		<frequency>360</frequency>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>full_command</log_format>
				     		
		<command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
				     		
		<alias>netstat listening ports</alias>
				     		
		<frequency>360</frequency>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>full_command</log_format>
				     		
		<command>last -n 20</command>
				     		
		<frequency>360</frequency>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>syslog</log_format>
				     		
		<location>/var/ossec/logs/active-responses.log</location>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>syslog</log_format>
				     		
		<location>/var/log/auth.log</location>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>syslog</log_format>
				     		
		<location>/var/log/syslog</location>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>syslog</log_format>
				     		
		<location>/var/log/dpkg.log</location>
				  	
	</localfile>
		  	
	<localfile>
				     		
		<log_format>syslog</log_format>
				     		
		<location>/var/log/kern.log</location>
				  	
	</localfile>
		  	
	<ruleset>
				    		
		<decoder_dir>ruleset/decoders</decoder_dir>
				  		
		<rule_dir>ruleset/rules</rule_dir>
				  		
		<rule_exclude>0215-policy_rules.xml</rule_exclude>
				  		
		<list>etc/lists/audit-keys</list>
				  		
		<list>etc/lists/security-eventchannel</list>
				  		
		<list>etc/lists/amazon/aws-eventnames</list>
				    		
		<decoder_dir>etc/decoders</decoder_dir>
				  		
		<rule_dir>etc/rules</rule_dir>
				  	
	</ruleset>
		  	
	<auth>
				    		
		<disabled>no</disabled>
				    		
		<port>1515</port>
				    		
		<use_source_ip>no</use_source_ip>
				    		
		<force>
						      			
			<enabled>yes</enabled>
						      			
			<key_mismatch>yes</key_mismatch>
						      			
			<disconnected_time enabled="yes">1h</disconnected_time>
						      			
			<after_registration_time>1h</after_registration_time>
						    		
		</force>
				    		
		<purge>yes</purge>
				    		
		<use_password>no</use_password>
				    		
		<ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
				    		
		<ssl_verify_host>no</ssl_verify_host>
				    		
		<ssl_manager_cert>/var/ossec/etc/sslmanager.cert</ssl_manager_cert>
				    		
		<ssl_manager_key>/var/ossec/etc/sslmanager.key</ssl_manager_key>
				    		
		<ssl_auto_negotiate>no</ssl_auto_negotiate>
				  	
	</auth>
		  	
	<cluster>
				    		
		<disabled>no</disabled>
				    		
		<name>wazuh</name>
				    		
		<node_name>master</node_name>
				    		
		<node_type>master</node_type>
				    		
		<key>c98b62a9b6169ac5f67dae55ae4a9088</key>
				    		
		<port>1516</port>
				    		
		<bind_addr>0.0.0.0</bind_addr>
				    		
		<nodes>
						      			
			<node>172.31.8.216</node>
						    		
		</nodes>
				    		
		<hidden>no</hidden>
				  	
	</cluster>
	<vulnerability-detection>
		<enabled>no</enabled>
	</vulnerability-detection>
	
  
	<indexer>
		
    
		<enabled>no</enabled>
		
  
	</indexer>
	

  
</ossec_config>




</details>

In [23]: configure_environment(hm, load_vulnerability_detector_configurations(hm))

In [24]: old_conf = hm.get_file_content('manager1', '/var/ossec/etc/ossec.conf')

In [25]: print(old_conf)
<ossec_config>
			  		
	<global>
						    				
		<jsonout_output>yes</jsonout_output>
						    				
		<alerts_log>yes</alerts_log>
						    				
		<logall>no</logall>
						    				
		<logall_json>no</logall_json>
						    				
		<email_notification>no</email_notification>
						    				
		<email_to>admin@example.net</email_to>
						    				
		<smtp_server>smtp.example.wazuh.com</smtp_server>
						    				
		<email_from>wazuh@example.wazuh.com</email_from>
						    				
		<email_maxperhour>12</email_maxperhour>
						    				
		<email_log_source>alerts.log</email_log_source>
						    				
		<agents_disconnection_time>20s</agents_disconnection_time>
						    				
		<agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
						  		
	</global>
			  		
	<alerts>
						    				
		<log_alert_level>3</log_alert_level>
						    				
		<email_alert_level>12</email_alert_level>
						  		
	</alerts>
			    		
	<logging>
						    				
		<log_format>plain</log_format>
						  		
	</logging>
			  		
	<remote>
						    				
		<connection>secure</connection>
						    				
		<port>1514</port>
						    				
		<protocol>tcp</protocol>
						    				
		<queue_size>131072</queue_size>
						  		
	</remote>
			    		
	<rootcheck>
						    				
		<disabled>yes</disabled>
		
  
	</rootcheck>
			  		
	<wodle name="cis-cat">
						    				
		<disabled>yes</disabled>
						    				
		<timeout>1800</timeout>
						    				
		<interval>1d</interval>
						    				
		<scan-on-start>yes</scan-on-start>
						    				
		<java_path>wodles/java</java_path>
						    				
		<ciscat_path>wodles/ciscat</ciscat_path>
						  		
	</wodle>
			    		
	<wodle name="osquery">
						    				
		<disabled>yes</disabled>
						    				
		<run_daemon>yes</run_daemon>
						    				
		<log_path>/var/log/osquery/osqueryd.results.log</log_path>
						    				
		<config_path>/etc/osquery/osquery.conf</config_path>
						    				
		<add_labels>yes</add_labels>
						  		
	</wodle>
			    		
	<wodle name="syscollector">
						    				
		<disabled>no</disabled>
		
  
	</wodle>
			  		
	<sca>
						    				
		<enabled>no</enabled>
		
  
	</sca>
			  		
	<syscheck>
						    				
		<disabled>yes</disabled>
		
  
	</syscheck>
			  		
	<global>
						    				
		<white_list>127.0.0.1</white_list>
						    				
		<white_list>^localhost.localdomain$</white_list>
						    				
		<white_list>127.0.0.53</white_list>
						  		
	</global>
			  		
	<command>
						    				
		<name>disable-account</name>
						    				
		<executable>disable-account</executable>
						        				
		<timeout_allowed>yes</timeout_allowed>
						  		
	</command>
			  		
	<command>
						    				
		<name>restart-wazuh</name>
						    				
		<executable>restart-wazuh</executable>
						  		
	</command>
			  		
	<command>
						    				
		<name>firewall-drop</name>
						    				
		<executable>firewall-drop</executable>
						        				
		<timeout_allowed>yes</timeout_allowed>
						  		
	</command>
			  		
	<command>
						    				
		<name>host-deny</name>
						    				
		<executable>host-deny</executable>
						        				
		<timeout_allowed>yes</timeout_allowed>
						  		
	</command>
			  		
	<command>
						    				
		<name>route-null</name>
						    				
		<executable>route-null</executable>
						        				
		<timeout_allowed>yes</timeout_allowed>
						  		
	</command>
			  		
	<command>
						    				
		<name>win_route-null</name>
						    				
		<executable>route-null.exe</executable>
						        				
		<timeout_allowed>yes</timeout_allowed>
						  		
	</command>
			  		
	<command>
						    				
		<name>netsh</name>
						    				
		<executable>netsh.exe</executable>
						        				
		<timeout_allowed>yes</timeout_allowed>
						  		
	</command>
			  		
	<localfile>
						     				
		<log_format>command</log_format>
						     				
		<command>df -P</command>
						     				
		<frequency>360</frequency>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>full_command</log_format>
						     				
		<command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
						     				
		<alias>netstat listening ports</alias>
						     				
		<frequency>360</frequency>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>full_command</log_format>
						     				
		<command>last -n 20</command>
						     				
		<frequency>360</frequency>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>syslog</log_format>
						     				
		<location>/var/ossec/logs/active-responses.log</location>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>syslog</log_format>
						     				
		<location>/var/log/auth.log</location>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>syslog</log_format>
						     				
		<location>/var/log/syslog</location>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>syslog</log_format>
						     				
		<location>/var/log/dpkg.log</location>
						  		
	</localfile>
			  		
	<localfile>
						     				
		<log_format>syslog</log_format>
						     				
		<location>/var/log/kern.log</location>
						  		
	</localfile>
			  		
	<ruleset>
						    				
		<decoder_dir>ruleset/decoders</decoder_dir>
						  				
		<rule_dir>ruleset/rules</rule_dir>
						  				
		<rule_exclude>0215-policy_rules.xml</rule_exclude>
						  				
		<list>etc/lists/audit-keys</list>
						  				
		<list>etc/lists/security-eventchannel</list>
						  				
		<list>etc/lists/amazon/aws-eventnames</list>
						    				
		<decoder_dir>etc/decoders</decoder_dir>
						  				
		<rule_dir>etc/rules</rule_dir>
						  		
	</ruleset>
			  		
	<auth>
						    				
		<disabled>no</disabled>
						    				
		<port>1515</port>
						    				
		<use_source_ip>no</use_source_ip>
						    				
		<force>
									      						
			<enabled>yes</enabled>
									      						
			<key_mismatch>yes</key_mismatch>
									      						
			<disconnected_time enabled="yes">1h</disconnected_time>
									      						
			<after_registration_time>1h</after_registration_time>
									    				
		</force>
						    				
		<purge>yes</purge>
						    				
		<use_password>no</use_password>
						    				
		<ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
						    				
		<ssl_verify_host>no</ssl_verify_host>
						    				
		<ssl_manager_cert>/var/ossec/etc/sslmanager.cert</ssl_manager_cert>
						    				
		<ssl_manager_key>/var/ossec/etc/sslmanager.key</ssl_manager_key>
						    				
		<ssl_auto_negotiate>no</ssl_auto_negotiate>
						  		
	</auth>
			  		
	<cluster>
						    				
		<disabled>no</disabled>
						    				
		<name>wazuh</name>
						    				
		<node_name>master</node_name>
						    				
		<node_type>master</node_type>
						    				
		<key>c98b62a9b6169ac5f67dae55ae4a9088</key>
						    				
		<port>1516</port>
						    				
		<bind_addr>0.0.0.0</bind_addr>
						    				
		<nodes>
									      						
			<node>172.31.8.216</node>
									    				
		</nodes>
						    				
		<hidden>no</hidden>
						  		
	</cluster>
		
	<vulnerability-detection>
				
		<enabled>yes</enabled>
		
    
		<index-status>yes</index-status>
		
    
		<feed-update-interval>2h</feed-update-interval>
		
  
	</vulnerability-detection>
		  	
	<indexer>
				    		
		<enabled>yes</enabled>
		
    
		<hosts>
			<host>https://172.31.8.216:9200</host>
			
  
		</hosts>
		
    
		<ssl>
			<certificate_authorities>
				<ca>/etc/pki/filebeat/root-ca.pem</ca>
				
  
			</certificate_authorities>
			
  
		</ssl>
		
    
		<certificate>/etc/pki/filebeat/node-2.pem</certificate>
		
    
		<key>/etc/pki/filebeat/node-2-key.pem</key>
		
  
	</indexer>
		  
</ossec_config>

``` 
</details>


<details>

<summary> Remote keystore initalization</summary>

- After configuring the environment, we can see that manager is failing to connect to the Indexer

```
2024/02/12 17:27:17 indexer-connector: WARNING: Error initializing IndexerConnector: HTTP response code said error: 401, we will try again after 4 seconds.
2024/02/12 17:27:21 indexer-connector: WARNING: Error initializing IndexerConnector: HTTP response code said error: 401, we will try again after 8 seconds.
2024/02/12 17:27:30 indexer-connector: WARNING: Error initializing IndexerConnector: HTTP response code said error: 401, we will try again after 16 seconds.
``` 

- If we run the command and restart the manager we can see that Indexer is connected
```
In [34]: save_indexer_credentials_into_keystore(hm)
In [35]: hm.run_shell('manager1', '/var/ossec/bin/wazuh-control restart')
```

```
2024/02/12 17:35:54 indexer-connector: INFO: IndexerConnector initialized.
2024/02/12 17:35:54 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2024/02/12 17:35:55 wazuh-modulesd:content-updater: INFO: Starting scheduled action for 'vulnerability_feed_manager'
2024/02/12 17:35:55 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' started
2024/02/12 17:35:55 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' finished
2024/02/12 17:35:55 wazuh-modulesd:vulnerability-scanner: INFO: Vulnerability scanner module started

```


</details>


> [!NOTE]
> Tested with https://github.com/wazuh/wazuh-qa/issues/4936

