### PR TITLE
Fix install package HostManager method

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -482,6 +482,7 @@ class HostManager:
             host_manager.install_package('my_host', 'http://example.com/package.deb', system='ubuntu')
         """
         result = False
+
         if system == 'windows':
             result = self.get_host(host).ansible("win_package", f"path={url} arguments=/S", check=False)
         elif system == 'ubuntu':
@@ -489,15 +490,15 @@ class HostManager:
             if result['changed'] and result['stderr'] == '':
                 result = True
         elif system == 'centos':
-            result = self.get_host(host).ansible("yum", f"name={url} state=present"
+            result = self.get_host(host).ansible("yum", f"name={url} state=present "
                                                  'sslverify=false disable_gpg_check=True', check=False)
-            if 'rc' in result and result['rc'] == 0 and result['changed']:
-                result = True
         elif system == 'macos':
             package_name = url.split('/')[-1]
             result = self.get_host(host).ansible("command", f"curl -LO {url}", check=False)
             cmd = f"installer -pkg {package_name} -target /"
             result = self.get_host(host).ansible("command", cmd, check=False)
+
+        logging.info(f"Package installed result {result}")
 
         return result
 


### PR DESCRIPTION
# Description

This PR includes a fix for the typo introduced in https://github.com/wazuh/wazuh-qa/pull/4878 for the install package method.

---

## Testing performed


<details>

<summary> centOS remote package installation </summary>

```
In [44]: hm.install_package('agent1', 'https://dl.grafana.com/enterprise/release/grafana-enterprise-8.5.6-1.x86_64.rpm', 'centos')
In [45]: hm.run_shell('agent1', 'yum list installed | grep grafana')
Out[45]: 'grafana-enterprise.x86_64               8.5.6-1                       @/grafana-enterprise-8.5.6-1.x86_64fhwMs1'
```


</details>
